### PR TITLE
MET-548

### DIFF
--- a/db/build.xml
+++ b/db/build.xml
@@ -21,7 +21,7 @@
   <property name="xmldb.user" value="admin" />
   <property name="xmldb.passwd" value="admin" />
   <property name="xmldb.url" value="xmldb:exist://${xmldb.host}:${xmldb.port}/exist/xmlrpc/db" />
-  <property name="xmldb.approot" value="${xmldb.url}/bluemtn" />
+  <property name="xmldb.approot" value="${xmldb.url}/bmtn-data" />
 
   <property name="approot" value="/Users/cwulfman/repos/github/cwulfman/BlueMountain" />
   

--- a/metadata/periodicals/bmtnaam/issues/1922/03_01/bmtnaam_1922-03_01.mets.xml
+++ b/metadata/periodicals/bmtnaam/issues/1922/03_01/bmtnaam_1922-03_01.mets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnaam_1922-03_01">
+<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnaam_1922-03_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>

--- a/metadata/periodicals/bmtnaam/issues/1922/05_01/bmtnaam_1922-05_01.mets.xml
+++ b/metadata/periodicals/bmtnaam/issues/1922/05_01/bmtnaam_1922-05_01.mets.xml
@@ -5,7 +5,7 @@
       xmlns:xlink="http://www.w3.org/1999/xlink"
       xmlns:local="http://diglib.princeton.edu"
       xmlns:mods="http://www.loc.gov/mods/v3"
-      xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
+      xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd"
       TYPE="Magazine"
       OBJID="urn:PUL:periodicals:bluemountain:bmtnaam_1922-05_01">
 	  <metsHdr>


### PR DESCRIPTION
In the xsi:schemaLocation attribute, the value for mods/v3 was
mods-3-3.xsd, which doesn’t allow the authorityURI attribute on some
elements. This patch updates the two Veshch issues to validate against
mods 3.5