### PR TITLE
fixes broken ids

### DIFF
--- a/metadata/periodicals/bmtnaab/issues/1920/03_01/bmtnaab_1920-03_01.mets.xml
+++ b/metadata/periodicals/bmtnaab/issues/1920/03_01/bmtnaab_1920-03_01.mets.xml
@@ -17,12 +17,10 @@
       <mdWrap MDTYPE="MODS">
          <xmlData>
             <mods xmlns="http://www.loc.gov/mods/v3">
-               <mods:identifier type="ark">ark:/88435/ff365789z</mods:identifier>
+               <identifier type="ark">ark:/88435/ff365789z</identifier>
                <recordInfo>
                   <recordIdentifier>urn:PUL:bluemountain:dmd:bmtnaab_1920-03_01</recordIdentifier>
                </recordInfo>
-            </mods>
-            <mods xmlns="http://www.loc.gov/mods/v3">
                <identifier type="bmtn">urn:PUL:bluemountain:bmtnaab_1920-03_01</identifier>
                <typeOfResource>text</typeOfResource>
                <genre>Periodicals-Issue</genre>
@@ -57,7 +55,7 @@
                      <recordIdentifier>urn:PUL:bluemountain:dmd:bmtnaab</recordIdentifier>
                   </recordInfo>
                </relatedItem>
-               <relatedItem ID="c001">
+               <relatedItem type="constituent" ID="c001">
                   <titleInfo lang="fre">
                      <title>SOMMAIRE</title>
                   </titleInfo>
@@ -72,7 +70,7 @@
                   </part>
                   <genre type="CCS">TextContent</genre>
                </relatedItem>
-               <relatedItem ID="c002">
+               <relatedItem type="constituent" ID="c002">
                   <titleInfo lang="fre">
                      <title>TITANIA</title>
                   </titleInfo>
@@ -92,9 +90,9 @@
                      </extent>
                   </part>
                   <genre type="CCS">TextContent</genre>
-                  <relatedItem ID="c003">
+                  <relatedItem type="constituent" ID="c003">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <typeOfResource>still image</typeOfResource>
                      <part>
@@ -104,7 +102,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c004">
+                  <relatedItem type="constituent" ID="c004">
                      <titleInfo lang="fre">
                         <title>Untitled Image</title>
                      </titleInfo>
@@ -122,7 +120,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c005">
+                  <relatedItem type="constituent" ID="c005">
                      <titleInfo>
                         <title>Untitled Image</title>
                      </titleInfo>
@@ -141,7 +139,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c006">
+                  <relatedItem type="constituent" ID="c006">
                      <titleInfo>
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -159,7 +157,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c007">
+                  <relatedItem type="constituent" ID="c007">
                      <titleInfo>
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -177,7 +175,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c008">
+                  <relatedItem type="constituent" ID="c008">
                      <titleInfo>
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -195,7 +193,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c009">
+                  <relatedItem type="constituent" ID="c009">
                      <titleInfo>
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -213,9 +211,9 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c010">
+                  <relatedItem type="constituent" ID="c010">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <typeOfResource>still image</typeOfResource>
                      <part>
@@ -226,7 +224,7 @@
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
                </relatedItem>
-               <relatedItem ID="c011">
+               <relatedItem type="constituent" ID="c011">
                   <titleInfo lang="fre">
                      <title>Eric Satie</title>
                   </titleInfo>
@@ -246,9 +244,9 @@
                      </extent>
                   </part>
                   <genre type="CCS">TextContent</genre>
-                  <relatedItem ID="c012">
+                  <relatedItem type="constituent" ID="c012">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled</mods:title>
+                        <title>Untitled</title>
                      </titleInfo>
                      <typeOfResource>still image</typeOfResource>
                      <part>
@@ -259,7 +257,7 @@
                      <genre type="CCS">Music</genre>
                   </relatedItem>
                </relatedItem>
-               <relatedItem ID="c013">
+               <relatedItem type="constituent" ID="c013">
                   <titleInfo lang="fre">
                      <title>1910-1920</title>
                   </titleInfo>
@@ -279,9 +277,9 @@
                      </extent>
                   </part>
                   <genre type="CCS">TextContent</genre>
-                  <relatedItem ID="c014">
+                  <relatedItem type="constituent" ID="c014">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <typeOfResource>still image</typeOfResource>
                      <part>
@@ -291,9 +289,9 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c015">
+                  <relatedItem type="constituent" ID="c015">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <typeOfResource>still image</typeOfResource>
                      <part>
@@ -304,7 +302,7 @@
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
                </relatedItem>
-               <relatedItem ID="c016">
+               <relatedItem type="constituent" ID="c016">
                   <titleInfo lang="fre">
                      <title>POÈMES</title>
                   </titleInfo>
@@ -325,7 +323,7 @@
                      </extent>
                   </part>
                   <genre type="CCS">TextContent</genre>
-                  <relatedItem ID="c016a">
+                  <relatedItem type="constituent" ID="c016a">
                      <titleInfo lang="fre">
                         <nonSort>LE</nonSort>
                         <title>DAMASQUINEUR</title>
@@ -339,9 +337,9 @@
                      </part>
                      <genre type="CCS">TextContent</genre>
                   </relatedItem>
-                  <relatedItem ID="c017">
+                  <relatedItem type="constituent" ID="c017">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <typeOfResource>still image</typeOfResource>
                      <part>
@@ -351,7 +349,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c018">
+                  <relatedItem type="constituent" ID="c018">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -370,7 +368,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c019">
+                  <relatedItem type="constituent" ID="c019">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -388,7 +386,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c020">
+                  <relatedItem type="constituent" ID="c020">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -407,7 +405,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c021">
+                  <relatedItem type="constituent" ID="c021">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -426,7 +424,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c022">
+                  <relatedItem type="constituent" ID="c022">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -445,9 +443,9 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c023">
+                  <relatedItem type="constituent" ID="c023">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <typeOfResource>still image</typeOfResource>
                      <part>
@@ -457,7 +455,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c024">
+                  <relatedItem type="constituent" ID="c024">
                      <titleInfo lang="fre">
                         <title>PLUS D’ASTROLOGIE</title>
                      </titleInfo>
@@ -477,9 +475,9 @@
                         </extent>
                      </part>
                      <genre type="CCS">TextContent</genre>
-                     <relatedItem ID="c025">
+                     <relatedItem type="constituent" ID="c025">
                         <titleInfo lang="fre">
-                           <mods:title>Untitled Image</mods:title>
+                           <title>Untitled Image</title>
                         </titleInfo>
                         <typeOfResource>still image</typeOfResource>
                         <part>
@@ -490,7 +488,7 @@
                         <genre type="CCS">Illustration</genre>
                      </relatedItem>
                   </relatedItem>
-                  <relatedItem ID="c026">
+                  <relatedItem type="constituent" ID="c026">
                      <titleInfo lang="fre">
                         <title>DON QUICHOTTE VOYAGE EN MER</title>
                      </titleInfo>
@@ -510,9 +508,9 @@
                         </extent>
                      </part>
                      <genre type="CCS">TextContent</genre>
-                     <relatedItem ID="c027">
+                     <relatedItem type="constituent" ID="c027">
                         <titleInfo lang="fre">
-                           <mods:title>Untitled Image</mods:title>
+                           <title>Untitled Image</title>
                         </titleInfo>
                         <typeOfResource>still image</typeOfResource>
                         <part>
@@ -523,7 +521,7 @@
                         <genre type="CCS">Illustration</genre>
                      </relatedItem>
                   </relatedItem>
-                  <relatedItem ID="c028">
+                  <relatedItem type="constituent" ID="c028">
                      <titleInfo lang="fre">
                         <title>ALLUSIONS ROM ANTIQUES A PROPOS DU MARDI-GRAS</title>
                      </titleInfo>
@@ -543,9 +541,9 @@
                         </extent>
                      </part>
                      <genre type="CCS">TextContent</genre>
-                     <relatedItem ID="c029">
+                     <relatedItem type="constituent" ID="c029">
                         <titleInfo lang="fre">
-                           <mods:title>Untitled Image</mods:title>
+                           <title>Untitled Image</title>
                         </titleInfo>
                         <typeOfResource>still image</typeOfResource>
                         <part>
@@ -559,7 +557,7 @@
                </relatedItem>
 
 
-               <relatedItem ID="c030">
+               <relatedItem type="constituent" ID="c030">
                   <titleInfo lang="fre">
                      <title>Rondeau</title>
                      <subTitle>sur certains Oiseaux nichés au bord de la Seine</subTitle>
@@ -580,9 +578,9 @@
                      </extent>
                   </part>
                   <genre type="CCS">TextContent</genre>
-                  <relatedItem ID="c031">
+                  <relatedItem type="constituent" ID="c031">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <typeOfResource>still image</typeOfResource>
                      <part>
@@ -593,7 +591,7 @@
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
                </relatedItem>
-               <relatedItem ID="c032">
+               <relatedItem type="constituent" ID="c032">
                   <titleInfo lang="fre">
                      <nonSort>LES</nonSort>
                      <title>HOMMES D’AUJOURD’HUI</title>
@@ -615,9 +613,9 @@
                      </extent>
                   </part>
                   <genre type="CCS">TextContent</genre>
-                  <relatedItem ID="c033">
+                  <relatedItem type="constituent" ID="c033">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <name>
                         <displayForm>Max Jacob</displayForm>
@@ -634,7 +632,7 @@
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
                </relatedItem>
-               <relatedItem ID="c034">
+               <relatedItem type="constituent" ID="c034">
                   <titleInfo lang="fre">
                      <title>Max Jacob</title>
                   </titleInfo>
@@ -654,9 +652,9 @@
                      </extent>
                   </part>
                   <genre type="CCS">TextContent</genre>
-                  <relatedItem ID="c035">
+                  <relatedItem type="constituent" ID="c035">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <name type="personal">
                         <displayForm>Max Jacob</displayForm>
@@ -672,9 +670,9 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c036">
+                  <relatedItem type="constituent" ID="c036">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <name>
                         <displayForm>VLAMINCK</displayForm>
@@ -690,7 +688,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c037">
+                  <relatedItem type="constituent" ID="c037">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -708,9 +706,9 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c038">
+                  <relatedItem type="constituent" ID="c038">
                      <titleInfo lang="fre">
-                        <mods:title>[Unknown Painting]</mods:title>
+                        <title>[Unknown Painting]</title>
                      </titleInfo>
                      <name>
                         <displayForm>LUC ALBERT MOREAU</displayForm>
@@ -726,7 +724,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c039">
+                  <relatedItem type="constituent" ID="c039">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -744,9 +742,9 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c040">
+                  <relatedItem type="constituent" ID="c040">
                      <titleInfo lang="fre">
-                        <mods:title>[Unknown Painting]</mods:title>
+                        <title>[Unknown Painting]</title>
                      </titleInfo>
                      <name>
                         <displayForm>MARCHAND</displayForm>
@@ -762,7 +760,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c041">
+                  <relatedItem type="constituent" ID="c041">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -780,7 +778,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c042">
+                  <relatedItem type="constituent" ID="c042">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -798,7 +796,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c043">
+                  <relatedItem type="constituent" ID="c043">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -817,7 +815,7 @@
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
                </relatedItem>
-               <relatedItem ID="c044">
+               <relatedItem type="constituent" ID="c044">
                   <titleInfo lang="fre">
                      <nonSort>La</nonSort>
                      <title>Peinture</title>
@@ -840,7 +838,7 @@
                   </part>
                   <genre type="CCS">TextContent</genre>
                </relatedItem>
-               <relatedItem ID="c045">
+               <relatedItem type="constituent" ID="c045">
                   <titleInfo lang="fre">
                      <title>Quelques Peintres</title>
                   </titleInfo>
@@ -861,7 +859,7 @@
                   </part>
                   <genre type="CCS">TextContent</genre>
                </relatedItem>
-               <relatedItem ID="c046">
+               <relatedItem type="constituent" ID="c046">
                   <titleInfo lang="fre">
                      <title>Encycliques</title>
                   </titleInfo>
@@ -881,9 +879,9 @@
                      </extent>
                   </part>
                   <genre type="CCS">TextContent</genre>
-                  <relatedItem ID="c047">
+                  <relatedItem type="constituent" ID="c047">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <typeOfResource>still image</typeOfResource>
                      <part>
@@ -894,7 +892,7 @@
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
                </relatedItem>
-               <relatedItem ID="c048">
+               <relatedItem type="constituent" ID="c048">
                   <titleInfo lang="fre">
                      <nonSort>Un</nonSort>
                      <title>Donneur d’lllusions "Plantin"</title>
@@ -916,7 +914,7 @@
                      </extent>
                   </part>
                   <genre type="CCS">TextContent</genre>
-                  <relatedItem ID="c049">
+                  <relatedItem type="constituent" ID="c049">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -934,7 +932,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c050">
+                  <relatedItem type="constituent" ID="c050">
                      <titleInfo lang="fre">
                         <nonSort>Les</nonSort>
                         <title>Dentelliéres de la Haute-Loire</title>
@@ -953,7 +951,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c051">
+                  <relatedItem type="constituent" ID="c051">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -971,7 +969,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c052">
+                  <relatedItem type="constituent" ID="c052">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -989,7 +987,7 @@
                      </part>
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
-                  <relatedItem ID="c053">
+                  <relatedItem type="constituent" ID="c053">
                      <titleInfo lang="fre">
                         <title>[Unknown Painting]</title>
                      </titleInfo>
@@ -1008,7 +1006,7 @@
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
                </relatedItem>
-               <relatedItem ID="c054">
+               <relatedItem type="constituent" ID="c054">
                   <titleInfo lang="fre">
                      <title>Lettres allemandes</title>
                   </titleInfo>
@@ -1028,9 +1026,9 @@
                      </extent>
                   </part>
                   <genre type="CCS">TextContent</genre>
-                  <relatedItem ID="c055">
+                  <relatedItem type="constituent" ID="c055">
                      <titleInfo lang="fre">
-                        <mods:title>Untitled Image</mods:title>
+                        <title>Untitled Image</title>
                      </titleInfo>
                      <typeOfResource>still image</typeOfResource>
                      <part>
@@ -1041,7 +1039,7 @@
                      <genre type="CCS">Illustration</genre>
                   </relatedItem>
                </relatedItem>
-               <relatedItem ID="c056">
+               <relatedItem type="constituent" ID="c056">
                   <titleInfo>
                      <title>[Advertisement]</title>
                   </titleInfo>
@@ -1054,7 +1052,7 @@
                   </part>
                   <genre type="CCS">SponsoredAdvertisement</genre>
                </relatedItem>
-               <relatedItem ID="c057">
+               <relatedItem type="constituent" ID="c057">
                   <titleInfo>
                      <title>[Advertisement]</title>
                   </titleInfo>
@@ -1067,7 +1065,7 @@
                   </part>
                   <genre type="CCS">SponsoredAdvertisement</genre>
                </relatedItem>
-               <relatedItem ID="c058">
+               <relatedItem type="constituent" ID="c058">
                   <titleInfo>
                      <title>[Advertisement]</title>
                   </titleInfo>
@@ -1080,7 +1078,7 @@
                   </part>
                   <genre type="CCS">SponsoredAdvertisement</genre>
                </relatedItem>
-               <relatedItem ID="c059">
+               <relatedItem type="constituent" ID="c059">
                   <titleInfo>
                      <title>[Advertisement]</title>
                   </titleInfo>
@@ -1093,7 +1091,7 @@
                   </part>
                   <genre type="CCS">SponsoredAdvertisement</genre>
                </relatedItem>
-               <relatedItem ID="c060">
+               <relatedItem type="constituent" ID="c060">
                   <titleInfo>
                      <title>[Advertisement]</title>
                   </titleInfo>

--- a/metadata/periodicals/bmtnabe/issues/1895/04_01/bmtnabe_1895-04_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1895/04_01/bmtnabe_1895-04_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1895-04_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1895-04_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-04_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-04_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1895-04_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1895-04_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,7 +46,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-04_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -7392,734 +7388,492 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T12:49:14" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="379e897839e6b8d125421282ccafc772a63f9e07" CHECKSUMTYPE="SHA-1" SIZE="4869127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T12:49:40" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="0100512c7d793dbd96d3cc33c22a0a139a012311" CHECKSUMTYPE="SHA-1" SIZE="4896129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T12:50:04" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="9c9e80da181d15df71bb099ef6deb5138dcbdd44" CHECKSUMTYPE="SHA-1" SIZE="4490210">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T12:50:30" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="edd1c819a27d69035725c87e6984e44e863de56f" CHECKSUMTYPE="SHA-1" SIZE="4922229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T12:50:57" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="1ae94388da45f79e98e4a9467c5e64c89dc77a54" CHECKSUMTYPE="SHA-1" SIZE="4802528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T12:51:22" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="f479dcb54658036a32a410f1a3769c678e0fbff0" CHECKSUMTYPE="SHA-1" SIZE="4880821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T12:51:50" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="c776b7a8e0164d6d6db980193cdbe38ad42f6b5a" CHECKSUMTYPE="SHA-1" SIZE="4798927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T12:52:14" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="8d9aa850285fc3af37a1233c321a9c43811d8016" CHECKSUMTYPE="SHA-1" SIZE="4906926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T12:52:40" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="21fa47b9dd497321d941e3d568e023ad798b0c05" CHECKSUMTYPE="SHA-1" SIZE="4826826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T12:53:06" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="9eb05780d341034a76492284386b68efec9af331" CHECKSUMTYPE="SHA-1" SIZE="4828616">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T12:53:30" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="d9be957dd556f62772d0ee42d47e3e1174c53430" CHECKSUMTYPE="SHA-1" SIZE="4808826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T12:53:55" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="c37ac381371cc6104c646a4a1c0d3af12e94c011" CHECKSUMTYPE="SHA-1" SIZE="4821422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T12:54:20" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="4286b1bceb9dc9143b5268ccb5ce3a8d45893906" CHECKSUMTYPE="SHA-1" SIZE="4764729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T12:54:44" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="c24f8111e339637bd53ad46fdaec98237e0712b4" CHECKSUMTYPE="SHA-1" SIZE="4919525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T12:55:09" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="bcbd01c9bc8b108aa4701436e2ca15e10f6e6038" CHECKSUMTYPE="SHA-1" SIZE="4799825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T12:55:35" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="b1495dd75b0e49e550bec1a46f68429c9c5a89e2" CHECKSUMTYPE="SHA-1" SIZE="4905124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T12:56:00" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="fb091000ee237eea2734ec4e3d6f47ba3fefdbb5" CHECKSUMTYPE="SHA-1" SIZE="4805228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T12:56:25" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="8ce1e9bea01969ab06791dca0999a714d46dba5a" CHECKSUMTYPE="SHA-1" SIZE="4898826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T12:56:51" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="8903a7073582f4a80fa382c10633be7f3b5a82af" CHECKSUMTYPE="SHA-1" SIZE="4835753">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T12:57:16" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="f77b3eaa32fba62d30fe3cf09dd7fa66fd9b8fe2" CHECKSUMTYPE="SHA-1" SIZE="4896099">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T12:57:41" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="f537ac12f8a6be0866075dad3d5fc1a0937b6a2a" CHECKSUMTYPE="SHA-1" SIZE="4830425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T12:58:06" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="2870bd2205b9e707aab9461c6d443b4443322d28" CHECKSUMTYPE="SHA-1" SIZE="4906029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T12:58:30" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="928845213f3a40574a717c0c094c7c0c13925ecb" CHECKSUMTYPE="SHA-1" SIZE="4857424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T12:58:55" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="583ec08a0b5abcf7da4bfd9b508a03a8a8266cb8" CHECKSUMTYPE="SHA-1" SIZE="4899727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T12:59:20" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="bc12615f0fea2b3c71e34eb35cb30afbfc223cdf" CHECKSUMTYPE="SHA-1" SIZE="4825896">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T12:59:45" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="f6fe5abe8892092d04e862945b1eb82e290b110e" CHECKSUMTYPE="SHA-1" SIZE="4928527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T13:00:10" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="4eed80042106ec8fcf674203ec8c9e7d4ef0ec5d" CHECKSUMTYPE="SHA-1" SIZE="4879928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T13:00:36" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="e19ef5cccf161a4ceb3583181d60dc05c4676f78" CHECKSUMTYPE="SHA-1" SIZE="4941938">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T13:01:03" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="81d33f0158336767e4102ea3df9ab7a097251c9d" CHECKSUMTYPE="SHA-1" SIZE="4840318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T13:01:29" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="9eceeac0013b27328cdcddfdd135f94673547ee0" CHECKSUMTYPE="SHA-1" SIZE="4860129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T13:01:53" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="4cce92a0fe4e14b513f6a347684ea4cc429de626" CHECKSUMTYPE="SHA-1" SIZE="4895229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T13:02:19" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="05d1dc3b4ba9032b7d89b7c15a23a1e7e626901e" CHECKSUMTYPE="SHA-1" SIZE="4914090">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T13:02:46" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="b515a199b56efe434a49a593b6f0db8f5735009f" CHECKSUMTYPE="SHA-1" SIZE="4902345">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T13:03:11" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="d8bfc1be90cd6d6f61e8b9819d25430ef8974c2c" CHECKSUMTYPE="SHA-1" SIZE="4877225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T13:03:37" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="7ec0bc9bb5dfdf844c72458976c23017519ff8dc" CHECKSUMTYPE="SHA-1" SIZE="4884406">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T13:04:04" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="4617babf1fa47e307bf1fb6d5dd3c5b81b73503b" CHECKSUMTYPE="SHA-1" SIZE="4960923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T13:04:30" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="fc51520b86ee029bfd8764eb442b83d755178ab6" CHECKSUMTYPE="SHA-1" SIZE="4912324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T13:04:57" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="41738252351f316bdd38adb4dd68cd581b8bd65e" CHECKSUMTYPE="SHA-1" SIZE="4960925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-10-09T13:05:21" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="bec98b2dd2b9790f638027c0073554e8938d3e50" CHECKSUMTYPE="SHA-1" SIZE="4928485">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-10-09T13:05:46" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="7ca5d3917ab53caea34323864ed8c03d0f2c76b4" CHECKSUMTYPE="SHA-1" SIZE="4963628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-10-09T13:06:14" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="ea5af6083c88d21ab103865f481155959f0b62da" CHECKSUMTYPE="SHA-1" SIZE="4898826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-10-09T13:06:39" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="56a0188a1a3ac97c73e7b63a8d0d3b8a285f85cf" CHECKSUMTYPE="SHA-1" SIZE="4980705">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-10-09T13:07:04" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="5814a09400aa769e91839db78c5c8a66c704f7a5" CHECKSUMTYPE="SHA-1" SIZE="4932037">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-10-09T13:07:28" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="f08d3d1dfed92ef80febd14cbe3f589972a91631" CHECKSUMTYPE="SHA-1" SIZE="4980729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-10-09T13:07:53" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="658ec3fa7fa5ae3923c95544c501113ee1523d4c" CHECKSUMTYPE="SHA-1" SIZE="4904225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-10-09T13:08:20" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="b243540cc9fa19a53a0bfdde0519f716f38494a3" CHECKSUMTYPE="SHA-1" SIZE="4994228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-10-09T13:08:46" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="88b3cce60f56f742cc1c102a8117791b44d2d36f" CHECKSUMTYPE="SHA-1" SIZE="4914122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-10-09T13:09:13" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="a5f95195611fd95a0d77a5dab1053858b0832bcc" CHECKSUMTYPE="SHA-1" SIZE="5027520">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-10-09T13:09:40" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="e6adf6acaf7bb1a3fb4a27d039c6a51f61011480" CHECKSUMTYPE="SHA-1" SIZE="4914120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-10-09T13:10:06" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="70fa9185e47672ce30e26f1d4f85af1c5822a909" CHECKSUMTYPE="SHA-1" SIZE="5032010">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-10-09T13:10:32" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="9c357a27814d0408624f12f987f08876fe999140" CHECKSUMTYPE="SHA-1" SIZE="4914125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-10-09T13:10:59" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="f17efdaf570ef8acef1fc2d99aa8ba48c4a60baf" CHECKSUMTYPE="SHA-1" SIZE="4938425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-10-09T13:11:23" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="7f2fca7722daa4728ac2bd88f886bf3729f52b87" CHECKSUMTYPE="SHA-1" SIZE="4913888">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-10-09T13:11:50" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="c1a5b32c50c07751c8a7f8fcef144dd45d4e5b97" CHECKSUMTYPE="SHA-1" SIZE="5008583">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-10-09T13:12:16" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="e6cf905379f651a1b1098eb94cd8c49ad6b99b7f" CHECKSUMTYPE="SHA-1" SIZE="4914107">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-10-09T13:12:41" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="15403403cdaede09b2ee17a79c3749b7f99f1794" CHECKSUMTYPE="SHA-1" SIZE="5050854">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-10-09T13:13:05" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="1af5a31c1d42d4c3b6d5d42174286cd27385c29c" CHECKSUMTYPE="SHA-1" SIZE="4897925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-10-09T13:13:32" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="55f5d838c6a51a1cb68735d92cd2a6f6b889ea7f" CHECKSUMTYPE="SHA-1" SIZE="5066193">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-10-09T13:13:56" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="57c492d0fa12c5c845f05b5192bca2aa04c29ca4" CHECKSUMTYPE="SHA-1" SIZE="4936532">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-10-09T13:14:22" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="f3397e2f8945caf22f265870ef124bb08fc347b6" CHECKSUMTYPE="SHA-1" SIZE="5062628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-10-09T13:14:49" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="286c4d137a614c9f5431bf73a296d5177a34a8f2" CHECKSUMTYPE="SHA-1" SIZE="4937405">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-10-09T13:15:14" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="c6dfb4a5417bd6725db34bf1450b767969b274f8" CHECKSUMTYPE="SHA-1" SIZE="5076073">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-10-09T13:15:41" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="2d53681623212df4f2826e371b6574fe1227e024" CHECKSUMTYPE="SHA-1" SIZE="4914127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-10-09T13:16:07" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="0c035eb67c49f93280935168b73576496cd25067" CHECKSUMTYPE="SHA-1" SIZE="5075229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-10-09T13:16:33" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="d6510ecfd61751057f2849da25b02aaef85d3921" CHECKSUMTYPE="SHA-1" SIZE="4939311">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-10-09T13:16:59" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="065b2f2dbc14457730fe03cd7c332004d6262874" CHECKSUMTYPE="SHA-1" SIZE="5093171">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-10-09T13:17:24" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="ee46cd4e530a7a2b7c5bdb18d2456091c7e66854" CHECKSUMTYPE="SHA-1" SIZE="4980729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-10-09T13:17:50" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="6b7e44ccd3c58ed7916df4a989e0f1ee77f46970" CHECKSUMTYPE="SHA-1" SIZE="5097724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-10-09T13:18:16" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="4123a0cbf55a8f198809d3c70c6e37a04290b93b" CHECKSUMTYPE="SHA-1" SIZE="4914114">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-10-09T13:18:43" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="e4e20aabc130d62a32db39b28eaa940895413ee0" CHECKSUMTYPE="SHA-1" SIZE="5132810">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-10-09T13:19:09" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="277ca1fa2e073fff7471b7b92573f5cda00c3f66" CHECKSUMTYPE="SHA-1" SIZE="4934826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-10-09T13:19:34" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="4824438304beecfe8b8fa0e8962fb729c1a58f2a" CHECKSUMTYPE="SHA-1" SIZE="5086926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-10-09T13:20:00" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="020138c7b78895583f3ad3ef5857c78d167c24ff" CHECKSUMTYPE="SHA-1" SIZE="4956404">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-10-09T13:20:26" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="913794779972b492ffbba6388afb840f94d9cd01" CHECKSUMTYPE="SHA-1" SIZE="5121128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-10-09T13:20:53" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="8f848ba71f21c1cff5f97e78c5f99212967109bf" CHECKSUMTYPE="SHA-1" SIZE="4951927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-10-09T13:21:18" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="f43d1fca78e7d3108cc64eea016d307e584ba08c" CHECKSUMTYPE="SHA-1" SIZE="5149929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-10-09T13:21:44" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="da306455db33c8127ba8f644165b42af09f640c3" CHECKSUMTYPE="SHA-1" SIZE="4879029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-10-09T13:22:09" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="17c2b43e655bf0075bbebf2ff372881c1d57f5a8" CHECKSUMTYPE="SHA-1" SIZE="4581128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-10-09T13:22:34" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="702c51f761f82dbcdace1d62aea085f7baa73b0c" CHECKSUMTYPE="SHA-1" SIZE="4888914">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-10-09T13:23:01" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="d0e5562fa7d62925b53503ca0d0e3dcb0b33a3b5" CHECKSUMTYPE="SHA-1" SIZE="5128327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0080.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T12:49:14" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="379e897839e6b8d125421282ccafc772a63f9e07" CHECKSUMTYPE="SHA-1" SIZE="4869127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T12:49:40" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="0100512c7d793dbd96d3cc33c22a0a139a012311" CHECKSUMTYPE="SHA-1" SIZE="4896129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T12:50:04" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="9c9e80da181d15df71bb099ef6deb5138dcbdd44" CHECKSUMTYPE="SHA-1" SIZE="4490210">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T12:50:30" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="edd1c819a27d69035725c87e6984e44e863de56f" CHECKSUMTYPE="SHA-1" SIZE="4922229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T12:50:57" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="1ae94388da45f79e98e4a9467c5e64c89dc77a54" CHECKSUMTYPE="SHA-1" SIZE="4802528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T12:51:22" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="f479dcb54658036a32a410f1a3769c678e0fbff0" CHECKSUMTYPE="SHA-1" SIZE="4880821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T12:51:50" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="c776b7a8e0164d6d6db980193cdbe38ad42f6b5a" CHECKSUMTYPE="SHA-1" SIZE="4798927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T12:52:14" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="8d9aa850285fc3af37a1233c321a9c43811d8016" CHECKSUMTYPE="SHA-1" SIZE="4906926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T12:52:40" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="21fa47b9dd497321d941e3d568e023ad798b0c05" CHECKSUMTYPE="SHA-1" SIZE="4826826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T12:53:06" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="9eb05780d341034a76492284386b68efec9af331" CHECKSUMTYPE="SHA-1" SIZE="4828616">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T12:53:30" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="d9be957dd556f62772d0ee42d47e3e1174c53430" CHECKSUMTYPE="SHA-1" SIZE="4808826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T12:53:55" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="c37ac381371cc6104c646a4a1c0d3af12e94c011" CHECKSUMTYPE="SHA-1" SIZE="4821422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T12:54:20" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="4286b1bceb9dc9143b5268ccb5ce3a8d45893906" CHECKSUMTYPE="SHA-1" SIZE="4764729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T12:54:44" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="c24f8111e339637bd53ad46fdaec98237e0712b4" CHECKSUMTYPE="SHA-1" SIZE="4919525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T12:55:09" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="bcbd01c9bc8b108aa4701436e2ca15e10f6e6038" CHECKSUMTYPE="SHA-1" SIZE="4799825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T12:55:35" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="b1495dd75b0e49e550bec1a46f68429c9c5a89e2" CHECKSUMTYPE="SHA-1" SIZE="4905124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T12:56:00" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="fb091000ee237eea2734ec4e3d6f47ba3fefdbb5" CHECKSUMTYPE="SHA-1" SIZE="4805228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T12:56:25" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="8ce1e9bea01969ab06791dca0999a714d46dba5a" CHECKSUMTYPE="SHA-1" SIZE="4898826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T12:56:51" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="8903a7073582f4a80fa382c10633be7f3b5a82af" CHECKSUMTYPE="SHA-1" SIZE="4835753">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T12:57:16" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="f77b3eaa32fba62d30fe3cf09dd7fa66fd9b8fe2" CHECKSUMTYPE="SHA-1" SIZE="4896099">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T12:57:41" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="f537ac12f8a6be0866075dad3d5fc1a0937b6a2a" CHECKSUMTYPE="SHA-1" SIZE="4830425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T12:58:06" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="2870bd2205b9e707aab9461c6d443b4443322d28" CHECKSUMTYPE="SHA-1" SIZE="4906029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T12:58:30" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="928845213f3a40574a717c0c094c7c0c13925ecb" CHECKSUMTYPE="SHA-1" SIZE="4857424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T12:58:55" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="583ec08a0b5abcf7da4bfd9b508a03a8a8266cb8" CHECKSUMTYPE="SHA-1" SIZE="4899727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T12:59:20" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="bc12615f0fea2b3c71e34eb35cb30afbfc223cdf" CHECKSUMTYPE="SHA-1" SIZE="4825896">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T12:59:45" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="f6fe5abe8892092d04e862945b1eb82e290b110e" CHECKSUMTYPE="SHA-1" SIZE="4928527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T13:00:10" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="4eed80042106ec8fcf674203ec8c9e7d4ef0ec5d" CHECKSUMTYPE="SHA-1" SIZE="4879928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T13:00:36" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="e19ef5cccf161a4ceb3583181d60dc05c4676f78" CHECKSUMTYPE="SHA-1" SIZE="4941938">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T13:01:03" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="81d33f0158336767e4102ea3df9ab7a097251c9d" CHECKSUMTYPE="SHA-1" SIZE="4840318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T13:01:29" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="9eceeac0013b27328cdcddfdd135f94673547ee0" CHECKSUMTYPE="SHA-1" SIZE="4860129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T13:01:53" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="4cce92a0fe4e14b513f6a347684ea4cc429de626" CHECKSUMTYPE="SHA-1" SIZE="4895229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T13:02:19" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="05d1dc3b4ba9032b7d89b7c15a23a1e7e626901e" CHECKSUMTYPE="SHA-1" SIZE="4914090">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T13:02:46" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="b515a199b56efe434a49a593b6f0db8f5735009f" CHECKSUMTYPE="SHA-1" SIZE="4902345">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T13:03:11" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="d8bfc1be90cd6d6f61e8b9819d25430ef8974c2c" CHECKSUMTYPE="SHA-1" SIZE="4877225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T13:03:37" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="7ec0bc9bb5dfdf844c72458976c23017519ff8dc" CHECKSUMTYPE="SHA-1" SIZE="4884406">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T13:04:04" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="4617babf1fa47e307bf1fb6d5dd3c5b81b73503b" CHECKSUMTYPE="SHA-1" SIZE="4960923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T13:04:30" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="fc51520b86ee029bfd8764eb442b83d755178ab6" CHECKSUMTYPE="SHA-1" SIZE="4912324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T13:04:57" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="41738252351f316bdd38adb4dd68cd581b8bd65e" CHECKSUMTYPE="SHA-1" SIZE="4960925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-10-09T13:05:21" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="bec98b2dd2b9790f638027c0073554e8938d3e50" CHECKSUMTYPE="SHA-1" SIZE="4928485">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-10-09T13:05:46" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="7ca5d3917ab53caea34323864ed8c03d0f2c76b4" CHECKSUMTYPE="SHA-1" SIZE="4963628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-10-09T13:06:14" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="ea5af6083c88d21ab103865f481155959f0b62da" CHECKSUMTYPE="SHA-1" SIZE="4898826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-10-09T13:06:39" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="56a0188a1a3ac97c73e7b63a8d0d3b8a285f85cf" CHECKSUMTYPE="SHA-1" SIZE="4980705">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-10-09T13:07:04" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="5814a09400aa769e91839db78c5c8a66c704f7a5" CHECKSUMTYPE="SHA-1" SIZE="4932037">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-10-09T13:07:28" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="f08d3d1dfed92ef80febd14cbe3f589972a91631" CHECKSUMTYPE="SHA-1" SIZE="4980729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-10-09T13:07:53" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="658ec3fa7fa5ae3923c95544c501113ee1523d4c" CHECKSUMTYPE="SHA-1" SIZE="4904225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-10-09T13:08:20" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="b243540cc9fa19a53a0bfdde0519f716f38494a3" CHECKSUMTYPE="SHA-1" SIZE="4994228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-10-09T13:08:46" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="88b3cce60f56f742cc1c102a8117791b44d2d36f" CHECKSUMTYPE="SHA-1" SIZE="4914122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-10-09T13:09:13" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="a5f95195611fd95a0d77a5dab1053858b0832bcc" CHECKSUMTYPE="SHA-1" SIZE="5027520">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-10-09T13:09:40" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="e6adf6acaf7bb1a3fb4a27d039c6a51f61011480" CHECKSUMTYPE="SHA-1" SIZE="4914120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-10-09T13:10:06" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="70fa9185e47672ce30e26f1d4f85af1c5822a909" CHECKSUMTYPE="SHA-1" SIZE="5032010">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-10-09T13:10:32" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="9c357a27814d0408624f12f987f08876fe999140" CHECKSUMTYPE="SHA-1" SIZE="4914125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-10-09T13:10:59" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="f17efdaf570ef8acef1fc2d99aa8ba48c4a60baf" CHECKSUMTYPE="SHA-1" SIZE="4938425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-10-09T13:11:23" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="7f2fca7722daa4728ac2bd88f886bf3729f52b87" CHECKSUMTYPE="SHA-1" SIZE="4913888">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-10-09T13:11:50" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="c1a5b32c50c07751c8a7f8fcef144dd45d4e5b97" CHECKSUMTYPE="SHA-1" SIZE="5008583">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-10-09T13:12:16" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="e6cf905379f651a1b1098eb94cd8c49ad6b99b7f" CHECKSUMTYPE="SHA-1" SIZE="4914107">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-10-09T13:12:41" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="15403403cdaede09b2ee17a79c3749b7f99f1794" CHECKSUMTYPE="SHA-1" SIZE="5050854">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-10-09T13:13:05" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="1af5a31c1d42d4c3b6d5d42174286cd27385c29c" CHECKSUMTYPE="SHA-1" SIZE="4897925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-10-09T13:13:32" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="55f5d838c6a51a1cb68735d92cd2a6f6b889ea7f" CHECKSUMTYPE="SHA-1" SIZE="5066193">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-10-09T13:13:56" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="57c492d0fa12c5c845f05b5192bca2aa04c29ca4" CHECKSUMTYPE="SHA-1" SIZE="4936532">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-10-09T13:14:22" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="f3397e2f8945caf22f265870ef124bb08fc347b6" CHECKSUMTYPE="SHA-1" SIZE="5062628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-10-09T13:14:49" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="286c4d137a614c9f5431bf73a296d5177a34a8f2" CHECKSUMTYPE="SHA-1" SIZE="4937405">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-10-09T13:15:14" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="c6dfb4a5417bd6725db34bf1450b767969b274f8" CHECKSUMTYPE="SHA-1" SIZE="5076073">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-10-09T13:15:41" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="2d53681623212df4f2826e371b6574fe1227e024" CHECKSUMTYPE="SHA-1" SIZE="4914127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-10-09T13:16:07" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="0c035eb67c49f93280935168b73576496cd25067" CHECKSUMTYPE="SHA-1" SIZE="5075229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-10-09T13:16:33" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="d6510ecfd61751057f2849da25b02aaef85d3921" CHECKSUMTYPE="SHA-1" SIZE="4939311">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-10-09T13:16:59" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="065b2f2dbc14457730fe03cd7c332004d6262874" CHECKSUMTYPE="SHA-1" SIZE="5093171">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-10-09T13:17:24" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="ee46cd4e530a7a2b7c5bdb18d2456091c7e66854" CHECKSUMTYPE="SHA-1" SIZE="4980729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-10-09T13:17:50" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="6b7e44ccd3c58ed7916df4a989e0f1ee77f46970" CHECKSUMTYPE="SHA-1" SIZE="5097724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-10-09T13:18:16" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="4123a0cbf55a8f198809d3c70c6e37a04290b93b" CHECKSUMTYPE="SHA-1" SIZE="4914114">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-10-09T13:18:43" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="e4e20aabc130d62a32db39b28eaa940895413ee0" CHECKSUMTYPE="SHA-1" SIZE="5132810">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-10-09T13:19:09" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="277ca1fa2e073fff7471b7b92573f5cda00c3f66" CHECKSUMTYPE="SHA-1" SIZE="4934826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-10-09T13:19:34" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="4824438304beecfe8b8fa0e8962fb729c1a58f2a" CHECKSUMTYPE="SHA-1" SIZE="5086926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-10-09T13:20:00" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="020138c7b78895583f3ad3ef5857c78d167c24ff" CHECKSUMTYPE="SHA-1" SIZE="4956404">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-10-09T13:20:26" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="913794779972b492ffbba6388afb840f94d9cd01" CHECKSUMTYPE="SHA-1" SIZE="5121128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-10-09T13:20:53" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="8f848ba71f21c1cff5f97e78c5f99212967109bf" CHECKSUMTYPE="SHA-1" SIZE="4951927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-10-09T13:21:18" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="f43d1fca78e7d3108cc64eea016d307e584ba08c" CHECKSUMTYPE="SHA-1" SIZE="5149929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-10-09T13:21:44" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="da306455db33c8127ba8f644165b42af09f640c3" CHECKSUMTYPE="SHA-1" SIZE="4879029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-10-09T13:22:09" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="17c2b43e655bf0075bbebf2ff372881c1d57f5a8" CHECKSUMTYPE="SHA-1" SIZE="4581128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-10-09T13:22:34" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="702c51f761f82dbcdace1d62aea085f7baa73b0c" CHECKSUMTYPE="SHA-1" SIZE="4888914">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-10-09T13:23:01" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="d0e5562fa7d62925b53503ca0d0e3dcb0b33a3b5" CHECKSUMTYPE="SHA-1" SIZE="5128327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/delivery/bmtnabe_1895-04_01_0080.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T13:23:16" MIMETYPE="text/xml" CHECKSUM="d6d125b0cdd09f0aae27a8b89dcb2614fdeb818e"
-				CHECKSUMTYPE="SHA-1" SIZE="2102">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T13:23:16" MIMETYPE="text/xml" CHECKSUM="d6d125b0cdd09f0aae27a8b89dcb2614fdeb818e" CHECKSUMTYPE="SHA-1" SIZE="2102">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T13:23:17" MIMETYPE="text/xml" CHECKSUM="b25d276d0addc522d7e054bbe2f0545bdf209326"
-				CHECKSUMTYPE="SHA-1" SIZE="60138">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T13:23:17" MIMETYPE="text/xml" CHECKSUM="b25d276d0addc522d7e054bbe2f0545bdf209326" CHECKSUMTYPE="SHA-1" SIZE="60138">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T13:23:17" MIMETYPE="text/xml" CHECKSUM="0cdafac67a0d3e87e71d94066c0d43e9d2cde5c0"
-				CHECKSUMTYPE="SHA-1" SIZE="56133">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T13:23:17" MIMETYPE="text/xml" CHECKSUM="0cdafac67a0d3e87e71d94066c0d43e9d2cde5c0" CHECKSUMTYPE="SHA-1" SIZE="56133">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T13:23:18" MIMETYPE="text/xml" CHECKSUM="b9c0012c3099df5f141525c6102f2bfcf5599091"
-				CHECKSUMTYPE="SHA-1" SIZE="48466">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T13:23:18" MIMETYPE="text/xml" CHECKSUM="b9c0012c3099df5f141525c6102f2bfcf5599091" CHECKSUMTYPE="SHA-1" SIZE="48466">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T13:23:18" MIMETYPE="text/xml" CHECKSUM="b79aa237854174440eef607173221a8d2a76a183"
-				CHECKSUMTYPE="SHA-1" SIZE="70452">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T13:23:18" MIMETYPE="text/xml" CHECKSUM="b79aa237854174440eef607173221a8d2a76a183" CHECKSUMTYPE="SHA-1" SIZE="70452">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T13:23:18" MIMETYPE="text/xml" CHECKSUM="17dba9a6e19520af1032af599dd1af17cbd9a284"
-				CHECKSUMTYPE="SHA-1" SIZE="19667">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T13:23:18" MIMETYPE="text/xml" CHECKSUM="17dba9a6e19520af1032af599dd1af17cbd9a284" CHECKSUMTYPE="SHA-1" SIZE="19667">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T13:23:18" MIMETYPE="text/xml" CHECKSUM="18a361fed069ab305f14a5644cd51f064cb4ee14"
-				CHECKSUMTYPE="SHA-1" SIZE="30483">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T13:23:18" MIMETYPE="text/xml" CHECKSUM="18a361fed069ab305f14a5644cd51f064cb4ee14" CHECKSUMTYPE="SHA-1" SIZE="30483">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T13:23:19" MIMETYPE="text/xml" CHECKSUM="30006aeb131d7483ed0eff82fa04cff66e07045c"
-				CHECKSUMTYPE="SHA-1" SIZE="4353">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T13:23:19" MIMETYPE="text/xml" CHECKSUM="30006aeb131d7483ed0eff82fa04cff66e07045c" CHECKSUMTYPE="SHA-1" SIZE="4353">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T13:23:19" MIMETYPE="text/xml" CHECKSUM="1707ce4d4bcc397e8b6e37096e53c95eebec9a25"
-				CHECKSUMTYPE="SHA-1" SIZE="5652">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T13:23:19" MIMETYPE="text/xml" CHECKSUM="1707ce4d4bcc397e8b6e37096e53c95eebec9a25" CHECKSUMTYPE="SHA-1" SIZE="5652">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T13:23:19" MIMETYPE="text/xml"
-				CHECKSUM="475a28249140c7f474642b3696abf83aedfec310" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T13:23:19" MIMETYPE="text/xml" CHECKSUM="475a28249140c7f474642b3696abf83aedfec310" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T13:23:20" MIMETYPE="text/xml"
-				CHECKSUM="b102f02f7a8239e589a9982219262911798e7239" CHECKSUMTYPE="SHA-1" SIZE="44476">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T13:23:20" MIMETYPE="text/xml" CHECKSUM="b102f02f7a8239e589a9982219262911798e7239" CHECKSUMTYPE="SHA-1" SIZE="44476">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T13:23:20" MIMETYPE="text/xml"
-				CHECKSUM="61f65c26642a574b269d4001e46303b89ae8f7f3" CHECKSUMTYPE="SHA-1" SIZE="59120">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T13:23:20" MIMETYPE="text/xml" CHECKSUM="61f65c26642a574b269d4001e46303b89ae8f7f3" CHECKSUMTYPE="SHA-1" SIZE="59120">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T13:23:20" MIMETYPE="text/xml"
-				CHECKSUM="64fabcd0493882071b282e5369843c4aafa3fc2e" CHECKSUMTYPE="SHA-1" SIZE="61283">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T13:23:20" MIMETYPE="text/xml" CHECKSUM="64fabcd0493882071b282e5369843c4aafa3fc2e" CHECKSUMTYPE="SHA-1" SIZE="61283">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T13:23:20" MIMETYPE="text/xml"
-				CHECKSUM="e5b1e065241d9520140700d78b0eab81a0519535" CHECKSUMTYPE="SHA-1" SIZE="62158">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T13:23:20" MIMETYPE="text/xml" CHECKSUM="e5b1e065241d9520140700d78b0eab81a0519535" CHECKSUMTYPE="SHA-1" SIZE="62158">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T13:23:21" MIMETYPE="text/xml"
-				CHECKSUM="80837553792576a792b03d429dbf6b7cef77526d" CHECKSUMTYPE="SHA-1" SIZE="2403">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T13:23:21" MIMETYPE="text/xml" CHECKSUM="80837553792576a792b03d429dbf6b7cef77526d" CHECKSUMTYPE="SHA-1" SIZE="2403">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T13:23:21" MIMETYPE="text/xml"
-				CHECKSUM="f4722840c57c99f3ce23b32a7084d75f8caad229" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T13:23:21" MIMETYPE="text/xml" CHECKSUM="f4722840c57c99f3ce23b32a7084d75f8caad229" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T13:23:21" MIMETYPE="text/xml"
-				CHECKSUM="a0266a85af025893269b939216dc51f8fd5cc9a7" CHECKSUMTYPE="SHA-1" SIZE="26944">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T13:23:21" MIMETYPE="text/xml" CHECKSUM="a0266a85af025893269b939216dc51f8fd5cc9a7" CHECKSUMTYPE="SHA-1" SIZE="26944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T13:23:22" MIMETYPE="text/xml"
-				CHECKSUM="84b4c34dfa644440dde22ac7d1536e4925f664ed" CHECKSUMTYPE="SHA-1" SIZE="85162">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T13:23:22" MIMETYPE="text/xml" CHECKSUM="84b4c34dfa644440dde22ac7d1536e4925f664ed" CHECKSUMTYPE="SHA-1" SIZE="85162">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T13:23:22" MIMETYPE="text/xml"
-				CHECKSUM="7f5866206b1d48562c37e2e36808540c92a1ff58" CHECKSUMTYPE="SHA-1" SIZE="2403">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T13:23:22" MIMETYPE="text/xml" CHECKSUM="7f5866206b1d48562c37e2e36808540c92a1ff58" CHECKSUMTYPE="SHA-1" SIZE="2403">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T13:23:22" MIMETYPE="text/xml"
-				CHECKSUM="01fe1c0237a6949ecc4a92e2d23c547158895133" CHECKSUMTYPE="SHA-1" SIZE="77320">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T13:23:22" MIMETYPE="text/xml" CHECKSUM="01fe1c0237a6949ecc4a92e2d23c547158895133" CHECKSUMTYPE="SHA-1" SIZE="77320">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T13:23:22" MIMETYPE="text/xml"
-				CHECKSUM="c4e5f5f727868c002b7339111ceeeb6822fb9660" CHECKSUMTYPE="SHA-1" SIZE="2403">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T13:23:22" MIMETYPE="text/xml" CHECKSUM="c4e5f5f727868c002b7339111ceeeb6822fb9660" CHECKSUMTYPE="SHA-1" SIZE="2403">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T13:23:23" MIMETYPE="text/xml"
-				CHECKSUM="ab65a08545b6d051751ba7833f5d43c8394093fe" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T13:23:23" MIMETYPE="text/xml" CHECKSUM="ab65a08545b6d051751ba7833f5d43c8394093fe" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T13:23:23" MIMETYPE="text/xml"
-				CHECKSUM="0ad83c46616fac5e1ccd14d2fccee676901ea67f" CHECKSUMTYPE="SHA-1" SIZE="44908">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T13:23:23" MIMETYPE="text/xml" CHECKSUM="0ad83c46616fac5e1ccd14d2fccee676901ea67f" CHECKSUMTYPE="SHA-1" SIZE="44908">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T13:23:23" MIMETYPE="text/xml"
-				CHECKSUM="27956bfbac6609756bb89549307fb25e9f8502d9" CHECKSUMTYPE="SHA-1" SIZE="40571">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T13:23:23" MIMETYPE="text/xml" CHECKSUM="27956bfbac6609756bb89549307fb25e9f8502d9" CHECKSUMTYPE="SHA-1" SIZE="40571">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T13:23:24" MIMETYPE="text/xml"
-				CHECKSUM="3b1380f4a1f089f150319a4c954acf14d2cf629d" CHECKSUMTYPE="SHA-1" SIZE="2403">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T13:23:24" MIMETYPE="text/xml" CHECKSUM="3b1380f4a1f089f150319a4c954acf14d2cf629d" CHECKSUMTYPE="SHA-1" SIZE="2403">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T13:23:24" MIMETYPE="text/xml"
-				CHECKSUM="dd44767b57d1b21d1e956ae347c7c85aeda16397" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T13:23:24" MIMETYPE="text/xml" CHECKSUM="dd44767b57d1b21d1e956ae347c7c85aeda16397" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T13:23:24" MIMETYPE="text/xml"
-				CHECKSUM="46dcd08785175f57125889fb3506ecd668816f2f" CHECKSUMTYPE="SHA-1" SIZE="25123">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T13:23:24" MIMETYPE="text/xml" CHECKSUM="46dcd08785175f57125889fb3506ecd668816f2f" CHECKSUMTYPE="SHA-1" SIZE="25123">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T13:23:24" MIMETYPE="text/xml"
-				CHECKSUM="76c2fb333df8e7dde9095c2e53c1ce9e8ca0ffdc" CHECKSUMTYPE="SHA-1" SIZE="14017">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T13:23:24" MIMETYPE="text/xml" CHECKSUM="76c2fb333df8e7dde9095c2e53c1ce9e8ca0ffdc" CHECKSUMTYPE="SHA-1" SIZE="14017">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T13:23:25" MIMETYPE="text/xml"
-				CHECKSUM="091bdaa5966ca401a583e2d59ad9114b72e5a61f" CHECKSUMTYPE="SHA-1" SIZE="12488">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T13:23:25" MIMETYPE="text/xml" CHECKSUM="091bdaa5966ca401a583e2d59ad9114b72e5a61f" CHECKSUMTYPE="SHA-1" SIZE="12488">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T13:23:25" MIMETYPE="text/xml"
-				CHECKSUM="81a33f334336ac62e5b3779d664715c2f0222075" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T13:23:25" MIMETYPE="text/xml" CHECKSUM="81a33f334336ac62e5b3779d664715c2f0222075" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T13:23:25" MIMETYPE="text/xml"
-				CHECKSUM="32bfc9267e979b22c85a6e8ac33a84f3ae85c1f4" CHECKSUMTYPE="SHA-1" SIZE="142953">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T13:23:25" MIMETYPE="text/xml" CHECKSUM="32bfc9267e979b22c85a6e8ac33a84f3ae85c1f4" CHECKSUMTYPE="SHA-1" SIZE="142953">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T13:23:26" MIMETYPE="text/xml"
-				CHECKSUM="b152bafa74d521535f1ce73f8c25302e330478f6" CHECKSUMTYPE="SHA-1" SIZE="172689">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T13:23:26" MIMETYPE="text/xml" CHECKSUM="b152bafa74d521535f1ce73f8c25302e330478f6" CHECKSUMTYPE="SHA-1" SIZE="172689">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T13:23:26" MIMETYPE="text/xml"
-				CHECKSUM="cdeb74cae19737b819ba497659986fad56160168" CHECKSUMTYPE="SHA-1" SIZE="166667">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T13:23:26" MIMETYPE="text/xml" CHECKSUM="cdeb74cae19737b819ba497659986fad56160168" CHECKSUMTYPE="SHA-1" SIZE="166667">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T13:23:26" MIMETYPE="text/xml"
-				CHECKSUM="c72b42aed76ec5fc42a146c944387d78c80359c5" CHECKSUMTYPE="SHA-1" SIZE="175613">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T13:23:26" MIMETYPE="text/xml" CHECKSUM="c72b42aed76ec5fc42a146c944387d78c80359c5" CHECKSUMTYPE="SHA-1" SIZE="175613">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T13:23:27" MIMETYPE="text/xml"
-				CHECKSUM="6a323c7cfa35d3a7db393f352aed21e80bd28a1f" CHECKSUMTYPE="SHA-1" SIZE="169458">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T13:23:27" MIMETYPE="text/xml" CHECKSUM="6a323c7cfa35d3a7db393f352aed21e80bd28a1f" CHECKSUMTYPE="SHA-1" SIZE="169458">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T13:23:27" MIMETYPE="text/xml"
-				CHECKSUM="b455ac2737faef58ac08c967c9c7632c98cafd08" CHECKSUMTYPE="SHA-1" SIZE="165169">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T13:23:27" MIMETYPE="text/xml" CHECKSUM="b455ac2737faef58ac08c967c9c7632c98cafd08" CHECKSUMTYPE="SHA-1" SIZE="165169">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T13:23:28" MIMETYPE="text/xml"
-				CHECKSUM="61ff9e90ca006630711b30235e1b7111980de157" CHECKSUMTYPE="SHA-1" SIZE="2418">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T13:23:28" MIMETYPE="text/xml" CHECKSUM="61ff9e90ca006630711b30235e1b7111980de157" CHECKSUMTYPE="SHA-1" SIZE="2418">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T13:23:28" MIMETYPE="text/xml"
-				CHECKSUM="9f20d291309e0a4329839984a15c8f9888c94690" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T13:23:28" MIMETYPE="text/xml" CHECKSUM="9f20d291309e0a4329839984a15c8f9888c94690" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-10-09T13:23:28" MIMETYPE="text/xml"
-				CHECKSUM="296f64e62c2470863eb401a0dc308271a97f7041" CHECKSUMTYPE="SHA-1" SIZE="132639">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-10-09T13:23:28" MIMETYPE="text/xml" CHECKSUM="296f64e62c2470863eb401a0dc308271a97f7041" CHECKSUMTYPE="SHA-1" SIZE="132639">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-10-09T13:23:29" MIMETYPE="text/xml"
-				CHECKSUM="4dee774654c7e5f01f09f4f859f7416475c04c21" CHECKSUMTYPE="SHA-1" SIZE="174510">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-10-09T13:23:29" MIMETYPE="text/xml" CHECKSUM="4dee774654c7e5f01f09f4f859f7416475c04c21" CHECKSUMTYPE="SHA-1" SIZE="174510">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-10-09T13:23:29" MIMETYPE="text/xml"
-				CHECKSUM="1a939b819ac777d1c7e2ecbab62af0a7965927c7" CHECKSUMTYPE="SHA-1" SIZE="225280">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-10-09T13:23:29" MIMETYPE="text/xml" CHECKSUM="1a939b819ac777d1c7e2ecbab62af0a7965927c7" CHECKSUMTYPE="SHA-1" SIZE="225280">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-10-09T13:23:30" MIMETYPE="text/xml"
-				CHECKSUM="6e20384506f4674a435664c0c3658010833d1ced" CHECKSUMTYPE="SHA-1" SIZE="231876">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-10-09T13:23:30" MIMETYPE="text/xml" CHECKSUM="6e20384506f4674a435664c0c3658010833d1ced" CHECKSUMTYPE="SHA-1" SIZE="231876">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-10-09T13:23:30" MIMETYPE="text/xml"
-				CHECKSUM="e33cde77e9242cb0dcbb16f187a3797a41cda5dc" CHECKSUMTYPE="SHA-1" SIZE="3345">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-10-09T13:23:30" MIMETYPE="text/xml" CHECKSUM="e33cde77e9242cb0dcbb16f187a3797a41cda5dc" CHECKSUMTYPE="SHA-1" SIZE="3345">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-10-09T13:23:30" MIMETYPE="text/xml"
-				CHECKSUM="8ee6d245ad97b7666842ab6c0ce3a03761581b96" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-10-09T13:23:30" MIMETYPE="text/xml" CHECKSUM="8ee6d245ad97b7666842ab6c0ce3a03761581b96" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-10-09T13:23:31" MIMETYPE="text/xml"
-				CHECKSUM="c886905aba3c6f5747cc57a897d6cd555cc43139" CHECKSUMTYPE="SHA-1" SIZE="221295">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-10-09T13:23:31" MIMETYPE="text/xml" CHECKSUM="c886905aba3c6f5747cc57a897d6cd555cc43139" CHECKSUMTYPE="SHA-1" SIZE="221295">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-10-09T13:23:31" MIMETYPE="text/xml"
-				CHECKSUM="a03a75bd9e60e5f50129dae4a0a7d3082c76459c" CHECKSUMTYPE="SHA-1" SIZE="230925">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-10-09T13:23:31" MIMETYPE="text/xml" CHECKSUM="a03a75bd9e60e5f50129dae4a0a7d3082c76459c" CHECKSUMTYPE="SHA-1" SIZE="230925">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-10-09T13:23:31" MIMETYPE="text/xml"
-				CHECKSUM="2fb01d8e033f425fbe6d2bb736d351fd580cbde0" CHECKSUMTYPE="SHA-1" SIZE="116572">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-10-09T13:23:31" MIMETYPE="text/xml" CHECKSUM="2fb01d8e033f425fbe6d2bb736d351fd580cbde0" CHECKSUMTYPE="SHA-1" SIZE="116572">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-10-09T13:23:32" MIMETYPE="text/xml"
-				CHECKSUM="66f2c29ca55846dc9853480fb9fa71b98f987c06" CHECKSUMTYPE="SHA-1" SIZE="84158">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-10-09T13:23:32" MIMETYPE="text/xml" CHECKSUM="66f2c29ca55846dc9853480fb9fa71b98f987c06" CHECKSUMTYPE="SHA-1" SIZE="84158">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-10-09T13:23:32" MIMETYPE="text/xml"
-				CHECKSUM="c116835f39042d88603b21b541165406cb4620f1" CHECKSUMTYPE="SHA-1" SIZE="74959">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-10-09T13:23:32" MIMETYPE="text/xml" CHECKSUM="c116835f39042d88603b21b541165406cb4620f1" CHECKSUMTYPE="SHA-1" SIZE="74959">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-10-09T13:23:32" MIMETYPE="text/xml"
-				CHECKSUM="b04e5934418d2972dd6e7527db695e1b45e66edb" CHECKSUMTYPE="SHA-1" SIZE="79595">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-10-09T13:23:32" MIMETYPE="text/xml" CHECKSUM="b04e5934418d2972dd6e7527db695e1b45e66edb" CHECKSUMTYPE="SHA-1" SIZE="79595">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-10-09T13:23:33" MIMETYPE="text/xml"
-				CHECKSUM="c63364c2adf52071adf87c964b8ba36d28efe99d" CHECKSUMTYPE="SHA-1" SIZE="2418">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-10-09T13:23:33" MIMETYPE="text/xml" CHECKSUM="c63364c2adf52071adf87c964b8ba36d28efe99d" CHECKSUMTYPE="SHA-1" SIZE="2418">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-10-09T13:23:33" MIMETYPE="text/xml"
-				CHECKSUM="8e7f20fe20aa8b7b35ded599a497a39cef171d8b" CHECKSUMTYPE="SHA-1" SIZE="2016">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-10-09T13:23:33" MIMETYPE="text/xml" CHECKSUM="8e7f20fe20aa8b7b35ded599a497a39cef171d8b" CHECKSUMTYPE="SHA-1" SIZE="2016">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-10-09T13:23:33" MIMETYPE="text/xml"
-				CHECKSUM="81521e26cb3e4ab7afcb4301ea2951c33d85430b" CHECKSUMTYPE="SHA-1" SIZE="116710">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-10-09T13:23:33" MIMETYPE="text/xml" CHECKSUM="81521e26cb3e4ab7afcb4301ea2951c33d85430b" CHECKSUMTYPE="SHA-1" SIZE="116710">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-10-09T13:23:34" MIMETYPE="text/xml"
-				CHECKSUM="63634ae39a97faf6eccbaa373c1446a941a3d232" CHECKSUMTYPE="SHA-1" SIZE="115400">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-10-09T13:23:34" MIMETYPE="text/xml" CHECKSUM="63634ae39a97faf6eccbaa373c1446a941a3d232" CHECKSUMTYPE="SHA-1" SIZE="115400">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-10-09T13:23:34" MIMETYPE="text/xml"
-				CHECKSUM="4b137596badc74a91406ecb3667f0305eb86edae" CHECKSUMTYPE="SHA-1" SIZE="42815">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-10-09T13:23:34" MIMETYPE="text/xml" CHECKSUM="4b137596badc74a91406ecb3667f0305eb86edae" CHECKSUMTYPE="SHA-1" SIZE="42815">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-10-09T13:23:34" MIMETYPE="text/xml"
-				CHECKSUM="a57d3b52d834fbf0ecd589aadc9a0419d822b429" CHECKSUMTYPE="SHA-1" SIZE="82672">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-10-09T13:23:34" MIMETYPE="text/xml" CHECKSUM="a57d3b52d834fbf0ecd589aadc9a0419d822b429" CHECKSUMTYPE="SHA-1" SIZE="82672">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-10-09T13:23:35" MIMETYPE="text/xml"
-				CHECKSUM="7f9a4be6a40dece8594e23688ba4ece90efebd8e" CHECKSUMTYPE="SHA-1" SIZE="2419">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-10-09T13:23:35" MIMETYPE="text/xml" CHECKSUM="7f9a4be6a40dece8594e23688ba4ece90efebd8e" CHECKSUMTYPE="SHA-1" SIZE="2419">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-10-09T13:23:35" MIMETYPE="text/xml"
-				CHECKSUM="525f19aaec73fcbea897726c5a5aca90ede9bbfa" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-10-09T13:23:35" MIMETYPE="text/xml" CHECKSUM="525f19aaec73fcbea897726c5a5aca90ede9bbfa" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-10-09T13:23:35" MIMETYPE="text/xml"
-				CHECKSUM="06268c92f9688dcc44e29c147d5345e51cd36236" CHECKSUMTYPE="SHA-1" SIZE="109564">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-10-09T13:23:35" MIMETYPE="text/xml" CHECKSUM="06268c92f9688dcc44e29c147d5345e51cd36236" CHECKSUMTYPE="SHA-1" SIZE="109564">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-10-09T13:23:36" MIMETYPE="text/xml"
-				CHECKSUM="2ef3fac3f523fe95487ee5833edea05a04c97138" CHECKSUMTYPE="SHA-1" SIZE="104348">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-10-09T13:23:36" MIMETYPE="text/xml" CHECKSUM="2ef3fac3f523fe95487ee5833edea05a04c97138" CHECKSUMTYPE="SHA-1" SIZE="104348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-10-09T13:23:36" MIMETYPE="text/xml"
-				CHECKSUM="ef334e73518443a19db888beb9b8f7e9be4575bf" CHECKSUMTYPE="SHA-1" SIZE="116864">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-10-09T13:23:36" MIMETYPE="text/xml" CHECKSUM="ef334e73518443a19db888beb9b8f7e9be4575bf" CHECKSUMTYPE="SHA-1" SIZE="116864">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-10-09T13:23:36" MIMETYPE="text/xml"
-				CHECKSUM="d4cac4ad28c6aa79023d100ce690a1da8de44755" CHECKSUMTYPE="SHA-1" SIZE="122366">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-10-09T13:23:36" MIMETYPE="text/xml" CHECKSUM="d4cac4ad28c6aa79023d100ce690a1da8de44755" CHECKSUMTYPE="SHA-1" SIZE="122366">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-10-09T13:23:37" MIMETYPE="text/xml"
-				CHECKSUM="087a9c56d1ba1a6d4552f0bdb5b255c6af34e555" CHECKSUMTYPE="SHA-1" SIZE="2403">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-10-09T13:23:37" MIMETYPE="text/xml" CHECKSUM="087a9c56d1ba1a6d4552f0bdb5b255c6af34e555" CHECKSUMTYPE="SHA-1" SIZE="2403">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-10-09T13:23:37" MIMETYPE="text/xml"
-				CHECKSUM="72f87bb7dedd8b2ddb17bae95710db37de8aa68a" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-10-09T13:23:37" MIMETYPE="text/xml" CHECKSUM="72f87bb7dedd8b2ddb17bae95710db37de8aa68a" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-10-09T13:23:37" MIMETYPE="text/xml"
-				CHECKSUM="ac9e62d247929e0134274399fff0e8e362a36102" CHECKSUMTYPE="SHA-1" SIZE="70590">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-10-09T13:23:37" MIMETYPE="text/xml" CHECKSUM="ac9e62d247929e0134274399fff0e8e362a36102" CHECKSUMTYPE="SHA-1" SIZE="70590">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-10-09T13:23:38" MIMETYPE="text/xml"
-				CHECKSUM="4f24d5e87400daeab0a1e6a72c332917ca6a6b97" CHECKSUMTYPE="SHA-1" SIZE="176429">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-10-09T13:23:38" MIMETYPE="text/xml" CHECKSUM="4f24d5e87400daeab0a1e6a72c332917ca6a6b97" CHECKSUMTYPE="SHA-1" SIZE="176429">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-10-09T13:23:38" MIMETYPE="text/xml"
-				CHECKSUM="18ea7262dfbb2f039b6b181f3bf3bc33ebb2fc27" CHECKSUMTYPE="SHA-1" SIZE="3845">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-10-09T13:23:38" MIMETYPE="text/xml" CHECKSUM="18ea7262dfbb2f039b6b181f3bf3bc33ebb2fc27" CHECKSUMTYPE="SHA-1" SIZE="3845">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-10-09T13:23:38" MIMETYPE="text/xml"
-				CHECKSUM="440337ea9b2eafa3a2e6c341df564aa0a894d698" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-10-09T13:23:38" MIMETYPE="text/xml" CHECKSUM="440337ea9b2eafa3a2e6c341df564aa0a894d698" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-10-09T13:23:39" MIMETYPE="text/xml"
-				CHECKSUM="c009204ec71c6fe63c5b48f7527ae39594e1070c" CHECKSUMTYPE="SHA-1" SIZE="207257">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-10-09T13:23:39" MIMETYPE="text/xml" CHECKSUM="c009204ec71c6fe63c5b48f7527ae39594e1070c" CHECKSUMTYPE="SHA-1" SIZE="207257">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-10-09T13:23:39" MIMETYPE="text/xml"
-				CHECKSUM="63e09fe97b025fc0411fffc07d8da0f67ee272ad" CHECKSUMTYPE="SHA-1" SIZE="193047">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-10-09T13:23:39" MIMETYPE="text/xml" CHECKSUM="63e09fe97b025fc0411fffc07d8da0f67ee272ad" CHECKSUMTYPE="SHA-1" SIZE="193047">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-10-09T13:23:39" MIMETYPE="text/xml"
-				CHECKSUM="427a338bb91d60077402c823efc4e98017daa508" CHECKSUMTYPE="SHA-1" SIZE="189499">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-10-09T13:23:39" MIMETYPE="text/xml" CHECKSUM="427a338bb91d60077402c823efc4e98017daa508" CHECKSUMTYPE="SHA-1" SIZE="189499">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-10-09T13:23:40" MIMETYPE="text/xml"
-				CHECKSUM="1054f56d9a4584974d0895c100d724f9bc42f254" CHECKSUMTYPE="SHA-1" SIZE="212308">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-10-09T13:23:40" MIMETYPE="text/xml" CHECKSUM="1054f56d9a4584974d0895c100d724f9bc42f254" CHECKSUMTYPE="SHA-1" SIZE="212308">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-10-09T13:23:40" MIMETYPE="text/xml"
-				CHECKSUM="8adb29cc7011a55866f739fdeac5aa8392e3f4f6" CHECKSUMTYPE="SHA-1" SIZE="221704">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-10-09T13:23:40" MIMETYPE="text/xml" CHECKSUM="8adb29cc7011a55866f739fdeac5aa8392e3f4f6" CHECKSUMTYPE="SHA-1" SIZE="221704">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-10-09T13:23:41" MIMETYPE="text/xml"
-				CHECKSUM="32c8ffe0950213c1d614e6892772fa375c4aaa63" CHECKSUMTYPE="SHA-1" SIZE="215614">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-10-09T13:23:41" MIMETYPE="text/xml" CHECKSUM="32c8ffe0950213c1d614e6892772fa375c4aaa63" CHECKSUMTYPE="SHA-1" SIZE="215614">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-10-09T13:23:41" MIMETYPE="text/xml"
-				CHECKSUM="63713c45cc98e60ad6217a4dc3282446f77cd80d" CHECKSUMTYPE="SHA-1" SIZE="187536">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-10-09T13:23:41" MIMETYPE="text/xml" CHECKSUM="63713c45cc98e60ad6217a4dc3282446f77cd80d" CHECKSUMTYPE="SHA-1" SIZE="187536">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-10-09T13:23:42" MIMETYPE="text/xml"
-				CHECKSUM="5d4772f122e5ae48c0dfa942a37a4c4875cef649" CHECKSUMTYPE="SHA-1" SIZE="30164">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-10-09T13:23:42" MIMETYPE="text/xml" CHECKSUM="5d4772f122e5ae48c0dfa942a37a4c4875cef649" CHECKSUMTYPE="SHA-1" SIZE="30164">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-10-09T13:23:42" MIMETYPE="text/xml"
-				CHECKSUM="ae6545ad3cc0dac712dd9ebc7d0a975dbe7d8061" CHECKSUMTYPE="SHA-1" SIZE="149720">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-10-09T13:23:42" MIMETYPE="text/xml" CHECKSUM="ae6545ad3cc0dac712dd9ebc7d0a975dbe7d8061" CHECKSUMTYPE="SHA-1" SIZE="149720">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-10-09T13:23:42" MIMETYPE="text/xml"
-				CHECKSUM="460c7fe0792e0f74d31c86a3f624ceb72673b2be" CHECKSUMTYPE="SHA-1" SIZE="152230">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-10-09T13:23:42" MIMETYPE="text/xml" CHECKSUM="460c7fe0792e0f74d31c86a3f624ceb72673b2be" CHECKSUMTYPE="SHA-1" SIZE="152230">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-10-09T13:23:43" MIMETYPE="text/xml"
-				CHECKSUM="b7f6d7a45b4b86be403a610d07098b02796e45af" CHECKSUMTYPE="SHA-1" SIZE="101430">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-10-09T13:23:43" MIMETYPE="text/xml" CHECKSUM="b7f6d7a45b4b86be403a610d07098b02796e45af" CHECKSUMTYPE="SHA-1" SIZE="101430">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-10-09T13:23:43" MIMETYPE="text/xml"
-				CHECKSUM="b9dc408a1093b214cc449dd532acf82eaf7ae6ed" CHECKSUMTYPE="SHA-1" SIZE="3908">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-10-09T13:23:43" MIMETYPE="text/xml" CHECKSUM="b9dc408a1093b214cc449dd532acf82eaf7ae6ed" CHECKSUMTYPE="SHA-1" SIZE="3908">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-04_01_0080.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T13:26:56" MIMETYPE="application/pdf" CHECKSUM="6bdaf3ca9abe27c200009f88ee95fef5fb08bb1a"
-				CHECKSUMTYPE="SHA-1" SIZE="48105545">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/bmtnabe_1895-04_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T13:26:56" MIMETYPE="application/pdf" CHECKSUM="6bdaf3ca9abe27c200009f88ee95fef5fb08bb1a" CHECKSUMTYPE="SHA-1" SIZE="48105545">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/04_01/bmtnabe_1895-04_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -9428,8 +9182,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.20" TYPE="TextContent" ORDER="17" DMDID="c045"
-					LABEL="Aus meinem Leben. Ersres Kapitel. Berlin 1840. (In der Roseschen Apotheke.)">
+				<div ID="L.1.1.20" TYPE="TextContent" ORDER="17" DMDID="c045" LABEL="Aus meinem Leben. Ersres Kapitel. Berlin 1840. (In der Roseschen Apotheke.)">
 					<div ID="L.1.1.20.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00040" BEGIN="P40_TB00002"/>
@@ -9583,8 +9336,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.23.3" TYPE="TextContent" ORDER="2" DMDID="c054"
-						LABEL="ANFORDERUNGEN AN DIE AUSSTATTUNG EINER ILLUSTRIERTEN KUNSTZEITSCHRIFT">
+					<div ID="L.1.1.23.3" TYPE="TextContent" ORDER="2" DMDID="c054" LABEL="ANFORDERUNGEN AN DIE AUSSTATTUNG EINER ILLUSTRIERTEN KUNSTZEITSCHRIFT">
 						<div ID="L.1.1.23.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00050" BEGIN="P50_TB00003"/>

--- a/metadata/periodicals/bmtnabe/issues/1895/06_01/bmtnabe_1895-06_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1895/06_01/bmtnabe_1895-06_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1895-06_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1895-06_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-06_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-06_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1895-06_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1895-06_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-06_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -11402,1148 +11398,768 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T16:27:02" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="18c5118d96339d20a5205ea02b73d4182c2bc94d" CHECKSUMTYPE="SHA-1" SIZE="4933023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T16:27:28" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="79fa5c6b8bba55445bec76e2b5d5e042321e388d" CHECKSUMTYPE="SHA-1" SIZE="5180528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T16:27:54" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="76bb15fb312be9b05a3a11cb925626f28aaad500" CHECKSUMTYPE="SHA-1" SIZE="4861028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T16:28:17" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="a190259f76305aba271d43b5c8b4eb2788aeda9b" CHECKSUMTYPE="SHA-1" SIZE="5139129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T16:28:43" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="f15f3d98c2dd743f1244ca7788adb43c4d479023" CHECKSUMTYPE="SHA-1" SIZE="4911289">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T16:29:07" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="26e725e5a70369fd7ba109d6f12b982786bec572" CHECKSUMTYPE="SHA-1" SIZE="5186696">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T16:29:32" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="17e3b96d432771943fab97d95e1471df3064f802" CHECKSUMTYPE="SHA-1" SIZE="4938414">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T16:29:58" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="321aac1c9a653809b603f4105f8a6985719230c4" CHECKSUMTYPE="SHA-1" SIZE="5132785">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T16:30:24" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="56ec0e5d5e90c67bf69d7bce5b9b516f789d7ebc" CHECKSUMTYPE="SHA-1" SIZE="4953720">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T16:30:48" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="bf257df6831b1ff9c4e9c91fb06251c0b6c9aad1" CHECKSUMTYPE="SHA-1" SIZE="5201029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T16:31:15" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="32c40b0c6990fd37423e1604339a5c85c18dbb2b" CHECKSUMTYPE="SHA-1" SIZE="4946461">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T16:31:39" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="253f7f412436f2a35723f33899b170901301373a" CHECKSUMTYPE="SHA-1" SIZE="5183221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T16:32:06" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="d6094ecfbd6181fe5ddd9afd5279905c4b5f3af6" CHECKSUMTYPE="SHA-1" SIZE="4855629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T16:32:30" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="e9a47a6ef28cdbdd050454f926d65a984b9f6e00" CHECKSUMTYPE="SHA-1" SIZE="5226357">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T16:32:56" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="a07f30b65f32f096ad62da519dc1de749eeb020f" CHECKSUMTYPE="SHA-1" SIZE="4819623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T16:33:21" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="6ee901c9abbd4f8e691635a6fdd01716bd2cdcf5" CHECKSUMTYPE="SHA-1" SIZE="5239914">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T16:33:45" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="407e9095521a09ca2106cf318048b0bfd3c0c9cc" CHECKSUMTYPE="SHA-1" SIZE="4837586">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T16:34:09" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="7beab7e4fb71d2ba1bed3804168c18715fcd8428" CHECKSUMTYPE="SHA-1" SIZE="5258829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T16:34:33" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="00691f2638727587cc9eb30fb0af5bc5f442cc8a" CHECKSUMTYPE="SHA-1" SIZE="4858221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T16:34:56" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="01f46dd977d6730a7397d102887386d347fa064c" CHECKSUMTYPE="SHA-1" SIZE="5219228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T16:35:22" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="affbd31d2c8e8ea0d65b4dc0c9a2abebbf7e0763" CHECKSUMTYPE="SHA-1" SIZE="4852929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T16:35:47" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="4017a16b90fc41389ed8471431f4a341f83e8e14" CHECKSUMTYPE="SHA-1" SIZE="5233629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T16:36:13" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="399b8794873158c745ec7ffa81056f6e820025ff" CHECKSUMTYPE="SHA-1" SIZE="4880829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T16:36:36" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="3f1aab3e656db247739c6db8b4c64c1a68c5144e" CHECKSUMTYPE="SHA-1" SIZE="5309222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T16:36:59" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="83664b398a7d6bb4bdf0c3ad0c7570ce53b87073" CHECKSUMTYPE="SHA-1" SIZE="4852607">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T16:37:24" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="ea4a14d4518d8c4874647f0f4c447ca55b2aed29" CHECKSUMTYPE="SHA-1" SIZE="5254322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T16:37:49" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="65fef876d0bff0524cdfad9d40beefc27baedd0c" CHECKSUMTYPE="SHA-1" SIZE="4881710">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T16:38:15" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="907aee4e9c4e332de6252f2199622aff490e5364" CHECKSUMTYPE="SHA-1" SIZE="5234529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T16:38:43" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="0a56457a09dfaa2bbe201e498f059cef078310de" CHECKSUMTYPE="SHA-1" SIZE="4875421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T16:39:07" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="535cde45eca7d2c5daecf2190956ce25a6141e19" CHECKSUMTYPE="SHA-1" SIZE="5216529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T16:39:33" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="9d3bce3b6134f267b0ee9a6da73d1e6d86bd1ac8" CHECKSUMTYPE="SHA-1" SIZE="4905128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T16:39:59" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="ecf229f52aeb5203d63d217807e18446b05df411" CHECKSUMTYPE="SHA-1" SIZE="5264112">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T16:40:24" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="b113c4e634226fdd8bc6249a0bcdb19a20941fbd" CHECKSUMTYPE="SHA-1" SIZE="4918614">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T16:40:49" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="6a0eeeee07afb69693bd22e8057bf5e22252955f" CHECKSUMTYPE="SHA-1" SIZE="5270529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T16:41:14" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="41ff4e9271f5e3d3a03cc5108059b98b5acdb28a" CHECKSUMTYPE="SHA-1" SIZE="4870929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T16:41:39" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="459f3102aa84094c0dafd853bccca46a67c46b27" CHECKSUMTYPE="SHA-1" SIZE="5226424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T16:42:05" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="8507498b65ed105f216432fac366bbe2eafdebcf" CHECKSUMTYPE="SHA-1" SIZE="4876325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T16:42:30" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="9c50181a4cba6fca0d61cbcb125b6d66245a22bc" CHECKSUMTYPE="SHA-1" SIZE="5258662">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T16:42:55" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="c10a73393730ede95e5356b7d021f8c8f76a1fdb" CHECKSUMTYPE="SHA-1" SIZE="4924021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T16:43:20" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="67c97b3b6bad06ff401551c319e22697b9481b22" CHECKSUMTYPE="SHA-1" SIZE="5239010">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T16:43:44" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="5320ea5fe3f29c29bfb8233eb487a9c308056e45" CHECKSUMTYPE="SHA-1" SIZE="4925828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T16:44:08" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="67b7a9d04ad34024acc0af16a50d36c99d8e6451" CHECKSUMTYPE="SHA-1" SIZE="5290323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T16:44:28" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="d005961f1a265699d161580eab7c3fa30c348cf8" CHECKSUMTYPE="SHA-1" SIZE="2506577">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T16:44:42" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="19da647ec46d371d66ab1d91df6ed9b786c65f17" CHECKSUMTYPE="SHA-1" SIZE="2753163">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T16:45:00" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="0f19820546e98d1097d7f6c6f4880d4be22ae15f" CHECKSUMTYPE="SHA-1" SIZE="4893391">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T16:45:24" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="86a176f7f73ca9ea6f8efd07a4beb1c839b0c3c7" CHECKSUMTYPE="SHA-1" SIZE="5320927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T16:45:48" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="3a74d57160e6a47ed5bfa35afc87efa3a9470172" CHECKSUMTYPE="SHA-1" SIZE="4870028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T16:46:13" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="6e22b2fa4f9430d0914e038a96c9c1e7cb298a07" CHECKSUMTYPE="SHA-1" SIZE="5336228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T16:46:39" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="89f74792660d38d57cd9b44159a75444b9286fb0" CHECKSUMTYPE="SHA-1" SIZE="4923998">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T16:47:04" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="543f6cb72fe073359b9f089409deecf6f428e8d0" CHECKSUMTYPE="SHA-1" SIZE="5356019">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T16:47:29" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="b0cfd3f5ce3c5e07b3d63745327c6ecb34dec2c1" CHECKSUMTYPE="SHA-1" SIZE="4985220">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T16:47:55" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="4bd0392a3ce4d695b17dd121713577ecf0404e48" CHECKSUMTYPE="SHA-1" SIZE="5335326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T16:48:20" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="56f448d69da488ca0ef478c97d08d1d58e06cb96" CHECKSUMTYPE="SHA-1" SIZE="5004015">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T16:48:46" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="17408ecdefa0a92f367cb84975207c48f071efa0" CHECKSUMTYPE="SHA-1" SIZE="5338917">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T16:49:09" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="f5029538a212a53da8bbd5b08afe5c05023b00e4" CHECKSUMTYPE="SHA-1" SIZE="5001423">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T16:49:35" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="3409f9a83d4015e4b97868bf6e7c82f8dc0b8b9f" CHECKSUMTYPE="SHA-1" SIZE="5302919">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T16:50:00" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="4908e0e5e2a969e04767dd3c6453a543665f3495" CHECKSUMTYPE="SHA-1" SIZE="5063525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T16:50:23" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="d3b497348a95038095b1f3502bbd7060a519e989" CHECKSUMTYPE="SHA-1" SIZE="5341460">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T16:50:47" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="b746bdb304a389414949186b208bd6c66548718f" CHECKSUMTYPE="SHA-1" SIZE="5091398">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T16:51:12" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="6459db4e4027386f0bd0adf7ef6af7e7b1106f22" CHECKSUMTYPE="SHA-1" SIZE="5299325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T16:51:36" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="254eb90b0ab3948a2cb5a21c6ba911fa061c882a" CHECKSUMTYPE="SHA-1" SIZE="5044620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T16:52:01" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="ce2167fcf3d63cd4f6693053ff93da44e5e7ccb2" CHECKSUMTYPE="SHA-1" SIZE="5315514">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T16:52:28" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="77829bdc43ab5ce0b4941cb970dcc2b2892075cd" CHECKSUMTYPE="SHA-1" SIZE="5070716">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T16:52:53" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="7cd9af6bd4281b2a33fa3f760797a250d9b575d9" CHECKSUMTYPE="SHA-1" SIZE="5286691">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T16:53:18" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="1c46287d6db93d2ca71ca1c7ee23feb48f1c3449" CHECKSUMTYPE="SHA-1" SIZE="5086929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T16:53:44" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="ca135cb231bfcc0a82348c3c61e4ad88a3c89997" CHECKSUMTYPE="SHA-1" SIZE="5275022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T16:54:08" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="db48b2acb1dcb2d9d43088a55fefd73219331664" CHECKSUMTYPE="SHA-1" SIZE="5082424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T16:54:36" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="b1db8698e8bb178d9032ce800f3f3cdd9bf8ff45" CHECKSUMTYPE="SHA-1" SIZE="5347927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T16:55:01" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="ce9f5f729ef642b370cd35f0e27cb618467bcf2e" CHECKSUMTYPE="SHA-1" SIZE="5069806">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T16:55:26" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="f02fd3a227dd7abf13d68bf333ba07c3d4bd151a" CHECKSUMTYPE="SHA-1" SIZE="5221924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T16:55:51" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="94fd3c8949a4b87c9608de25ed6a1b16d5860bde" CHECKSUMTYPE="SHA-1" SIZE="5074097">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T16:56:17" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="3de157b9ef7372680f982e2c1d2a2623c3773bea" CHECKSUMTYPE="SHA-1" SIZE="5370422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T16:56:44" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="b36a932eda0a6d00fb37e2d86870edb86982d8bd" CHECKSUMTYPE="SHA-1" SIZE="5066763">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T16:57:13" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="b70d06e8ec9c49e3cb17e3c080e18597fc3e2593" CHECKSUMTYPE="SHA-1" SIZE="5391126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T16:57:38" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="d8d7fb78452f693c2d0a3b69035c415ae5d96fe1" CHECKSUMTYPE="SHA-1" SIZE="5052712">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T16:58:03" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="29355600d6ea7bfd26c4dd62db5212ed7eb64452" CHECKSUMTYPE="SHA-1" SIZE="5406332">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T16:58:30" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="893b9f41a1f2b83ea39794962186ae0871b28c0b" CHECKSUMTYPE="SHA-1" SIZE="5091228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T16:58:54" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="32e82abff3e6a678896ba0a7bd7097dffe0f2608" CHECKSUMTYPE="SHA-1" SIZE="5338026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T16:59:19" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="1e0d41fbeacd6e6a1b2a357695ce084e150f2822" CHECKSUMTYPE="SHA-1" SIZE="5076922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T16:59:44" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="1a789476d0e37d4a33400f26d82e55d32c5a7bc0" CHECKSUMTYPE="SHA-1" SIZE="5420829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:00:10" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="79d80edcea9273542d6c145e5140d6c24a884b90" CHECKSUMTYPE="SHA-1" SIZE="5053626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:00:36" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="50ba77f947db5452132cee1c0817add5f2c6fdcb" CHECKSUMTYPE="SHA-1" SIZE="5402606">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:01:00" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="0ad1f5ba43fbb79ff9f4a3ca476cf12b43a183dd" CHECKSUMTYPE="SHA-1" SIZE="5087827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:01:24" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="e304f7b0788f3eec09fedfceac8a3c8c4dee852e" CHECKSUMTYPE="SHA-1" SIZE="5319898">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:01:50" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="d58523e56c68cba2debc0c270db158738dd8b3c4" CHECKSUMTYPE="SHA-1" SIZE="5114826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:02:15" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="cd3cc322bb5f7a6d94806e263a1995730ceb5437" CHECKSUMTYPE="SHA-1" SIZE="5360410">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:02:41" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="ea201546332568e61f1d80ea452c37329ff882a8" CHECKSUMTYPE="SHA-1" SIZE="5126528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:03:05" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="1304c7f8cb1005b95157a61c797573e2c109a98c" CHECKSUMTYPE="SHA-1" SIZE="5350626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:03:32" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="b66291f4ad70098ee9460ab1ce4e98cc7cc296a8" CHECKSUMTYPE="SHA-1" SIZE="5105596">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:03:58" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="c6a2e48c2986970dde4b67f8405def0158e90389" CHECKSUMTYPE="SHA-1" SIZE="5353253">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:04:23" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="1b32546f67f723db9021e05682c6f84cad381287" CHECKSUMTYPE="SHA-1" SIZE="5113926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:04:51" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="61d7053388ca202725245152e0bd2ad2f125b614" CHECKSUMTYPE="SHA-1" SIZE="5347928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:05:13" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="f0489e93802e5bbba801e43eb7da9ec41253a28e" CHECKSUMTYPE="SHA-1" SIZE="5104920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T17:05:40" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="94c6c21fbe68a5e77e509d4fc35f0ba85b3b0cca" CHECKSUMTYPE="SHA-1" SIZE="5438826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0094.jp2"/>
-			</file>
-			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T17:06:06" MIMETYPE="image/jp2" SEQ="95"
-				CHECKSUM="1f624cd317860a447963d5492e2597182973519b" CHECKSUMTYPE="SHA-1" SIZE="5121106">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0095.jp2"/>
-			</file>
-			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T17:06:33" MIMETYPE="image/jp2" SEQ="96"
-				CHECKSUM="c6bb7df8548fdc453336158c2faa7d54307e44c3" CHECKSUMTYPE="SHA-1" SIZE="5332624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0096.jp2"/>
-			</file>
-			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T17:06:58" MIMETYPE="image/jp2" SEQ="97"
-				CHECKSUM="314fba3b95b17c22be0d7101f0309a1fd20f7d33" CHECKSUMTYPE="SHA-1" SIZE="5094106">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0097.jp2"/>
-			</file>
-			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T17:07:23" MIMETYPE="image/jp2" SEQ="98"
-				CHECKSUM="e20dec60ad666b9175d27792b4eb24a73ab489cf" CHECKSUMTYPE="SHA-1" SIZE="5384829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0098.jp2"/>
-			</file>
-			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T17:07:50" MIMETYPE="image/jp2" SEQ="99"
-				CHECKSUM="e13a83586c5e8550a6b89967ce3f901be7058351" CHECKSUMTYPE="SHA-1" SIZE="5117323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0099.jp2"/>
-			</file>
-			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T17:08:16" MIMETYPE="image/jp2" SEQ="100"
-				CHECKSUM="3920dff88e7c4bb5f0f34cb6c10f86e1b91bfa80" CHECKSUMTYPE="SHA-1" SIZE="5353321">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0100.jp2"/>
-			</file>
-			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T17:08:41" MIMETYPE="image/jp2" SEQ="101"
-				CHECKSUM="2bfb3063e53100e6ad03f2bb63bbca0865b6b8dd" CHECKSUMTYPE="SHA-1" SIZE="5131904">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0101.jp2"/>
-			</file>
-			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T17:09:07" MIMETYPE="image/jp2" SEQ="102"
-				CHECKSUM="834142a5afa3eab2bc8f3635b72d278ba225f6b9" CHECKSUMTYPE="SHA-1" SIZE="5406289">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0102.jp2"/>
-			</file>
-			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T17:09:33" MIMETYPE="image/jp2" SEQ="103"
-				CHECKSUM="e62c4af2d8e5d52ecf39a4d0f8b2435e19a2ca41" CHECKSUMTYPE="SHA-1" SIZE="5089628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0103.jp2"/>
-			</file>
-			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T17:09:56" MIMETYPE="image/jp2" SEQ="104"
-				CHECKSUM="2f16bfde105631540e142797b5d192c9f39c6b1a" CHECKSUMTYPE="SHA-1" SIZE="5333508">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0104.jp2"/>
-			</file>
-			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T17:10:23" MIMETYPE="image/jp2" SEQ="105"
-				CHECKSUM="cb4b317ac0a4701c7da1d72154b8bd5cbef5d583" CHECKSUMTYPE="SHA-1" SIZE="5125572">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0105.jp2"/>
-			</file>
-			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T17:10:47" MIMETYPE="image/jp2" SEQ="106"
-				CHECKSUM="c4f3d89eb6d392ec552528c68c0a214b6919eb3a" CHECKSUMTYPE="SHA-1" SIZE="5352354">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0106.jp2"/>
-			</file>
-			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T17:11:13" MIMETYPE="image/jp2" SEQ="107"
-				CHECKSUM="090ea13f134caf1d1858c422fb0081c9df5d1c8a" CHECKSUMTYPE="SHA-1" SIZE="5151720">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0107.jp2"/>
-			</file>
-			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T17:11:42" MIMETYPE="image/jp2" SEQ="108"
-				CHECKSUM="2364caaa0ac9e8e106f3c0f90c1eb7dabecb1ebf" CHECKSUMTYPE="SHA-1" SIZE="5395627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0108.jp2"/>
-			</file>
-			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T17:12:11" MIMETYPE="image/jp2" SEQ="109"
-				CHECKSUM="72c39836e4a72c20738d04f486c6e2f4392b3417" CHECKSUMTYPE="SHA-1" SIZE="5137318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0109.jp2"/>
-			</file>
-			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T17:12:36" MIMETYPE="image/jp2" SEQ="110"
-				CHECKSUM="6207b343d49e3091392f338d5e800ccb48def3ae" CHECKSUMTYPE="SHA-1" SIZE="5412728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0110.jp2"/>
-			</file>
-			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-07-30T17:13:00" MIMETYPE="image/jp2" SEQ="111"
-				CHECKSUM="d331c60d2d3bb140bfa3d0cc54f25e95633cc14b" CHECKSUMTYPE="SHA-1" SIZE="5129225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0111.jp2"/>
-			</file>
-			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-07-30T17:13:25" MIMETYPE="image/jp2" SEQ="112"
-				CHECKSUM="354f864386d56962ad4385218a9ad23a4b11ebc9" CHECKSUMTYPE="SHA-1" SIZE="5367729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0112.jp2"/>
-			</file>
-			<file ID="IMG00113" ADMID="techmd113" GROUPID="page113" CREATED="2015-07-30T17:13:51" MIMETYPE="image/jp2" SEQ="113"
-				CHECKSUM="730f910af2cdfd8a7b0c8f3c21e8686c32db7503" CHECKSUMTYPE="SHA-1" SIZE="5118407">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0113.jp2"/>
-			</file>
-			<file ID="IMG00114" ADMID="techmd114" GROUPID="page114" CREATED="2015-07-30T17:14:20" MIMETYPE="image/jp2" SEQ="114"
-				CHECKSUM="84c7cea1b02df8c95cdde0679f7e618d40bf41b6" CHECKSUMTYPE="SHA-1" SIZE="5401019">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0114.jp2"/>
-			</file>
-			<file ID="IMG00115" ADMID="techmd115" GROUPID="page115" CREATED="2015-07-30T17:14:44" MIMETYPE="image/jp2" SEQ="115"
-				CHECKSUM="b8ff197e1cd56a663d435b23976f8b2cdee4dbfd" CHECKSUMTYPE="SHA-1" SIZE="5091261">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0115.jp2"/>
-			</file>
-			<file ID="IMG00116" ADMID="techmd116" GROUPID="page116" CREATED="2015-07-30T17:15:12" MIMETYPE="image/jp2" SEQ="116"
-				CHECKSUM="b2c2745db1ac78a76819fc95c38523683589e937" CHECKSUMTYPE="SHA-1" SIZE="5345955">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0116.jp2"/>
-			</file>
-			<file ID="IMG00117" ADMID="techmd117" GROUPID="page117" CREATED="2015-07-30T17:15:38" MIMETYPE="image/jp2" SEQ="117"
-				CHECKSUM="0d2fd79e6b6678654d94f68038289183e7131026" CHECKSUMTYPE="SHA-1" SIZE="5149029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0117.jp2"/>
-			</file>
-			<file ID="IMG00118" ADMID="techmd118" GROUPID="page118" CREATED="2015-07-30T17:16:04" MIMETYPE="image/jp2" SEQ="118"
-				CHECKSUM="4c222efce265897866e4666643f833e0c94becfa" CHECKSUMTYPE="SHA-1" SIZE="5383927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0118.jp2"/>
-			</file>
-			<file ID="IMG00119" ADMID="techmd119" GROUPID="page119" CREATED="2015-07-30T17:16:28" MIMETYPE="image/jp2" SEQ="119"
-				CHECKSUM="6c7a7af5744a1ab671f6fb00bc99c2308389391a" CHECKSUMTYPE="SHA-1" SIZE="5128959">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0119.jp2"/>
-			</file>
-			<file ID="IMG00120" ADMID="techmd120" GROUPID="page120" CREATED="2015-07-30T17:16:54" MIMETYPE="image/jp2" SEQ="120"
-				CHECKSUM="7d415ecba378ae6ea53c4cb3953b2cc38c66edfa" CHECKSUMTYPE="SHA-1" SIZE="5451420">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0120.jp2"/>
-			</file>
-			<file ID="IMG00121" ADMID="techmd121" GROUPID="page121" CREATED="2015-07-30T17:17:20" MIMETYPE="image/jp2" SEQ="121"
-				CHECKSUM="25e14ca54a9b92a152cffdd798c339fd689cf448" CHECKSUMTYPE="SHA-1" SIZE="5167834">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0121.jp2"/>
-			</file>
-			<file ID="IMG00122" ADMID="techmd122" GROUPID="page122" CREATED="2015-07-30T17:17:45" MIMETYPE="image/jp2" SEQ="122"
-				CHECKSUM="96d74a898aafe770d0359e03d82304545c0fe876" CHECKSUMTYPE="SHA-1" SIZE="5388429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0122.jp2"/>
-			</file>
-			<file ID="IMG00123" ADMID="techmd123" GROUPID="page123" CREATED="2015-07-30T17:18:15" MIMETYPE="image/jp2" SEQ="123"
-				CHECKSUM="6771f8604f7a3acead5ac91c20cfb828823a5d1e" CHECKSUMTYPE="SHA-1" SIZE="5095929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0123.jp2"/>
-			</file>
-			<file ID="IMG00124" ADMID="techmd124" GROUPID="page124" CREATED="2015-07-30T17:18:40" MIMETYPE="image/jp2" SEQ="124"
-				CHECKSUM="a55ff9512ccaa9064c62e5b36a32fb8d88a22bcd" CHECKSUMTYPE="SHA-1" SIZE="5402811">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0124.jp2"/>
-			</file>
-			<file ID="IMG00125" ADMID="techmd125" GROUPID="page125" CREATED="2015-07-30T17:19:04" MIMETYPE="image/jp2" SEQ="125"
-				CHECKSUM="abf29dbc77edc3cf5bb887549887ae2e9ac969dc" CHECKSUMTYPE="SHA-1" SIZE="5076128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0125.jp2"/>
-			</file>
-			<file ID="IMG00126" ADMID="techmd126" GROUPID="page126" CREATED="2015-07-30T17:19:31" MIMETYPE="image/jp2" SEQ="126"
-				CHECKSUM="031417fcbd98aa3aadbc210ef7a1dcb09fc64fca" CHECKSUMTYPE="SHA-1" SIZE="5443329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0126.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T16:27:02" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="18c5118d96339d20a5205ea02b73d4182c2bc94d" CHECKSUMTYPE="SHA-1" SIZE="4933023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T16:27:28" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="79fa5c6b8bba55445bec76e2b5d5e042321e388d" CHECKSUMTYPE="SHA-1" SIZE="5180528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T16:27:54" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="76bb15fb312be9b05a3a11cb925626f28aaad500" CHECKSUMTYPE="SHA-1" SIZE="4861028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T16:28:17" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a190259f76305aba271d43b5c8b4eb2788aeda9b" CHECKSUMTYPE="SHA-1" SIZE="5139129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T16:28:43" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="f15f3d98c2dd743f1244ca7788adb43c4d479023" CHECKSUMTYPE="SHA-1" SIZE="4911289">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T16:29:07" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="26e725e5a70369fd7ba109d6f12b982786bec572" CHECKSUMTYPE="SHA-1" SIZE="5186696">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T16:29:32" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="17e3b96d432771943fab97d95e1471df3064f802" CHECKSUMTYPE="SHA-1" SIZE="4938414">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T16:29:58" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="321aac1c9a653809b603f4105f8a6985719230c4" CHECKSUMTYPE="SHA-1" SIZE="5132785">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T16:30:24" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="56ec0e5d5e90c67bf69d7bce5b9b516f789d7ebc" CHECKSUMTYPE="SHA-1" SIZE="4953720">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T16:30:48" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="bf257df6831b1ff9c4e9c91fb06251c0b6c9aad1" CHECKSUMTYPE="SHA-1" SIZE="5201029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T16:31:15" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="32c40b0c6990fd37423e1604339a5c85c18dbb2b" CHECKSUMTYPE="SHA-1" SIZE="4946461">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T16:31:39" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="253f7f412436f2a35723f33899b170901301373a" CHECKSUMTYPE="SHA-1" SIZE="5183221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T16:32:06" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="d6094ecfbd6181fe5ddd9afd5279905c4b5f3af6" CHECKSUMTYPE="SHA-1" SIZE="4855629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T16:32:30" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="e9a47a6ef28cdbdd050454f926d65a984b9f6e00" CHECKSUMTYPE="SHA-1" SIZE="5226357">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T16:32:56" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="a07f30b65f32f096ad62da519dc1de749eeb020f" CHECKSUMTYPE="SHA-1" SIZE="4819623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T16:33:21" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="6ee901c9abbd4f8e691635a6fdd01716bd2cdcf5" CHECKSUMTYPE="SHA-1" SIZE="5239914">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T16:33:45" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="407e9095521a09ca2106cf318048b0bfd3c0c9cc" CHECKSUMTYPE="SHA-1" SIZE="4837586">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T16:34:09" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="7beab7e4fb71d2ba1bed3804168c18715fcd8428" CHECKSUMTYPE="SHA-1" SIZE="5258829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T16:34:33" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="00691f2638727587cc9eb30fb0af5bc5f442cc8a" CHECKSUMTYPE="SHA-1" SIZE="4858221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T16:34:56" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="01f46dd977d6730a7397d102887386d347fa064c" CHECKSUMTYPE="SHA-1" SIZE="5219228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T16:35:22" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="affbd31d2c8e8ea0d65b4dc0c9a2abebbf7e0763" CHECKSUMTYPE="SHA-1" SIZE="4852929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T16:35:47" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="4017a16b90fc41389ed8471431f4a341f83e8e14" CHECKSUMTYPE="SHA-1" SIZE="5233629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T16:36:13" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="399b8794873158c745ec7ffa81056f6e820025ff" CHECKSUMTYPE="SHA-1" SIZE="4880829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T16:36:36" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="3f1aab3e656db247739c6db8b4c64c1a68c5144e" CHECKSUMTYPE="SHA-1" SIZE="5309222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T16:36:59" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="83664b398a7d6bb4bdf0c3ad0c7570ce53b87073" CHECKSUMTYPE="SHA-1" SIZE="4852607">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T16:37:24" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ea4a14d4518d8c4874647f0f4c447ca55b2aed29" CHECKSUMTYPE="SHA-1" SIZE="5254322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T16:37:49" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="65fef876d0bff0524cdfad9d40beefc27baedd0c" CHECKSUMTYPE="SHA-1" SIZE="4881710">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T16:38:15" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="907aee4e9c4e332de6252f2199622aff490e5364" CHECKSUMTYPE="SHA-1" SIZE="5234529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T16:38:43" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="0a56457a09dfaa2bbe201e498f059cef078310de" CHECKSUMTYPE="SHA-1" SIZE="4875421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T16:39:07" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="535cde45eca7d2c5daecf2190956ce25a6141e19" CHECKSUMTYPE="SHA-1" SIZE="5216529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T16:39:33" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="9d3bce3b6134f267b0ee9a6da73d1e6d86bd1ac8" CHECKSUMTYPE="SHA-1" SIZE="4905128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T16:39:59" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="ecf229f52aeb5203d63d217807e18446b05df411" CHECKSUMTYPE="SHA-1" SIZE="5264112">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T16:40:24" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="b113c4e634226fdd8bc6249a0bcdb19a20941fbd" CHECKSUMTYPE="SHA-1" SIZE="4918614">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T16:40:49" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="6a0eeeee07afb69693bd22e8057bf5e22252955f" CHECKSUMTYPE="SHA-1" SIZE="5270529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T16:41:14" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="41ff4e9271f5e3d3a03cc5108059b98b5acdb28a" CHECKSUMTYPE="SHA-1" SIZE="4870929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T16:41:39" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="459f3102aa84094c0dafd853bccca46a67c46b27" CHECKSUMTYPE="SHA-1" SIZE="5226424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T16:42:05" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="8507498b65ed105f216432fac366bbe2eafdebcf" CHECKSUMTYPE="SHA-1" SIZE="4876325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T16:42:30" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="9c50181a4cba6fca0d61cbcb125b6d66245a22bc" CHECKSUMTYPE="SHA-1" SIZE="5258662">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T16:42:55" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="c10a73393730ede95e5356b7d021f8c8f76a1fdb" CHECKSUMTYPE="SHA-1" SIZE="4924021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T16:43:20" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="67c97b3b6bad06ff401551c319e22697b9481b22" CHECKSUMTYPE="SHA-1" SIZE="5239010">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T16:43:44" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="5320ea5fe3f29c29bfb8233eb487a9c308056e45" CHECKSUMTYPE="SHA-1" SIZE="4925828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T16:44:08" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="67b7a9d04ad34024acc0af16a50d36c99d8e6451" CHECKSUMTYPE="SHA-1" SIZE="5290323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T16:44:28" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="d005961f1a265699d161580eab7c3fa30c348cf8" CHECKSUMTYPE="SHA-1" SIZE="2506577">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T16:44:42" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="19da647ec46d371d66ab1d91df6ed9b786c65f17" CHECKSUMTYPE="SHA-1" SIZE="2753163">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T16:45:00" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="0f19820546e98d1097d7f6c6f4880d4be22ae15f" CHECKSUMTYPE="SHA-1" SIZE="4893391">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T16:45:24" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="86a176f7f73ca9ea6f8efd07a4beb1c839b0c3c7" CHECKSUMTYPE="SHA-1" SIZE="5320927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T16:45:48" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="3a74d57160e6a47ed5bfa35afc87efa3a9470172" CHECKSUMTYPE="SHA-1" SIZE="4870028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T16:46:13" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="6e22b2fa4f9430d0914e038a96c9c1e7cb298a07" CHECKSUMTYPE="SHA-1" SIZE="5336228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T16:46:39" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="89f74792660d38d57cd9b44159a75444b9286fb0" CHECKSUMTYPE="SHA-1" SIZE="4923998">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T16:47:04" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="543f6cb72fe073359b9f089409deecf6f428e8d0" CHECKSUMTYPE="SHA-1" SIZE="5356019">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T16:47:29" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="b0cfd3f5ce3c5e07b3d63745327c6ecb34dec2c1" CHECKSUMTYPE="SHA-1" SIZE="4985220">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T16:47:55" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="4bd0392a3ce4d695b17dd121713577ecf0404e48" CHECKSUMTYPE="SHA-1" SIZE="5335326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T16:48:20" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="56f448d69da488ca0ef478c97d08d1d58e06cb96" CHECKSUMTYPE="SHA-1" SIZE="5004015">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T16:48:46" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="17408ecdefa0a92f367cb84975207c48f071efa0" CHECKSUMTYPE="SHA-1" SIZE="5338917">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T16:49:09" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="f5029538a212a53da8bbd5b08afe5c05023b00e4" CHECKSUMTYPE="SHA-1" SIZE="5001423">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T16:49:35" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="3409f9a83d4015e4b97868bf6e7c82f8dc0b8b9f" CHECKSUMTYPE="SHA-1" SIZE="5302919">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T16:50:00" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="4908e0e5e2a969e04767dd3c6453a543665f3495" CHECKSUMTYPE="SHA-1" SIZE="5063525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T16:50:23" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="d3b497348a95038095b1f3502bbd7060a519e989" CHECKSUMTYPE="SHA-1" SIZE="5341460">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T16:50:47" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="b746bdb304a389414949186b208bd6c66548718f" CHECKSUMTYPE="SHA-1" SIZE="5091398">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T16:51:12" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="6459db4e4027386f0bd0adf7ef6af7e7b1106f22" CHECKSUMTYPE="SHA-1" SIZE="5299325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T16:51:36" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="254eb90b0ab3948a2cb5a21c6ba911fa061c882a" CHECKSUMTYPE="SHA-1" SIZE="5044620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T16:52:01" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="ce2167fcf3d63cd4f6693053ff93da44e5e7ccb2" CHECKSUMTYPE="SHA-1" SIZE="5315514">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T16:52:28" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="77829bdc43ab5ce0b4941cb970dcc2b2892075cd" CHECKSUMTYPE="SHA-1" SIZE="5070716">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T16:52:53" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="7cd9af6bd4281b2a33fa3f760797a250d9b575d9" CHECKSUMTYPE="SHA-1" SIZE="5286691">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T16:53:18" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="1c46287d6db93d2ca71ca1c7ee23feb48f1c3449" CHECKSUMTYPE="SHA-1" SIZE="5086929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T16:53:44" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="ca135cb231bfcc0a82348c3c61e4ad88a3c89997" CHECKSUMTYPE="SHA-1" SIZE="5275022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T16:54:08" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="db48b2acb1dcb2d9d43088a55fefd73219331664" CHECKSUMTYPE="SHA-1" SIZE="5082424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T16:54:36" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="b1db8698e8bb178d9032ce800f3f3cdd9bf8ff45" CHECKSUMTYPE="SHA-1" SIZE="5347927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T16:55:01" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="ce9f5f729ef642b370cd35f0e27cb618467bcf2e" CHECKSUMTYPE="SHA-1" SIZE="5069806">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T16:55:26" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="f02fd3a227dd7abf13d68bf333ba07c3d4bd151a" CHECKSUMTYPE="SHA-1" SIZE="5221924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T16:55:51" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="94fd3c8949a4b87c9608de25ed6a1b16d5860bde" CHECKSUMTYPE="SHA-1" SIZE="5074097">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T16:56:17" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="3de157b9ef7372680f982e2c1d2a2623c3773bea" CHECKSUMTYPE="SHA-1" SIZE="5370422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T16:56:44" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="b36a932eda0a6d00fb37e2d86870edb86982d8bd" CHECKSUMTYPE="SHA-1" SIZE="5066763">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T16:57:13" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="b70d06e8ec9c49e3cb17e3c080e18597fc3e2593" CHECKSUMTYPE="SHA-1" SIZE="5391126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T16:57:38" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="d8d7fb78452f693c2d0a3b69035c415ae5d96fe1" CHECKSUMTYPE="SHA-1" SIZE="5052712">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T16:58:03" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="29355600d6ea7bfd26c4dd62db5212ed7eb64452" CHECKSUMTYPE="SHA-1" SIZE="5406332">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T16:58:30" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="893b9f41a1f2b83ea39794962186ae0871b28c0b" CHECKSUMTYPE="SHA-1" SIZE="5091228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T16:58:54" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="32e82abff3e6a678896ba0a7bd7097dffe0f2608" CHECKSUMTYPE="SHA-1" SIZE="5338026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T16:59:19" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="1e0d41fbeacd6e6a1b2a357695ce084e150f2822" CHECKSUMTYPE="SHA-1" SIZE="5076922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T16:59:44" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="1a789476d0e37d4a33400f26d82e55d32c5a7bc0" CHECKSUMTYPE="SHA-1" SIZE="5420829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:00:10" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="79d80edcea9273542d6c145e5140d6c24a884b90" CHECKSUMTYPE="SHA-1" SIZE="5053626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:00:36" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="50ba77f947db5452132cee1c0817add5f2c6fdcb" CHECKSUMTYPE="SHA-1" SIZE="5402606">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:01:00" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="0ad1f5ba43fbb79ff9f4a3ca476cf12b43a183dd" CHECKSUMTYPE="SHA-1" SIZE="5087827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:01:24" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="e304f7b0788f3eec09fedfceac8a3c8c4dee852e" CHECKSUMTYPE="SHA-1" SIZE="5319898">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:01:50" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="d58523e56c68cba2debc0c270db158738dd8b3c4" CHECKSUMTYPE="SHA-1" SIZE="5114826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:02:15" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="cd3cc322bb5f7a6d94806e263a1995730ceb5437" CHECKSUMTYPE="SHA-1" SIZE="5360410">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:02:41" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="ea201546332568e61f1d80ea452c37329ff882a8" CHECKSUMTYPE="SHA-1" SIZE="5126528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:03:05" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="1304c7f8cb1005b95157a61c797573e2c109a98c" CHECKSUMTYPE="SHA-1" SIZE="5350626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:03:32" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="b66291f4ad70098ee9460ab1ce4e98cc7cc296a8" CHECKSUMTYPE="SHA-1" SIZE="5105596">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:03:58" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="c6a2e48c2986970dde4b67f8405def0158e90389" CHECKSUMTYPE="SHA-1" SIZE="5353253">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:04:23" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="1b32546f67f723db9021e05682c6f84cad381287" CHECKSUMTYPE="SHA-1" SIZE="5113926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:04:51" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="61d7053388ca202725245152e0bd2ad2f125b614" CHECKSUMTYPE="SHA-1" SIZE="5347928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:05:13" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="f0489e93802e5bbba801e43eb7da9ec41253a28e" CHECKSUMTYPE="SHA-1" SIZE="5104920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T17:05:40" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="94c6c21fbe68a5e77e509d4fc35f0ba85b3b0cca" CHECKSUMTYPE="SHA-1" SIZE="5438826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0094.jp2"/>
+			</file>
+			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T17:06:06" MIMETYPE="image/jp2" SEQ="95" CHECKSUM="1f624cd317860a447963d5492e2597182973519b" CHECKSUMTYPE="SHA-1" SIZE="5121106">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0095.jp2"/>
+			</file>
+			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T17:06:33" MIMETYPE="image/jp2" SEQ="96" CHECKSUM="c6bb7df8548fdc453336158c2faa7d54307e44c3" CHECKSUMTYPE="SHA-1" SIZE="5332624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0096.jp2"/>
+			</file>
+			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T17:06:58" MIMETYPE="image/jp2" SEQ="97" CHECKSUM="314fba3b95b17c22be0d7101f0309a1fd20f7d33" CHECKSUMTYPE="SHA-1" SIZE="5094106">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0097.jp2"/>
+			</file>
+			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T17:07:23" MIMETYPE="image/jp2" SEQ="98" CHECKSUM="e20dec60ad666b9175d27792b4eb24a73ab489cf" CHECKSUMTYPE="SHA-1" SIZE="5384829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0098.jp2"/>
+			</file>
+			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T17:07:50" MIMETYPE="image/jp2" SEQ="99" CHECKSUM="e13a83586c5e8550a6b89967ce3f901be7058351" CHECKSUMTYPE="SHA-1" SIZE="5117323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0099.jp2"/>
+			</file>
+			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T17:08:16" MIMETYPE="image/jp2" SEQ="100" CHECKSUM="3920dff88e7c4bb5f0f34cb6c10f86e1b91bfa80" CHECKSUMTYPE="SHA-1" SIZE="5353321">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0100.jp2"/>
+			</file>
+			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T17:08:41" MIMETYPE="image/jp2" SEQ="101" CHECKSUM="2bfb3063e53100e6ad03f2bb63bbca0865b6b8dd" CHECKSUMTYPE="SHA-1" SIZE="5131904">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0101.jp2"/>
+			</file>
+			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T17:09:07" MIMETYPE="image/jp2" SEQ="102" CHECKSUM="834142a5afa3eab2bc8f3635b72d278ba225f6b9" CHECKSUMTYPE="SHA-1" SIZE="5406289">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0102.jp2"/>
+			</file>
+			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T17:09:33" MIMETYPE="image/jp2" SEQ="103" CHECKSUM="e62c4af2d8e5d52ecf39a4d0f8b2435e19a2ca41" CHECKSUMTYPE="SHA-1" SIZE="5089628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0103.jp2"/>
+			</file>
+			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T17:09:56" MIMETYPE="image/jp2" SEQ="104" CHECKSUM="2f16bfde105631540e142797b5d192c9f39c6b1a" CHECKSUMTYPE="SHA-1" SIZE="5333508">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0104.jp2"/>
+			</file>
+			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T17:10:23" MIMETYPE="image/jp2" SEQ="105" CHECKSUM="cb4b317ac0a4701c7da1d72154b8bd5cbef5d583" CHECKSUMTYPE="SHA-1" SIZE="5125572">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0105.jp2"/>
+			</file>
+			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T17:10:47" MIMETYPE="image/jp2" SEQ="106" CHECKSUM="c4f3d89eb6d392ec552528c68c0a214b6919eb3a" CHECKSUMTYPE="SHA-1" SIZE="5352354">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0106.jp2"/>
+			</file>
+			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T17:11:13" MIMETYPE="image/jp2" SEQ="107" CHECKSUM="090ea13f134caf1d1858c422fb0081c9df5d1c8a" CHECKSUMTYPE="SHA-1" SIZE="5151720">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0107.jp2"/>
+			</file>
+			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T17:11:42" MIMETYPE="image/jp2" SEQ="108" CHECKSUM="2364caaa0ac9e8e106f3c0f90c1eb7dabecb1ebf" CHECKSUMTYPE="SHA-1" SIZE="5395627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0108.jp2"/>
+			</file>
+			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T17:12:11" MIMETYPE="image/jp2" SEQ="109" CHECKSUM="72c39836e4a72c20738d04f486c6e2f4392b3417" CHECKSUMTYPE="SHA-1" SIZE="5137318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0109.jp2"/>
+			</file>
+			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T17:12:36" MIMETYPE="image/jp2" SEQ="110" CHECKSUM="6207b343d49e3091392f338d5e800ccb48def3ae" CHECKSUMTYPE="SHA-1" SIZE="5412728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0110.jp2"/>
+			</file>
+			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-07-30T17:13:00" MIMETYPE="image/jp2" SEQ="111" CHECKSUM="d331c60d2d3bb140bfa3d0cc54f25e95633cc14b" CHECKSUMTYPE="SHA-1" SIZE="5129225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0111.jp2"/>
+			</file>
+			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-07-30T17:13:25" MIMETYPE="image/jp2" SEQ="112" CHECKSUM="354f864386d56962ad4385218a9ad23a4b11ebc9" CHECKSUMTYPE="SHA-1" SIZE="5367729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0112.jp2"/>
+			</file>
+			<file ID="IMG00113" ADMID="techmd113" GROUPID="page113" CREATED="2015-07-30T17:13:51" MIMETYPE="image/jp2" SEQ="113" CHECKSUM="730f910af2cdfd8a7b0c8f3c21e8686c32db7503" CHECKSUMTYPE="SHA-1" SIZE="5118407">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0113.jp2"/>
+			</file>
+			<file ID="IMG00114" ADMID="techmd114" GROUPID="page114" CREATED="2015-07-30T17:14:20" MIMETYPE="image/jp2" SEQ="114" CHECKSUM="84c7cea1b02df8c95cdde0679f7e618d40bf41b6" CHECKSUMTYPE="SHA-1" SIZE="5401019">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0114.jp2"/>
+			</file>
+			<file ID="IMG00115" ADMID="techmd115" GROUPID="page115" CREATED="2015-07-30T17:14:44" MIMETYPE="image/jp2" SEQ="115" CHECKSUM="b8ff197e1cd56a663d435b23976f8b2cdee4dbfd" CHECKSUMTYPE="SHA-1" SIZE="5091261">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0115.jp2"/>
+			</file>
+			<file ID="IMG00116" ADMID="techmd116" GROUPID="page116" CREATED="2015-07-30T17:15:12" MIMETYPE="image/jp2" SEQ="116" CHECKSUM="b2c2745db1ac78a76819fc95c38523683589e937" CHECKSUMTYPE="SHA-1" SIZE="5345955">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0116.jp2"/>
+			</file>
+			<file ID="IMG00117" ADMID="techmd117" GROUPID="page117" CREATED="2015-07-30T17:15:38" MIMETYPE="image/jp2" SEQ="117" CHECKSUM="0d2fd79e6b6678654d94f68038289183e7131026" CHECKSUMTYPE="SHA-1" SIZE="5149029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0117.jp2"/>
+			</file>
+			<file ID="IMG00118" ADMID="techmd118" GROUPID="page118" CREATED="2015-07-30T17:16:04" MIMETYPE="image/jp2" SEQ="118" CHECKSUM="4c222efce265897866e4666643f833e0c94becfa" CHECKSUMTYPE="SHA-1" SIZE="5383927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0118.jp2"/>
+			</file>
+			<file ID="IMG00119" ADMID="techmd119" GROUPID="page119" CREATED="2015-07-30T17:16:28" MIMETYPE="image/jp2" SEQ="119" CHECKSUM="6c7a7af5744a1ab671f6fb00bc99c2308389391a" CHECKSUMTYPE="SHA-1" SIZE="5128959">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0119.jp2"/>
+			</file>
+			<file ID="IMG00120" ADMID="techmd120" GROUPID="page120" CREATED="2015-07-30T17:16:54" MIMETYPE="image/jp2" SEQ="120" CHECKSUM="7d415ecba378ae6ea53c4cb3953b2cc38c66edfa" CHECKSUMTYPE="SHA-1" SIZE="5451420">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0120.jp2"/>
+			</file>
+			<file ID="IMG00121" ADMID="techmd121" GROUPID="page121" CREATED="2015-07-30T17:17:20" MIMETYPE="image/jp2" SEQ="121" CHECKSUM="25e14ca54a9b92a152cffdd798c339fd689cf448" CHECKSUMTYPE="SHA-1" SIZE="5167834">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0121.jp2"/>
+			</file>
+			<file ID="IMG00122" ADMID="techmd122" GROUPID="page122" CREATED="2015-07-30T17:17:45" MIMETYPE="image/jp2" SEQ="122" CHECKSUM="96d74a898aafe770d0359e03d82304545c0fe876" CHECKSUMTYPE="SHA-1" SIZE="5388429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0122.jp2"/>
+			</file>
+			<file ID="IMG00123" ADMID="techmd123" GROUPID="page123" CREATED="2015-07-30T17:18:15" MIMETYPE="image/jp2" SEQ="123" CHECKSUM="6771f8604f7a3acead5ac91c20cfb828823a5d1e" CHECKSUMTYPE="SHA-1" SIZE="5095929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0123.jp2"/>
+			</file>
+			<file ID="IMG00124" ADMID="techmd124" GROUPID="page124" CREATED="2015-07-30T17:18:40" MIMETYPE="image/jp2" SEQ="124" CHECKSUM="a55ff9512ccaa9064c62e5b36a32fb8d88a22bcd" CHECKSUMTYPE="SHA-1" SIZE="5402811">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0124.jp2"/>
+			</file>
+			<file ID="IMG00125" ADMID="techmd125" GROUPID="page125" CREATED="2015-07-30T17:19:04" MIMETYPE="image/jp2" SEQ="125" CHECKSUM="abf29dbc77edc3cf5bb887549887ae2e9ac969dc" CHECKSUMTYPE="SHA-1" SIZE="5076128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0125.jp2"/>
+			</file>
+			<file ID="IMG00126" ADMID="techmd126" GROUPID="page126" CREATED="2015-07-30T17:19:31" MIMETYPE="image/jp2" SEQ="126" CHECKSUM="031417fcbd98aa3aadbc210ef7a1dcb09fc64fca" CHECKSUMTYPE="SHA-1" SIZE="5443329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/delivery/bmtnabe_1895-06_01_0126.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml" CHECKSUM="82351e3be83131f16906787c2c7598a5d792360a"
-				CHECKSUMTYPE="SHA-1" SIZE="2112">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml" CHECKSUM="82351e3be83131f16906787c2c7598a5d792360a" CHECKSUMTYPE="SHA-1" SIZE="2112">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml" CHECKSUM="9365bd84226465f97ad83d1aa72d48c0d42f11d3"
-				CHECKSUMTYPE="SHA-1" SIZE="38201">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml" CHECKSUM="9365bd84226465f97ad83d1aa72d48c0d42f11d3" CHECKSUMTYPE="SHA-1" SIZE="38201">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml" CHECKSUM="775cbcc67fa7300ba2598e51823f8aba36b0bfd5"
-				CHECKSUMTYPE="SHA-1" SIZE="4594">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml" CHECKSUM="775cbcc67fa7300ba2598e51823f8aba36b0bfd5" CHECKSUMTYPE="SHA-1" SIZE="4594">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml" CHECKSUM="513b84b4cc9cbece0b51c8fa3fc33d58ce9ae466"
-				CHECKSUMTYPE="SHA-1" SIZE="2011">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml" CHECKSUM="513b84b4cc9cbece0b51c8fa3fc33d58ce9ae466" CHECKSUMTYPE="SHA-1" SIZE="2011">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml" CHECKSUM="97681f03671152bbd9fb1fe8cad810c3d5ec275e"
-				CHECKSUMTYPE="SHA-1" SIZE="131735">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml" CHECKSUM="97681f03671152bbd9fb1fe8cad810c3d5ec275e" CHECKSUMTYPE="SHA-1" SIZE="131735">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml" CHECKSUM="8368e99a23c98523d2bc7c29eaa3410a2f8be9c2"
-				CHECKSUMTYPE="SHA-1" SIZE="190980">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml" CHECKSUM="8368e99a23c98523d2bc7c29eaa3410a2f8be9c2" CHECKSUMTYPE="SHA-1" SIZE="190980">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml" CHECKSUM="c0f600c5f83dfec883676e5e704d15fa3a798f68"
-				CHECKSUMTYPE="SHA-1" SIZE="200873">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml" CHECKSUM="c0f600c5f83dfec883676e5e704d15fa3a798f68" CHECKSUMTYPE="SHA-1" SIZE="200873">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T17:19:49" MIMETYPE="text/xml" CHECKSUM="573bb1ffff03d60aa768a678eb589e169127ecb8"
-				CHECKSUMTYPE="SHA-1" SIZE="202939">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T17:19:49" MIMETYPE="text/xml" CHECKSUM="573bb1ffff03d60aa768a678eb589e169127ecb8" CHECKSUMTYPE="SHA-1" SIZE="202939">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T17:19:49" MIMETYPE="text/xml" CHECKSUM="467077ef8896efe1db2a99172c5f489f847c5af2"
-				CHECKSUMTYPE="SHA-1" SIZE="202555">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T17:19:49" MIMETYPE="text/xml" CHECKSUM="467077ef8896efe1db2a99172c5f489f847c5af2" CHECKSUMTYPE="SHA-1" SIZE="202555">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T17:19:50" MIMETYPE="text/xml"
-				CHECKSUM="0b89ba596e45606e086c6516862b364b8d5b1445" CHECKSUMTYPE="SHA-1" SIZE="201966">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T17:19:50" MIMETYPE="text/xml" CHECKSUM="0b89ba596e45606e086c6516862b364b8d5b1445" CHECKSUMTYPE="SHA-1" SIZE="201966">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T17:19:50" MIMETYPE="text/xml"
-				CHECKSUM="cffc7d2b5ec1509eb7dc0111861393f5d5cfd7e2" CHECKSUMTYPE="SHA-1" SIZE="211663">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T17:19:50" MIMETYPE="text/xml" CHECKSUM="cffc7d2b5ec1509eb7dc0111861393f5d5cfd7e2" CHECKSUMTYPE="SHA-1" SIZE="211663">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T17:19:50" MIMETYPE="text/xml"
-				CHECKSUM="8a4de126d87fbec3b2b0f49697f05753193592b9" CHECKSUMTYPE="SHA-1" SIZE="207418">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T17:19:50" MIMETYPE="text/xml" CHECKSUM="8a4de126d87fbec3b2b0f49697f05753193592b9" CHECKSUMTYPE="SHA-1" SIZE="207418">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T17:19:51" MIMETYPE="text/xml"
-				CHECKSUM="bd4af8365da5fd941191a529d4241ec72bb4dd4c" CHECKSUMTYPE="SHA-1" SIZE="214027">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T17:19:51" MIMETYPE="text/xml" CHECKSUM="bd4af8365da5fd941191a529d4241ec72bb4dd4c" CHECKSUMTYPE="SHA-1" SIZE="214027">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T17:19:51" MIMETYPE="text/xml"
-				CHECKSUM="025a1ccf4142226a578a9d315995a869c1f8fe77" CHECKSUMTYPE="SHA-1" SIZE="100985">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T17:19:51" MIMETYPE="text/xml" CHECKSUM="025a1ccf4142226a578a9d315995a869c1f8fe77" CHECKSUMTYPE="SHA-1" SIZE="100985">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T17:19:52" MIMETYPE="text/xml"
-				CHECKSUM="dfe7bb33b81e68b567b1b8089aa335273c5d5539" CHECKSUMTYPE="SHA-1" SIZE="4402">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T17:19:52" MIMETYPE="text/xml" CHECKSUM="dfe7bb33b81e68b567b1b8089aa335273c5d5539" CHECKSUMTYPE="SHA-1" SIZE="4402">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T17:19:52" MIMETYPE="text/xml"
-				CHECKSUM="1316e433ab5edb18d384d19818c44e6c717334b9" CHECKSUMTYPE="SHA-1" SIZE="2018">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T17:19:52" MIMETYPE="text/xml" CHECKSUM="1316e433ab5edb18d384d19818c44e6c717334b9" CHECKSUMTYPE="SHA-1" SIZE="2018">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T17:19:52" MIMETYPE="text/xml"
-				CHECKSUM="1911d867a91010e0a3b2107bbb4835d9e7cec5ae" CHECKSUMTYPE="SHA-1" SIZE="72347">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T17:19:52" MIMETYPE="text/xml" CHECKSUM="1911d867a91010e0a3b2107bbb4835d9e7cec5ae" CHECKSUMTYPE="SHA-1" SIZE="72347">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T17:19:53" MIMETYPE="text/xml"
-				CHECKSUM="04d22f92c75b9be52c9cd4aef83323af5ef6206f" CHECKSUMTYPE="SHA-1" SIZE="83349">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T17:19:53" MIMETYPE="text/xml" CHECKSUM="04d22f92c75b9be52c9cd4aef83323af5ef6206f" CHECKSUMTYPE="SHA-1" SIZE="83349">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T17:19:53" MIMETYPE="text/xml"
-				CHECKSUM="4cf97a1191cf98d9244103be38bed13e8687e4b3" CHECKSUMTYPE="SHA-1" SIZE="66754">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T17:19:53" MIMETYPE="text/xml" CHECKSUM="4cf97a1191cf98d9244103be38bed13e8687e4b3" CHECKSUMTYPE="SHA-1" SIZE="66754">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T17:19:53" MIMETYPE="text/xml"
-				CHECKSUM="2029f003dd7b46e5b7e54c484d79fe59b02c647f" CHECKSUMTYPE="SHA-1" SIZE="111862">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T17:19:53" MIMETYPE="text/xml" CHECKSUM="2029f003dd7b46e5b7e54c484d79fe59b02c647f" CHECKSUMTYPE="SHA-1" SIZE="111862">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T17:19:53" MIMETYPE="text/xml"
-				CHECKSUM="63603185343b4d6ea35e88b24d901e1cd67fff60" CHECKSUMTYPE="SHA-1" SIZE="93892">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T17:19:53" MIMETYPE="text/xml" CHECKSUM="63603185343b4d6ea35e88b24d901e1cd67fff60" CHECKSUMTYPE="SHA-1" SIZE="93892">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T17:19:54" MIMETYPE="text/xml"
-				CHECKSUM="9bc351ceeb9e5bc9e87f4cd8a83d2be36a7209df" CHECKSUMTYPE="SHA-1" SIZE="103592">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T17:19:54" MIMETYPE="text/xml" CHECKSUM="9bc351ceeb9e5bc9e87f4cd8a83d2be36a7209df" CHECKSUMTYPE="SHA-1" SIZE="103592">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T17:19:54" MIMETYPE="text/xml"
-				CHECKSUM="bae026df9821e50c7aa0ef0268af36d00a253c7f" CHECKSUMTYPE="SHA-1" SIZE="78113">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T17:19:54" MIMETYPE="text/xml" CHECKSUM="bae026df9821e50c7aa0ef0268af36d00a253c7f" CHECKSUMTYPE="SHA-1" SIZE="78113">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T17:19:55" MIMETYPE="text/xml"
-				CHECKSUM="e841f70a8b6808f3b0a0f8e92f4e37fda03e9db4" CHECKSUMTYPE="SHA-1" SIZE="91986">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T17:19:55" MIMETYPE="text/xml" CHECKSUM="e841f70a8b6808f3b0a0f8e92f4e37fda03e9db4" CHECKSUMTYPE="SHA-1" SIZE="91986">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T17:19:55" MIMETYPE="text/xml"
-				CHECKSUM="22c45dabcf8658c843d70c4b7eb1d97309c6a6be" CHECKSUMTYPE="SHA-1" SIZE="74550">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T17:19:55" MIMETYPE="text/xml" CHECKSUM="22c45dabcf8658c843d70c4b7eb1d97309c6a6be" CHECKSUMTYPE="SHA-1" SIZE="74550">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T17:19:55" MIMETYPE="text/xml"
-				CHECKSUM="cbc3e97d921877a146c65caca987a794843b49c1" CHECKSUMTYPE="SHA-1" SIZE="47787">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T17:19:55" MIMETYPE="text/xml" CHECKSUM="cbc3e97d921877a146c65caca987a794843b49c1" CHECKSUMTYPE="SHA-1" SIZE="47787">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T17:19:55" MIMETYPE="text/xml"
-				CHECKSUM="9e58842d5a221c70d814895e904361b52db3a8c0" CHECKSUMTYPE="SHA-1" SIZE="95533">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T17:19:55" MIMETYPE="text/xml" CHECKSUM="9e58842d5a221c70d814895e904361b52db3a8c0" CHECKSUMTYPE="SHA-1" SIZE="95533">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T17:19:56" MIMETYPE="text/xml"
-				CHECKSUM="124306d1d2ad9be534846f2984f96566726aa9d9" CHECKSUMTYPE="SHA-1" SIZE="30045">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T17:19:56" MIMETYPE="text/xml" CHECKSUM="124306d1d2ad9be534846f2984f96566726aa9d9" CHECKSUMTYPE="SHA-1" SIZE="30045">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T17:19:56" MIMETYPE="text/xml"
-				CHECKSUM="6fa32535334fe0df84ef87ac3da2eaf76bf5d937" CHECKSUMTYPE="SHA-1" SIZE="4413">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T17:19:56" MIMETYPE="text/xml" CHECKSUM="6fa32535334fe0df84ef87ac3da2eaf76bf5d937" CHECKSUMTYPE="SHA-1" SIZE="4413">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T17:19:56" MIMETYPE="text/xml"
-				CHECKSUM="5e5bc1597568031ce765441afb6ade15e345ab30" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T17:19:56" MIMETYPE="text/xml" CHECKSUM="5e5bc1597568031ce765441afb6ade15e345ab30" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T17:19:57" MIMETYPE="text/xml"
-				CHECKSUM="904421aafb999964676c460aaa836c7afba77cb2" CHECKSUMTYPE="SHA-1" SIZE="92122">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T17:19:57" MIMETYPE="text/xml" CHECKSUM="904421aafb999964676c460aaa836c7afba77cb2" CHECKSUMTYPE="SHA-1" SIZE="92122">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T17:19:57" MIMETYPE="text/xml"
-				CHECKSUM="9b34896b809a981e94c04a96bec3b35f0bd50509" CHECKSUMTYPE="SHA-1" SIZE="186037">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T17:19:57" MIMETYPE="text/xml" CHECKSUM="9b34896b809a981e94c04a96bec3b35f0bd50509" CHECKSUMTYPE="SHA-1" SIZE="186037">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T17:19:57" MIMETYPE="text/xml"
-				CHECKSUM="17bcc8a19e7d80514d9e3f50daf77fb5ed6aec52" CHECKSUMTYPE="SHA-1" SIZE="184623">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T17:19:57" MIMETYPE="text/xml" CHECKSUM="17bcc8a19e7d80514d9e3f50daf77fb5ed6aec52" CHECKSUMTYPE="SHA-1" SIZE="184623">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T17:19:58" MIMETYPE="text/xml"
-				CHECKSUM="3a374e4746565e1b771a0e77af95d6c3d66899fd" CHECKSUMTYPE="SHA-1" SIZE="182310">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T17:19:58" MIMETYPE="text/xml" CHECKSUM="3a374e4746565e1b771a0e77af95d6c3d66899fd" CHECKSUMTYPE="SHA-1" SIZE="182310">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T17:19:58" MIMETYPE="text/xml"
-				CHECKSUM="3750e36aaa51f4442c51af865c982f3c517be5ad" CHECKSUMTYPE="SHA-1" SIZE="195441">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T17:19:58" MIMETYPE="text/xml" CHECKSUM="3750e36aaa51f4442c51af865c982f3c517be5ad" CHECKSUMTYPE="SHA-1" SIZE="195441">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T17:19:59" MIMETYPE="text/xml"
-				CHECKSUM="c47a2b7f2c630158421703d10adad6571e75d23f" CHECKSUMTYPE="SHA-1" SIZE="188921">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T17:19:59" MIMETYPE="text/xml" CHECKSUM="c47a2b7f2c630158421703d10adad6571e75d23f" CHECKSUMTYPE="SHA-1" SIZE="188921">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T17:19:59" MIMETYPE="text/xml"
-				CHECKSUM="78174165e496929f9b3f911fa37c66ea7954cacc" CHECKSUMTYPE="SHA-1" SIZE="190755">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T17:19:59" MIMETYPE="text/xml" CHECKSUM="78174165e496929f9b3f911fa37c66ea7954cacc" CHECKSUMTYPE="SHA-1" SIZE="190755">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T17:19:59" MIMETYPE="text/xml"
-				CHECKSUM="0f2e3030ca223a060bbd6cd089aff417fb8aac0d" CHECKSUMTYPE="SHA-1" SIZE="180045">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T17:19:59" MIMETYPE="text/xml" CHECKSUM="0f2e3030ca223a060bbd6cd089aff417fb8aac0d" CHECKSUMTYPE="SHA-1" SIZE="180045">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T17:20:00" MIMETYPE="text/xml"
-				CHECKSUM="80d9928bfba257c3b50acd11384386caaabb01ee" CHECKSUMTYPE="SHA-1" SIZE="174360">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T17:20:00" MIMETYPE="text/xml" CHECKSUM="80d9928bfba257c3b50acd11384386caaabb01ee" CHECKSUMTYPE="SHA-1" SIZE="174360">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T17:20:00" MIMETYPE="text/xml"
-				CHECKSUM="90402d8efbd42fa0c48f59f3166296d8596a213a" CHECKSUMTYPE="SHA-1" SIZE="174284">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T17:20:00" MIMETYPE="text/xml" CHECKSUM="90402d8efbd42fa0c48f59f3166296d8596a213a" CHECKSUMTYPE="SHA-1" SIZE="174284">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T17:20:01" MIMETYPE="text/xml"
-				CHECKSUM="9cef19832df2478723cabc1da68ef84182dad660" CHECKSUMTYPE="SHA-1" SIZE="178771">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T17:20:01" MIMETYPE="text/xml" CHECKSUM="9cef19832df2478723cabc1da68ef84182dad660" CHECKSUMTYPE="SHA-1" SIZE="178771">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T17:20:01" MIMETYPE="text/xml"
-				CHECKSUM="24844ad14426e0e8fade4015253ab9eed26827de" CHECKSUMTYPE="SHA-1" SIZE="58044">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T17:20:01" MIMETYPE="text/xml" CHECKSUM="24844ad14426e0e8fade4015253ab9eed26827de" CHECKSUMTYPE="SHA-1" SIZE="58044">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T17:20:01" MIMETYPE="text/xml"
-				CHECKSUM="b19e112e3894cf2452df9569aae0c95005c87696" CHECKSUMTYPE="SHA-1" SIZE="5919">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T17:20:01" MIMETYPE="text/xml" CHECKSUM="b19e112e3894cf2452df9569aae0c95005c87696" CHECKSUMTYPE="SHA-1" SIZE="5919">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T17:20:02" MIMETYPE="text/xml"
-				CHECKSUM="083f0cf436c096e8684629b69597d24a5e4c5dc6" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T17:20:02" MIMETYPE="text/xml" CHECKSUM="083f0cf436c096e8684629b69597d24a5e4c5dc6" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T17:20:02" MIMETYPE="text/xml"
-				CHECKSUM="27dd928d5a17e3b5f868f4202e7dd9257dc56afb" CHECKSUMTYPE="SHA-1" SIZE="13881">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T17:20:02" MIMETYPE="text/xml" CHECKSUM="27dd928d5a17e3b5f868f4202e7dd9257dc56afb" CHECKSUMTYPE="SHA-1" SIZE="13881">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T17:20:02" MIMETYPE="text/xml"
-				CHECKSUM="ab8428be6e7a6309377f710b3aa4f29ef56eeab7" CHECKSUMTYPE="SHA-1" SIZE="21460">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T17:20:02" MIMETYPE="text/xml" CHECKSUM="ab8428be6e7a6309377f710b3aa4f29ef56eeab7" CHECKSUMTYPE="SHA-1" SIZE="21460">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T17:20:02" MIMETYPE="text/xml"
-				CHECKSUM="c6445c2e051bab1af43f5a63193727a5f6c58649" CHECKSUMTYPE="SHA-1" SIZE="21397">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T17:20:02" MIMETYPE="text/xml" CHECKSUM="c6445c2e051bab1af43f5a63193727a5f6c58649" CHECKSUMTYPE="SHA-1" SIZE="21397">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T17:20:03" MIMETYPE="text/xml"
-				CHECKSUM="45a7c4566c3b11d384235f5b75344aafdf15167e" CHECKSUMTYPE="SHA-1" SIZE="18056">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T17:20:03" MIMETYPE="text/xml" CHECKSUM="45a7c4566c3b11d384235f5b75344aafdf15167e" CHECKSUMTYPE="SHA-1" SIZE="18056">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T17:20:03" MIMETYPE="text/xml"
-				CHECKSUM="3818d0698bec0e4a2e0f9b5fe702cd46957d597f" CHECKSUMTYPE="SHA-1" SIZE="22877">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T17:20:03" MIMETYPE="text/xml" CHECKSUM="3818d0698bec0e4a2e0f9b5fe702cd46957d597f" CHECKSUMTYPE="SHA-1" SIZE="22877">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T17:20:03" MIMETYPE="text/xml"
-				CHECKSUM="7b84a8c5ce3e3a51a45c6e8db67a643bebcb9c50" CHECKSUMTYPE="SHA-1" SIZE="20997">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T17:20:03" MIMETYPE="text/xml" CHECKSUM="7b84a8c5ce3e3a51a45c6e8db67a643bebcb9c50" CHECKSUMTYPE="SHA-1" SIZE="20997">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T17:20:03" MIMETYPE="text/xml"
-				CHECKSUM="8657dfbf4986055a6abdd2e7ad05adc2c45c472e" CHECKSUMTYPE="SHA-1" SIZE="33577">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T17:20:03" MIMETYPE="text/xml" CHECKSUM="8657dfbf4986055a6abdd2e7ad05adc2c45c472e" CHECKSUMTYPE="SHA-1" SIZE="33577">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T17:20:04" MIMETYPE="text/xml"
-				CHECKSUM="7b28c29b7bb5961df04d11f5cc3abdf1aa1b429e" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T17:20:04" MIMETYPE="text/xml" CHECKSUM="7b28c29b7bb5961df04d11f5cc3abdf1aa1b429e" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T17:20:04" MIMETYPE="text/xml"
-				CHECKSUM="0d16364618b73a4df9043c2ffcbdaf73fc70eaeb" CHECKSUMTYPE="SHA-1" SIZE="11014">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T17:20:04" MIMETYPE="text/xml" CHECKSUM="0d16364618b73a4df9043c2ffcbdaf73fc70eaeb" CHECKSUMTYPE="SHA-1" SIZE="11014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T17:20:04" MIMETYPE="text/xml"
-				CHECKSUM="2e11fd600ea9e48a9c5ed08d24724d12f1fbf1ae" CHECKSUMTYPE="SHA-1" SIZE="32068">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T17:20:04" MIMETYPE="text/xml" CHECKSUM="2e11fd600ea9e48a9c5ed08d24724d12f1fbf1ae" CHECKSUMTYPE="SHA-1" SIZE="32068">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T17:20:05" MIMETYPE="text/xml"
-				CHECKSUM="7d85e32fe9f190c7ed83a175337fe0bbd3082810" CHECKSUMTYPE="SHA-1" SIZE="32416">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T17:20:05" MIMETYPE="text/xml" CHECKSUM="7d85e32fe9f190c7ed83a175337fe0bbd3082810" CHECKSUMTYPE="SHA-1" SIZE="32416">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T17:20:05" MIMETYPE="text/xml"
-				CHECKSUM="c38912579e0ca18c87d7009138a1f22553f8dd47" CHECKSUMTYPE="SHA-1" SIZE="30979">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T17:20:05" MIMETYPE="text/xml" CHECKSUM="c38912579e0ca18c87d7009138a1f22553f8dd47" CHECKSUMTYPE="SHA-1" SIZE="30979">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T17:20:05" MIMETYPE="text/xml"
-				CHECKSUM="7bbfd060020634097944edea561bddf6dc82818a" CHECKSUMTYPE="SHA-1" SIZE="21312">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T17:20:05" MIMETYPE="text/xml" CHECKSUM="7bbfd060020634097944edea561bddf6dc82818a" CHECKSUMTYPE="SHA-1" SIZE="21312">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T17:20:06" MIMETYPE="text/xml"
-				CHECKSUM="35be0a0b831b3add8081dc67d383c567575b9df5" CHECKSUMTYPE="SHA-1" SIZE="117478">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T17:20:06" MIMETYPE="text/xml" CHECKSUM="35be0a0b831b3add8081dc67d383c567575b9df5" CHECKSUMTYPE="SHA-1" SIZE="117478">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T17:20:06" MIMETYPE="text/xml"
-				CHECKSUM="33de9a4d30ece20778c21b0a1c16970f8d9cf742" CHECKSUMTYPE="SHA-1" SIZE="4545">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T17:20:06" MIMETYPE="text/xml" CHECKSUM="33de9a4d30ece20778c21b0a1c16970f8d9cf742" CHECKSUMTYPE="SHA-1" SIZE="4545">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T17:20:06" MIMETYPE="text/xml"
-				CHECKSUM="90836a14476bdb4190a4b04cc081cb6181c16fba" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T17:20:06" MIMETYPE="text/xml" CHECKSUM="90836a14476bdb4190a4b04cc081cb6181c16fba" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T17:20:06" MIMETYPE="text/xml"
-				CHECKSUM="54381b38fcbe639e4bd8351752d253ed42492113" CHECKSUMTYPE="SHA-1" SIZE="110637">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T17:20:06" MIMETYPE="text/xml" CHECKSUM="54381b38fcbe639e4bd8351752d253ed42492113" CHECKSUMTYPE="SHA-1" SIZE="110637">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T17:20:07" MIMETYPE="text/xml"
-				CHECKSUM="5209d585794e47df274f9d2d9fc95c6fa54b6c1d" CHECKSUMTYPE="SHA-1" SIZE="67658">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T17:20:07" MIMETYPE="text/xml" CHECKSUM="5209d585794e47df274f9d2d9fc95c6fa54b6c1d" CHECKSUMTYPE="SHA-1" SIZE="67658">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T17:20:07" MIMETYPE="text/xml"
-				CHECKSUM="d743f3aa31fbcecbeed391bb6446851f7b002231" CHECKSUMTYPE="SHA-1" SIZE="5181">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T17:20:07" MIMETYPE="text/xml" CHECKSUM="d743f3aa31fbcecbeed391bb6446851f7b002231" CHECKSUMTYPE="SHA-1" SIZE="5181">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T17:20:07" MIMETYPE="text/xml"
-				CHECKSUM="e53bf1b385095bfc151df358fb537431cfe643c0" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T17:20:07" MIMETYPE="text/xml" CHECKSUM="e53bf1b385095bfc151df358fb537431cfe643c0" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T17:20:07" MIMETYPE="text/xml"
-				CHECKSUM="b4982b8d233ee49574d717f3c807f6741687a891" CHECKSUMTYPE="SHA-1" SIZE="60381">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T17:20:07" MIMETYPE="text/xml" CHECKSUM="b4982b8d233ee49574d717f3c807f6741687a891" CHECKSUMTYPE="SHA-1" SIZE="60381">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T17:20:08" MIMETYPE="text/xml"
-				CHECKSUM="2c28d61886fb51e3f4967752febbb27a56fc02ca" CHECKSUMTYPE="SHA-1" SIZE="138812">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T17:20:08" MIMETYPE="text/xml" CHECKSUM="2c28d61886fb51e3f4967752febbb27a56fc02ca" CHECKSUMTYPE="SHA-1" SIZE="138812">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T17:20:08" MIMETYPE="text/xml"
-				CHECKSUM="d813424efa41ae3892d82a48e5eab98cd41b3260" CHECKSUMTYPE="SHA-1" SIZE="135971">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T17:20:08" MIMETYPE="text/xml" CHECKSUM="d813424efa41ae3892d82a48e5eab98cd41b3260" CHECKSUMTYPE="SHA-1" SIZE="135971">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T17:20:08" MIMETYPE="text/xml"
-				CHECKSUM="9dc73c8bc38bacdf50655b92ae60264157699947" CHECKSUMTYPE="SHA-1" SIZE="131160">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T17:20:08" MIMETYPE="text/xml" CHECKSUM="9dc73c8bc38bacdf50655b92ae60264157699947" CHECKSUMTYPE="SHA-1" SIZE="131160">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T17:20:09" MIMETYPE="text/xml"
-				CHECKSUM="8f7f71e66e7d92a3c84280f49c9845379270bcb4" CHECKSUMTYPE="SHA-1" SIZE="4460">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T17:20:09" MIMETYPE="text/xml" CHECKSUM="8f7f71e66e7d92a3c84280f49c9845379270bcb4" CHECKSUMTYPE="SHA-1" SIZE="4460">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T17:20:09" MIMETYPE="text/xml"
-				CHECKSUM="8489f92281bf1e9ea4719de1eabb9cc97ca1d4a7" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T17:20:09" MIMETYPE="text/xml" CHECKSUM="8489f92281bf1e9ea4719de1eabb9cc97ca1d4a7" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T17:20:09" MIMETYPE="text/xml"
-				CHECKSUM="480c6bbf141dd6b7cddc272c3d77c4191f4ab988" CHECKSUMTYPE="SHA-1" SIZE="125098">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T17:20:09" MIMETYPE="text/xml" CHECKSUM="480c6bbf141dd6b7cddc272c3d77c4191f4ab988" CHECKSUMTYPE="SHA-1" SIZE="125098">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T17:20:10" MIMETYPE="text/xml"
-				CHECKSUM="d3497996aacae4ae371114e133f775820180f774" CHECKSUMTYPE="SHA-1" SIZE="151085">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T17:20:10" MIMETYPE="text/xml" CHECKSUM="d3497996aacae4ae371114e133f775820180f774" CHECKSUMTYPE="SHA-1" SIZE="151085">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T17:20:10" MIMETYPE="text/xml"
-				CHECKSUM="9c473a1ba601f16717422e400259b2b45bdd93bc" CHECKSUMTYPE="SHA-1" SIZE="149584">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T17:20:10" MIMETYPE="text/xml" CHECKSUM="9c473a1ba601f16717422e400259b2b45bdd93bc" CHECKSUMTYPE="SHA-1" SIZE="149584">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T17:20:11" MIMETYPE="text/xml"
-				CHECKSUM="b81add0194b5bb25f901d2048083653efff70e4f" CHECKSUMTYPE="SHA-1" SIZE="146070">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T17:20:11" MIMETYPE="text/xml" CHECKSUM="b81add0194b5bb25f901d2048083653efff70e4f" CHECKSUMTYPE="SHA-1" SIZE="146070">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T17:20:11" MIMETYPE="text/xml"
-				CHECKSUM="6c66a9393977251874e89826d77300e74bdfb406" CHECKSUMTYPE="SHA-1" SIZE="72545">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T17:20:11" MIMETYPE="text/xml" CHECKSUM="6c66a9393977251874e89826d77300e74bdfb406" CHECKSUMTYPE="SHA-1" SIZE="72545">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T17:20:11" MIMETYPE="text/xml"
-				CHECKSUM="09427008048e1090055e7c3e2b2595fbcaebd9c4" CHECKSUMTYPE="SHA-1" SIZE="130629">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T17:20:11" MIMETYPE="text/xml" CHECKSUM="09427008048e1090055e7c3e2b2595fbcaebd9c4" CHECKSUMTYPE="SHA-1" SIZE="130629">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T17:20:12" MIMETYPE="text/xml"
-				CHECKSUM="d30076bc1bf28dafbbea2bf8eb3117cd98d48041" CHECKSUMTYPE="SHA-1" SIZE="138957">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T17:20:12" MIMETYPE="text/xml" CHECKSUM="d30076bc1bf28dafbbea2bf8eb3117cd98d48041" CHECKSUMTYPE="SHA-1" SIZE="138957">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T17:20:12" MIMETYPE="text/xml"
-				CHECKSUM="7ce5291bd7f8af43f9c18b412cd06c563a6200dc" CHECKSUMTYPE="SHA-1" SIZE="138987">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T17:20:12" MIMETYPE="text/xml" CHECKSUM="7ce5291bd7f8af43f9c18b412cd06c563a6200dc" CHECKSUMTYPE="SHA-1" SIZE="138987">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T17:20:12" MIMETYPE="text/xml"
-				CHECKSUM="df2cfd6ffe22de8c992ba1f52daff90e09048d29" CHECKSUMTYPE="SHA-1" SIZE="4415">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T17:20:12" MIMETYPE="text/xml" CHECKSUM="df2cfd6ffe22de8c992ba1f52daff90e09048d29" CHECKSUMTYPE="SHA-1" SIZE="4415">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T17:20:13" MIMETYPE="text/xml"
-				CHECKSUM="5bcdbfd84a2c25f83cf1d8bf1a401ace2b11eff1" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T17:20:13" MIMETYPE="text/xml" CHECKSUM="5bcdbfd84a2c25f83cf1d8bf1a401ace2b11eff1" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T17:20:13" MIMETYPE="text/xml"
-				CHECKSUM="e8aaedb4cf0978a621ad2cdf23b71ab323d5ddae" CHECKSUMTYPE="SHA-1" SIZE="97332">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T17:20:13" MIMETYPE="text/xml" CHECKSUM="e8aaedb4cf0978a621ad2cdf23b71ab323d5ddae" CHECKSUMTYPE="SHA-1" SIZE="97332">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T17:20:13" MIMETYPE="text/xml"
-				CHECKSUM="90060bfe0958b9bdac8ba88b3c578c033e156219" CHECKSUMTYPE="SHA-1" SIZE="198569">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T17:20:13" MIMETYPE="text/xml" CHECKSUM="90060bfe0958b9bdac8ba88b3c578c033e156219" CHECKSUMTYPE="SHA-1" SIZE="198569">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T17:20:14" MIMETYPE="text/xml"
-				CHECKSUM="ebc58332ecab40b98eea84a978999f4e02958af8" CHECKSUMTYPE="SHA-1" SIZE="195423">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T17:20:14" MIMETYPE="text/xml" CHECKSUM="ebc58332ecab40b98eea84a978999f4e02958af8" CHECKSUMTYPE="SHA-1" SIZE="195423">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T17:20:14" MIMETYPE="text/xml"
-				CHECKSUM="adc883a8047572729fa04c5ee5d05f50952bf638" CHECKSUMTYPE="SHA-1" SIZE="192261">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T17:20:14" MIMETYPE="text/xml" CHECKSUM="adc883a8047572729fa04c5ee5d05f50952bf638" CHECKSUMTYPE="SHA-1" SIZE="192261">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T17:20:14" MIMETYPE="text/xml"
-				CHECKSUM="51d5241ed7909ab45faea63863651f6e12fb99b3" CHECKSUMTYPE="SHA-1" SIZE="193705">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T17:20:14" MIMETYPE="text/xml" CHECKSUM="51d5241ed7909ab45faea63863651f6e12fb99b3" CHECKSUMTYPE="SHA-1" SIZE="193705">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T17:20:15" MIMETYPE="text/xml"
-				CHECKSUM="52b2bfd74236add87c40e1eacdf2ca807f22a2a3" CHECKSUMTYPE="SHA-1" SIZE="195120">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T17:20:15" MIMETYPE="text/xml" CHECKSUM="52b2bfd74236add87c40e1eacdf2ca807f22a2a3" CHECKSUMTYPE="SHA-1" SIZE="195120">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T17:20:15" MIMETYPE="text/xml"
-				CHECKSUM="198b39ed6b7f1178ff9dc0be89122ad3dfb5a2ec" CHECKSUMTYPE="SHA-1" SIZE="196878">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T17:20:15" MIMETYPE="text/xml" CHECKSUM="198b39ed6b7f1178ff9dc0be89122ad3dfb5a2ec" CHECKSUMTYPE="SHA-1" SIZE="196878">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T17:20:16" MIMETYPE="text/xml"
-				CHECKSUM="88c00e0ffaa1ec4328adf206b73d18c9adffed2e" CHECKSUMTYPE="SHA-1" SIZE="191636">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T17:20:16" MIMETYPE="text/xml" CHECKSUM="88c00e0ffaa1ec4328adf206b73d18c9adffed2e" CHECKSUMTYPE="SHA-1" SIZE="191636">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T17:20:16" MIMETYPE="text/xml"
-				CHECKSUM="7f0e06c8a636ac6842917beffcca3e8de36e084c" CHECKSUMTYPE="SHA-1" SIZE="189470">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T17:20:16" MIMETYPE="text/xml" CHECKSUM="7f0e06c8a636ac6842917beffcca3e8de36e084c" CHECKSUMTYPE="SHA-1" SIZE="189470">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T17:20:17" MIMETYPE="text/xml"
-				CHECKSUM="aaf3da4235896abd0ba6be421c5bda48e5baead0" CHECKSUMTYPE="SHA-1" SIZE="180388">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T17:20:17" MIMETYPE="text/xml" CHECKSUM="aaf3da4235896abd0ba6be421c5bda48e5baead0" CHECKSUMTYPE="SHA-1" SIZE="180388">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T17:20:17" MIMETYPE="text/xml"
-				CHECKSUM="0bb0ba5ee82989bf364947de9144111417f5034e" CHECKSUMTYPE="SHA-1" SIZE="4882">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T17:20:17" MIMETYPE="text/xml" CHECKSUM="0bb0ba5ee82989bf364947de9144111417f5034e" CHECKSUMTYPE="SHA-1" SIZE="4882">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T17:20:17" MIMETYPE="text/xml"
-				CHECKSUM="f3d22ef76591bbea10d467a21387fe8b009e2dde" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T17:20:17" MIMETYPE="text/xml" CHECKSUM="f3d22ef76591bbea10d467a21387fe8b009e2dde" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T17:20:18" MIMETYPE="text/xml"
-				CHECKSUM="d03b15d0e71d433bd03a4d324e56f6734aaf7820" CHECKSUMTYPE="SHA-1" SIZE="175383">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T17:20:18" MIMETYPE="text/xml" CHECKSUM="d03b15d0e71d433bd03a4d324e56f6734aaf7820" CHECKSUMTYPE="SHA-1" SIZE="175383">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T17:20:18" MIMETYPE="text/xml"
-				CHECKSUM="537c830595490c0a320f8dcaf11cfe545ce153b3" CHECKSUMTYPE="SHA-1" SIZE="178529">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T17:20:18" MIMETYPE="text/xml" CHECKSUM="537c830595490c0a320f8dcaf11cfe545ce153b3" CHECKSUMTYPE="SHA-1" SIZE="178529">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0094.alto.xml"/>
 			</file>
-			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T17:20:19" MIMETYPE="text/xml"
-				CHECKSUM="661baa8f3f5bd0c8d193d76feaf407ad4ba79b75" CHECKSUMTYPE="SHA-1" SIZE="2419">
+			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T17:20:19" MIMETYPE="text/xml" CHECKSUM="661baa8f3f5bd0c8d193d76feaf407ad4ba79b75" CHECKSUMTYPE="SHA-1" SIZE="2419">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0095.alto.xml"/>
 			</file>
-			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T17:20:19" MIMETYPE="text/xml"
-				CHECKSUM="73326636127f411167c0e05ab988351fddfed97b" CHECKSUMTYPE="SHA-1" SIZE="2016">
+			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T17:20:19" MIMETYPE="text/xml" CHECKSUM="73326636127f411167c0e05ab988351fddfed97b" CHECKSUMTYPE="SHA-1" SIZE="2016">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0096.alto.xml"/>
 			</file>
-			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T17:20:19" MIMETYPE="text/xml"
-				CHECKSUM="6f744405d5c789d2272877a6369209eb3c511215" CHECKSUMTYPE="SHA-1" SIZE="185876">
+			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T17:20:19" MIMETYPE="text/xml" CHECKSUM="6f744405d5c789d2272877a6369209eb3c511215" CHECKSUMTYPE="SHA-1" SIZE="185876">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0097.alto.xml"/>
 			</file>
-			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T17:20:20" MIMETYPE="text/xml"
-				CHECKSUM="270c1bfa1801438431a163e8b011e3f42b75544a" CHECKSUMTYPE="SHA-1" SIZE="192562">
+			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T17:20:20" MIMETYPE="text/xml" CHECKSUM="270c1bfa1801438431a163e8b011e3f42b75544a" CHECKSUMTYPE="SHA-1" SIZE="192562">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0098.alto.xml"/>
 			</file>
-			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T17:20:20" MIMETYPE="text/xml"
-				CHECKSUM="9f7c5633d22d939a65868a681e50eedf6fb54d7e" CHECKSUMTYPE="SHA-1" SIZE="190044">
+			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T17:20:20" MIMETYPE="text/xml" CHECKSUM="9f7c5633d22d939a65868a681e50eedf6fb54d7e" CHECKSUMTYPE="SHA-1" SIZE="190044">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0099.alto.xml"/>
 			</file>
-			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T17:20:20" MIMETYPE="text/xml"
-				CHECKSUM="6bdc7ceed2371dc402115e3323ab6555b46b600f" CHECKSUMTYPE="SHA-1" SIZE="188375">
+			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T17:20:20" MIMETYPE="text/xml" CHECKSUM="6bdc7ceed2371dc402115e3323ab6555b46b600f" CHECKSUMTYPE="SHA-1" SIZE="188375">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0100.alto.xml"/>
 			</file>
-			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T17:20:21" MIMETYPE="text/xml"
-				CHECKSUM="2371578b079d6ebb09b3603b747fce8d8353506c" CHECKSUMTYPE="SHA-1" SIZE="168211">
+			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T17:20:21" MIMETYPE="text/xml" CHECKSUM="2371578b079d6ebb09b3603b747fce8d8353506c" CHECKSUMTYPE="SHA-1" SIZE="168211">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0101.alto.xml"/>
 			</file>
-			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T17:20:21" MIMETYPE="text/xml"
-				CHECKSUM="45de79e1fd232481119a403d8c32ca902a245f72" CHECKSUMTYPE="SHA-1" SIZE="199882">
+			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T17:20:21" MIMETYPE="text/xml" CHECKSUM="45de79e1fd232481119a403d8c32ca902a245f72" CHECKSUMTYPE="SHA-1" SIZE="199882">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0102.alto.xml"/>
 			</file>
-			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T17:20:22" MIMETYPE="text/xml"
-				CHECKSUM="71575366e868d4e075f0e9de96aa0850ccaf794c" CHECKSUMTYPE="SHA-1" SIZE="192900">
+			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T17:20:22" MIMETYPE="text/xml" CHECKSUM="71575366e868d4e075f0e9de96aa0850ccaf794c" CHECKSUMTYPE="SHA-1" SIZE="192900">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0103.alto.xml"/>
 			</file>
-			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T17:20:22" MIMETYPE="text/xml"
-				CHECKSUM="fbbce69aaa19cd9b7e862d298692ddd9ff50214f" CHECKSUMTYPE="SHA-1" SIZE="58084">
+			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T17:20:22" MIMETYPE="text/xml" CHECKSUM="fbbce69aaa19cd9b7e862d298692ddd9ff50214f" CHECKSUMTYPE="SHA-1" SIZE="58084">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0104.alto.xml"/>
 			</file>
-			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T17:20:22" MIMETYPE="text/xml"
-				CHECKSUM="20bfa98d71653deafe0defb4f650b51a9b3d8b08" CHECKSUMTYPE="SHA-1" SIZE="125914">
+			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T17:20:22" MIMETYPE="text/xml" CHECKSUM="20bfa98d71653deafe0defb4f650b51a9b3d8b08" CHECKSUMTYPE="SHA-1" SIZE="125914">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0105.alto.xml"/>
 			</file>
-			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T17:20:23" MIMETYPE="text/xml"
-				CHECKSUM="32d07d1af6580402b4af39f9b353d80613eb4ff3" CHECKSUMTYPE="SHA-1" SIZE="211256">
+			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T17:20:23" MIMETYPE="text/xml" CHECKSUM="32d07d1af6580402b4af39f9b353d80613eb4ff3" CHECKSUMTYPE="SHA-1" SIZE="211256">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0106.alto.xml"/>
 			</file>
-			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T17:20:23" MIMETYPE="text/xml"
-				CHECKSUM="723c94f84351c593419d928912e218f9b06362f7" CHECKSUMTYPE="SHA-1" SIZE="185360">
+			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T17:20:23" MIMETYPE="text/xml" CHECKSUM="723c94f84351c593419d928912e218f9b06362f7" CHECKSUMTYPE="SHA-1" SIZE="185360">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0107.alto.xml"/>
 			</file>
-			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T17:20:23" MIMETYPE="text/xml"
-				CHECKSUM="cd25492fc9053364c23566c79c91985bfed7be53" CHECKSUMTYPE="SHA-1" SIZE="188359">
+			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T17:20:23" MIMETYPE="text/xml" CHECKSUM="cd25492fc9053364c23566c79c91985bfed7be53" CHECKSUMTYPE="SHA-1" SIZE="188359">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0108.alto.xml"/>
 			</file>
-			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T17:20:24" MIMETYPE="text/xml"
-				CHECKSUM="a9524a5691f418fa3e59b7a29703d186db04944b" CHECKSUMTYPE="SHA-1" SIZE="2427">
+			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T17:20:24" MIMETYPE="text/xml" CHECKSUM="a9524a5691f418fa3e59b7a29703d186db04944b" CHECKSUMTYPE="SHA-1" SIZE="2427">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0109.alto.xml"/>
 			</file>
-			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T17:20:24" MIMETYPE="text/xml"
-				CHECKSUM="5c200493c37dc79783412d8bfd52868740fbba08" CHECKSUMTYPE="SHA-1" SIZE="2012">
+			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T17:20:24" MIMETYPE="text/xml" CHECKSUM="5c200493c37dc79783412d8bfd52868740fbba08" CHECKSUMTYPE="SHA-1" SIZE="2012">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0110.alto.xml"/>
 			</file>
-			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-07-30T17:20:24" MIMETYPE="text/xml"
-				CHECKSUM="720b1bfbedd1a4315b831fcf74bc65864b1bc652" CHECKSUMTYPE="SHA-1" SIZE="2412">
+			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-07-30T17:20:24" MIMETYPE="text/xml" CHECKSUM="720b1bfbedd1a4315b831fcf74bc65864b1bc652" CHECKSUMTYPE="SHA-1" SIZE="2412">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0111.alto.xml"/>
 			</file>
-			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-07-30T17:20:25" MIMETYPE="text/xml"
-				CHECKSUM="61f072ac59eb3d35a5c4c6a42fd855fe23a45337" CHECKSUMTYPE="SHA-1" SIZE="2021">
+			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-07-30T17:20:25" MIMETYPE="text/xml" CHECKSUM="61f072ac59eb3d35a5c4c6a42fd855fe23a45337" CHECKSUMTYPE="SHA-1" SIZE="2021">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0112.alto.xml"/>
 			</file>
-			<file ID="ALTO00113" GROUPID="page113" CREATED="2015-07-30T17:20:25" MIMETYPE="text/xml"
-				CHECKSUM="1d744f45bc259e97764b1df740d4212cfe3ac08b" CHECKSUMTYPE="SHA-1" SIZE="2428">
+			<file ID="ALTO00113" GROUPID="page113" CREATED="2015-07-30T17:20:25" MIMETYPE="text/xml" CHECKSUM="1d744f45bc259e97764b1df740d4212cfe3ac08b" CHECKSUMTYPE="SHA-1" SIZE="2428">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0113.alto.xml"/>
 			</file>
-			<file ID="ALTO00114" GROUPID="page114" CREATED="2015-07-30T17:20:25" MIMETYPE="text/xml"
-				CHECKSUM="f4e74b88f50f22613a1df401bca208c21eb45175" CHECKSUMTYPE="SHA-1" SIZE="2022">
+			<file ID="ALTO00114" GROUPID="page114" CREATED="2015-07-30T17:20:25" MIMETYPE="text/xml" CHECKSUM="f4e74b88f50f22613a1df401bca208c21eb45175" CHECKSUMTYPE="SHA-1" SIZE="2022">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0114.alto.xml"/>
 			</file>
-			<file ID="ALTO00115" GROUPID="page115" CREATED="2015-07-30T17:20:25" MIMETYPE="text/xml"
-				CHECKSUM="b5dbc822392a9fc0119a43166bf7214658dd4075" CHECKSUMTYPE="SHA-1" SIZE="186114">
+			<file ID="ALTO00115" GROUPID="page115" CREATED="2015-07-30T17:20:25" MIMETYPE="text/xml" CHECKSUM="b5dbc822392a9fc0119a43166bf7214658dd4075" CHECKSUMTYPE="SHA-1" SIZE="186114">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0115.alto.xml"/>
 			</file>
-			<file ID="ALTO00116" GROUPID="page116" CREATED="2015-07-30T17:20:26" MIMETYPE="text/xml"
-				CHECKSUM="f3716a3e1386ebb62a7adad2f47f2ea8276ecfc3" CHECKSUMTYPE="SHA-1" SIZE="181187">
+			<file ID="ALTO00116" GROUPID="page116" CREATED="2015-07-30T17:20:26" MIMETYPE="text/xml" CHECKSUM="f3716a3e1386ebb62a7adad2f47f2ea8276ecfc3" CHECKSUMTYPE="SHA-1" SIZE="181187">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0116.alto.xml"/>
 			</file>
-			<file ID="ALTO00117" GROUPID="page117" CREATED="2015-07-30T17:20:26" MIMETYPE="text/xml"
-				CHECKSUM="cf9abfca7b681a8e08d6c5b0ad0ebb450eae3788" CHECKSUMTYPE="SHA-1" SIZE="150569">
+			<file ID="ALTO00117" GROUPID="page117" CREATED="2015-07-30T17:20:26" MIMETYPE="text/xml" CHECKSUM="cf9abfca7b681a8e08d6c5b0ad0ebb450eae3788" CHECKSUMTYPE="SHA-1" SIZE="150569">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0117.alto.xml"/>
 			</file>
-			<file ID="ALTO00118" GROUPID="page118" CREATED="2015-07-30T17:20:27" MIMETYPE="text/xml"
-				CHECKSUM="aff5561a49f4b5fbae7a9257efd37196de434a0e" CHECKSUMTYPE="SHA-1" SIZE="211028">
+			<file ID="ALTO00118" GROUPID="page118" CREATED="2015-07-30T17:20:27" MIMETYPE="text/xml" CHECKSUM="aff5561a49f4b5fbae7a9257efd37196de434a0e" CHECKSUMTYPE="SHA-1" SIZE="211028">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0118.alto.xml"/>
 			</file>
-			<file ID="ALTO00119" GROUPID="page119" CREATED="2015-07-30T17:20:27" MIMETYPE="text/xml"
-				CHECKSUM="0ff070bed257c10cdcad2b5e2bf0d0e14d3b1990" CHECKSUMTYPE="SHA-1" SIZE="183745">
+			<file ID="ALTO00119" GROUPID="page119" CREATED="2015-07-30T17:20:27" MIMETYPE="text/xml" CHECKSUM="0ff070bed257c10cdcad2b5e2bf0d0e14d3b1990" CHECKSUMTYPE="SHA-1" SIZE="183745">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0119.alto.xml"/>
 			</file>
-			<file ID="ALTO00120" GROUPID="page120" CREATED="2015-07-30T17:20:28" MIMETYPE="text/xml"
-				CHECKSUM="9739f817b8925828b59932ed56a8a0a66c856777" CHECKSUMTYPE="SHA-1" SIZE="133663">
+			<file ID="ALTO00120" GROUPID="page120" CREATED="2015-07-30T17:20:28" MIMETYPE="text/xml" CHECKSUM="9739f817b8925828b59932ed56a8a0a66c856777" CHECKSUMTYPE="SHA-1" SIZE="133663">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0120.alto.xml"/>
 			</file>
-			<file ID="ALTO00121" GROUPID="page121" CREATED="2015-07-30T17:20:28" MIMETYPE="text/xml"
-				CHECKSUM="2880146859015fc34feb084196b9cbb8688d27c9" CHECKSUMTYPE="SHA-1" SIZE="207474">
+			<file ID="ALTO00121" GROUPID="page121" CREATED="2015-07-30T17:20:28" MIMETYPE="text/xml" CHECKSUM="2880146859015fc34feb084196b9cbb8688d27c9" CHECKSUMTYPE="SHA-1" SIZE="207474">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0121.alto.xml"/>
 			</file>
-			<file ID="ALTO00122" GROUPID="page122" CREATED="2015-07-30T17:20:28" MIMETYPE="text/xml"
-				CHECKSUM="37650409548efd6c6067295decb196ef49610900" CHECKSUMTYPE="SHA-1" SIZE="106401">
+			<file ID="ALTO00122" GROUPID="page122" CREATED="2015-07-30T17:20:28" MIMETYPE="text/xml" CHECKSUM="37650409548efd6c6067295decb196ef49610900" CHECKSUMTYPE="SHA-1" SIZE="106401">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0122.alto.xml"/>
 			</file>
-			<file ID="ALTO00123" GROUPID="page123" CREATED="2015-07-30T17:20:29" MIMETYPE="text/xml"
-				CHECKSUM="394336672a6c9e96ab223f8bd2ba4d336e1ec5e6" CHECKSUMTYPE="SHA-1" SIZE="94406">
+			<file ID="ALTO00123" GROUPID="page123" CREATED="2015-07-30T17:20:29" MIMETYPE="text/xml" CHECKSUM="394336672a6c9e96ab223f8bd2ba4d336e1ec5e6" CHECKSUMTYPE="SHA-1" SIZE="94406">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0123.alto.xml"/>
 			</file>
-			<file ID="ALTO00124" GROUPID="page124" CREATED="2015-07-30T17:20:29" MIMETYPE="text/xml"
-				CHECKSUM="e8b437f4dc30c628eb285f756713be38f4f40cc3" CHECKSUMTYPE="SHA-1" SIZE="40441">
+			<file ID="ALTO00124" GROUPID="page124" CREATED="2015-07-30T17:20:29" MIMETYPE="text/xml" CHECKSUM="e8b437f4dc30c628eb285f756713be38f4f40cc3" CHECKSUMTYPE="SHA-1" SIZE="40441">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0124.alto.xml"/>
 			</file>
-			<file ID="ALTO00125" GROUPID="page125" CREATED="2015-07-30T17:20:29" MIMETYPE="text/xml"
-				CHECKSUM="4af48a2f9911d775029b0f914c4cf3a06c798207" CHECKSUMTYPE="SHA-1" SIZE="86257">
+			<file ID="ALTO00125" GROUPID="page125" CREATED="2015-07-30T17:20:29" MIMETYPE="text/xml" CHECKSUM="4af48a2f9911d775029b0f914c4cf3a06c798207" CHECKSUMTYPE="SHA-1" SIZE="86257">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0125.alto.xml"/>
 			</file>
-			<file ID="ALTO00126" GROUPID="page126" CREATED="2015-07-30T17:20:30" MIMETYPE="text/xml"
-				CHECKSUM="4ec7685f7c9cdf3543caf78f217d83acb3f68acb" CHECKSUMTYPE="SHA-1" SIZE="4016">
+			<file ID="ALTO00126" GROUPID="page126" CREATED="2015-07-30T17:20:30" MIMETYPE="text/xml" CHECKSUM="4ec7685f7c9cdf3543caf78f217d83acb3f68acb" CHECKSUMTYPE="SHA-1" SIZE="4016">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-06_01_0126.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T17:25:37" MIMETYPE="application/pdf" CHECKSUM="208801d22a3a72cf375b8029c97c258ba133de88"
-				CHECKSUMTYPE="SHA-1" SIZE="73110640">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/bmtnabe_1895-06_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T17:25:37" MIMETYPE="application/pdf" CHECKSUM="208801d22a3a72cf375b8029c97c258ba133de88" CHECKSUMTYPE="SHA-1" SIZE="73110640">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/06_01/bmtnabe_1895-06_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>

--- a/metadata/periodicals/bmtnabe/issues/1895/09_01/bmtnabe_1895-09_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1895/09_01/bmtnabe_1895-09_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1895-09_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1895-09_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-09_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-09_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1895-09_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1895-09_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-09_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -9627,1004 +9623,672 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T16:26:59" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="e9bcff8dbc2609b4e2f6e2e88a72e33780750ada" CHECKSUMTYPE="SHA-1" SIZE="5117526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T16:27:23" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="9334c79d42be7c33f2e94cbded40993dfec1ccf0" CHECKSUMTYPE="SHA-1" SIZE="5419028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T16:27:49" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="7759c19ab5b9227c82fba02b831ecad88a153f1a" CHECKSUMTYPE="SHA-1" SIZE="5113019">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T16:28:14" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="4f5fe9f5d77f1c30e13bd1dc4a005c998b5e5d90" CHECKSUMTYPE="SHA-1" SIZE="5448727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T16:28:39" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="d2a65967eddfef574fdc5448d6dff3adf80d672b" CHECKSUMTYPE="SHA-1" SIZE="5117462">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T16:29:05" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="c3fb0a3ea18d90f416db690cb33cf4a929c4b35c" CHECKSUMTYPE="SHA-1" SIZE="5447766">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T16:29:32" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="518c95f34c7672ac433d0245f0b871a691256211" CHECKSUMTYPE="SHA-1" SIZE="5101139">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T16:29:57" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="eff8803e353dc9c8634c72eeeebd3bdf380c5f3f" CHECKSUMTYPE="SHA-1" SIZE="5396529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T16:30:21" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="66e744e5577b5ba4c464fa01e510140922c6e4e9" CHECKSUMTYPE="SHA-1" SIZE="5136429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T16:30:45" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="3d1dbd7f0d4251a6a70a8cce90faca6d418c27d4" CHECKSUMTYPE="SHA-1" SIZE="5437923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T16:31:12" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="e52e042a809fb3013d5ee16ff8c9589299913d01" CHECKSUMTYPE="SHA-1" SIZE="5136429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T16:31:38" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="d0ad87d42e92124e42983f61f24631a8c5773fb4" CHECKSUMTYPE="SHA-1" SIZE="5530629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T16:32:02" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="c80784cb935a2cd2dfb60b57acf998eab5e66856" CHECKSUMTYPE="SHA-1" SIZE="5035629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T16:32:25" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="aba3913d293c465aedcfda5e39f42b5df49e4d09" CHECKSUMTYPE="SHA-1" SIZE="5454128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T16:32:52" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="3ccb2b2fe3febeb97de324f544529bd008cc670b" CHECKSUMTYPE="SHA-1" SIZE="5130812">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T16:33:18" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="a6fbcd2caccf7b42f99dc34023e11c21d47fa555" CHECKSUMTYPE="SHA-1" SIZE="5427124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T16:33:45" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="cb977900abdd30e4147788170b344b11fb9d7429" CHECKSUMTYPE="SHA-1" SIZE="5131923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T16:34:12" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="11be07ca5b881761a86cb78af740872030ca780f" CHECKSUMTYPE="SHA-1" SIZE="5486526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T16:34:37" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="fee78c7fee8859dcdb490bd3d2c734e9a0631232" CHECKSUMTYPE="SHA-1" SIZE="5165927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T16:35:03" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="9157f6b0b9721b9913b8e75ed5b8a25307358327" CHECKSUMTYPE="SHA-1" SIZE="5475727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T16:35:26" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="170d863b932450d02a682bbf537d87c1bea00821" CHECKSUMTYPE="SHA-1" SIZE="5167029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T16:35:51" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="3f903fc710ac3ac69dc8324d0ccd8e0553e165d8" CHECKSUMTYPE="SHA-1" SIZE="5530411">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T16:36:16" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="c221d10363f76c8277d1f115fb3e37369715792b" CHECKSUMTYPE="SHA-1" SIZE="5099500">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T16:36:41" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="7940f3742e747fd3343d54168cd495c95e1e61aa" CHECKSUMTYPE="SHA-1" SIZE="5490039">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T16:37:06" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="35a803df830dbac53f6451f08766788be18de742" CHECKSUMTYPE="SHA-1" SIZE="5098610">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T16:37:29" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="34477fbe34585d3847248f580b9aab3b1a27ebb7" CHECKSUMTYPE="SHA-1" SIZE="5530624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T16:37:53" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="95e08845096912cd15401a7b9c564d96b1a3519a" CHECKSUMTYPE="SHA-1" SIZE="5119295">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T16:38:17" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="45fa5d24e3a61ee7536681e3a6c4780826f193cf" CHECKSUMTYPE="SHA-1" SIZE="5467626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T16:38:43" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="5cd8f0d9b3fab8100be93a60a000078e78156205" CHECKSUMTYPE="SHA-1" SIZE="5134626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T16:39:09" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="b5f4cdb3cb6fda2babb70b969ca043864933fd69" CHECKSUMTYPE="SHA-1" SIZE="5530628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T16:39:36" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="f2aaa2c4df9ff8315fc3f3d9ec2f4f76de44e024" CHECKSUMTYPE="SHA-1" SIZE="5113928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T16:40:01" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="68d65e977ca08d501631aa4d2906417f23e1b34d" CHECKSUMTYPE="SHA-1" SIZE="5530588">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T16:40:28" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="b26238dbb889fa2f01a8b9c59141d2c00bfe3984" CHECKSUMTYPE="SHA-1" SIZE="5104024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T16:40:54" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="04e231635258fe35af0a19e7cafd94186635da0a" CHECKSUMTYPE="SHA-1" SIZE="5530616">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T16:41:20" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="81c0c79d2f438a71d21ee1fc7591afdc68df7dd5" CHECKSUMTYPE="SHA-1" SIZE="5170627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T16:41:46" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="370813e4fa007c56b3cd227c2fc4b2931c925ad4" CHECKSUMTYPE="SHA-1" SIZE="5530629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T16:42:11" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="56e2b1a30ea568042311312ff25bf7ddf285ceb7" CHECKSUMTYPE="SHA-1" SIZE="5119326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T16:42:36" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="73a0eff34261cd5e069274f8a207ace98e2e34fd" CHECKSUMTYPE="SHA-1" SIZE="5530623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T16:43:01" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="bedd48319ef0309634cb8aeb232667dbbf1b4d2a" CHECKSUMTYPE="SHA-1" SIZE="5084229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T16:43:27" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="5c18dd0828b6ed70350844f2136f92295c4828f3" CHECKSUMTYPE="SHA-1" SIZE="5530629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T16:43:55" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="f02a49d86b796e4585b0cf24494994e388ef1cb2" CHECKSUMTYPE="SHA-1" SIZE="5140014">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T16:44:23" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="76ac9c360275bfe975e06f72c11e0569f17c50e8" CHECKSUMTYPE="SHA-1" SIZE="5530503">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T16:44:48" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="8a85f824c00ef25a4c15383d5bcdcd909cc1e457" CHECKSUMTYPE="SHA-1" SIZE="5146328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T16:45:14" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="1e91db6fdce1ffc8e9e35781a4bc5c5bcafee1f8" CHECKSUMTYPE="SHA-1" SIZE="5530628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T16:45:40" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="e18571ef719fc79166ce6fe399be14089f9b2b1d" CHECKSUMTYPE="SHA-1" SIZE="5184127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T16:46:06" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="125d1b1e07839e749c8541820a48fbddf7ce599b" CHECKSUMTYPE="SHA-1" SIZE="5530627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T16:46:32" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="fbff0f98df3270d6880ea644b3d840fed32ff5da" CHECKSUMTYPE="SHA-1" SIZE="5187729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T16:46:58" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="253ebc3f3fe8f2d7e7e43fc039159471e43ff268" CHECKSUMTYPE="SHA-1" SIZE="5469423">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T16:47:25" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="3a9f73985560204602dfc519e08c24e896f9da66" CHECKSUMTYPE="SHA-1" SIZE="5184121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T16:47:49" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="4c3ee4aa5e8976393b7338809872b3718fb4c1fc" CHECKSUMTYPE="SHA-1" SIZE="5477528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T16:48:15" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="d32897033a35fb0b802474544828f11263f7ca64" CHECKSUMTYPE="SHA-1" SIZE="5182304">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T16:48:41" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="778850590acf14f0bf0cbf5b60fc85cf8a2d84ae" CHECKSUMTYPE="SHA-1" SIZE="5509926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T16:49:07" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="36966ff07a51a93660191e7619be696840b0e9c4" CHECKSUMTYPE="SHA-1" SIZE="5203011">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T16:49:35" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="c1b274240cff49eb04c12afc9097e2391c9c51a7" CHECKSUMTYPE="SHA-1" SIZE="5530624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T16:50:01" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="6d0910483835d59de1102053fa4a6f7d64dfb3f1" CHECKSUMTYPE="SHA-1" SIZE="5189527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T16:50:27" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="8ab61dc14d59602ebb4ccedb2ee2158793de7cce" CHECKSUMTYPE="SHA-1" SIZE="5530629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T16:50:51" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="12bdf9485614b0b76e486a347663bbb3c84ad305" CHECKSUMTYPE="SHA-1" SIZE="5174224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T16:51:16" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="8bb03ffe03f0c6d9a77165f9086021972fe9263d" CHECKSUMTYPE="SHA-1" SIZE="5530624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T16:51:40" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="3622ca2065146cbe8b97dfb4a4ccea16a9842560" CHECKSUMTYPE="SHA-1" SIZE="5212013">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T16:52:08" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="f3ebc9e3a43478ad14431f527c603304d6405bb8" CHECKSUMTYPE="SHA-1" SIZE="5530628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T16:52:34" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="600b77a82c40c229dd52135edfd468d3d1e73ebd" CHECKSUMTYPE="SHA-1" SIZE="5225528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T16:53:00" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="d1bfef64201db0e60f66687ed0922d7ad75ec55c" CHECKSUMTYPE="SHA-1" SIZE="5530626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T16:53:26" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="26002d6f67b1cb780a26eb035299a5c7bf9f420b" CHECKSUMTYPE="SHA-1" SIZE="5224623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T16:53:52" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="7c0a2ab22cff98ae73f0d219d673326829864247" CHECKSUMTYPE="SHA-1" SIZE="5505429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T16:54:17" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="7be1fff922f7ebe4cae2ef2cb86c567e470bd8b8" CHECKSUMTYPE="SHA-1" SIZE="5212929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T16:54:43" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="8afa0365bb3862f8449778f294a55f9c3d6b25b3" CHECKSUMTYPE="SHA-1" SIZE="5466725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T16:55:08" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="4fd9c19e7e8a82b7eaed64f21fc481a34aa4e788" CHECKSUMTYPE="SHA-1" SIZE="5195790">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T16:55:32" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="d70f4afaaaee12ab0ac47cb4b82c7fa663800fcf" CHECKSUMTYPE="SHA-1" SIZE="5402826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T16:55:59" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="c58a40246b410383bd0de7e10b6c480d28ec7157" CHECKSUMTYPE="SHA-1" SIZE="5240826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T16:56:23" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="984593b1e020a123b2f2aa2b6a6c19722bc2bfde" CHECKSUMTYPE="SHA-1" SIZE="5455925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T16:56:49" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="89614c14b2fef0adfdd83a43ccb531420e8f2632" CHECKSUMTYPE="SHA-1" SIZE="5199428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T16:57:15" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="3f4ed301496e076859c5be15591a0f320ccd85e9" CHECKSUMTYPE="SHA-1" SIZE="5468525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T16:57:41" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="3d6d5c66b30f5be1b3c72043f61347fde2a70f33" CHECKSUMTYPE="SHA-1" SIZE="5225527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T16:58:05" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="ab49f27ab84cf871f533378986d342677c269de7" CHECKSUMTYPE="SHA-1" SIZE="5484722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T16:58:30" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="408dc17b30b32f79a36b695265ae6d1a943dc4c5" CHECKSUMTYPE="SHA-1" SIZE="5194015">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T16:58:56" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="b62f23dd5addd97f5e10847360e0b848930fe6bf" CHECKSUMTYPE="SHA-1" SIZE="5473024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T16:59:22" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="23eaa055980bb41ce90e8f3a09737c9fcbb9e904" CHECKSUMTYPE="SHA-1" SIZE="5168796">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T16:59:48" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="25d38c9fe0c9fec809ebbb60a816d96923841079" CHECKSUMTYPE="SHA-1" SIZE="5425327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:00:16" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="cac10505932abfb7c4fbb7700aa0bf168ab9ac48" CHECKSUMTYPE="SHA-1" SIZE="5214723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:00:41" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="a81760388a2083a8e254d42d2e4d886470971f52" CHECKSUMTYPE="SHA-1" SIZE="5410925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:01:05" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="6a73f61afdbe72b8ef9e824bb3f65e3e8ec0b9bf" CHECKSUMTYPE="SHA-1" SIZE="5147225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:01:31" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="c98e97a71e2a405a528576c0b3432228a553302e" CHECKSUMTYPE="SHA-1" SIZE="5372196">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:01:54" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="b03a43e060daff24195515ab8954934a2becef31" CHECKSUMTYPE="SHA-1" SIZE="5181269">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:02:21" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="2b02df0af7f688886b950a1a099b4cadae572887" CHECKSUMTYPE="SHA-1" SIZE="5421729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:02:46" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="4687922897733b457ca2aecc5e745fea37739266" CHECKSUMTYPE="SHA-1" SIZE="5163376">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:03:11" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="dfdeb2516cf7bf6fcd382be0ce18ed21340ff261" CHECKSUMTYPE="SHA-1" SIZE="5456828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:03:35" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="99a3003729ba75d20469f44fabba6e8174e22cff" CHECKSUMTYPE="SHA-1" SIZE="5130113">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:04:01" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="7002ea6fafdbdf310a858fda3453c10f9aceaf7f" CHECKSUMTYPE="SHA-1" SIZE="5372229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:04:24" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="ca0f0ac61d5b34731a1c252241a9956a4a923c72" CHECKSUMTYPE="SHA-1" SIZE="5146327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:04:49" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="ac9797993ed737175012b7ebeaf88f5b7864a655" CHECKSUMTYPE="SHA-1" SIZE="5400021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:05:16" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="b1ad7cd24bf8c2a36cb8271850eb742590bab46e" CHECKSUMTYPE="SHA-1" SIZE="5155328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:05:42" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="0c5aa93871fc9a46eb61c9356741515b1505795b" CHECKSUMTYPE="SHA-1" SIZE="5372226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:06:05" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="3be780652a2debb334fdce441572c30b9889e133" CHECKSUMTYPE="SHA-1" SIZE="5099529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T17:06:30" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="7001897e92ae16e8ab0d078a21ac32d4663a8fde" CHECKSUMTYPE="SHA-1" SIZE="5404629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0094.jp2"/>
-			</file>
-			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T17:06:56" MIMETYPE="image/jp2" SEQ="95"
-				CHECKSUM="085baeac04ca201d953b8bbdd40ece4e29140e3f" CHECKSUMTYPE="SHA-1" SIZE="5180515">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0095.jp2"/>
-			</file>
-			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T17:07:21" MIMETYPE="image/jp2" SEQ="96"
-				CHECKSUM="d68d6e5d4d9e5840573d1728788ee3969598ffbc" CHECKSUMTYPE="SHA-1" SIZE="5401918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0096.jp2"/>
-			</file>
-			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T17:07:47" MIMETYPE="image/jp2" SEQ="97"
-				CHECKSUM="ba41bf5b68825ee82247dab0a12c2064c0af859b" CHECKSUMTYPE="SHA-1" SIZE="5210217">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0097.jp2"/>
-			</file>
-			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T17:08:14" MIMETYPE="image/jp2" SEQ="98"
-				CHECKSUM="28b4c36980a79e13f68eb132b53c7884efeea23a" CHECKSUMTYPE="SHA-1" SIZE="5379428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0098.jp2"/>
-			</file>
-			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T17:08:38" MIMETYPE="image/jp2" SEQ="99"
-				CHECKSUM="a52c51b239fe89f3e8cdaf5175c118c81d4bceb4" CHECKSUMTYPE="SHA-1" SIZE="5119327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0099.jp2"/>
-			</file>
-			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T17:09:03" MIMETYPE="image/jp2" SEQ="100"
-				CHECKSUM="5c3689f659eaca92626072202bcc3c3187252710" CHECKSUMTYPE="SHA-1" SIZE="5372212">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0100.jp2"/>
-			</file>
-			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T17:09:29" MIMETYPE="image/jp2" SEQ="101"
-				CHECKSUM="0bc910e4c8aebcc1616db1966d889a3285c07c6f" CHECKSUMTYPE="SHA-1" SIZE="5160699">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0101.jp2"/>
-			</file>
-			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T17:09:54" MIMETYPE="image/jp2" SEQ="102"
-				CHECKSUM="73962739d9a4f1146a1e2ff6caf0fcf550367aeb" CHECKSUMTYPE="SHA-1" SIZE="5409029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0102.jp2"/>
-			</file>
-			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T17:10:23" MIMETYPE="image/jp2" SEQ="103"
-				CHECKSUM="ae47018f364804170d222f82b167f02ff52fcd87" CHECKSUMTYPE="SHA-1" SIZE="5150828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0103.jp2"/>
-			</file>
-			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T17:10:49" MIMETYPE="image/jp2" SEQ="104"
-				CHECKSUM="be2e9a7aff1c5bd6b3c428770afeef630d9a13df" CHECKSUMTYPE="SHA-1" SIZE="5395629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0104.jp2"/>
-			</file>
-			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T17:11:14" MIMETYPE="image/jp2" SEQ="105"
-				CHECKSUM="eb6887f4f6d5bc531238ddef2d389e25d0929c0d" CHECKSUMTYPE="SHA-1" SIZE="5083280">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0105.jp2"/>
-			</file>
-			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T17:11:37" MIMETYPE="image/jp2" SEQ="106"
-				CHECKSUM="6cb6c094dd11791f96f2a1d2f3aec0d614c63a71" CHECKSUMTYPE="SHA-1" SIZE="5399228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0106.jp2"/>
-			</file>
-			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T17:12:03" MIMETYPE="image/jp2" SEQ="107"
-				CHECKSUM="8289604fc58dc15b2238aeb78e17291875620f54" CHECKSUMTYPE="SHA-1" SIZE="5224525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0107.jp2"/>
-			</file>
-			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T17:12:29" MIMETYPE="image/jp2" SEQ="108"
-				CHECKSUM="68af660d0dd6350c4a69c7b982ecb3bc765c1910" CHECKSUMTYPE="SHA-1" SIZE="5406419">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0108.jp2"/>
-			</file>
-			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T17:12:54" MIMETYPE="image/jp2" SEQ="109"
-				CHECKSUM="2f9c6642faa77b78efde3520ff28231e866e9dc6" CHECKSUMTYPE="SHA-1" SIZE="5233627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0109.jp2"/>
-			</file>
-			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T17:13:20" MIMETYPE="image/jp2" SEQ="110"
-				CHECKSUM="38a3f3d227e974e25f705a19d919b82cc8c70f00" CHECKSUMTYPE="SHA-1" SIZE="5372227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0110.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T16:26:59" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="e9bcff8dbc2609b4e2f6e2e88a72e33780750ada" CHECKSUMTYPE="SHA-1" SIZE="5117526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T16:27:23" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="9334c79d42be7c33f2e94cbded40993dfec1ccf0" CHECKSUMTYPE="SHA-1" SIZE="5419028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T16:27:49" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="7759c19ab5b9227c82fba02b831ecad88a153f1a" CHECKSUMTYPE="SHA-1" SIZE="5113019">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T16:28:14" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="4f5fe9f5d77f1c30e13bd1dc4a005c998b5e5d90" CHECKSUMTYPE="SHA-1" SIZE="5448727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T16:28:39" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="d2a65967eddfef574fdc5448d6dff3adf80d672b" CHECKSUMTYPE="SHA-1" SIZE="5117462">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T16:29:05" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="c3fb0a3ea18d90f416db690cb33cf4a929c4b35c" CHECKSUMTYPE="SHA-1" SIZE="5447766">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T16:29:32" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="518c95f34c7672ac433d0245f0b871a691256211" CHECKSUMTYPE="SHA-1" SIZE="5101139">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T16:29:57" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="eff8803e353dc9c8634c72eeeebd3bdf380c5f3f" CHECKSUMTYPE="SHA-1" SIZE="5396529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T16:30:21" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="66e744e5577b5ba4c464fa01e510140922c6e4e9" CHECKSUMTYPE="SHA-1" SIZE="5136429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T16:30:45" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="3d1dbd7f0d4251a6a70a8cce90faca6d418c27d4" CHECKSUMTYPE="SHA-1" SIZE="5437923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T16:31:12" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="e52e042a809fb3013d5ee16ff8c9589299913d01" CHECKSUMTYPE="SHA-1" SIZE="5136429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T16:31:38" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="d0ad87d42e92124e42983f61f24631a8c5773fb4" CHECKSUMTYPE="SHA-1" SIZE="5530629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T16:32:02" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="c80784cb935a2cd2dfb60b57acf998eab5e66856" CHECKSUMTYPE="SHA-1" SIZE="5035629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T16:32:25" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="aba3913d293c465aedcfda5e39f42b5df49e4d09" CHECKSUMTYPE="SHA-1" SIZE="5454128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T16:32:52" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="3ccb2b2fe3febeb97de324f544529bd008cc670b" CHECKSUMTYPE="SHA-1" SIZE="5130812">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T16:33:18" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="a6fbcd2caccf7b42f99dc34023e11c21d47fa555" CHECKSUMTYPE="SHA-1" SIZE="5427124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T16:33:45" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="cb977900abdd30e4147788170b344b11fb9d7429" CHECKSUMTYPE="SHA-1" SIZE="5131923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T16:34:12" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="11be07ca5b881761a86cb78af740872030ca780f" CHECKSUMTYPE="SHA-1" SIZE="5486526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T16:34:37" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="fee78c7fee8859dcdb490bd3d2c734e9a0631232" CHECKSUMTYPE="SHA-1" SIZE="5165927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T16:35:03" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="9157f6b0b9721b9913b8e75ed5b8a25307358327" CHECKSUMTYPE="SHA-1" SIZE="5475727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T16:35:26" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="170d863b932450d02a682bbf537d87c1bea00821" CHECKSUMTYPE="SHA-1" SIZE="5167029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T16:35:51" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="3f903fc710ac3ac69dc8324d0ccd8e0553e165d8" CHECKSUMTYPE="SHA-1" SIZE="5530411">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T16:36:16" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="c221d10363f76c8277d1f115fb3e37369715792b" CHECKSUMTYPE="SHA-1" SIZE="5099500">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T16:36:41" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="7940f3742e747fd3343d54168cd495c95e1e61aa" CHECKSUMTYPE="SHA-1" SIZE="5490039">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T16:37:06" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="35a803df830dbac53f6451f08766788be18de742" CHECKSUMTYPE="SHA-1" SIZE="5098610">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T16:37:29" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="34477fbe34585d3847248f580b9aab3b1a27ebb7" CHECKSUMTYPE="SHA-1" SIZE="5530624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T16:37:53" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="95e08845096912cd15401a7b9c564d96b1a3519a" CHECKSUMTYPE="SHA-1" SIZE="5119295">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T16:38:17" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="45fa5d24e3a61ee7536681e3a6c4780826f193cf" CHECKSUMTYPE="SHA-1" SIZE="5467626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T16:38:43" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="5cd8f0d9b3fab8100be93a60a000078e78156205" CHECKSUMTYPE="SHA-1" SIZE="5134626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T16:39:09" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="b5f4cdb3cb6fda2babb70b969ca043864933fd69" CHECKSUMTYPE="SHA-1" SIZE="5530628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T16:39:36" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="f2aaa2c4df9ff8315fc3f3d9ec2f4f76de44e024" CHECKSUMTYPE="SHA-1" SIZE="5113928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T16:40:01" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="68d65e977ca08d501631aa4d2906417f23e1b34d" CHECKSUMTYPE="SHA-1" SIZE="5530588">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T16:40:28" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="b26238dbb889fa2f01a8b9c59141d2c00bfe3984" CHECKSUMTYPE="SHA-1" SIZE="5104024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T16:40:54" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="04e231635258fe35af0a19e7cafd94186635da0a" CHECKSUMTYPE="SHA-1" SIZE="5530616">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T16:41:20" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="81c0c79d2f438a71d21ee1fc7591afdc68df7dd5" CHECKSUMTYPE="SHA-1" SIZE="5170627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T16:41:46" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="370813e4fa007c56b3cd227c2fc4b2931c925ad4" CHECKSUMTYPE="SHA-1" SIZE="5530629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T16:42:11" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="56e2b1a30ea568042311312ff25bf7ddf285ceb7" CHECKSUMTYPE="SHA-1" SIZE="5119326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T16:42:36" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="73a0eff34261cd5e069274f8a207ace98e2e34fd" CHECKSUMTYPE="SHA-1" SIZE="5530623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T16:43:01" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="bedd48319ef0309634cb8aeb232667dbbf1b4d2a" CHECKSUMTYPE="SHA-1" SIZE="5084229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T16:43:27" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="5c18dd0828b6ed70350844f2136f92295c4828f3" CHECKSUMTYPE="SHA-1" SIZE="5530629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T16:43:55" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="f02a49d86b796e4585b0cf24494994e388ef1cb2" CHECKSUMTYPE="SHA-1" SIZE="5140014">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T16:44:23" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="76ac9c360275bfe975e06f72c11e0569f17c50e8" CHECKSUMTYPE="SHA-1" SIZE="5530503">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T16:44:48" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="8a85f824c00ef25a4c15383d5bcdcd909cc1e457" CHECKSUMTYPE="SHA-1" SIZE="5146328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T16:45:14" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="1e91db6fdce1ffc8e9e35781a4bc5c5bcafee1f8" CHECKSUMTYPE="SHA-1" SIZE="5530628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T16:45:40" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="e18571ef719fc79166ce6fe399be14089f9b2b1d" CHECKSUMTYPE="SHA-1" SIZE="5184127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T16:46:06" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="125d1b1e07839e749c8541820a48fbddf7ce599b" CHECKSUMTYPE="SHA-1" SIZE="5530627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T16:46:32" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="fbff0f98df3270d6880ea644b3d840fed32ff5da" CHECKSUMTYPE="SHA-1" SIZE="5187729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T16:46:58" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="253ebc3f3fe8f2d7e7e43fc039159471e43ff268" CHECKSUMTYPE="SHA-1" SIZE="5469423">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T16:47:25" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="3a9f73985560204602dfc519e08c24e896f9da66" CHECKSUMTYPE="SHA-1" SIZE="5184121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T16:47:49" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="4c3ee4aa5e8976393b7338809872b3718fb4c1fc" CHECKSUMTYPE="SHA-1" SIZE="5477528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T16:48:15" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="d32897033a35fb0b802474544828f11263f7ca64" CHECKSUMTYPE="SHA-1" SIZE="5182304">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T16:48:41" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="778850590acf14f0bf0cbf5b60fc85cf8a2d84ae" CHECKSUMTYPE="SHA-1" SIZE="5509926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T16:49:07" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="36966ff07a51a93660191e7619be696840b0e9c4" CHECKSUMTYPE="SHA-1" SIZE="5203011">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T16:49:35" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="c1b274240cff49eb04c12afc9097e2391c9c51a7" CHECKSUMTYPE="SHA-1" SIZE="5530624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T16:50:01" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="6d0910483835d59de1102053fa4a6f7d64dfb3f1" CHECKSUMTYPE="SHA-1" SIZE="5189527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T16:50:27" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="8ab61dc14d59602ebb4ccedb2ee2158793de7cce" CHECKSUMTYPE="SHA-1" SIZE="5530629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T16:50:51" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="12bdf9485614b0b76e486a347663bbb3c84ad305" CHECKSUMTYPE="SHA-1" SIZE="5174224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T16:51:16" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="8bb03ffe03f0c6d9a77165f9086021972fe9263d" CHECKSUMTYPE="SHA-1" SIZE="5530624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T16:51:40" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="3622ca2065146cbe8b97dfb4a4ccea16a9842560" CHECKSUMTYPE="SHA-1" SIZE="5212013">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T16:52:08" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="f3ebc9e3a43478ad14431f527c603304d6405bb8" CHECKSUMTYPE="SHA-1" SIZE="5530628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T16:52:34" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="600b77a82c40c229dd52135edfd468d3d1e73ebd" CHECKSUMTYPE="SHA-1" SIZE="5225528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T16:53:00" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="d1bfef64201db0e60f66687ed0922d7ad75ec55c" CHECKSUMTYPE="SHA-1" SIZE="5530626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T16:53:26" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="26002d6f67b1cb780a26eb035299a5c7bf9f420b" CHECKSUMTYPE="SHA-1" SIZE="5224623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T16:53:52" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="7c0a2ab22cff98ae73f0d219d673326829864247" CHECKSUMTYPE="SHA-1" SIZE="5505429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T16:54:17" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="7be1fff922f7ebe4cae2ef2cb86c567e470bd8b8" CHECKSUMTYPE="SHA-1" SIZE="5212929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T16:54:43" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="8afa0365bb3862f8449778f294a55f9c3d6b25b3" CHECKSUMTYPE="SHA-1" SIZE="5466725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T16:55:08" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="4fd9c19e7e8a82b7eaed64f21fc481a34aa4e788" CHECKSUMTYPE="SHA-1" SIZE="5195790">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T16:55:32" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="d70f4afaaaee12ab0ac47cb4b82c7fa663800fcf" CHECKSUMTYPE="SHA-1" SIZE="5402826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T16:55:59" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="c58a40246b410383bd0de7e10b6c480d28ec7157" CHECKSUMTYPE="SHA-1" SIZE="5240826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T16:56:23" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="984593b1e020a123b2f2aa2b6a6c19722bc2bfde" CHECKSUMTYPE="SHA-1" SIZE="5455925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T16:56:49" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="89614c14b2fef0adfdd83a43ccb531420e8f2632" CHECKSUMTYPE="SHA-1" SIZE="5199428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T16:57:15" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="3f4ed301496e076859c5be15591a0f320ccd85e9" CHECKSUMTYPE="SHA-1" SIZE="5468525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T16:57:41" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="3d6d5c66b30f5be1b3c72043f61347fde2a70f33" CHECKSUMTYPE="SHA-1" SIZE="5225527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T16:58:05" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="ab49f27ab84cf871f533378986d342677c269de7" CHECKSUMTYPE="SHA-1" SIZE="5484722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T16:58:30" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="408dc17b30b32f79a36b695265ae6d1a943dc4c5" CHECKSUMTYPE="SHA-1" SIZE="5194015">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T16:58:56" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="b62f23dd5addd97f5e10847360e0b848930fe6bf" CHECKSUMTYPE="SHA-1" SIZE="5473024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T16:59:22" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="23eaa055980bb41ce90e8f3a09737c9fcbb9e904" CHECKSUMTYPE="SHA-1" SIZE="5168796">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T16:59:48" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="25d38c9fe0c9fec809ebbb60a816d96923841079" CHECKSUMTYPE="SHA-1" SIZE="5425327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:00:16" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="cac10505932abfb7c4fbb7700aa0bf168ab9ac48" CHECKSUMTYPE="SHA-1" SIZE="5214723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:00:41" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="a81760388a2083a8e254d42d2e4d886470971f52" CHECKSUMTYPE="SHA-1" SIZE="5410925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:01:05" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="6a73f61afdbe72b8ef9e824bb3f65e3e8ec0b9bf" CHECKSUMTYPE="SHA-1" SIZE="5147225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:01:31" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="c98e97a71e2a405a528576c0b3432228a553302e" CHECKSUMTYPE="SHA-1" SIZE="5372196">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:01:54" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="b03a43e060daff24195515ab8954934a2becef31" CHECKSUMTYPE="SHA-1" SIZE="5181269">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:02:21" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="2b02df0af7f688886b950a1a099b4cadae572887" CHECKSUMTYPE="SHA-1" SIZE="5421729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:02:46" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="4687922897733b457ca2aecc5e745fea37739266" CHECKSUMTYPE="SHA-1" SIZE="5163376">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:03:11" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="dfdeb2516cf7bf6fcd382be0ce18ed21340ff261" CHECKSUMTYPE="SHA-1" SIZE="5456828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:03:35" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="99a3003729ba75d20469f44fabba6e8174e22cff" CHECKSUMTYPE="SHA-1" SIZE="5130113">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:04:01" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="7002ea6fafdbdf310a858fda3453c10f9aceaf7f" CHECKSUMTYPE="SHA-1" SIZE="5372229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:04:24" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="ca0f0ac61d5b34731a1c252241a9956a4a923c72" CHECKSUMTYPE="SHA-1" SIZE="5146327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:04:49" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="ac9797993ed737175012b7ebeaf88f5b7864a655" CHECKSUMTYPE="SHA-1" SIZE="5400021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:05:16" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="b1ad7cd24bf8c2a36cb8271850eb742590bab46e" CHECKSUMTYPE="SHA-1" SIZE="5155328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:05:42" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="0c5aa93871fc9a46eb61c9356741515b1505795b" CHECKSUMTYPE="SHA-1" SIZE="5372226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:06:05" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="3be780652a2debb334fdce441572c30b9889e133" CHECKSUMTYPE="SHA-1" SIZE="5099529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T17:06:30" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="7001897e92ae16e8ab0d078a21ac32d4663a8fde" CHECKSUMTYPE="SHA-1" SIZE="5404629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0094.jp2"/>
+			</file>
+			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T17:06:56" MIMETYPE="image/jp2" SEQ="95" CHECKSUM="085baeac04ca201d953b8bbdd40ece4e29140e3f" CHECKSUMTYPE="SHA-1" SIZE="5180515">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0095.jp2"/>
+			</file>
+			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T17:07:21" MIMETYPE="image/jp2" SEQ="96" CHECKSUM="d68d6e5d4d9e5840573d1728788ee3969598ffbc" CHECKSUMTYPE="SHA-1" SIZE="5401918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0096.jp2"/>
+			</file>
+			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T17:07:47" MIMETYPE="image/jp2" SEQ="97" CHECKSUM="ba41bf5b68825ee82247dab0a12c2064c0af859b" CHECKSUMTYPE="SHA-1" SIZE="5210217">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0097.jp2"/>
+			</file>
+			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T17:08:14" MIMETYPE="image/jp2" SEQ="98" CHECKSUM="28b4c36980a79e13f68eb132b53c7884efeea23a" CHECKSUMTYPE="SHA-1" SIZE="5379428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0098.jp2"/>
+			</file>
+			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T17:08:38" MIMETYPE="image/jp2" SEQ="99" CHECKSUM="a52c51b239fe89f3e8cdaf5175c118c81d4bceb4" CHECKSUMTYPE="SHA-1" SIZE="5119327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0099.jp2"/>
+			</file>
+			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T17:09:03" MIMETYPE="image/jp2" SEQ="100" CHECKSUM="5c3689f659eaca92626072202bcc3c3187252710" CHECKSUMTYPE="SHA-1" SIZE="5372212">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0100.jp2"/>
+			</file>
+			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T17:09:29" MIMETYPE="image/jp2" SEQ="101" CHECKSUM="0bc910e4c8aebcc1616db1966d889a3285c07c6f" CHECKSUMTYPE="SHA-1" SIZE="5160699">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0101.jp2"/>
+			</file>
+			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T17:09:54" MIMETYPE="image/jp2" SEQ="102" CHECKSUM="73962739d9a4f1146a1e2ff6caf0fcf550367aeb" CHECKSUMTYPE="SHA-1" SIZE="5409029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0102.jp2"/>
+			</file>
+			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T17:10:23" MIMETYPE="image/jp2" SEQ="103" CHECKSUM="ae47018f364804170d222f82b167f02ff52fcd87" CHECKSUMTYPE="SHA-1" SIZE="5150828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0103.jp2"/>
+			</file>
+			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T17:10:49" MIMETYPE="image/jp2" SEQ="104" CHECKSUM="be2e9a7aff1c5bd6b3c428770afeef630d9a13df" CHECKSUMTYPE="SHA-1" SIZE="5395629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0104.jp2"/>
+			</file>
+			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T17:11:14" MIMETYPE="image/jp2" SEQ="105" CHECKSUM="eb6887f4f6d5bc531238ddef2d389e25d0929c0d" CHECKSUMTYPE="SHA-1" SIZE="5083280">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0105.jp2"/>
+			</file>
+			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T17:11:37" MIMETYPE="image/jp2" SEQ="106" CHECKSUM="6cb6c094dd11791f96f2a1d2f3aec0d614c63a71" CHECKSUMTYPE="SHA-1" SIZE="5399228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0106.jp2"/>
+			</file>
+			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T17:12:03" MIMETYPE="image/jp2" SEQ="107" CHECKSUM="8289604fc58dc15b2238aeb78e17291875620f54" CHECKSUMTYPE="SHA-1" SIZE="5224525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0107.jp2"/>
+			</file>
+			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T17:12:29" MIMETYPE="image/jp2" SEQ="108" CHECKSUM="68af660d0dd6350c4a69c7b982ecb3bc765c1910" CHECKSUMTYPE="SHA-1" SIZE="5406419">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0108.jp2"/>
+			</file>
+			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T17:12:54" MIMETYPE="image/jp2" SEQ="109" CHECKSUM="2f9c6642faa77b78efde3520ff28231e866e9dc6" CHECKSUMTYPE="SHA-1" SIZE="5233627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0109.jp2"/>
+			</file>
+			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T17:13:20" MIMETYPE="image/jp2" SEQ="110" CHECKSUM="38a3f3d227e974e25f705a19d919b82cc8c70f00" CHECKSUMTYPE="SHA-1" SIZE="5372227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/delivery/bmtnabe_1895-09_01_0110.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T17:13:36" MIMETYPE="text/xml" CHECKSUM="25589615957e2ef86259a5ad7150d6b532b0c70e"
-				CHECKSUMTYPE="SHA-1" SIZE="2110">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T17:13:36" MIMETYPE="text/xml" CHECKSUM="25589615957e2ef86259a5ad7150d6b532b0c70e" CHECKSUMTYPE="SHA-1" SIZE="2110">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T17:13:36" MIMETYPE="text/xml" CHECKSUM="a82f21ed0cba9ef5bae688b9b20df3afa64f524c"
-				CHECKSUMTYPE="SHA-1" SIZE="19411">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T17:13:36" MIMETYPE="text/xml" CHECKSUM="a82f21ed0cba9ef5bae688b9b20df3afa64f524c" CHECKSUMTYPE="SHA-1" SIZE="19411">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T17:13:36" MIMETYPE="text/xml" CHECKSUM="bf6e85a9a865207f11880d5d5e0eb99e295392bc"
-				CHECKSUMTYPE="SHA-1" SIZE="26348">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T17:13:36" MIMETYPE="text/xml" CHECKSUM="bf6e85a9a865207f11880d5d5e0eb99e295392bc" CHECKSUMTYPE="SHA-1" SIZE="26348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T17:13:37" MIMETYPE="text/xml" CHECKSUM="c4845c80151842350caabe9303b87a53d1dbe782"
-				CHECKSUMTYPE="SHA-1" SIZE="18237">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T17:13:37" MIMETYPE="text/xml" CHECKSUM="c4845c80151842350caabe9303b87a53d1dbe782" CHECKSUMTYPE="SHA-1" SIZE="18237">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T17:13:37" MIMETYPE="text/xml" CHECKSUM="9ff6af059e96b90c92af878996e68c4a3a73fee8"
-				CHECKSUMTYPE="SHA-1" SIZE="25558">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T17:13:37" MIMETYPE="text/xml" CHECKSUM="9ff6af059e96b90c92af878996e68c4a3a73fee8" CHECKSUMTYPE="SHA-1" SIZE="25558">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T17:13:37" MIMETYPE="text/xml" CHECKSUM="73f327a17706804fe1c5f40a842791dd2a3b2b67"
-				CHECKSUMTYPE="SHA-1" SIZE="3891">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T17:13:37" MIMETYPE="text/xml" CHECKSUM="73f327a17706804fe1c5f40a842791dd2a3b2b67" CHECKSUMTYPE="SHA-1" SIZE="3891">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T17:13:37" MIMETYPE="text/xml" CHECKSUM="9ae23be8e5ada3d08e289cb4bde337b1f1d52f81"
-				CHECKSUMTYPE="SHA-1" SIZE="3925">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T17:13:37" MIMETYPE="text/xml" CHECKSUM="9ae23be8e5ada3d08e289cb4bde337b1f1d52f81" CHECKSUMTYPE="SHA-1" SIZE="3925">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T17:13:38" MIMETYPE="text/xml" CHECKSUM="8c0d02dcd549ec731cfa69af883fc4401864ea8a"
-				CHECKSUMTYPE="SHA-1" SIZE="2008">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T17:13:38" MIMETYPE="text/xml" CHECKSUM="8c0d02dcd549ec731cfa69af883fc4401864ea8a" CHECKSUMTYPE="SHA-1" SIZE="2008">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T17:13:38" MIMETYPE="text/xml" CHECKSUM="5e920e7412731f4684d4136afc5fa02113e09b63"
-				CHECKSUMTYPE="SHA-1" SIZE="18727">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T17:13:38" MIMETYPE="text/xml" CHECKSUM="5e920e7412731f4684d4136afc5fa02113e09b63" CHECKSUMTYPE="SHA-1" SIZE="18727">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T17:13:38" MIMETYPE="text/xml"
-				CHECKSUM="37bad9622844d6cd88ce2075c2b44e3329730547" CHECKSUMTYPE="SHA-1" SIZE="26776">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T17:13:38" MIMETYPE="text/xml" CHECKSUM="37bad9622844d6cd88ce2075c2b44e3329730547" CHECKSUMTYPE="SHA-1" SIZE="26776">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T17:13:39" MIMETYPE="text/xml"
-				CHECKSUM="ccdfcf5c36c0ec7803299613938a11abd0e49990" CHECKSUMTYPE="SHA-1" SIZE="21491">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T17:13:39" MIMETYPE="text/xml" CHECKSUM="ccdfcf5c36c0ec7803299613938a11abd0e49990" CHECKSUMTYPE="SHA-1" SIZE="21491">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T17:13:39" MIMETYPE="text/xml"
-				CHECKSUM="ec8e90c5c94545af3799c2c2e69022375172a5b2" CHECKSUMTYPE="SHA-1" SIZE="2017">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T17:13:39" MIMETYPE="text/xml" CHECKSUM="ec8e90c5c94545af3799c2c2e69022375172a5b2" CHECKSUMTYPE="SHA-1" SIZE="2017">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T17:13:39" MIMETYPE="text/xml"
-				CHECKSUM="09be8636bb4576a75be6f9720544184be956e440" CHECKSUMTYPE="SHA-1" SIZE="134867">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T17:13:39" MIMETYPE="text/xml" CHECKSUM="09be8636bb4576a75be6f9720544184be956e440" CHECKSUMTYPE="SHA-1" SIZE="134867">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T17:13:40" MIMETYPE="text/xml"
-				CHECKSUM="0f8460690e8c7ec9f70aaec90725626cd94b848c" CHECKSUMTYPE="SHA-1" SIZE="213144">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T17:13:40" MIMETYPE="text/xml" CHECKSUM="0f8460690e8c7ec9f70aaec90725626cd94b848c" CHECKSUMTYPE="SHA-1" SIZE="213144">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T17:13:40" MIMETYPE="text/xml"
-				CHECKSUM="df7e9b07329064c8cb9cf51d9061d02e3cd85c10" CHECKSUMTYPE="SHA-1" SIZE="194984">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T17:13:40" MIMETYPE="text/xml" CHECKSUM="df7e9b07329064c8cb9cf51d9061d02e3cd85c10" CHECKSUMTYPE="SHA-1" SIZE="194984">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T17:13:40" MIMETYPE="text/xml"
-				CHECKSUM="5a8be3871a95b36892bf774971558a0994701dec" CHECKSUMTYPE="SHA-1" SIZE="201371">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T17:13:40" MIMETYPE="text/xml" CHECKSUM="5a8be3871a95b36892bf774971558a0994701dec" CHECKSUMTYPE="SHA-1" SIZE="201371">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T17:13:41" MIMETYPE="text/xml"
-				CHECKSUM="abff8532419bdfd8b081c4c1e663e2df61d28ea9" CHECKSUMTYPE="SHA-1" SIZE="211985">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T17:13:41" MIMETYPE="text/xml" CHECKSUM="abff8532419bdfd8b081c4c1e663e2df61d28ea9" CHECKSUMTYPE="SHA-1" SIZE="211985">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T17:13:41" MIMETYPE="text/xml"
-				CHECKSUM="11217a3e492240ebe5b198e873f27d455aded64a" CHECKSUMTYPE="SHA-1" SIZE="193799">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T17:13:41" MIMETYPE="text/xml" CHECKSUM="11217a3e492240ebe5b198e873f27d455aded64a" CHECKSUMTYPE="SHA-1" SIZE="193799">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T17:13:42" MIMETYPE="text/xml"
-				CHECKSUM="6e7215d9d0dc3d9dee755e4c7cada8986a78c2a2" CHECKSUMTYPE="SHA-1" SIZE="211600">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T17:13:42" MIMETYPE="text/xml" CHECKSUM="6e7215d9d0dc3d9dee755e4c7cada8986a78c2a2" CHECKSUMTYPE="SHA-1" SIZE="211600">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T17:13:42" MIMETYPE="text/xml"
-				CHECKSUM="eb484e7d683c06f69b7f8933a0a0570ea06a0f8d" CHECKSUMTYPE="SHA-1" SIZE="87013">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T17:13:42" MIMETYPE="text/xml" CHECKSUM="eb484e7d683c06f69b7f8933a0a0570ea06a0f8d" CHECKSUMTYPE="SHA-1" SIZE="87013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T17:13:42" MIMETYPE="text/xml"
-				CHECKSUM="b813ccf28004323e702af57d8ed5628ff457ef25" CHECKSUMTYPE="SHA-1" SIZE="24707">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T17:13:42" MIMETYPE="text/xml" CHECKSUM="b813ccf28004323e702af57d8ed5628ff457ef25" CHECKSUMTYPE="SHA-1" SIZE="24707">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T17:13:42" MIMETYPE="text/xml"
-				CHECKSUM="678471a10448c61ffa0fbef836c237f209667e50" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T17:13:42" MIMETYPE="text/xml" CHECKSUM="678471a10448c61ffa0fbef836c237f209667e50" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T17:13:43" MIMETYPE="text/xml"
-				CHECKSUM="b42d2a6cae7218e98755379f896bbe6e3bf8d078" CHECKSUMTYPE="SHA-1" SIZE="10177">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T17:13:43" MIMETYPE="text/xml" CHECKSUM="b42d2a6cae7218e98755379f896bbe6e3bf8d078" CHECKSUMTYPE="SHA-1" SIZE="10177">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T17:13:43" MIMETYPE="text/xml"
-				CHECKSUM="6e29548a246d75197e5c176e4fd4cfddba39edc2" CHECKSUMTYPE="SHA-1" SIZE="41053">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T17:13:43" MIMETYPE="text/xml" CHECKSUM="6e29548a246d75197e5c176e4fd4cfddba39edc2" CHECKSUMTYPE="SHA-1" SIZE="41053">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T17:13:43" MIMETYPE="text/xml"
-				CHECKSUM="12f9c782b8a83551610e55d99697eeb10f745948" CHECKSUMTYPE="SHA-1" SIZE="3629">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T17:13:43" MIMETYPE="text/xml" CHECKSUM="12f9c782b8a83551610e55d99697eeb10f745948" CHECKSUMTYPE="SHA-1" SIZE="3629">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T17:13:43" MIMETYPE="text/xml"
-				CHECKSUM="14c1bc181da40a6121ba6a4afa6b463b4b29b362" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T17:13:43" MIMETYPE="text/xml" CHECKSUM="14c1bc181da40a6121ba6a4afa6b463b4b29b362" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T17:13:44" MIMETYPE="text/xml"
-				CHECKSUM="c860385fbb6e553957f5f7f2704c1480728588ab" CHECKSUMTYPE="SHA-1" SIZE="65235">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T17:13:44" MIMETYPE="text/xml" CHECKSUM="c860385fbb6e553957f5f7f2704c1480728588ab" CHECKSUMTYPE="SHA-1" SIZE="65235">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T17:13:44" MIMETYPE="text/xml"
-				CHECKSUM="19b9d781ecc3a25b4195f369621de3cfa9347e2e" CHECKSUMTYPE="SHA-1" SIZE="85765">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T17:13:44" MIMETYPE="text/xml" CHECKSUM="19b9d781ecc3a25b4195f369621de3cfa9347e2e" CHECKSUMTYPE="SHA-1" SIZE="85765">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T17:13:44" MIMETYPE="text/xml"
-				CHECKSUM="c0812e44ea5653a6c924fa57c5ce6414c3c47cd2" CHECKSUMTYPE="SHA-1" SIZE="84820">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T17:13:44" MIMETYPE="text/xml" CHECKSUM="c0812e44ea5653a6c924fa57c5ce6414c3c47cd2" CHECKSUMTYPE="SHA-1" SIZE="84820">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T17:13:45" MIMETYPE="text/xml"
-				CHECKSUM="825aa6f6a7a93c44bec6575fdb04a40f8bff255f" CHECKSUMTYPE="SHA-1" SIZE="74798">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T17:13:45" MIMETYPE="text/xml" CHECKSUM="825aa6f6a7a93c44bec6575fdb04a40f8bff255f" CHECKSUMTYPE="SHA-1" SIZE="74798">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T17:13:45" MIMETYPE="text/xml"
-				CHECKSUM="dbd50ad80c6aaa1294e4f9ccf78a08d71db984ff" CHECKSUMTYPE="SHA-1" SIZE="4588">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T17:13:45" MIMETYPE="text/xml" CHECKSUM="dbd50ad80c6aaa1294e4f9ccf78a08d71db984ff" CHECKSUMTYPE="SHA-1" SIZE="4588">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T17:13:45" MIMETYPE="text/xml"
-				CHECKSUM="663fad26b46095e1316eaceb3b97e6149c7c4d16" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T17:13:45" MIMETYPE="text/xml" CHECKSUM="663fad26b46095e1316eaceb3b97e6149c7c4d16" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T17:13:45" MIMETYPE="text/xml"
-				CHECKSUM="d3000bbd129afddf878edc2f33e0ecc1446630e7" CHECKSUMTYPE="SHA-1" SIZE="87226">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T17:13:45" MIMETYPE="text/xml" CHECKSUM="d3000bbd129afddf878edc2f33e0ecc1446630e7" CHECKSUMTYPE="SHA-1" SIZE="87226">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T17:13:46" MIMETYPE="text/xml"
-				CHECKSUM="71165bb7df683e67d8fab8e9712a8b18229be5cf" CHECKSUMTYPE="SHA-1" SIZE="87965">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T17:13:46" MIMETYPE="text/xml" CHECKSUM="71165bb7df683e67d8fab8e9712a8b18229be5cf" CHECKSUMTYPE="SHA-1" SIZE="87965">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T17:13:46" MIMETYPE="text/xml"
-				CHECKSUM="215f39b02ec71b953e8aab23c44a4b23e2954fbe" CHECKSUMTYPE="SHA-1" SIZE="90714">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T17:13:46" MIMETYPE="text/xml" CHECKSUM="215f39b02ec71b953e8aab23c44a4b23e2954fbe" CHECKSUMTYPE="SHA-1" SIZE="90714">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T17:13:46" MIMETYPE="text/xml"
-				CHECKSUM="919dba2485f8358b616f6c14b38a1c738d4130e6" CHECKSUMTYPE="SHA-1" SIZE="74768">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T17:13:46" MIMETYPE="text/xml" CHECKSUM="919dba2485f8358b616f6c14b38a1c738d4130e6" CHECKSUMTYPE="SHA-1" SIZE="74768">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T17:13:47" MIMETYPE="text/xml"
-				CHECKSUM="1acdff53a538d3bea8ea741594aec6b5390e4b87" CHECKSUMTYPE="SHA-1" SIZE="76830">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T17:13:47" MIMETYPE="text/xml" CHECKSUM="1acdff53a538d3bea8ea741594aec6b5390e4b87" CHECKSUMTYPE="SHA-1" SIZE="76830">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T17:13:47" MIMETYPE="text/xml"
-				CHECKSUM="a6b1e521c3004a018a6f444bb427c37b608d5d7c" CHECKSUMTYPE="SHA-1" SIZE="14276">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T17:13:47" MIMETYPE="text/xml" CHECKSUM="a6b1e521c3004a018a6f444bb427c37b608d5d7c" CHECKSUMTYPE="SHA-1" SIZE="14276">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T17:13:47" MIMETYPE="text/xml"
-				CHECKSUM="90327f6be8a4b8a0132e38587aa04004def78f6d" CHECKSUMTYPE="SHA-1" SIZE="5085">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T17:13:47" MIMETYPE="text/xml" CHECKSUM="90327f6be8a4b8a0132e38587aa04004def78f6d" CHECKSUMTYPE="SHA-1" SIZE="5085">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T17:13:47" MIMETYPE="text/xml"
-				CHECKSUM="10411cee7f77ccd709672436f8f761f65d525fd3" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T17:13:47" MIMETYPE="text/xml" CHECKSUM="10411cee7f77ccd709672436f8f761f65d525fd3" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T17:13:49" MIMETYPE="text/xml"
-				CHECKSUM="651ec8dffb09aad2af3f3f1d995cb2757da3ae97" CHECKSUMTYPE="SHA-1" SIZE="120206">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T17:13:49" MIMETYPE="text/xml" CHECKSUM="651ec8dffb09aad2af3f3f1d995cb2757da3ae97" CHECKSUMTYPE="SHA-1" SIZE="120206">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T17:13:49" MIMETYPE="text/xml"
-				CHECKSUM="a1a1c18e2664dd18a9be3938926daba4a8627a86" CHECKSUMTYPE="SHA-1" SIZE="132119">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T17:13:49" MIMETYPE="text/xml" CHECKSUM="a1a1c18e2664dd18a9be3938926daba4a8627a86" CHECKSUMTYPE="SHA-1" SIZE="132119">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T17:13:50" MIMETYPE="text/xml"
-				CHECKSUM="38a1a7fd9ce7ed4f6fe52cc8e78d570af5fc4771" CHECKSUMTYPE="SHA-1" SIZE="147353">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T17:13:50" MIMETYPE="text/xml" CHECKSUM="38a1a7fd9ce7ed4f6fe52cc8e78d570af5fc4771" CHECKSUMTYPE="SHA-1" SIZE="147353">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T17:13:50" MIMETYPE="text/xml"
-				CHECKSUM="6b382d6ca819d679e763bd16f58f1bfaaaeeb210" CHECKSUMTYPE="SHA-1" SIZE="140023">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T17:13:50" MIMETYPE="text/xml" CHECKSUM="6b382d6ca819d679e763bd16f58f1bfaaaeeb210" CHECKSUMTYPE="SHA-1" SIZE="140023">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T17:13:50" MIMETYPE="text/xml"
-				CHECKSUM="a893d298aebd669cc1b17636824573f20550fe0f" CHECKSUMTYPE="SHA-1" SIZE="126792">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T17:13:50" MIMETYPE="text/xml" CHECKSUM="a893d298aebd669cc1b17636824573f20550fe0f" CHECKSUMTYPE="SHA-1" SIZE="126792">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T17:13:51" MIMETYPE="text/xml"
-				CHECKSUM="30ca21183c94db1d919987c9fdf140dbafefe9ef" CHECKSUMTYPE="SHA-1" SIZE="144599">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T17:13:51" MIMETYPE="text/xml" CHECKSUM="30ca21183c94db1d919987c9fdf140dbafefe9ef" CHECKSUMTYPE="SHA-1" SIZE="144599">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T17:13:51" MIMETYPE="text/xml"
-				CHECKSUM="2770f7a5802eeba4808af0816702f2849f0e3f20" CHECKSUMTYPE="SHA-1" SIZE="109397">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T17:13:51" MIMETYPE="text/xml" CHECKSUM="2770f7a5802eeba4808af0816702f2849f0e3f20" CHECKSUMTYPE="SHA-1" SIZE="109397">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T17:13:51" MIMETYPE="text/xml"
-				CHECKSUM="adb46874d20f8f02e12f92794dde6b948a749e9c" CHECKSUMTYPE="SHA-1" SIZE="74583">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T17:13:51" MIMETYPE="text/xml" CHECKSUM="adb46874d20f8f02e12f92794dde6b948a749e9c" CHECKSUMTYPE="SHA-1" SIZE="74583">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T17:13:52" MIMETYPE="text/xml"
-				CHECKSUM="e0d4170add60764abdb55026a842d9d1d98c1856" CHECKSUMTYPE="SHA-1" SIZE="4989">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T17:13:52" MIMETYPE="text/xml" CHECKSUM="e0d4170add60764abdb55026a842d9d1d98c1856" CHECKSUMTYPE="SHA-1" SIZE="4989">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T17:13:52" MIMETYPE="text/xml"
-				CHECKSUM="234102e755037299008efc60d8886a892317de0a" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T17:13:52" MIMETYPE="text/xml" CHECKSUM="234102e755037299008efc60d8886a892317de0a" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T17:13:52" MIMETYPE="text/xml"
-				CHECKSUM="92a33ac7f2baeadbe150041fea03ea47f3c450fc" CHECKSUMTYPE="SHA-1" SIZE="90181">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T17:13:52" MIMETYPE="text/xml" CHECKSUM="92a33ac7f2baeadbe150041fea03ea47f3c450fc" CHECKSUMTYPE="SHA-1" SIZE="90181">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T17:13:52" MIMETYPE="text/xml"
-				CHECKSUM="70158630cca77cd3b8f79868dc0d509e7c737d00" CHECKSUMTYPE="SHA-1" SIZE="140649">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T17:13:52" MIMETYPE="text/xml" CHECKSUM="70158630cca77cd3b8f79868dc0d509e7c737d00" CHECKSUMTYPE="SHA-1" SIZE="140649">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T17:13:53" MIMETYPE="text/xml"
-				CHECKSUM="90b27ca8ab39d1dda3db29e8de8292f8295d5980" CHECKSUMTYPE="SHA-1" SIZE="143712">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T17:13:53" MIMETYPE="text/xml" CHECKSUM="90b27ca8ab39d1dda3db29e8de8292f8295d5980" CHECKSUMTYPE="SHA-1" SIZE="143712">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T17:13:53" MIMETYPE="text/xml"
-				CHECKSUM="dcd3826f4c75576dced7c09c0d293b6de7740f8c" CHECKSUMTYPE="SHA-1" SIZE="123730">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T17:13:53" MIMETYPE="text/xml" CHECKSUM="dcd3826f4c75576dced7c09c0d293b6de7740f8c" CHECKSUMTYPE="SHA-1" SIZE="123730">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T17:13:53" MIMETYPE="text/xml"
-				CHECKSUM="56c629a91806776ed51a1933912f655251d4ede7" CHECKSUMTYPE="SHA-1" SIZE="5355">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T17:13:53" MIMETYPE="text/xml" CHECKSUM="56c629a91806776ed51a1933912f655251d4ede7" CHECKSUMTYPE="SHA-1" SIZE="5355">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T17:13:54" MIMETYPE="text/xml"
-				CHECKSUM="75ba37751d793e9048ce4d7a99e412734e32ef0b" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T17:13:54" MIMETYPE="text/xml" CHECKSUM="75ba37751d793e9048ce4d7a99e412734e32ef0b" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T17:13:54" MIMETYPE="text/xml"
-				CHECKSUM="cae1dbee000b84425e29ddcf0d25fc1c76902b84" CHECKSUMTYPE="SHA-1" SIZE="62346">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T17:13:54" MIMETYPE="text/xml" CHECKSUM="cae1dbee000b84425e29ddcf0d25fc1c76902b84" CHECKSUMTYPE="SHA-1" SIZE="62346">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T17:13:54" MIMETYPE="text/xml"
-				CHECKSUM="0074d6c6e36b28a5728cb4ca08a329065e69f251" CHECKSUMTYPE="SHA-1" SIZE="144383">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T17:13:54" MIMETYPE="text/xml" CHECKSUM="0074d6c6e36b28a5728cb4ca08a329065e69f251" CHECKSUMTYPE="SHA-1" SIZE="144383">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T17:13:55" MIMETYPE="text/xml"
-				CHECKSUM="ff95968d7c2007fd52bb27b787e75d09562bbd5a" CHECKSUMTYPE="SHA-1" SIZE="145525">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T17:13:55" MIMETYPE="text/xml" CHECKSUM="ff95968d7c2007fd52bb27b787e75d09562bbd5a" CHECKSUMTYPE="SHA-1" SIZE="145525">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T17:13:55" MIMETYPE="text/xml"
-				CHECKSUM="a976c88d7dce1ec068ba08f715291bf4d931aec9" CHECKSUMTYPE="SHA-1" SIZE="76559">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T17:13:55" MIMETYPE="text/xml" CHECKSUM="a976c88d7dce1ec068ba08f715291bf4d931aec9" CHECKSUMTYPE="SHA-1" SIZE="76559">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T17:13:55" MIMETYPE="text/xml"
-				CHECKSUM="f4bf0347c83d3af3c4b55289b688055401c0f0ae" CHECKSUMTYPE="SHA-1" SIZE="77109">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T17:13:55" MIMETYPE="text/xml" CHECKSUM="f4bf0347c83d3af3c4b55289b688055401c0f0ae" CHECKSUMTYPE="SHA-1" SIZE="77109">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T17:13:56" MIMETYPE="text/xml"
-				CHECKSUM="52d3feb7e3d53591e34f8802b9bcbf15a8c5f2eb" CHECKSUMTYPE="SHA-1" SIZE="142176">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T17:13:56" MIMETYPE="text/xml" CHECKSUM="52d3feb7e3d53591e34f8802b9bcbf15a8c5f2eb" CHECKSUMTYPE="SHA-1" SIZE="142176">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T17:13:56" MIMETYPE="text/xml"
-				CHECKSUM="1088f7bf19126474948147eb73a586814691df4a" CHECKSUMTYPE="SHA-1" SIZE="4893">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T17:13:56" MIMETYPE="text/xml" CHECKSUM="1088f7bf19126474948147eb73a586814691df4a" CHECKSUMTYPE="SHA-1" SIZE="4893">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T17:13:56" MIMETYPE="text/xml"
-				CHECKSUM="a80a7eacc5af622314044d07943804e2fdddcf61" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T17:13:56" MIMETYPE="text/xml" CHECKSUM="a80a7eacc5af622314044d07943804e2fdddcf61" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T17:13:56" MIMETYPE="text/xml"
-				CHECKSUM="ccea8bfc126131883fda1a3e6e7b2461ee542e44" CHECKSUMTYPE="SHA-1" SIZE="144734">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T17:13:56" MIMETYPE="text/xml" CHECKSUM="ccea8bfc126131883fda1a3e6e7b2461ee542e44" CHECKSUMTYPE="SHA-1" SIZE="144734">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T17:13:57" MIMETYPE="text/xml"
-				CHECKSUM="e0cb906a7efbe6dfa2371a08e57f5cd37d7aabb4" CHECKSUMTYPE="SHA-1" SIZE="78448">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T17:13:57" MIMETYPE="text/xml" CHECKSUM="e0cb906a7efbe6dfa2371a08e57f5cd37d7aabb4" CHECKSUMTYPE="SHA-1" SIZE="78448">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T17:13:57" MIMETYPE="text/xml"
-				CHECKSUM="8edbeaccd9f421d165109ec070768a01744c0abf" CHECKSUMTYPE="SHA-1" SIZE="70148">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T17:13:57" MIMETYPE="text/xml" CHECKSUM="8edbeaccd9f421d165109ec070768a01744c0abf" CHECKSUMTYPE="SHA-1" SIZE="70148">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T17:13:57" MIMETYPE="text/xml"
-				CHECKSUM="92863cb8bddfe90c6af2aa54a9866064b326e5e1" CHECKSUMTYPE="SHA-1" SIZE="154657">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T17:13:57" MIMETYPE="text/xml" CHECKSUM="92863cb8bddfe90c6af2aa54a9866064b326e5e1" CHECKSUMTYPE="SHA-1" SIZE="154657">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T17:13:58" MIMETYPE="text/xml"
-				CHECKSUM="0f4be489dac40c1c9d7b4db22f9bb3cefa677d70" CHECKSUMTYPE="SHA-1" SIZE="145584">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T17:13:58" MIMETYPE="text/xml" CHECKSUM="0f4be489dac40c1c9d7b4db22f9bb3cefa677d70" CHECKSUMTYPE="SHA-1" SIZE="145584">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T17:13:58" MIMETYPE="text/xml"
-				CHECKSUM="ed640c0b883aa7c0d5d33e24525b574486e65321" CHECKSUMTYPE="SHA-1" SIZE="97780">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T17:13:58" MIMETYPE="text/xml" CHECKSUM="ed640c0b883aa7c0d5d33e24525b574486e65321" CHECKSUMTYPE="SHA-1" SIZE="97780">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T17:13:58" MIMETYPE="text/xml"
-				CHECKSUM="69f345c15cb843f5aa23436140861b98de59b5ed" CHECKSUMTYPE="SHA-1" SIZE="104897">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T17:13:58" MIMETYPE="text/xml" CHECKSUM="69f345c15cb843f5aa23436140861b98de59b5ed" CHECKSUMTYPE="SHA-1" SIZE="104897">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T17:13:58" MIMETYPE="text/xml"
-				CHECKSUM="ece43c125412c43c1fd2f7c93ac70e19f600c3ae" CHECKSUMTYPE="SHA-1" SIZE="146692">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T17:13:58" MIMETYPE="text/xml" CHECKSUM="ece43c125412c43c1fd2f7c93ac70e19f600c3ae" CHECKSUMTYPE="SHA-1" SIZE="146692">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T17:13:59" MIMETYPE="text/xml"
-				CHECKSUM="82feaa8bb4c201f8b4a80ae3d9d38748d3f5a128" CHECKSUMTYPE="SHA-1" SIZE="152151">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T17:13:59" MIMETYPE="text/xml" CHECKSUM="82feaa8bb4c201f8b4a80ae3d9d38748d3f5a128" CHECKSUMTYPE="SHA-1" SIZE="152151">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T17:13:59" MIMETYPE="text/xml"
-				CHECKSUM="85909f13b58345656c958ff5d055b1b1a7fee1aa" CHECKSUMTYPE="SHA-1" SIZE="55881">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T17:13:59" MIMETYPE="text/xml" CHECKSUM="85909f13b58345656c958ff5d055b1b1a7fee1aa" CHECKSUMTYPE="SHA-1" SIZE="55881">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T17:13:59" MIMETYPE="text/xml"
-				CHECKSUM="4a210adaf974931be6bf09e7663d495a3a22a0f0" CHECKSUMTYPE="SHA-1" SIZE="4854">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T17:13:59" MIMETYPE="text/xml" CHECKSUM="4a210adaf974931be6bf09e7663d495a3a22a0f0" CHECKSUMTYPE="SHA-1" SIZE="4854">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T17:14:00" MIMETYPE="text/xml"
-				CHECKSUM="0ed1e0b29020a5b1f8c33bc252becb77c8f59914" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T17:14:00" MIMETYPE="text/xml" CHECKSUM="0ed1e0b29020a5b1f8c33bc252becb77c8f59914" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T17:14:00" MIMETYPE="text/xml"
-				CHECKSUM="a8297ae0cce059d022e67ed9938ca37ee8ebbcf1" CHECKSUMTYPE="SHA-1" SIZE="70970">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T17:14:00" MIMETYPE="text/xml" CHECKSUM="a8297ae0cce059d022e67ed9938ca37ee8ebbcf1" CHECKSUMTYPE="SHA-1" SIZE="70970">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T17:14:00" MIMETYPE="text/xml"
-				CHECKSUM="2824987a302e6b6be44d66c503b8c428eb1c4679" CHECKSUMTYPE="SHA-1" SIZE="153287">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T17:14:00" MIMETYPE="text/xml" CHECKSUM="2824987a302e6b6be44d66c503b8c428eb1c4679" CHECKSUMTYPE="SHA-1" SIZE="153287">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T17:14:02" MIMETYPE="text/xml"
-				CHECKSUM="fd451e1f28c26c51731a3abdbd7d3cfef942d82f" CHECKSUMTYPE="SHA-1" SIZE="95830">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T17:14:02" MIMETYPE="text/xml" CHECKSUM="fd451e1f28c26c51731a3abdbd7d3cfef942d82f" CHECKSUMTYPE="SHA-1" SIZE="95830">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T17:14:03" MIMETYPE="text/xml"
-				CHECKSUM="4ea288ea89d817fd0a7c2bb8040db103feaa052f" CHECKSUMTYPE="SHA-1" SIZE="118164">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T17:14:03" MIMETYPE="text/xml" CHECKSUM="4ea288ea89d817fd0a7c2bb8040db103feaa052f" CHECKSUMTYPE="SHA-1" SIZE="118164">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T17:14:03" MIMETYPE="text/xml"
-				CHECKSUM="78696776626ee7d992aa3dfa97f6df8baa5b43d7" CHECKSUMTYPE="SHA-1" SIZE="5248">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T17:14:03" MIMETYPE="text/xml" CHECKSUM="78696776626ee7d992aa3dfa97f6df8baa5b43d7" CHECKSUMTYPE="SHA-1" SIZE="5248">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T17:14:03" MIMETYPE="text/xml"
-				CHECKSUM="1c4beee1f75d70ea44e1edfb3cae63f406bc9ac2" CHECKSUMTYPE="SHA-1" SIZE="2020">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T17:14:03" MIMETYPE="text/xml" CHECKSUM="1c4beee1f75d70ea44e1edfb3cae63f406bc9ac2" CHECKSUMTYPE="SHA-1" SIZE="2020">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T17:14:04" MIMETYPE="text/xml"
-				CHECKSUM="ffaf38e62a01d5233add02374402338b5f0510e7" CHECKSUMTYPE="SHA-1" SIZE="103646">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T17:14:04" MIMETYPE="text/xml" CHECKSUM="ffaf38e62a01d5233add02374402338b5f0510e7" CHECKSUMTYPE="SHA-1" SIZE="103646">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T17:14:04" MIMETYPE="text/xml"
-				CHECKSUM="04b94033fc01c19eab0f2ec7905e817fd6707808" CHECKSUMTYPE="SHA-1" SIZE="144702">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T17:14:04" MIMETYPE="text/xml" CHECKSUM="04b94033fc01c19eab0f2ec7905e817fd6707808" CHECKSUMTYPE="SHA-1" SIZE="144702">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T17:14:04" MIMETYPE="text/xml"
-				CHECKSUM="10e30cf98f2d8ccd62b81a9dd5266a2ecab2c6dd" CHECKSUMTYPE="SHA-1" SIZE="146504">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T17:14:04" MIMETYPE="text/xml" CHECKSUM="10e30cf98f2d8ccd62b81a9dd5266a2ecab2c6dd" CHECKSUMTYPE="SHA-1" SIZE="146504">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T17:14:05" MIMETYPE="text/xml"
-				CHECKSUM="dce1f91a585e4d780a436832d2d4b9a90409c449" CHECKSUMTYPE="SHA-1" SIZE="133715">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T17:14:05" MIMETYPE="text/xml" CHECKSUM="dce1f91a585e4d780a436832d2d4b9a90409c449" CHECKSUMTYPE="SHA-1" SIZE="133715">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T17:14:05" MIMETYPE="text/xml"
-				CHECKSUM="a1e634314c660c6c22ad752af590aec8e7c2b4c6" CHECKSUMTYPE="SHA-1" SIZE="3898">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T17:14:05" MIMETYPE="text/xml" CHECKSUM="a1e634314c660c6c22ad752af590aec8e7c2b4c6" CHECKSUMTYPE="SHA-1" SIZE="3898">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T17:14:05" MIMETYPE="text/xml"
-				CHECKSUM="6e92a6a7143480fdffef2877b4fc802392ad8ce1" CHECKSUMTYPE="SHA-1" SIZE="2017">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T17:14:05" MIMETYPE="text/xml" CHECKSUM="6e92a6a7143480fdffef2877b4fc802392ad8ce1" CHECKSUMTYPE="SHA-1" SIZE="2017">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T17:14:06" MIMETYPE="text/xml"
-				CHECKSUM="e0c4387b32f23b4151c558d10d52d4b352dc9549" CHECKSUMTYPE="SHA-1" SIZE="109052">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T17:14:06" MIMETYPE="text/xml" CHECKSUM="e0c4387b32f23b4151c558d10d52d4b352dc9549" CHECKSUMTYPE="SHA-1" SIZE="109052">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T17:14:06" MIMETYPE="text/xml"
-				CHECKSUM="4e67248592a3450f11f1a1063041d665a8866009" CHECKSUMTYPE="SHA-1" SIZE="197037">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T17:14:06" MIMETYPE="text/xml" CHECKSUM="4e67248592a3450f11f1a1063041d665a8866009" CHECKSUMTYPE="SHA-1" SIZE="197037">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T17:14:06" MIMETYPE="text/xml"
-				CHECKSUM="341cc12e0322e25e592c18739c442493798f988f" CHECKSUMTYPE="SHA-1" SIZE="4929">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T17:14:06" MIMETYPE="text/xml" CHECKSUM="341cc12e0322e25e592c18739c442493798f988f" CHECKSUMTYPE="SHA-1" SIZE="4929">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T17:14:06" MIMETYPE="text/xml"
-				CHECKSUM="521e06de1e7c20d0de9597179c354a5e42aea1b2" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T17:14:06" MIMETYPE="text/xml" CHECKSUM="521e06de1e7c20d0de9597179c354a5e42aea1b2" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T17:14:07" MIMETYPE="text/xml"
-				CHECKSUM="8d786672f2c4de3fb91e94c5efb512e1fc691a4f" CHECKSUMTYPE="SHA-1" SIZE="177219">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T17:14:07" MIMETYPE="text/xml" CHECKSUM="8d786672f2c4de3fb91e94c5efb512e1fc691a4f" CHECKSUMTYPE="SHA-1" SIZE="177219">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T17:14:07" MIMETYPE="text/xml"
-				CHECKSUM="f02d32c60e9ffd2ac787ad170af38dc4c2f3be91" CHECKSUMTYPE="SHA-1" SIZE="41428">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T17:14:07" MIMETYPE="text/xml" CHECKSUM="f02d32c60e9ffd2ac787ad170af38dc4c2f3be91" CHECKSUMTYPE="SHA-1" SIZE="41428">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0094.alto.xml"/>
 			</file>
-			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T17:14:08" MIMETYPE="text/xml"
-				CHECKSUM="38910fb9ff84919f229cf894ee714cbdb18b8d77" CHECKSUMTYPE="SHA-1" SIZE="86111">
+			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T17:14:08" MIMETYPE="text/xml" CHECKSUM="38910fb9ff84919f229cf894ee714cbdb18b8d77" CHECKSUMTYPE="SHA-1" SIZE="86111">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0095.alto.xml"/>
 			</file>
-			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T17:14:08" MIMETYPE="text/xml"
-				CHECKSUM="3e501e8c38c672e6af105cedfb893ca83ef265f3" CHECKSUMTYPE="SHA-1" SIZE="121165">
+			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T17:14:08" MIMETYPE="text/xml" CHECKSUM="3e501e8c38c672e6af105cedfb893ca83ef265f3" CHECKSUMTYPE="SHA-1" SIZE="121165">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0096.alto.xml"/>
 			</file>
-			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T17:14:08" MIMETYPE="text/xml"
-				CHECKSUM="22fcef17065bf73d7405d62507855a77b8856dc4" CHECKSUMTYPE="SHA-1" SIZE="112711">
+			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T17:14:08" MIMETYPE="text/xml" CHECKSUM="22fcef17065bf73d7405d62507855a77b8856dc4" CHECKSUMTYPE="SHA-1" SIZE="112711">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0097.alto.xml"/>
 			</file>
-			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T17:14:09" MIMETYPE="text/xml"
-				CHECKSUM="907743f30759e7830fc795f6c0a48af7697657d8" CHECKSUMTYPE="SHA-1" SIZE="57674">
+			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T17:14:09" MIMETYPE="text/xml" CHECKSUM="907743f30759e7830fc795f6c0a48af7697657d8" CHECKSUMTYPE="SHA-1" SIZE="57674">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0098.alto.xml"/>
 			</file>
-			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T17:14:09" MIMETYPE="text/xml"
-				CHECKSUM="ff48262ffc4c718ed3dd822e4f7f9da903249b4c" CHECKSUMTYPE="SHA-1" SIZE="4695">
+			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T17:14:09" MIMETYPE="text/xml" CHECKSUM="ff48262ffc4c718ed3dd822e4f7f9da903249b4c" CHECKSUMTYPE="SHA-1" SIZE="4695">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0099.alto.xml"/>
 			</file>
-			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T17:14:09" MIMETYPE="text/xml"
-				CHECKSUM="426ad9533684335361738afac8171a59070cedc2" CHECKSUMTYPE="SHA-1" SIZE="2022">
+			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T17:14:09" MIMETYPE="text/xml" CHECKSUM="426ad9533684335361738afac8171a59070cedc2" CHECKSUMTYPE="SHA-1" SIZE="2022">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0100.alto.xml"/>
 			</file>
-			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T17:14:10" MIMETYPE="text/xml"
-				CHECKSUM="e2992f8f7f520cea3972d11ef67b8ac1bbc96dc4" CHECKSUMTYPE="SHA-1" SIZE="206639">
+			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T17:14:10" MIMETYPE="text/xml" CHECKSUM="e2992f8f7f520cea3972d11ef67b8ac1bbc96dc4" CHECKSUMTYPE="SHA-1" SIZE="206639">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0101.alto.xml"/>
 			</file>
-			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T17:14:10" MIMETYPE="text/xml"
-				CHECKSUM="75dd6761d870f7939679c5c1acb659f432048274" CHECKSUMTYPE="SHA-1" SIZE="199781">
+			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T17:14:10" MIMETYPE="text/xml" CHECKSUM="75dd6761d870f7939679c5c1acb659f432048274" CHECKSUMTYPE="SHA-1" SIZE="199781">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0102.alto.xml"/>
 			</file>
-			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T17:14:10" MIMETYPE="text/xml"
-				CHECKSUM="010c7820b7934e1a0bd675e6126bf6321bced23b" CHECKSUMTYPE="SHA-1" SIZE="5665">
+			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T17:14:10" MIMETYPE="text/xml" CHECKSUM="010c7820b7934e1a0bd675e6126bf6321bced23b" CHECKSUMTYPE="SHA-1" SIZE="5665">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0103.alto.xml"/>
 			</file>
-			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T17:14:10" MIMETYPE="text/xml"
-				CHECKSUM="02cbd1488e69311374942da9e44f3480e9db6ae0" CHECKSUMTYPE="SHA-1" SIZE="2012">
+			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T17:14:10" MIMETYPE="text/xml" CHECKSUM="02cbd1488e69311374942da9e44f3480e9db6ae0" CHECKSUMTYPE="SHA-1" SIZE="2012">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0104.alto.xml"/>
 			</file>
-			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T17:14:11" MIMETYPE="text/xml"
-				CHECKSUM="38bfbf18980c535ce7c85c4e06e6a317394758ad" CHECKSUMTYPE="SHA-1" SIZE="87739">
+			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T17:14:11" MIMETYPE="text/xml" CHECKSUM="38bfbf18980c535ce7c85c4e06e6a317394758ad" CHECKSUMTYPE="SHA-1" SIZE="87739">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0105.alto.xml"/>
 			</file>
-			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T17:14:11" MIMETYPE="text/xml"
-				CHECKSUM="d6fab45c1011e019c7e6a40296d96786b15a7a8e" CHECKSUMTYPE="SHA-1" SIZE="167999">
+			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T17:14:11" MIMETYPE="text/xml" CHECKSUM="d6fab45c1011e019c7e6a40296d96786b15a7a8e" CHECKSUMTYPE="SHA-1" SIZE="167999">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0106.alto.xml"/>
 			</file>
-			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T17:14:11" MIMETYPE="text/xml"
-				CHECKSUM="2aa233573ebee04a5f63f3302f4f09c48f61039e" CHECKSUMTYPE="SHA-1" SIZE="146905">
+			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T17:14:11" MIMETYPE="text/xml" CHECKSUM="2aa233573ebee04a5f63f3302f4f09c48f61039e" CHECKSUMTYPE="SHA-1" SIZE="146905">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0107.alto.xml"/>
 			</file>
-			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T17:14:12" MIMETYPE="text/xml"
-				CHECKSUM="5c1521f62ef3bb9571bbf9d6b5cc550c19d9d601" CHECKSUMTYPE="SHA-1" SIZE="38408">
+			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T17:14:12" MIMETYPE="text/xml" CHECKSUM="5c1521f62ef3bb9571bbf9d6b5cc550c19d9d601" CHECKSUMTYPE="SHA-1" SIZE="38408">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0108.alto.xml"/>
 			</file>
-			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T17:14:12" MIMETYPE="text/xml"
-				CHECKSUM="27c21103e77cb570614a7f6ba20132c3081b8f7c" CHECKSUMTYPE="SHA-1" SIZE="2021">
+			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T17:14:12" MIMETYPE="text/xml" CHECKSUM="27c21103e77cb570614a7f6ba20132c3081b8f7c" CHECKSUMTYPE="SHA-1" SIZE="2021">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0109.alto.xml"/>
 			</file>
-			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T17:14:12" MIMETYPE="text/xml"
-				CHECKSUM="b7134fc34884ad0bdf6349981be19b698f158db8" CHECKSUMTYPE="SHA-1" SIZE="3921">
+			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T17:14:12" MIMETYPE="text/xml" CHECKSUM="b7134fc34884ad0bdf6349981be19b698f158db8" CHECKSUMTYPE="SHA-1" SIZE="3921">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-09_01_0110.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T17:17:55" MIMETYPE="application/pdf" CHECKSUM="bf18307acd0f6c56e5a6d6fa3d96bceb3e61aa4f"
-				CHECKSUMTYPE="SHA-1" SIZE="59838763">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/bmtnabe_1895-09_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T17:17:55" MIMETYPE="application/pdf" CHECKSUM="bf18307acd0f6c56e5a6d6fa3d96bceb3e61aa4f" CHECKSUMTYPE="SHA-1" SIZE="59838763">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/09_01/bmtnabe_1895-09_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>

--- a/metadata/periodicals/bmtnabe/issues/1895/11_01/bmtnabe_1895-11_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1895/11_01/bmtnabe_1895-11_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1895-11_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1895-11_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-11_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-11_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1895-11_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1895-11_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,7 +46,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1895-11_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -7340,770 +7336,516 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-11-11T15:47:19" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="01977a814dd4b6681fb2de2ab63652591d78a488" CHECKSUMTYPE="SHA-1" SIZE="5267709">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-11-11T15:47:53" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="af68cde65f4993e53f618265424fbc61e80d2946" CHECKSUMTYPE="SHA-1" SIZE="5387468">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-11-11T15:48:26" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="a59fc00e583cd4b98fac42e9a68a78fb8fad2422" CHECKSUMTYPE="SHA-1" SIZE="5146325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-11-11T15:48:58" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="bb08eda029bd5217465a796ba076610d002ecc54" CHECKSUMTYPE="SHA-1" SIZE="5371876">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-11-11T15:49:28" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="fc6ebf1e4dc8a6538ddda5b654c022588daeea91" CHECKSUMTYPE="SHA-1" SIZE="5193129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-11-11T15:49:57" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="90ab31cc677f4cabe03e79275251588ff28bdd77" CHECKSUMTYPE="SHA-1" SIZE="5400129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-11-11T15:50:27" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="3dcab4e8664c7c47be8ac9a1b91d118828fd7709" CHECKSUMTYPE="SHA-1" SIZE="5252527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-11-11T15:50:56" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="7ee0d44fc71ad73f4b0c8f9349041c48ee43f793" CHECKSUMTYPE="SHA-1" SIZE="5378524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-11-11T15:51:26" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="ad11cafe820a25b557dd601f93d2f07e1097b784" CHECKSUMTYPE="SHA-1" SIZE="5247128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-11-11T15:51:58" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="a7207557be778f7cfe6d4113457d565c2b2b280f" CHECKSUMTYPE="SHA-1" SIZE="5372227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-11-11T15:52:27" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="a80cfe351b0e1104bbdbf2ec8f6a13b7d5fd3717" CHECKSUMTYPE="SHA-1" SIZE="5146312">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-11-11T15:52:58" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="24cb99959e66630aec547601890c1967ec2d5cae" CHECKSUMTYPE="SHA-1" SIZE="5372226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-11-11T15:53:30" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="59abb158be345dc1f453ba726dcd544147f505a0" CHECKSUMTYPE="SHA-1" SIZE="5239029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-11-11T15:53:59" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="6010e11eafe1f2ffb8abbcd8ca57de8749593798" CHECKSUMTYPE="SHA-1" SIZE="5443317">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-11-11T15:54:28" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="d08aa2e95039900e148e64fa31747b4749af9839" CHECKSUMTYPE="SHA-1" SIZE="5155326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-11-11T15:54:57" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="7be51db3b1ada03436cdbabd329896fe97c2cd74" CHECKSUMTYPE="SHA-1" SIZE="5372207">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-11-11T15:55:27" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="357b745153d16c5c0e5ac94bda58295d456bf109" CHECKSUMTYPE="SHA-1" SIZE="5199427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-11-11T15:55:57" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="568d8fb6661b6baf5aac5c7377c46836209e0968" CHECKSUMTYPE="SHA-1" SIZE="5400128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-11-11T15:56:25" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="e83b7d841541f33092f74cc05bdd2ab3cc55e93e" CHECKSUMTYPE="SHA-1" SIZE="5182324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-11-11T15:56:54" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="6448b4982d98538e4b66fd562f03f06071b2baa4" CHECKSUMTYPE="SHA-1" SIZE="5372228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-11-11T15:57:23" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="ecb9aa0d1b43267d2e57f3c9864ec62116013283" CHECKSUMTYPE="SHA-1" SIZE="5209322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-11-11T15:57:52" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="412f77332f2f6c22f1f1da49f429319daa8df772" CHECKSUMTYPE="SHA-1" SIZE="5372223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-11-11T15:58:23" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="c3d79126f3513b24a3ebf099cb8245297e34e1d4" CHECKSUMTYPE="SHA-1" SIZE="5193125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-11-11T15:58:53" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="a49af0308e3df453361fe2fde50ab2ce2443abc2" CHECKSUMTYPE="SHA-1" SIZE="5372219">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-11-11T15:59:21" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="dd994ba63df333f0762633ea470076a3b984476c" CHECKSUMTYPE="SHA-1" SIZE="5201229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-11-11T15:59:52" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="d3ec7a1ad5bb686a4466e2dba9b4ba070dc77033" CHECKSUMTYPE="SHA-1" SIZE="5372229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-11-11T16:00:21" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="68c19cb04ac748e6a6b6e0320cc98cb6478d5251" CHECKSUMTYPE="SHA-1" SIZE="5257029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-11-11T16:00:51" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="aee44fe1065bb340ab0abd98eb15dac1481c5507" CHECKSUMTYPE="SHA-1" SIZE="5428929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-11-11T16:01:21" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="784b95656049982d0bc8f3fd771452dd51727ab4" CHECKSUMTYPE="SHA-1" SIZE="5218322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-11-11T16:01:51" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="4ff066433ed5732f27ed2c2cc0ed8421bd09fec7" CHECKSUMTYPE="SHA-1" SIZE="5438826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-11-11T16:02:22" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="f3bbf15dd0559e235e3eeda53e76e4702dd509e0" CHECKSUMTYPE="SHA-1" SIZE="5176028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-11-11T16:02:53" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="43ebed36ff435edbac00fca0dc82ab06444cb14c" CHECKSUMTYPE="SHA-1" SIZE="5407329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-11-11T16:03:22" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="04c417df726a2172340eab88a3a204294c52c8ff" CHECKSUMTYPE="SHA-1" SIZE="5160668">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-11-11T16:03:53" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="8c7690d445f70ec40ec9cecb30ee2763ff54354c" CHECKSUMTYPE="SHA-1" SIZE="5453229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-11-11T16:04:23" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="24febf0283c20e982fcab4cf8aa1291cf094289f" CHECKSUMTYPE="SHA-1" SIZE="5229127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-11-11T16:04:54" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="db35de6335691e34a39cc2bb6a3e014e5c6d91dd" CHECKSUMTYPE="SHA-1" SIZE="5460428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-11-11T16:05:24" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="0332a2f8ce71e8d081fdbc2c9b23406a8d234032" CHECKSUMTYPE="SHA-1" SIZE="5165229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-11-11T16:05:54" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="251bb1d586052639305151c9caf2182796c91cb8" CHECKSUMTYPE="SHA-1" SIZE="5412716">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-11-11T16:06:23" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="f2470cc182a77489d5d1d655312c0173a095a549" CHECKSUMTYPE="SHA-1" SIZE="5211129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-11-11T16:06:53" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="b33e771e4305cdd9884ee5e2ab8ca51a9052dfe7" CHECKSUMTYPE="SHA-1" SIZE="5372229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-11-11T16:07:22" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="4dd880cbb843de871af7e824d778b97f89b48307" CHECKSUMTYPE="SHA-1" SIZE="5230025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-11-11T16:07:53" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="796df7fa8bcd35781e3e0f3e3316a2abe885174d" CHECKSUMTYPE="SHA-1" SIZE="5372227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-11-11T16:08:22" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="4a44fc39bd05de8f6a3d9cf499b22c603ecce5fd" CHECKSUMTYPE="SHA-1" SIZE="5420824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-11-11T16:08:50" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="9eafd71803ee7c280d08e37f48c5e4f2276d9cae" CHECKSUMTYPE="SHA-1" SIZE="5230917">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-11-11T16:09:18" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="cb43f7fd2596d1cf1dd717e7f7dc3043ed9087be" CHECKSUMTYPE="SHA-1" SIZE="5372228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-11-11T16:09:47" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="6c0f513edcc04c380c7e196907fa2279651071b3" CHECKSUMTYPE="SHA-1" SIZE="5217187">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-11-11T16:10:18" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="9211a73343bc6c815581fb89aee9dd2424a40682" CHECKSUMTYPE="SHA-1" SIZE="5372221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-11-11T16:10:47" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="4d6e007a3db66bdcd5bf41be755ea96f87100b65" CHECKSUMTYPE="SHA-1" SIZE="5116629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-11-11T16:11:13" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="efca8404a2788e3e4325386794e0655dce2c7494" CHECKSUMTYPE="SHA-1" SIZE="5256979">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-11-11T16:11:43" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="e302f9755a8db4ebeedae8e65164df742de3bfc4" CHECKSUMTYPE="SHA-1" SIZE="5372209">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-11-11T16:12:10" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="fcb71e63f101051d45926f82898bf1a78154fd66" CHECKSUMTYPE="SHA-1" SIZE="5174053">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-11-11T16:12:38" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="66931d02f18da41357782a61a3c69a0d78a58c95" CHECKSUMTYPE="SHA-1" SIZE="5425329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-11-11T16:13:07" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="b5486979c6aed62bd3b911930dd9f52cfb8021aa" CHECKSUMTYPE="SHA-1" SIZE="5438829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-11-11T16:13:34" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="3a23a3e3b810f75907865a236c0893673e31c7d5" CHECKSUMTYPE="SHA-1" SIZE="5131909">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-11-11T16:14:03" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="f116a8eecbc473fb44674ca046dc1d76e77dfe74" CHECKSUMTYPE="SHA-1" SIZE="5425315">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-11-11T16:14:33" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="403217afa1dd09732ebec12915b7e4309c94b216" CHECKSUMTYPE="SHA-1" SIZE="5219226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-11-11T16:15:01" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="165fa543fd28d125b814c8bf02676dd13d0f2679" CHECKSUMTYPE="SHA-1" SIZE="5404615">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-11-11T16:15:28" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="6fce456774c424e52f18767acac326b2ce37ad3a" CHECKSUMTYPE="SHA-1" SIZE="5149011">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-11-11T16:15:59" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="9f6e7e74836cecfa5a0fcf18086202a87997689d" CHECKSUMTYPE="SHA-1" SIZE="5392918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-11-11T16:16:27" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="72e7dc3c2920230292133d8dd39b02366116a8d7" CHECKSUMTYPE="SHA-1" SIZE="5174013">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-11-11T16:16:56" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="35cef1e3dd9f28e368616e2ad7551b042ce76e73" CHECKSUMTYPE="SHA-1" SIZE="5393812">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-11-11T16:17:26" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="7cd09b0175f2bfb1c03258da747ad3bd4dac93f9" CHECKSUMTYPE="SHA-1" SIZE="5150709">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-11-11T16:17:55" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="3d9ba41f08699b63968440003a2e2a05a85652a0" CHECKSUMTYPE="SHA-1" SIZE="5372224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-11-11T16:18:22" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="66ec8dad5c2949cb37242c19fb481831ca7224be" CHECKSUMTYPE="SHA-1" SIZE="5193990">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-11-11T16:18:48" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="e2400e1222bbf44794a735299999958ad18dfb51" CHECKSUMTYPE="SHA-1" SIZE="5166127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-11-11T16:19:17" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="558fcbfa0b79f16f5d15d23d68d7227c859c95e1" CHECKSUMTYPE="SHA-1" SIZE="5372216">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-11-11T16:19:45" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="cb37d62693dda9b3c9ef68d9b98a1b5b6d85528e" CHECKSUMTYPE="SHA-1" SIZE="5137297">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-11-11T16:20:14" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="894a1d29735c717eddcd0404478130fa1094b39c" CHECKSUMTYPE="SHA-1" SIZE="5372088">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-11-11T16:20:41" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="ea1dc50f57f59eeb626f75ac283f3d196d906371" CHECKSUMTYPE="SHA-1" SIZE="5372174">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-11-11T16:21:08" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="4e76a6e8b1d0f7f4899bf4ee4c6a568f9339cc07" CHECKSUMTYPE="SHA-1" SIZE="5198528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-11-11T16:21:36" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="e599e0f67af47121772f9d2b2a5dffaee8d38619" CHECKSUMTYPE="SHA-1" SIZE="5192224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-11-11T16:22:02" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="1d4ca209cd3d4010f714c91ced4776ed7faefcae" CHECKSUMTYPE="SHA-1" SIZE="5372203">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-11-11T16:22:31" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="ad4c8904df2a77f5d5a5f2e5d69148905e8f8476" CHECKSUMTYPE="SHA-1" SIZE="5192093">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-11-11T16:22:59" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="66f3f6b5ebf7f8fda528a49f00654417738da5c8" CHECKSUMTYPE="SHA-1" SIZE="5372229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-11-11T16:23:24" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="8bbb25083f863fd59310c4e35ec4057e61c181d5" CHECKSUMTYPE="SHA-1" SIZE="5127425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-11-11T16:23:52" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="d745a9956eac4d94e34b8f8765b67c1a32940590" CHECKSUMTYPE="SHA-1" SIZE="5372222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-11-11T16:24:19" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="0a176110d2f1c26508e5d9c8b52bc5733664e4a4" CHECKSUMTYPE="SHA-1" SIZE="5078663">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-11-11T16:24:47" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="62479e6afe5c04afd7e284ee0a0821e17808c0e6" CHECKSUMTYPE="SHA-1" SIZE="5372228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-11-11T16:25:15" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="ff1d6f8026cad02c81e9416441e9d82075431053" CHECKSUMTYPE="SHA-1" SIZE="5106726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-11-11T16:25:46" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="71ed97946ce3414ce566dc3f19f40ee29eabaab6" CHECKSUMTYPE="SHA-1" SIZE="5300226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-11-11T16:26:13" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="21bddb8a2b19edd63e6989cdd6246eb3c190710d" CHECKSUMTYPE="SHA-1" SIZE="5111203">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-11-11T16:26:42" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="e1b3dbb80b9f36ca24751e335bbbbd2e82d7ebe9" CHECKSUMTYPE="SHA-1" SIZE="5401925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-11-11T16:27:09" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="b877e94e13214926c881057d97ff4da6a30c2b0b" CHECKSUMTYPE="SHA-1" SIZE="5167925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-11-11T16:27:41" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="6aac151a6ff76a6f688b247d69229f48836f0ac7" CHECKSUMTYPE="SHA-1" SIZE="5255221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0084.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-11-11T15:47:19" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="01977a814dd4b6681fb2de2ab63652591d78a488" CHECKSUMTYPE="SHA-1" SIZE="5267709">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-11-11T15:47:53" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="af68cde65f4993e53f618265424fbc61e80d2946" CHECKSUMTYPE="SHA-1" SIZE="5387468">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-11-11T15:48:26" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="a59fc00e583cd4b98fac42e9a68a78fb8fad2422" CHECKSUMTYPE="SHA-1" SIZE="5146325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-11-11T15:48:58" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="bb08eda029bd5217465a796ba076610d002ecc54" CHECKSUMTYPE="SHA-1" SIZE="5371876">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-11-11T15:49:28" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="fc6ebf1e4dc8a6538ddda5b654c022588daeea91" CHECKSUMTYPE="SHA-1" SIZE="5193129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-11-11T15:49:57" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="90ab31cc677f4cabe03e79275251588ff28bdd77" CHECKSUMTYPE="SHA-1" SIZE="5400129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-11-11T15:50:27" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="3dcab4e8664c7c47be8ac9a1b91d118828fd7709" CHECKSUMTYPE="SHA-1" SIZE="5252527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-11-11T15:50:56" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="7ee0d44fc71ad73f4b0c8f9349041c48ee43f793" CHECKSUMTYPE="SHA-1" SIZE="5378524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-11-11T15:51:26" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="ad11cafe820a25b557dd601f93d2f07e1097b784" CHECKSUMTYPE="SHA-1" SIZE="5247128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-11-11T15:51:58" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="a7207557be778f7cfe6d4113457d565c2b2b280f" CHECKSUMTYPE="SHA-1" SIZE="5372227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-11-11T15:52:27" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="a80cfe351b0e1104bbdbf2ec8f6a13b7d5fd3717" CHECKSUMTYPE="SHA-1" SIZE="5146312">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-11-11T15:52:58" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="24cb99959e66630aec547601890c1967ec2d5cae" CHECKSUMTYPE="SHA-1" SIZE="5372226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-11-11T15:53:30" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="59abb158be345dc1f453ba726dcd544147f505a0" CHECKSUMTYPE="SHA-1" SIZE="5239029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-11-11T15:53:59" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="6010e11eafe1f2ffb8abbcd8ca57de8749593798" CHECKSUMTYPE="SHA-1" SIZE="5443317">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-11-11T15:54:28" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="d08aa2e95039900e148e64fa31747b4749af9839" CHECKSUMTYPE="SHA-1" SIZE="5155326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-11-11T15:54:57" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="7be51db3b1ada03436cdbabd329896fe97c2cd74" CHECKSUMTYPE="SHA-1" SIZE="5372207">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-11-11T15:55:27" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="357b745153d16c5c0e5ac94bda58295d456bf109" CHECKSUMTYPE="SHA-1" SIZE="5199427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-11-11T15:55:57" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="568d8fb6661b6baf5aac5c7377c46836209e0968" CHECKSUMTYPE="SHA-1" SIZE="5400128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-11-11T15:56:25" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="e83b7d841541f33092f74cc05bdd2ab3cc55e93e" CHECKSUMTYPE="SHA-1" SIZE="5182324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-11-11T15:56:54" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="6448b4982d98538e4b66fd562f03f06071b2baa4" CHECKSUMTYPE="SHA-1" SIZE="5372228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-11-11T15:57:23" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="ecb9aa0d1b43267d2e57f3c9864ec62116013283" CHECKSUMTYPE="SHA-1" SIZE="5209322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-11-11T15:57:52" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="412f77332f2f6c22f1f1da49f429319daa8df772" CHECKSUMTYPE="SHA-1" SIZE="5372223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-11-11T15:58:23" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="c3d79126f3513b24a3ebf099cb8245297e34e1d4" CHECKSUMTYPE="SHA-1" SIZE="5193125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-11-11T15:58:53" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="a49af0308e3df453361fe2fde50ab2ce2443abc2" CHECKSUMTYPE="SHA-1" SIZE="5372219">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-11-11T15:59:21" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="dd994ba63df333f0762633ea470076a3b984476c" CHECKSUMTYPE="SHA-1" SIZE="5201229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-11-11T15:59:52" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="d3ec7a1ad5bb686a4466e2dba9b4ba070dc77033" CHECKSUMTYPE="SHA-1" SIZE="5372229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-11-11T16:00:21" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="68c19cb04ac748e6a6b6e0320cc98cb6478d5251" CHECKSUMTYPE="SHA-1" SIZE="5257029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-11-11T16:00:51" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="aee44fe1065bb340ab0abd98eb15dac1481c5507" CHECKSUMTYPE="SHA-1" SIZE="5428929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-11-11T16:01:21" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="784b95656049982d0bc8f3fd771452dd51727ab4" CHECKSUMTYPE="SHA-1" SIZE="5218322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-11-11T16:01:51" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="4ff066433ed5732f27ed2c2cc0ed8421bd09fec7" CHECKSUMTYPE="SHA-1" SIZE="5438826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-11-11T16:02:22" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="f3bbf15dd0559e235e3eeda53e76e4702dd509e0" CHECKSUMTYPE="SHA-1" SIZE="5176028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-11-11T16:02:53" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="43ebed36ff435edbac00fca0dc82ab06444cb14c" CHECKSUMTYPE="SHA-1" SIZE="5407329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-11-11T16:03:22" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="04c417df726a2172340eab88a3a204294c52c8ff" CHECKSUMTYPE="SHA-1" SIZE="5160668">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-11-11T16:03:53" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="8c7690d445f70ec40ec9cecb30ee2763ff54354c" CHECKSUMTYPE="SHA-1" SIZE="5453229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-11-11T16:04:23" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="24febf0283c20e982fcab4cf8aa1291cf094289f" CHECKSUMTYPE="SHA-1" SIZE="5229127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-11-11T16:04:54" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="db35de6335691e34a39cc2bb6a3e014e5c6d91dd" CHECKSUMTYPE="SHA-1" SIZE="5460428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-11-11T16:05:24" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="0332a2f8ce71e8d081fdbc2c9b23406a8d234032" CHECKSUMTYPE="SHA-1" SIZE="5165229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-11-11T16:05:54" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="251bb1d586052639305151c9caf2182796c91cb8" CHECKSUMTYPE="SHA-1" SIZE="5412716">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-11-11T16:06:23" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="f2470cc182a77489d5d1d655312c0173a095a549" CHECKSUMTYPE="SHA-1" SIZE="5211129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-11-11T16:06:53" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="b33e771e4305cdd9884ee5e2ab8ca51a9052dfe7" CHECKSUMTYPE="SHA-1" SIZE="5372229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-11-11T16:07:22" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="4dd880cbb843de871af7e824d778b97f89b48307" CHECKSUMTYPE="SHA-1" SIZE="5230025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-11-11T16:07:53" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="796df7fa8bcd35781e3e0f3e3316a2abe885174d" CHECKSUMTYPE="SHA-1" SIZE="5372227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-11-11T16:08:22" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="4a44fc39bd05de8f6a3d9cf499b22c603ecce5fd" CHECKSUMTYPE="SHA-1" SIZE="5420824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-11-11T16:08:50" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="9eafd71803ee7c280d08e37f48c5e4f2276d9cae" CHECKSUMTYPE="SHA-1" SIZE="5230917">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-11-11T16:09:18" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="cb43f7fd2596d1cf1dd717e7f7dc3043ed9087be" CHECKSUMTYPE="SHA-1" SIZE="5372228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-11-11T16:09:47" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="6c0f513edcc04c380c7e196907fa2279651071b3" CHECKSUMTYPE="SHA-1" SIZE="5217187">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-11-11T16:10:18" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="9211a73343bc6c815581fb89aee9dd2424a40682" CHECKSUMTYPE="SHA-1" SIZE="5372221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-11-11T16:10:47" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="4d6e007a3db66bdcd5bf41be755ea96f87100b65" CHECKSUMTYPE="SHA-1" SIZE="5116629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-11-11T16:11:13" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="efca8404a2788e3e4325386794e0655dce2c7494" CHECKSUMTYPE="SHA-1" SIZE="5256979">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-11-11T16:11:43" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="e302f9755a8db4ebeedae8e65164df742de3bfc4" CHECKSUMTYPE="SHA-1" SIZE="5372209">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-11-11T16:12:10" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="fcb71e63f101051d45926f82898bf1a78154fd66" CHECKSUMTYPE="SHA-1" SIZE="5174053">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-11-11T16:12:38" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="66931d02f18da41357782a61a3c69a0d78a58c95" CHECKSUMTYPE="SHA-1" SIZE="5425329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-11-11T16:13:07" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="b5486979c6aed62bd3b911930dd9f52cfb8021aa" CHECKSUMTYPE="SHA-1" SIZE="5438829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-11-11T16:13:34" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="3a23a3e3b810f75907865a236c0893673e31c7d5" CHECKSUMTYPE="SHA-1" SIZE="5131909">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-11-11T16:14:03" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="f116a8eecbc473fb44674ca046dc1d76e77dfe74" CHECKSUMTYPE="SHA-1" SIZE="5425315">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-11-11T16:14:33" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="403217afa1dd09732ebec12915b7e4309c94b216" CHECKSUMTYPE="SHA-1" SIZE="5219226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-11-11T16:15:01" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="165fa543fd28d125b814c8bf02676dd13d0f2679" CHECKSUMTYPE="SHA-1" SIZE="5404615">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-11-11T16:15:28" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="6fce456774c424e52f18767acac326b2ce37ad3a" CHECKSUMTYPE="SHA-1" SIZE="5149011">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-11-11T16:15:59" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="9f6e7e74836cecfa5a0fcf18086202a87997689d" CHECKSUMTYPE="SHA-1" SIZE="5392918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-11-11T16:16:27" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="72e7dc3c2920230292133d8dd39b02366116a8d7" CHECKSUMTYPE="SHA-1" SIZE="5174013">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-11-11T16:16:56" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="35cef1e3dd9f28e368616e2ad7551b042ce76e73" CHECKSUMTYPE="SHA-1" SIZE="5393812">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-11-11T16:17:26" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="7cd09b0175f2bfb1c03258da747ad3bd4dac93f9" CHECKSUMTYPE="SHA-1" SIZE="5150709">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-11-11T16:17:55" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="3d9ba41f08699b63968440003a2e2a05a85652a0" CHECKSUMTYPE="SHA-1" SIZE="5372224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-11-11T16:18:22" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="66ec8dad5c2949cb37242c19fb481831ca7224be" CHECKSUMTYPE="SHA-1" SIZE="5193990">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-11-11T16:18:48" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="e2400e1222bbf44794a735299999958ad18dfb51" CHECKSUMTYPE="SHA-1" SIZE="5166127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-11-11T16:19:17" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="558fcbfa0b79f16f5d15d23d68d7227c859c95e1" CHECKSUMTYPE="SHA-1" SIZE="5372216">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-11-11T16:19:45" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="cb37d62693dda9b3c9ef68d9b98a1b5b6d85528e" CHECKSUMTYPE="SHA-1" SIZE="5137297">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-11-11T16:20:14" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="894a1d29735c717eddcd0404478130fa1094b39c" CHECKSUMTYPE="SHA-1" SIZE="5372088">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-11-11T16:20:41" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="ea1dc50f57f59eeb626f75ac283f3d196d906371" CHECKSUMTYPE="SHA-1" SIZE="5372174">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-11-11T16:21:08" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="4e76a6e8b1d0f7f4899bf4ee4c6a568f9339cc07" CHECKSUMTYPE="SHA-1" SIZE="5198528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-11-11T16:21:36" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="e599e0f67af47121772f9d2b2a5dffaee8d38619" CHECKSUMTYPE="SHA-1" SIZE="5192224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-11-11T16:22:02" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="1d4ca209cd3d4010f714c91ced4776ed7faefcae" CHECKSUMTYPE="SHA-1" SIZE="5372203">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-11-11T16:22:31" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="ad4c8904df2a77f5d5a5f2e5d69148905e8f8476" CHECKSUMTYPE="SHA-1" SIZE="5192093">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-11-11T16:22:59" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="66f3f6b5ebf7f8fda528a49f00654417738da5c8" CHECKSUMTYPE="SHA-1" SIZE="5372229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-11-11T16:23:24" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="8bbb25083f863fd59310c4e35ec4057e61c181d5" CHECKSUMTYPE="SHA-1" SIZE="5127425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-11-11T16:23:52" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="d745a9956eac4d94e34b8f8765b67c1a32940590" CHECKSUMTYPE="SHA-1" SIZE="5372222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-11-11T16:24:19" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="0a176110d2f1c26508e5d9c8b52bc5733664e4a4" CHECKSUMTYPE="SHA-1" SIZE="5078663">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-11-11T16:24:47" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="62479e6afe5c04afd7e284ee0a0821e17808c0e6" CHECKSUMTYPE="SHA-1" SIZE="5372228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-11-11T16:25:15" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="ff1d6f8026cad02c81e9416441e9d82075431053" CHECKSUMTYPE="SHA-1" SIZE="5106726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-11-11T16:25:46" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="71ed97946ce3414ce566dc3f19f40ee29eabaab6" CHECKSUMTYPE="SHA-1" SIZE="5300226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-11-11T16:26:13" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="21bddb8a2b19edd63e6989cdd6246eb3c190710d" CHECKSUMTYPE="SHA-1" SIZE="5111203">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-11-11T16:26:42" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="e1b3dbb80b9f36ca24751e335bbbbd2e82d7ebe9" CHECKSUMTYPE="SHA-1" SIZE="5401925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-11-11T16:27:09" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="b877e94e13214926c881057d97ff4da6a30c2b0b" CHECKSUMTYPE="SHA-1" SIZE="5167925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-11-11T16:27:41" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="6aac151a6ff76a6f688b247d69229f48836f0ac7" CHECKSUMTYPE="SHA-1" SIZE="5255221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/delivery/bmtnabe_1895-11_01_0084.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-11-11T16:27:58" MIMETYPE="text/xml" CHECKSUM="ef2b7c633a391ef37d85b46a61d0ab90f573842b"
-				CHECKSUMTYPE="SHA-1" SIZE="2043">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-11-11T16:27:58" MIMETYPE="text/xml" CHECKSUM="ef2b7c633a391ef37d85b46a61d0ab90f573842b" CHECKSUMTYPE="SHA-1" SIZE="2043">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-11-11T16:27:59" MIMETYPE="text/xml" CHECKSUM="53a58ef952fd80e3fad1514d7b65f98b607a0195"
-				CHECKSUMTYPE="SHA-1" SIZE="1645">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-11-11T16:27:59" MIMETYPE="text/xml" CHECKSUM="53a58ef952fd80e3fad1514d7b65f98b607a0195" CHECKSUMTYPE="SHA-1" SIZE="1645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-11-11T16:27:59" MIMETYPE="text/xml" CHECKSUM="cd35e172d19930551055d409dd287abd741893cb"
-				CHECKSUMTYPE="SHA-1" SIZE="3778">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-11-11T16:27:59" MIMETYPE="text/xml" CHECKSUM="cd35e172d19930551055d409dd287abd741893cb" CHECKSUMTYPE="SHA-1" SIZE="3778">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-11-11T16:27:59" MIMETYPE="text/xml" CHECKSUM="fcb6a8684dd17bd426adf3dfc857c741a20053c6"
-				CHECKSUMTYPE="SHA-1" SIZE="1661">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-11-11T16:27:59" MIMETYPE="text/xml" CHECKSUM="fcb6a8684dd17bd426adf3dfc857c741a20053c6" CHECKSUMTYPE="SHA-1" SIZE="1661">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-11-11T16:27:59" MIMETYPE="text/xml" CHECKSUM="73eaeb2387584abc2653d8ad0d6f0229e514cd84"
-				CHECKSUMTYPE="SHA-1" SIZE="32071">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-11-11T16:27:59" MIMETYPE="text/xml" CHECKSUM="73eaeb2387584abc2653d8ad0d6f0229e514cd84" CHECKSUMTYPE="SHA-1" SIZE="32071">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-11-11T16:28:00" MIMETYPE="text/xml" CHECKSUM="b32c86bc44ab51e60a8fbbebd3cae3f1933359a9"
-				CHECKSUMTYPE="SHA-1" SIZE="41811">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-11-11T16:28:00" MIMETYPE="text/xml" CHECKSUM="b32c86bc44ab51e60a8fbbebd3cae3f1933359a9" CHECKSUMTYPE="SHA-1" SIZE="41811">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-11-11T16:28:00" MIMETYPE="text/xml" CHECKSUM="4fdfad78e7eb6bfc8d51ba01c7ea59d244407a4e"
-				CHECKSUMTYPE="SHA-1" SIZE="42833">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-11-11T16:28:00" MIMETYPE="text/xml" CHECKSUM="4fdfad78e7eb6bfc8d51ba01c7ea59d244407a4e" CHECKSUMTYPE="SHA-1" SIZE="42833">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-11-11T16:28:00" MIMETYPE="text/xml" CHECKSUM="6118c4499a80f0918634d9faa3ae35afd40152a0"
-				CHECKSUMTYPE="SHA-1" SIZE="41020">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-11-11T16:28:00" MIMETYPE="text/xml" CHECKSUM="6118c4499a80f0918634d9faa3ae35afd40152a0" CHECKSUMTYPE="SHA-1" SIZE="41020">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-11-11T16:28:00" MIMETYPE="text/xml" CHECKSUM="abb17a9b284a6b0b4bee73e9a8adf31449a763df"
-				CHECKSUMTYPE="SHA-1" SIZE="4148">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-11-11T16:28:00" MIMETYPE="text/xml" CHECKSUM="abb17a9b284a6b0b4bee73e9a8adf31449a763df" CHECKSUMTYPE="SHA-1" SIZE="4148">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-11-11T16:28:01" MIMETYPE="text/xml"
-				CHECKSUM="e407c38b56534a464470a07cdd3f25976ef6d3ca" CHECKSUMTYPE="SHA-1" SIZE="1954">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-11-11T16:28:01" MIMETYPE="text/xml" CHECKSUM="e407c38b56534a464470a07cdd3f25976ef6d3ca" CHECKSUMTYPE="SHA-1" SIZE="1954">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-11-11T16:28:01" MIMETYPE="text/xml"
-				CHECKSUM="d456236be6f7eb194e7cbfd748e55edd03ee56e4" CHECKSUMTYPE="SHA-1" SIZE="69171">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-11-11T16:28:01" MIMETYPE="text/xml" CHECKSUM="d456236be6f7eb194e7cbfd748e55edd03ee56e4" CHECKSUMTYPE="SHA-1" SIZE="69171">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-11-11T16:28:01" MIMETYPE="text/xml"
-				CHECKSUM="7d7d23b342986a67c71748db8f75d223d3da9af9" CHECKSUMTYPE="SHA-1" SIZE="74136">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-11-11T16:28:01" MIMETYPE="text/xml" CHECKSUM="7d7d23b342986a67c71748db8f75d223d3da9af9" CHECKSUMTYPE="SHA-1" SIZE="74136">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-11-11T16:28:01" MIMETYPE="text/xml"
-				CHECKSUM="477b7b31e8add4f6052708f5ec771154cf401cb0" CHECKSUMTYPE="SHA-1" SIZE="18571">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-11-11T16:28:01" MIMETYPE="text/xml" CHECKSUM="477b7b31e8add4f6052708f5ec771154cf401cb0" CHECKSUMTYPE="SHA-1" SIZE="18571">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-11-11T16:28:02" MIMETYPE="text/xml"
-				CHECKSUM="31bf3d2734d7ef93873ca50f89bfc990539eb66b" CHECKSUMTYPE="SHA-1" SIZE="30798">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-11-11T16:28:02" MIMETYPE="text/xml" CHECKSUM="31bf3d2734d7ef93873ca50f89bfc990539eb66b" CHECKSUMTYPE="SHA-1" SIZE="30798">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-11-11T16:28:02" MIMETYPE="text/xml"
-				CHECKSUM="51086a9894942e902b88dffbde766ac6f3273ec0" CHECKSUMTYPE="SHA-1" SIZE="31247">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-11-11T16:28:02" MIMETYPE="text/xml" CHECKSUM="51086a9894942e902b88dffbde766ac6f3273ec0" CHECKSUMTYPE="SHA-1" SIZE="31247">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-11-11T16:28:02" MIMETYPE="text/xml"
-				CHECKSUM="977552e404d1b69b85ebf37e4449bc8174bfdd01" CHECKSUMTYPE="SHA-1" SIZE="20497">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-11-11T16:28:02" MIMETYPE="text/xml" CHECKSUM="977552e404d1b69b85ebf37e4449bc8174bfdd01" CHECKSUMTYPE="SHA-1" SIZE="20497">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-11-11T16:28:03" MIMETYPE="text/xml"
-				CHECKSUM="83d49cf714b1491ba74aa9208c98ee8ee169019d" CHECKSUMTYPE="SHA-1" SIZE="4209">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-11-11T16:28:03" MIMETYPE="text/xml" CHECKSUM="83d49cf714b1491ba74aa9208c98ee8ee169019d" CHECKSUMTYPE="SHA-1" SIZE="4209">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-11-11T16:28:03" MIMETYPE="text/xml"
-				CHECKSUM="2cc722de445368e5ed81de85d57cce6179e74d63" CHECKSUMTYPE="SHA-1" SIZE="1960">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-11-11T16:28:03" MIMETYPE="text/xml" CHECKSUM="2cc722de445368e5ed81de85d57cce6179e74d63" CHECKSUMTYPE="SHA-1" SIZE="1960">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-11-11T16:28:03" MIMETYPE="text/xml"
-				CHECKSUM="e3651e7278d91abfe20fc45d4fb7bcf7266d6b80" CHECKSUMTYPE="SHA-1" SIZE="72486">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-11-11T16:28:03" MIMETYPE="text/xml" CHECKSUM="e3651e7278d91abfe20fc45d4fb7bcf7266d6b80" CHECKSUMTYPE="SHA-1" SIZE="72486">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-11-11T16:28:03" MIMETYPE="text/xml"
-				CHECKSUM="a7cb38cd65ea2ef2064c6b800da4250dd9f50f43" CHECKSUMTYPE="SHA-1" SIZE="104668">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-11-11T16:28:03" MIMETYPE="text/xml" CHECKSUM="a7cb38cd65ea2ef2064c6b800da4250dd9f50f43" CHECKSUMTYPE="SHA-1" SIZE="104668">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-11-11T16:28:04" MIMETYPE="text/xml"
-				CHECKSUM="b775eabefc83e7919fba5bf1142dea2ddd00d54a" CHECKSUMTYPE="SHA-1" SIZE="106758">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-11-11T16:28:04" MIMETYPE="text/xml" CHECKSUM="b775eabefc83e7919fba5bf1142dea2ddd00d54a" CHECKSUMTYPE="SHA-1" SIZE="106758">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-11-11T16:28:04" MIMETYPE="text/xml"
-				CHECKSUM="f43ff7ca1dff10d355157e1ca1662b87ca696462" CHECKSUMTYPE="SHA-1" SIZE="92911">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-11-11T16:28:04" MIMETYPE="text/xml" CHECKSUM="f43ff7ca1dff10d355157e1ca1662b87ca696462" CHECKSUMTYPE="SHA-1" SIZE="92911">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-11-11T16:28:05" MIMETYPE="text/xml"
-				CHECKSUM="b2c5ff1ef4a4aa02c32a06b3a03250cd4d1488b8" CHECKSUMTYPE="SHA-1" SIZE="4123">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-11-11T16:28:05" MIMETYPE="text/xml" CHECKSUM="b2c5ff1ef4a4aa02c32a06b3a03250cd4d1488b8" CHECKSUMTYPE="SHA-1" SIZE="4123">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-11-11T16:28:05" MIMETYPE="text/xml"
-				CHECKSUM="d591293e263a61ee2789f382a625caef7bcd0156" CHECKSUMTYPE="SHA-1" SIZE="1955">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-11-11T16:28:05" MIMETYPE="text/xml" CHECKSUM="d591293e263a61ee2789f382a625caef7bcd0156" CHECKSUMTYPE="SHA-1" SIZE="1955">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-11-11T16:28:05" MIMETYPE="text/xml"
-				CHECKSUM="96b88e23d4883333b361f0721c77610fe47ad341" CHECKSUMTYPE="SHA-1" SIZE="116747">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-11-11T16:28:05" MIMETYPE="text/xml" CHECKSUM="96b88e23d4883333b361f0721c77610fe47ad341" CHECKSUMTYPE="SHA-1" SIZE="116747">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-11-11T16:28:05" MIMETYPE="text/xml"
-				CHECKSUM="4587d19c5ea943d21fd45a71daf8c44f36671d50" CHECKSUMTYPE="SHA-1" SIZE="89858">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-11-11T16:28:05" MIMETYPE="text/xml" CHECKSUM="4587d19c5ea943d21fd45a71daf8c44f36671d50" CHECKSUMTYPE="SHA-1" SIZE="89858">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-11-11T16:28:06" MIMETYPE="text/xml"
-				CHECKSUM="aaddfef392f5f2f8a0b387c4a2d7a519cf59f303" CHECKSUMTYPE="SHA-1" SIZE="105582">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-11-11T16:28:06" MIMETYPE="text/xml" CHECKSUM="aaddfef392f5f2f8a0b387c4a2d7a519cf59f303" CHECKSUMTYPE="SHA-1" SIZE="105582">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-11-11T16:28:06" MIMETYPE="text/xml"
-				CHECKSUM="66daa7cac39d02b72ee583a489dccf153b52ab59" CHECKSUMTYPE="SHA-1" SIZE="99719">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-11-11T16:28:06" MIMETYPE="text/xml" CHECKSUM="66daa7cac39d02b72ee583a489dccf153b52ab59" CHECKSUMTYPE="SHA-1" SIZE="99719">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-11-11T16:28:06" MIMETYPE="text/xml"
-				CHECKSUM="621dca78c188e29406e145efd169837eaff8f40a" CHECKSUMTYPE="SHA-1" SIZE="20468">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-11-11T16:28:06" MIMETYPE="text/xml" CHECKSUM="621dca78c188e29406e145efd169837eaff8f40a" CHECKSUMTYPE="SHA-1" SIZE="20468">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-11-11T16:28:07" MIMETYPE="text/xml"
-				CHECKSUM="8ceab8f01269b83dd8cd7bc69bc046d210541309" CHECKSUMTYPE="SHA-1" SIZE="29969">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-11-11T16:28:07" MIMETYPE="text/xml" CHECKSUM="8ceab8f01269b83dd8cd7bc69bc046d210541309" CHECKSUMTYPE="SHA-1" SIZE="29969">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-11-11T16:28:07" MIMETYPE="text/xml"
-				CHECKSUM="b44c0022f19afb07cc462afbfb5781d50225238e" CHECKSUMTYPE="SHA-1" SIZE="4873">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-11-11T16:28:07" MIMETYPE="text/xml" CHECKSUM="b44c0022f19afb07cc462afbfb5781d50225238e" CHECKSUMTYPE="SHA-1" SIZE="4873">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-11-11T16:28:07" MIMETYPE="text/xml"
-				CHECKSUM="b11d19fda8ed4104e511b9e4f633a982285dc5d7" CHECKSUMTYPE="SHA-1" SIZE="1954">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-11-11T16:28:07" MIMETYPE="text/xml" CHECKSUM="b11d19fda8ed4104e511b9e4f633a982285dc5d7" CHECKSUMTYPE="SHA-1" SIZE="1954">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-11-11T16:28:07" MIMETYPE="text/xml"
-				CHECKSUM="45a94bfcd489b235be245d561d6ef3d1ab23f27e" CHECKSUMTYPE="SHA-1" SIZE="79156">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-11-11T16:28:07" MIMETYPE="text/xml" CHECKSUM="45a94bfcd489b235be245d561d6ef3d1ab23f27e" CHECKSUMTYPE="SHA-1" SIZE="79156">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-11-11T16:28:08" MIMETYPE="text/xml"
-				CHECKSUM="c8ca1277722a21295ed81c70f2c02a66cff1ad12" CHECKSUMTYPE="SHA-1" SIZE="147106">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-11-11T16:28:08" MIMETYPE="text/xml" CHECKSUM="c8ca1277722a21295ed81c70f2c02a66cff1ad12" CHECKSUMTYPE="SHA-1" SIZE="147106">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-11-11T16:28:08" MIMETYPE="text/xml"
-				CHECKSUM="25cfe593f4cdf66c4367ab5109a639a56bde4515" CHECKSUMTYPE="SHA-1" SIZE="147967">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-11-11T16:28:08" MIMETYPE="text/xml" CHECKSUM="25cfe593f4cdf66c4367ab5109a639a56bde4515" CHECKSUMTYPE="SHA-1" SIZE="147967">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-11-11T16:28:09" MIMETYPE="text/xml"
-				CHECKSUM="bcea2d50df27bac01cef4bafc00f0780a49e6f3c" CHECKSUMTYPE="SHA-1" SIZE="144045">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-11-11T16:28:09" MIMETYPE="text/xml" CHECKSUM="bcea2d50df27bac01cef4bafc00f0780a49e6f3c" CHECKSUMTYPE="SHA-1" SIZE="144045">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-11-11T16:28:09" MIMETYPE="text/xml"
-				CHECKSUM="f03829f187059f6b2ef281ad9a287a0c64475978" CHECKSUMTYPE="SHA-1" SIZE="154128">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-11-11T16:28:09" MIMETYPE="text/xml" CHECKSUM="f03829f187059f6b2ef281ad9a287a0c64475978" CHECKSUMTYPE="SHA-1" SIZE="154128">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-11-11T16:28:09" MIMETYPE="text/xml"
-				CHECKSUM="8d78f21c93ea5b0aabd374e2fe669ef02a677a4c" CHECKSUMTYPE="SHA-1" SIZE="146503">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-11-11T16:28:09" MIMETYPE="text/xml" CHECKSUM="8d78f21c93ea5b0aabd374e2fe669ef02a677a4c" CHECKSUMTYPE="SHA-1" SIZE="146503">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-11-11T16:28:10" MIMETYPE="text/xml"
-				CHECKSUM="8322d43800ae8b12cb54de6d8ca3fe7a8960a7fe" CHECKSUMTYPE="SHA-1" SIZE="4299">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-11-11T16:28:10" MIMETYPE="text/xml" CHECKSUM="8322d43800ae8b12cb54de6d8ca3fe7a8960a7fe" CHECKSUMTYPE="SHA-1" SIZE="4299">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-11-11T16:28:10" MIMETYPE="text/xml"
-				CHECKSUM="1bf36d3c8d61a553c4231dd55e06075c787ec387" CHECKSUMTYPE="SHA-1" SIZE="44347">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-11-11T16:28:10" MIMETYPE="text/xml" CHECKSUM="1bf36d3c8d61a553c4231dd55e06075c787ec387" CHECKSUMTYPE="SHA-1" SIZE="44347">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-11-11T16:28:10" MIMETYPE="text/xml"
-				CHECKSUM="e07a6748d1f65360d9e155cae76ebb922e97f74d" CHECKSUMTYPE="SHA-1" SIZE="92585">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-11-11T16:28:10" MIMETYPE="text/xml" CHECKSUM="e07a6748d1f65360d9e155cae76ebb922e97f74d" CHECKSUMTYPE="SHA-1" SIZE="92585">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-11-11T16:28:11" MIMETYPE="text/xml"
-				CHECKSUM="2030901e173ea1411f76647e8a45b4a6840f9b5c" CHECKSUMTYPE="SHA-1" SIZE="1954">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-11-11T16:28:11" MIMETYPE="text/xml" CHECKSUM="2030901e173ea1411f76647e8a45b4a6840f9b5c" CHECKSUMTYPE="SHA-1" SIZE="1954">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-11-11T16:28:11" MIMETYPE="text/xml"
-				CHECKSUM="21f940bf41a932e013fc81cd674de3d910f10e1f" CHECKSUMTYPE="SHA-1" SIZE="178183">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-11-11T16:28:11" MIMETYPE="text/xml" CHECKSUM="21f940bf41a932e013fc81cd674de3d910f10e1f" CHECKSUMTYPE="SHA-1" SIZE="178183">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-11-11T16:28:11" MIMETYPE="text/xml"
-				CHECKSUM="bd098029b4538d89f0762c8f7d7291bb5b98dab8" CHECKSUMTYPE="SHA-1" SIZE="191002">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-11-11T16:28:11" MIMETYPE="text/xml" CHECKSUM="bd098029b4538d89f0762c8f7d7291bb5b98dab8" CHECKSUMTYPE="SHA-1" SIZE="191002">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-11-11T16:28:12" MIMETYPE="text/xml"
-				CHECKSUM="9d2c1bb8c7e8d7ee995c14ab4297bf2333cc0b06" CHECKSUMTYPE="SHA-1" SIZE="196702">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-11-11T16:28:12" MIMETYPE="text/xml" CHECKSUM="9d2c1bb8c7e8d7ee995c14ab4297bf2333cc0b06" CHECKSUMTYPE="SHA-1" SIZE="196702">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-11-11T16:28:12" MIMETYPE="text/xml"
-				CHECKSUM="3eb233db55da69d1e73c6043ab743d94d434b5c8" CHECKSUMTYPE="SHA-1" SIZE="188282">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-11-11T16:28:12" MIMETYPE="text/xml" CHECKSUM="3eb233db55da69d1e73c6043ab743d94d434b5c8" CHECKSUMTYPE="SHA-1" SIZE="188282">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-11-11T16:28:13" MIMETYPE="text/xml"
-				CHECKSUM="d7491a0afba0cea54003e71409849c0b4fbbe3c8" CHECKSUMTYPE="SHA-1" SIZE="181839">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-11-11T16:28:13" MIMETYPE="text/xml" CHECKSUM="d7491a0afba0cea54003e71409849c0b4fbbe3c8" CHECKSUMTYPE="SHA-1" SIZE="181839">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-11-11T16:28:13" MIMETYPE="text/xml"
-				CHECKSUM="032555b65b14a5c162381ebb9c8f3c5b91b471c4" CHECKSUMTYPE="SHA-1" SIZE="43243">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-11-11T16:28:13" MIMETYPE="text/xml" CHECKSUM="032555b65b14a5c162381ebb9c8f3c5b91b471c4" CHECKSUMTYPE="SHA-1" SIZE="43243">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-11-11T16:28:13" MIMETYPE="text/xml"
-				CHECKSUM="6ef74f847f74f52a1e5345683148d12022863be7" CHECKSUMTYPE="SHA-1" SIZE="4913">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-11-11T16:28:13" MIMETYPE="text/xml" CHECKSUM="6ef74f847f74f52a1e5345683148d12022863be7" CHECKSUMTYPE="SHA-1" SIZE="4913">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-11-11T16:28:14" MIMETYPE="text/xml"
-				CHECKSUM="c79e7675bb54ca7db9fed0369ebc7f060fcb0a01" CHECKSUMTYPE="SHA-1" SIZE="101716">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-11-11T16:28:14" MIMETYPE="text/xml" CHECKSUM="c79e7675bb54ca7db9fed0369ebc7f060fcb0a01" CHECKSUMTYPE="SHA-1" SIZE="101716">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-11-11T16:28:14" MIMETYPE="text/xml"
-				CHECKSUM="17571f5168dac7d4a8efc0299c7427198e37531a" CHECKSUMTYPE="SHA-1" SIZE="148420">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-11-11T16:28:14" MIMETYPE="text/xml" CHECKSUM="17571f5168dac7d4a8efc0299c7427198e37531a" CHECKSUMTYPE="SHA-1" SIZE="148420">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-11-11T16:28:14" MIMETYPE="text/xml"
-				CHECKSUM="f3e4c90d2721f23e46bce446aec7c04a4eae40aa" CHECKSUMTYPE="SHA-1" SIZE="1958">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-11-11T16:28:14" MIMETYPE="text/xml" CHECKSUM="f3e4c90d2721f23e46bce446aec7c04a4eae40aa" CHECKSUMTYPE="SHA-1" SIZE="1958">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-11-11T16:28:15" MIMETYPE="text/xml"
-				CHECKSUM="e79058c494b749ffd3550db1a1981820fe7703a9" CHECKSUMTYPE="SHA-1" SIZE="53504">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-11-11T16:28:15" MIMETYPE="text/xml" CHECKSUM="e79058c494b749ffd3550db1a1981820fe7703a9" CHECKSUMTYPE="SHA-1" SIZE="53504">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-11-11T16:28:15" MIMETYPE="text/xml"
-				CHECKSUM="a629f38cbea9856584d53519586c8e357c13e137" CHECKSUMTYPE="SHA-1" SIZE="114814">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-11-11T16:28:15" MIMETYPE="text/xml" CHECKSUM="a629f38cbea9856584d53519586c8e357c13e137" CHECKSUMTYPE="SHA-1" SIZE="114814">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-11-11T16:28:15" MIMETYPE="text/xml"
-				CHECKSUM="6d099199731bca8c2595a430e0a6b4f9652c98d0" CHECKSUMTYPE="SHA-1" SIZE="150358">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-11-11T16:28:15" MIMETYPE="text/xml" CHECKSUM="6d099199731bca8c2595a430e0a6b4f9652c98d0" CHECKSUMTYPE="SHA-1" SIZE="150358">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-11-11T16:28:16" MIMETYPE="text/xml"
-				CHECKSUM="61e1cacc181214fc1096be53479db61e1ba64543" CHECKSUMTYPE="SHA-1" SIZE="41832">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-11-11T16:28:16" MIMETYPE="text/xml" CHECKSUM="61e1cacc181214fc1096be53479db61e1ba64543" CHECKSUMTYPE="SHA-1" SIZE="41832">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-11-11T16:28:16" MIMETYPE="text/xml"
-				CHECKSUM="b5c6f48bf1b81b00eb9e5f6ef94d0d850d69035c" CHECKSUMTYPE="SHA-1" SIZE="119840">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-11-11T16:28:16" MIMETYPE="text/xml" CHECKSUM="b5c6f48bf1b81b00eb9e5f6ef94d0d850d69035c" CHECKSUMTYPE="SHA-1" SIZE="119840">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-11-11T16:28:16" MIMETYPE="text/xml"
-				CHECKSUM="4c541ca650a7de424a958aefae0b87d26d0e049e" CHECKSUMTYPE="SHA-1" SIZE="143317">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-11-11T16:28:16" MIMETYPE="text/xml" CHECKSUM="4c541ca650a7de424a958aefae0b87d26d0e049e" CHECKSUMTYPE="SHA-1" SIZE="143317">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-11-11T16:28:17" MIMETYPE="text/xml"
-				CHECKSUM="88e8e31a96032c51a169cc342a6db38ea0f23c73" CHECKSUMTYPE="SHA-1" SIZE="113933">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-11-11T16:28:17" MIMETYPE="text/xml" CHECKSUM="88e8e31a96032c51a169cc342a6db38ea0f23c73" CHECKSUMTYPE="SHA-1" SIZE="113933">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-11-11T16:28:17" MIMETYPE="text/xml"
-				CHECKSUM="10361d70cadc32aba8279b549856720751cfaa20" CHECKSUMTYPE="SHA-1" SIZE="144624">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-11-11T16:28:17" MIMETYPE="text/xml" CHECKSUM="10361d70cadc32aba8279b549856720751cfaa20" CHECKSUMTYPE="SHA-1" SIZE="144624">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-11-11T16:28:18" MIMETYPE="text/xml"
-				CHECKSUM="50da678cfc5ad862c938fbba07e194a33f084f2e" CHECKSUMTYPE="SHA-1" SIZE="118816">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-11-11T16:28:18" MIMETYPE="text/xml" CHECKSUM="50da678cfc5ad862c938fbba07e194a33f084f2e" CHECKSUMTYPE="SHA-1" SIZE="118816">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-11-11T16:28:18" MIMETYPE="text/xml"
-				CHECKSUM="9e641359281899e7c40095b3930e2359821ebc17" CHECKSUMTYPE="SHA-1" SIZE="147338">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-11-11T16:28:18" MIMETYPE="text/xml" CHECKSUM="9e641359281899e7c40095b3930e2359821ebc17" CHECKSUMTYPE="SHA-1" SIZE="147338">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-11-11T16:28:18" MIMETYPE="text/xml"
-				CHECKSUM="b240db65346f35d9f9537c038a8b58a732a1d148" CHECKSUMTYPE="SHA-1" SIZE="146102">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-11-11T16:28:18" MIMETYPE="text/xml" CHECKSUM="b240db65346f35d9f9537c038a8b58a732a1d148" CHECKSUMTYPE="SHA-1" SIZE="146102">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-11-11T16:28:19" MIMETYPE="text/xml"
-				CHECKSUM="267e5a1c6b70573570d480da350e5fbae2015f45" CHECKSUMTYPE="SHA-1" SIZE="144949">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-11-11T16:28:19" MIMETYPE="text/xml" CHECKSUM="267e5a1c6b70573570d480da350e5fbae2015f45" CHECKSUMTYPE="SHA-1" SIZE="144949">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-11-11T16:28:19" MIMETYPE="text/xml"
-				CHECKSUM="79ecce7a674102f5ef2fea62a2c445b1b116e7f6" CHECKSUMTYPE="SHA-1" SIZE="2341">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-11-11T16:28:19" MIMETYPE="text/xml" CHECKSUM="79ecce7a674102f5ef2fea62a2c445b1b116e7f6" CHECKSUMTYPE="SHA-1" SIZE="2341">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-11-11T16:28:19" MIMETYPE="text/xml"
-				CHECKSUM="a87624b7d3c88fd7192acf0a5863cb06a5c8a7f8" CHECKSUMTYPE="SHA-1" SIZE="36976">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-11-11T16:28:19" MIMETYPE="text/xml" CHECKSUM="a87624b7d3c88fd7192acf0a5863cb06a5c8a7f8" CHECKSUMTYPE="SHA-1" SIZE="36976">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-11-11T16:28:20" MIMETYPE="text/xml"
-				CHECKSUM="52a513cfd7fc0bdd5450d2d6ba565386349d219f" CHECKSUMTYPE="SHA-1" SIZE="99038">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-11-11T16:28:20" MIMETYPE="text/xml" CHECKSUM="52a513cfd7fc0bdd5450d2d6ba565386349d219f" CHECKSUMTYPE="SHA-1" SIZE="99038">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-11-11T16:28:20" MIMETYPE="text/xml"
-				CHECKSUM="ef8bb1f83dda5828f164b921d8bc41708244b928" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-11-11T16:28:20" MIMETYPE="text/xml" CHECKSUM="ef8bb1f83dda5828f164b921d8bc41708244b928" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-11-11T16:28:20" MIMETYPE="text/xml"
-				CHECKSUM="fc3f6be18f2b5aabc153505d297d941d1a45b3f3" CHECKSUMTYPE="SHA-1" SIZE="124603">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-11-11T16:28:20" MIMETYPE="text/xml" CHECKSUM="fc3f6be18f2b5aabc153505d297d941d1a45b3f3" CHECKSUMTYPE="SHA-1" SIZE="124603">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-11-11T16:28:21" MIMETYPE="text/xml"
-				CHECKSUM="2a86f6c52c7c3330229c361f79534f67fb328ec4" CHECKSUMTYPE="SHA-1" SIZE="117534">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-11-11T16:28:21" MIMETYPE="text/xml" CHECKSUM="2a86f6c52c7c3330229c361f79534f67fb328ec4" CHECKSUMTYPE="SHA-1" SIZE="117534">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-11-11T16:28:21" MIMETYPE="text/xml"
-				CHECKSUM="b206bd19a345874a16ee3f6c65536211c423a7a3" CHECKSUMTYPE="SHA-1" SIZE="2352">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-11-11T16:28:21" MIMETYPE="text/xml" CHECKSUM="b206bd19a345874a16ee3f6c65536211c423a7a3" CHECKSUMTYPE="SHA-1" SIZE="2352">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-11-11T16:28:21" MIMETYPE="text/xml"
-				CHECKSUM="9ee80326236acd4a5728aa5182af1cacd5b3ca8d" CHECKSUMTYPE="SHA-1" SIZE="116131">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-11-11T16:28:21" MIMETYPE="text/xml" CHECKSUM="9ee80326236acd4a5728aa5182af1cacd5b3ca8d" CHECKSUMTYPE="SHA-1" SIZE="116131">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-11-11T16:28:22" MIMETYPE="text/xml"
-				CHECKSUM="45affbc9770fb6680a053241121d107b66291432" CHECKSUMTYPE="SHA-1" SIZE="124150">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-11-11T16:28:22" MIMETYPE="text/xml" CHECKSUM="45affbc9770fb6680a053241121d107b66291432" CHECKSUMTYPE="SHA-1" SIZE="124150">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-11-11T16:28:22" MIMETYPE="text/xml"
-				CHECKSUM="350a7c6b51cf9a85a441e0509e102c2ae10ae283" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-11-11T16:28:22" MIMETYPE="text/xml" CHECKSUM="350a7c6b51cf9a85a441e0509e102c2ae10ae283" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-11-11T16:28:22" MIMETYPE="text/xml"
-				CHECKSUM="dd5b9b28b83840244dfef1c6c538754b950ad26f" CHECKSUMTYPE="SHA-1" SIZE="2341">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-11-11T16:28:22" MIMETYPE="text/xml" CHECKSUM="dd5b9b28b83840244dfef1c6c538754b950ad26f" CHECKSUMTYPE="SHA-1" SIZE="2341">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-11-11T16:28:23" MIMETYPE="text/xml"
-				CHECKSUM="144f597845a7208d548baa74cf84391d26a066ff" CHECKSUMTYPE="SHA-1" SIZE="35981">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-11-11T16:28:23" MIMETYPE="text/xml" CHECKSUM="144f597845a7208d548baa74cf84391d26a066ff" CHECKSUMTYPE="SHA-1" SIZE="35981">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-11-11T16:28:23" MIMETYPE="text/xml"
-				CHECKSUM="bebb119ffb78e06d26295ae14e56e2183de81ccd" CHECKSUMTYPE="SHA-1" SIZE="155270">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-11-11T16:28:23" MIMETYPE="text/xml" CHECKSUM="bebb119ffb78e06d26295ae14e56e2183de81ccd" CHECKSUMTYPE="SHA-1" SIZE="155270">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-11-11T16:28:23" MIMETYPE="text/xml"
-				CHECKSUM="ea74bbd8e31a24e01fb71556e69985d5aedceb5c" CHECKSUMTYPE="SHA-1" SIZE="1959">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-11-11T16:28:23" MIMETYPE="text/xml" CHECKSUM="ea74bbd8e31a24e01fb71556e69985d5aedceb5c" CHECKSUMTYPE="SHA-1" SIZE="1959">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-11-11T16:28:24" MIMETYPE="text/xml"
-				CHECKSUM="3ebcbed3f9ade8f565fd87a03c0995fdde3c5030" CHECKSUMTYPE="SHA-1" SIZE="5447">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-11-11T16:28:24" MIMETYPE="text/xml" CHECKSUM="3ebcbed3f9ade8f565fd87a03c0995fdde3c5030" CHECKSUMTYPE="SHA-1" SIZE="5447">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-11-11T16:28:24" MIMETYPE="text/xml"
-				CHECKSUM="bc1e9456aa1d508f89964246815af95d95e57d5f" CHECKSUMTYPE="SHA-1" SIZE="123276">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-11-11T16:28:24" MIMETYPE="text/xml" CHECKSUM="bc1e9456aa1d508f89964246815af95d95e57d5f" CHECKSUMTYPE="SHA-1" SIZE="123276">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-11-11T16:28:24" MIMETYPE="text/xml"
-				CHECKSUM="49e9a36409368eea260bd8b642b004b211873635" CHECKSUMTYPE="SHA-1" SIZE="45930">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-11-11T16:28:24" MIMETYPE="text/xml" CHECKSUM="49e9a36409368eea260bd8b642b004b211873635" CHECKSUMTYPE="SHA-1" SIZE="45930">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-11-11T16:28:24" MIMETYPE="text/xml"
-				CHECKSUM="6eff1118027da665ae1981bdaed4b49f05af2af6" CHECKSUMTYPE="SHA-1" SIZE="34225">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-11-11T16:28:24" MIMETYPE="text/xml" CHECKSUM="6eff1118027da665ae1981bdaed4b49f05af2af6" CHECKSUMTYPE="SHA-1" SIZE="34225">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-11-11T16:28:25" MIMETYPE="text/xml"
-				CHECKSUM="b22331fb0ceffb529893258fc35a9da0f19576bc" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-11-11T16:28:25" MIMETYPE="text/xml" CHECKSUM="b22331fb0ceffb529893258fc35a9da0f19576bc" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-11-11T16:28:25" MIMETYPE="text/xml"
-				CHECKSUM="4a2f48d0d9dd5e2f19630d6d1a7cb8791b9daf02" CHECKSUMTYPE="SHA-1" SIZE="2044">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-11-11T16:28:25" MIMETYPE="text/xml" CHECKSUM="4a2f48d0d9dd5e2f19630d6d1a7cb8791b9daf02" CHECKSUMTYPE="SHA-1" SIZE="2044">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1895-11_01_0084.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-11-11T16:31:57" MIMETYPE="application/pdf" CHECKSUM="90e4e2fc980b31535107ddcd49a2f93f749423a1"
-				CHECKSUMTYPE="SHA-1" SIZE="44561114">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/bmtnabe_1895-11_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-11-11T16:31:57" MIMETYPE="application/pdf" CHECKSUM="90e4e2fc980b31535107ddcd49a2f93f749423a1" CHECKSUMTYPE="SHA-1" SIZE="44561114">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1895/11_01/bmtnabe_1895-11_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -9612,8 +9354,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.8" TYPE="TextContent" ORDER="8" DMDID="c035"
-						LABEL="AUS DER ABTEILUNG ITALIENISCHER BRONZEN IN DEN BERLINER MUSEEN">
+					<div ID="L.1.1.3.8" TYPE="TextContent" ORDER="8" DMDID="c035" LABEL="AUS DER ABTEILUNG ITALIENISCHER BRONZEN IN DEN BERLINER MUSEEN">
 						<div ID="L.1.1.3.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00050" BEGIN="P50_TB00002"/>

--- a/metadata/periodicals/bmtnabe/issues/1896/02_01/bmtnabe_1896-02_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1896/02_01/bmtnabe_1896-02_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1896-02_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1896-02_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +15,9 @@
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<!-- This  issue has a problem where the table of contents page numbers start becoming one off from the numbers printed on the page. That was generally not a problem for determining which illustration is referred to -->
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-02_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-02_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1896-02_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1896-02_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +43,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-02_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -9637,1004 +9633,672 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T16:28:12" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="024e0ad9c4dc7fb251838f78893881ac6134aebc" CHECKSUMTYPE="SHA-1" SIZE="5091426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T16:28:41" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="e4863ddae6581c06fb927cfa66f754e8ed7ef11a" CHECKSUMTYPE="SHA-1" SIZE="5206627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T16:29:13" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="d3400ebb0e8f15e729cf7d0876ef1c7ed150a736" CHECKSUMTYPE="SHA-1" SIZE="5167914">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T16:29:42" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="686fbaedb62634756dd26d52e0122c04d4bd4966" CHECKSUMTYPE="SHA-1" SIZE="5329028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T16:30:09" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="06c64c581fe1d8a93293eae55ec88e09d85fbd88" CHECKSUMTYPE="SHA-1" SIZE="4919374">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T16:30:36" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="9b7849cda087d0ef18ff70a9bace1aa868dc1797" CHECKSUMTYPE="SHA-1" SIZE="5177828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T16:31:07" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="8cdc57a96ec617160bd4041f3bbd522b7af1c78b" CHECKSUMTYPE="SHA-1" SIZE="5117527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T16:31:34" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="0916e12d0c421dc86d0539aa4e8cdf701b7a8411" CHECKSUMTYPE="SHA-1" SIZE="5319125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T16:31:59" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="4ee1c08bbf18b27a0205a02b660640d65950fc8a" CHECKSUMTYPE="SHA-1" SIZE="5104926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T16:32:29" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="285afb467f023309dd1378c022e8a9cc1f4e61b6" CHECKSUMTYPE="SHA-1" SIZE="5341614">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T16:32:55" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="e6cc4915041f7ceac1c9faa5d95111d831c6658a" CHECKSUMTYPE="SHA-1" SIZE="4929427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T16:33:23" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="e06b3a2c6f3be6ea7f2d92d984707adeee8e1ea5" CHECKSUMTYPE="SHA-1" SIZE="5288510">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T16:33:51" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="f63c98a18f8f3a0b3f67f6d9f3fbd7f856b57dda" CHECKSUMTYPE="SHA-1" SIZE="5083987">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T16:34:19" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="eaf62a4e4aa743afd026a3b0d3c54cf92ea9da87" CHECKSUMTYPE="SHA-1" SIZE="5306526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T16:34:46" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="e7ea47d9cfca8433c793e0ffc4b5bf8e20d56a0e" CHECKSUMTYPE="SHA-1" SIZE="5000489">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T16:35:16" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="d90aa832590fa75c590fd2a3ecae0b4f72411730" CHECKSUMTYPE="SHA-1" SIZE="5239027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T16:35:41" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="7cba0e03f40ca3258f82be58966faa186882a60f" CHECKSUMTYPE="SHA-1" SIZE="4975288">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T16:36:07" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="3735054b016194ddb07c6065a137c1ad14a232c7" CHECKSUMTYPE="SHA-1" SIZE="5217429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T16:36:34" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="debcf1d8a8659281b02c9375e664ba815eadc6fc" CHECKSUMTYPE="SHA-1" SIZE="5073354">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T16:37:01" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="32cd30033ef2ebf68386a10fe8a1a0534b791358" CHECKSUMTYPE="SHA-1" SIZE="5272307">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T16:37:28" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="15f30204bd3a12beaed7560ad2043032698f96a8" CHECKSUMTYPE="SHA-1" SIZE="5059829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T16:37:56" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="c394c8acaff6e5f68122fa742bcfbdd5c24bc31b" CHECKSUMTYPE="SHA-1" SIZE="5312826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T16:38:22" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="743a0df0a8ece253ee3bcb748fd6851359f1ec30" CHECKSUMTYPE="SHA-1" SIZE="5201116">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T16:38:51" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="abd93382f858d6d6cc858346e518138033a6b116" CHECKSUMTYPE="SHA-1" SIZE="5257026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T16:39:20" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="37f0044cf3f6586ecd8089a564a3bb9248b6ae08" CHECKSUMTYPE="SHA-1" SIZE="5019429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T16:39:45" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="afc8493e9a0f6738ddb63275f932341beba57242" CHECKSUMTYPE="SHA-1" SIZE="5200175">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T16:40:10" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="83f0ff898e8ab4b3490744f5730197e8ea76dcac" CHECKSUMTYPE="SHA-1" SIZE="5006828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T16:40:38" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="b55df8fe9cae70418d6b24c7494609285fe620cb" CHECKSUMTYPE="SHA-1" SIZE="5202118">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T16:41:05" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="9abc11418f075df42674ce325e970860f1055600" CHECKSUMTYPE="SHA-1" SIZE="4921326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T16:41:32" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="3584f46597a84fc1af81be27b8be3c1d78cf5d66" CHECKSUMTYPE="SHA-1" SIZE="5216529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T16:41:57" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="5cabfd11d51635478df792cd7693e883ec3325fd" CHECKSUMTYPE="SHA-1" SIZE="5031122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T16:42:26" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="a9c30fddd064a8bf07574046d31cccf472660ba5" CHECKSUMTYPE="SHA-1" SIZE="5193128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T16:42:51" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="d615dd907e50618aee8d36981cb8eaf8ca132ef0" CHECKSUMTYPE="SHA-1" SIZE="5055429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T16:43:17" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="029bff1a16d60ddb4c6d2e47ebbea3603c28cef0" CHECKSUMTYPE="SHA-1" SIZE="5247084">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T16:43:43" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="fa0bd333e71b70cb33851f7584806e6b11d56c6e" CHECKSUMTYPE="SHA-1" SIZE="5044614">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T16:44:07" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="270e19eed51716422c91b7762b88676cbcf94458" CHECKSUMTYPE="SHA-1" SIZE="5243528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T16:44:31" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="e3d0abab07f5e22e95192ef9d9061652f845bfe7" CHECKSUMTYPE="SHA-1" SIZE="5000523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T16:44:58" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="cf746296fffb66a50597d2765e04b834cecb59b2" CHECKSUMTYPE="SHA-1" SIZE="5236287">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T16:45:27" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="72f2d963a25637b9241585192657e5e78102e27c" CHECKSUMTYPE="SHA-1" SIZE="5053584">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T16:45:52" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="523f3944c9cedcf64ff0012786502eb809651105" CHECKSUMTYPE="SHA-1" SIZE="5168829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T16:46:17" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="1d4fd8128c2ab4aee7638464ac26ed119551fdb3" CHECKSUMTYPE="SHA-1" SIZE="5014908">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T16:46:46" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="6183c818b3d85718c6600009d527bada90e119ae" CHECKSUMTYPE="SHA-1" SIZE="5171518">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T16:47:11" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="9df353a20f3fb60e3e177ce02a40f39dcc1c87ff" CHECKSUMTYPE="SHA-1" SIZE="5029329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T16:47:38" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="490b1e47f146e030d230ffefca5feee15909b38e" CHECKSUMTYPE="SHA-1" SIZE="5134627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T16:48:04" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="5c9ac7003343075623dd024c631d79c8b2565073" CHECKSUMTYPE="SHA-1" SIZE="5005027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T16:48:33" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="6de2f333809674599b647117567073c467c082a8" CHECKSUMTYPE="SHA-1" SIZE="5181426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T16:48:59" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="740f25ea627ae80bcc3cf02d00bc1e86039f590a" CHECKSUMTYPE="SHA-1" SIZE="5005029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T16:49:26" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="d47afeceb9ff0774402b1e61dbd993796d0919aa" CHECKSUMTYPE="SHA-1" SIZE="5161621">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T16:49:53" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="a381e037791c76ac2f59f776a2e569d8e4762df6" CHECKSUMTYPE="SHA-1" SIZE="5053608">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T16:50:23" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="67b424c7a2efe2776b24bfb2e1a9b73dce2c0295" CHECKSUMTYPE="SHA-1" SIZE="5153528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T16:50:49" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="c7f9f204a3cd7aea7cb5b7e744b02597375911b1" CHECKSUMTYPE="SHA-1" SIZE="5005927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T16:51:14" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="0295c1e5fe6c472877dcd86ce0c62f47dc3d5c51" CHECKSUMTYPE="SHA-1" SIZE="5110281">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T16:51:43" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="fd7740ab53bb3c6382aa574dffda5ab09690e9c0" CHECKSUMTYPE="SHA-1" SIZE="5006810">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T16:52:07" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="56ebeb14a87d36c51bf4dde687888b4abbf9550d" CHECKSUMTYPE="SHA-1" SIZE="5098616">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T16:52:33" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="f034e5ba0659ac947bc0cb46bd0d1ced4488197c" CHECKSUMTYPE="SHA-1" SIZE="5018528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T16:52:59" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="6edbc3ebe7e9316f230cecf97b1346e78142b0ee" CHECKSUMTYPE="SHA-1" SIZE="5103128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T16:53:26" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="65425fd2700b127e41383f35b13b07a023d7bc6e" CHECKSUMTYPE="SHA-1" SIZE="5018525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T16:53:52" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="b8df4520a473c7a8d77edbf5cd571866412297a7" CHECKSUMTYPE="SHA-1" SIZE="5112127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T16:54:17" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="855f0ddd28d7d0592c2c77c0ec88d34891d4b28e" CHECKSUMTYPE="SHA-1" SIZE="5015803">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T16:54:43" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="faba2f7fb40fac5c7e9f9cd1e97c9272195da1e0" CHECKSUMTYPE="SHA-1" SIZE="5112125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T16:55:10" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="aa417093187142db4f573da5b6a5efa832e82a5f" CHECKSUMTYPE="SHA-1" SIZE="5014018">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T16:55:37" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="8309253b063dbd24935713ac27c20bb5df8cc9ee" CHECKSUMTYPE="SHA-1" SIZE="5084229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T16:56:00" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="06d9c8b300cbbe80e5d6e417d343081f954b969c" CHECKSUMTYPE="SHA-1" SIZE="5006661">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T16:56:28" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="4e800eed5c12b1bfdbca04b11a12834b61813372" CHECKSUMTYPE="SHA-1" SIZE="5066220">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T16:56:54" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="e33207ecf84de837b1ec10d462d2eb1ddf5fdb98" CHECKSUMTYPE="SHA-1" SIZE="5005927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T16:57:23" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="5caca6928803e1ed884d6ec8f8e76c2b41b760ef" CHECKSUMTYPE="SHA-1" SIZE="5045526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T16:57:49" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="5057495a9d05f3df49cd9b026e0537ec07638eed" CHECKSUMTYPE="SHA-1" SIZE="5000529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T16:58:17" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="eef56d34ce81115827ad2800e27d9821d4182039" CHECKSUMTYPE="SHA-1" SIZE="5007724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T16:58:41" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="53bbc6b0c909f0dbaeb2919f572a2cb3ef38b6d3" CHECKSUMTYPE="SHA-1" SIZE="5000524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T16:59:07" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="fe571090a5708bdd06524d8b4f466524969d0fb9" CHECKSUMTYPE="SHA-1" SIZE="4993311">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T16:59:33" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="f261c66974d0112d41b15e16570e7a9a6b5d3f66" CHECKSUMTYPE="SHA-1" SIZE="4987925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T17:00:02" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="ddb498a55aad76856d6c663e1c0ab54660ce6315" CHECKSUMTYPE="SHA-1" SIZE="4990620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T17:00:26" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="4fb4be399795214ec9c6294da223cb730ba7db74" CHECKSUMTYPE="SHA-1" SIZE="4983410">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T17:00:53" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="bf28f18a9f6138440b8806a87d30944eb7768c43" CHECKSUMTYPE="SHA-1" SIZE="4984054">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T17:01:18" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="01de025f6d04c5137eb369b30b6f1e0a42c1809f" CHECKSUMTYPE="SHA-1" SIZE="4991447">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T17:01:45" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="c8a32b7064a36a9a17c3388c576a787c9a9cc4ce" CHECKSUMTYPE="SHA-1" SIZE="4994228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T17:02:09" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="2f985de42c120d7fc5d9466930560bcc1974df4c" CHECKSUMTYPE="SHA-1" SIZE="5005016">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T17:02:41" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="1001636565d8efd3bdbb0ff51547a16a50efea35" CHECKSUMTYPE="SHA-1" SIZE="4948245">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:03:04" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="244d8173eebce7cd847053b8ec8d45fc36133672" CHECKSUMTYPE="SHA-1" SIZE="4967228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:03:30" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="4522831759e11fe1287bbe2585a1689d103a9757" CHECKSUMTYPE="SHA-1" SIZE="4933014">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:04:00" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="3a5f612be39037b08396d5d90506f787c8483e3b" CHECKSUMTYPE="SHA-1" SIZE="4960899">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:04:27" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="a8f77e795a704923305f8591599d506213853686" CHECKSUMTYPE="SHA-1" SIZE="4932116">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:04:56" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="df27c64c5773dc4e1bcf3d07ab29ff23e3ca88a5" CHECKSUMTYPE="SHA-1" SIZE="4985874">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:05:21" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="b7d62b63be6b6cc66cc78fb23457b76b58a4c9d1" CHECKSUMTYPE="SHA-1" SIZE="4968069">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:05:46" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="bff204d0e73fe13f41fe48880a1ee71c7fcf0141" CHECKSUMTYPE="SHA-1" SIZE="4988820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:06:11" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="6e64315576e5b733a3aa61552b433a5a40562b97" CHECKSUMTYPE="SHA-1" SIZE="4927612">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:06:38" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="f91d5fd07c892218fa7de8b611223b62f5062a30" CHECKSUMTYPE="SHA-1" SIZE="4986127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:07:06" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="065e8e064ba9d4e66199f6f90dfefabfeb739551" CHECKSUMTYPE="SHA-1" SIZE="4918533">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:07:33" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="95c3e7bc50e3660711d14997a3f5432d06efd52a" CHECKSUMTYPE="SHA-1" SIZE="5064269">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:08:00" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="f053d74912e7f211fd2e6bd9c5e3b4461f5ac8df" CHECKSUMTYPE="SHA-1" SIZE="4939303">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:08:25" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="867676a2163dcafe42324cf27960a758d158c332" CHECKSUMTYPE="SHA-1" SIZE="4948328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:08:48" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="f64d3ff1f862c8b6ca0dffcdbdee3a964c77c36c" CHECKSUMTYPE="SHA-1" SIZE="4939328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:09:11" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="1ba27fa03819721cb7f0334174ac4c62d7be86b0" CHECKSUMTYPE="SHA-1" SIZE="4977116">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T17:09:40" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="07f1cad069da83d2238c6ba91ae02184601b92d8" CHECKSUMTYPE="SHA-1" SIZE="4969026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0094.jp2"/>
-			</file>
-			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T17:10:06" MIMETYPE="image/jp2" SEQ="95"
-				CHECKSUM="b3a3fefea1ed6734fa1122fe6669a903ca710fc3" CHECKSUMTYPE="SHA-1" SIZE="5032028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0095.jp2"/>
-			</file>
-			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T17:10:31" MIMETYPE="image/jp2" SEQ="96"
-				CHECKSUM="4b3463e0421b303e58cc84155457ba4672c009fd" CHECKSUMTYPE="SHA-1" SIZE="4943821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0096.jp2"/>
-			</file>
-			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T17:10:56" MIMETYPE="image/jp2" SEQ="97"
-				CHECKSUM="e1f3978a97b515522e86470ba9fbf349da5cd919" CHECKSUMTYPE="SHA-1" SIZE="4954619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0097.jp2"/>
-			</file>
-			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T17:11:20" MIMETYPE="image/jp2" SEQ="98"
-				CHECKSUM="2e44ec58e85072b7cb79b33d4134322e12ff1df4" CHECKSUMTYPE="SHA-1" SIZE="4918625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0098.jp2"/>
-			</file>
-			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T17:11:44" MIMETYPE="image/jp2" SEQ="99"
-				CHECKSUM="0189f0e0582e82082e992790b25bb8331b5ac10b" CHECKSUMTYPE="SHA-1" SIZE="4985229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0099.jp2"/>
-			</file>
-			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T17:12:12" MIMETYPE="image/jp2" SEQ="100"
-				CHECKSUM="e27a7b6b467adbc61d87ff8969a40cd95664efd8" CHECKSUMTYPE="SHA-1" SIZE="4945628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0100.jp2"/>
-			</file>
-			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T17:12:36" MIMETYPE="image/jp2" SEQ="101"
-				CHECKSUM="2342058b6cc6cc44cf47568020ad9f83b78a26c6" CHECKSUMTYPE="SHA-1" SIZE="4966316">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0101.jp2"/>
-			</file>
-			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T17:13:03" MIMETYPE="image/jp2" SEQ="102"
-				CHECKSUM="96a92d256101b462a73fb8a6ca31bf46958db35b" CHECKSUMTYPE="SHA-1" SIZE="4960860">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0102.jp2"/>
-			</file>
-			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T17:13:28" MIMETYPE="image/jp2" SEQ="103"
-				CHECKSUM="97afa8aaf0d1046ff08c7bf8ae1b3bb970fd11ea" CHECKSUMTYPE="SHA-1" SIZE="4977128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0103.jp2"/>
-			</file>
-			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T17:13:53" MIMETYPE="image/jp2" SEQ="104"
-				CHECKSUM="3d8e797bce7e7a2b0499a0ffc50fa514f3db70a2" CHECKSUMTYPE="SHA-1" SIZE="4996929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0104.jp2"/>
-			</file>
-			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T17:14:21" MIMETYPE="image/jp2" SEQ="105"
-				CHECKSUM="48bc4a346c2c7905ee89ec1d4a2f440e06419eac" CHECKSUMTYPE="SHA-1" SIZE="4983428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0105.jp2"/>
-			</file>
-			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T17:14:49" MIMETYPE="image/jp2" SEQ="106"
-				CHECKSUM="ff8f50bb58030beba0c33856a3cddb298d65372e" CHECKSUMTYPE="SHA-1" SIZE="4998728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0106.jp2"/>
-			</file>
-			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T17:15:14" MIMETYPE="image/jp2" SEQ="107"
-				CHECKSUM="566103317b45cbfebecde5f63295bce99b99601b" CHECKSUMTYPE="SHA-1" SIZE="4993326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0107.jp2"/>
-			</file>
-			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T17:15:41" MIMETYPE="image/jp2" SEQ="108"
-				CHECKSUM="e119c79864d6ca334c8d191b82d9beb99ce11a78" CHECKSUMTYPE="SHA-1" SIZE="5033817">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0108.jp2"/>
-			</file>
-			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T17:16:08" MIMETYPE="image/jp2" SEQ="109"
-				CHECKSUM="e9fb4223dc1eba9e7f35be961ba21e2b023b70fe" CHECKSUMTYPE="SHA-1" SIZE="4987929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0109.jp2"/>
-			</file>
-			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T17:16:35" MIMETYPE="image/jp2" SEQ="110"
-				CHECKSUM="6ee5d54d57929860ab84e35be0083406c598b103" CHECKSUMTYPE="SHA-1" SIZE="4987020">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0110.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T16:28:12" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="024e0ad9c4dc7fb251838f78893881ac6134aebc" CHECKSUMTYPE="SHA-1" SIZE="5091426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T16:28:41" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="e4863ddae6581c06fb927cfa66f754e8ed7ef11a" CHECKSUMTYPE="SHA-1" SIZE="5206627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T16:29:13" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="d3400ebb0e8f15e729cf7d0876ef1c7ed150a736" CHECKSUMTYPE="SHA-1" SIZE="5167914">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T16:29:42" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="686fbaedb62634756dd26d52e0122c04d4bd4966" CHECKSUMTYPE="SHA-1" SIZE="5329028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T16:30:09" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="06c64c581fe1d8a93293eae55ec88e09d85fbd88" CHECKSUMTYPE="SHA-1" SIZE="4919374">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T16:30:36" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="9b7849cda087d0ef18ff70a9bace1aa868dc1797" CHECKSUMTYPE="SHA-1" SIZE="5177828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T16:31:07" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="8cdc57a96ec617160bd4041f3bbd522b7af1c78b" CHECKSUMTYPE="SHA-1" SIZE="5117527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T16:31:34" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="0916e12d0c421dc86d0539aa4e8cdf701b7a8411" CHECKSUMTYPE="SHA-1" SIZE="5319125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T16:31:59" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="4ee1c08bbf18b27a0205a02b660640d65950fc8a" CHECKSUMTYPE="SHA-1" SIZE="5104926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T16:32:29" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="285afb467f023309dd1378c022e8a9cc1f4e61b6" CHECKSUMTYPE="SHA-1" SIZE="5341614">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T16:32:55" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="e6cc4915041f7ceac1c9faa5d95111d831c6658a" CHECKSUMTYPE="SHA-1" SIZE="4929427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T16:33:23" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="e06b3a2c6f3be6ea7f2d92d984707adeee8e1ea5" CHECKSUMTYPE="SHA-1" SIZE="5288510">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T16:33:51" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="f63c98a18f8f3a0b3f67f6d9f3fbd7f856b57dda" CHECKSUMTYPE="SHA-1" SIZE="5083987">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T16:34:19" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="eaf62a4e4aa743afd026a3b0d3c54cf92ea9da87" CHECKSUMTYPE="SHA-1" SIZE="5306526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T16:34:46" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="e7ea47d9cfca8433c793e0ffc4b5bf8e20d56a0e" CHECKSUMTYPE="SHA-1" SIZE="5000489">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T16:35:16" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d90aa832590fa75c590fd2a3ecae0b4f72411730" CHECKSUMTYPE="SHA-1" SIZE="5239027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T16:35:41" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7cba0e03f40ca3258f82be58966faa186882a60f" CHECKSUMTYPE="SHA-1" SIZE="4975288">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T16:36:07" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="3735054b016194ddb07c6065a137c1ad14a232c7" CHECKSUMTYPE="SHA-1" SIZE="5217429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T16:36:34" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="debcf1d8a8659281b02c9375e664ba815eadc6fc" CHECKSUMTYPE="SHA-1" SIZE="5073354">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T16:37:01" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="32cd30033ef2ebf68386a10fe8a1a0534b791358" CHECKSUMTYPE="SHA-1" SIZE="5272307">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T16:37:28" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="15f30204bd3a12beaed7560ad2043032698f96a8" CHECKSUMTYPE="SHA-1" SIZE="5059829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T16:37:56" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="c394c8acaff6e5f68122fa742bcfbdd5c24bc31b" CHECKSUMTYPE="SHA-1" SIZE="5312826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T16:38:22" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="743a0df0a8ece253ee3bcb748fd6851359f1ec30" CHECKSUMTYPE="SHA-1" SIZE="5201116">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T16:38:51" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="abd93382f858d6d6cc858346e518138033a6b116" CHECKSUMTYPE="SHA-1" SIZE="5257026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T16:39:20" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="37f0044cf3f6586ecd8089a564a3bb9248b6ae08" CHECKSUMTYPE="SHA-1" SIZE="5019429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T16:39:45" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="afc8493e9a0f6738ddb63275f932341beba57242" CHECKSUMTYPE="SHA-1" SIZE="5200175">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T16:40:10" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="83f0ff898e8ab4b3490744f5730197e8ea76dcac" CHECKSUMTYPE="SHA-1" SIZE="5006828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T16:40:38" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="b55df8fe9cae70418d6b24c7494609285fe620cb" CHECKSUMTYPE="SHA-1" SIZE="5202118">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T16:41:05" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="9abc11418f075df42674ce325e970860f1055600" CHECKSUMTYPE="SHA-1" SIZE="4921326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T16:41:32" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="3584f46597a84fc1af81be27b8be3c1d78cf5d66" CHECKSUMTYPE="SHA-1" SIZE="5216529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T16:41:57" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="5cabfd11d51635478df792cd7693e883ec3325fd" CHECKSUMTYPE="SHA-1" SIZE="5031122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T16:42:26" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="a9c30fddd064a8bf07574046d31cccf472660ba5" CHECKSUMTYPE="SHA-1" SIZE="5193128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T16:42:51" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="d615dd907e50618aee8d36981cb8eaf8ca132ef0" CHECKSUMTYPE="SHA-1" SIZE="5055429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T16:43:17" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="029bff1a16d60ddb4c6d2e47ebbea3603c28cef0" CHECKSUMTYPE="SHA-1" SIZE="5247084">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T16:43:43" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="fa0bd333e71b70cb33851f7584806e6b11d56c6e" CHECKSUMTYPE="SHA-1" SIZE="5044614">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T16:44:07" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="270e19eed51716422c91b7762b88676cbcf94458" CHECKSUMTYPE="SHA-1" SIZE="5243528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T16:44:31" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="e3d0abab07f5e22e95192ef9d9061652f845bfe7" CHECKSUMTYPE="SHA-1" SIZE="5000523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T16:44:58" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="cf746296fffb66a50597d2765e04b834cecb59b2" CHECKSUMTYPE="SHA-1" SIZE="5236287">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T16:45:27" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="72f2d963a25637b9241585192657e5e78102e27c" CHECKSUMTYPE="SHA-1" SIZE="5053584">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T16:45:52" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="523f3944c9cedcf64ff0012786502eb809651105" CHECKSUMTYPE="SHA-1" SIZE="5168829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T16:46:17" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="1d4fd8128c2ab4aee7638464ac26ed119551fdb3" CHECKSUMTYPE="SHA-1" SIZE="5014908">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T16:46:46" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="6183c818b3d85718c6600009d527bada90e119ae" CHECKSUMTYPE="SHA-1" SIZE="5171518">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T16:47:11" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="9df353a20f3fb60e3e177ce02a40f39dcc1c87ff" CHECKSUMTYPE="SHA-1" SIZE="5029329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T16:47:38" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="490b1e47f146e030d230ffefca5feee15909b38e" CHECKSUMTYPE="SHA-1" SIZE="5134627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T16:48:04" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="5c9ac7003343075623dd024c631d79c8b2565073" CHECKSUMTYPE="SHA-1" SIZE="5005027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T16:48:33" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="6de2f333809674599b647117567073c467c082a8" CHECKSUMTYPE="SHA-1" SIZE="5181426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T16:48:59" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="740f25ea627ae80bcc3cf02d00bc1e86039f590a" CHECKSUMTYPE="SHA-1" SIZE="5005029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T16:49:26" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="d47afeceb9ff0774402b1e61dbd993796d0919aa" CHECKSUMTYPE="SHA-1" SIZE="5161621">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T16:49:53" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="a381e037791c76ac2f59f776a2e569d8e4762df6" CHECKSUMTYPE="SHA-1" SIZE="5053608">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T16:50:23" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="67b424c7a2efe2776b24bfb2e1a9b73dce2c0295" CHECKSUMTYPE="SHA-1" SIZE="5153528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T16:50:49" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="c7f9f204a3cd7aea7cb5b7e744b02597375911b1" CHECKSUMTYPE="SHA-1" SIZE="5005927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T16:51:14" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="0295c1e5fe6c472877dcd86ce0c62f47dc3d5c51" CHECKSUMTYPE="SHA-1" SIZE="5110281">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T16:51:43" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="fd7740ab53bb3c6382aa574dffda5ab09690e9c0" CHECKSUMTYPE="SHA-1" SIZE="5006810">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T16:52:07" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="56ebeb14a87d36c51bf4dde687888b4abbf9550d" CHECKSUMTYPE="SHA-1" SIZE="5098616">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T16:52:33" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="f034e5ba0659ac947bc0cb46bd0d1ced4488197c" CHECKSUMTYPE="SHA-1" SIZE="5018528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T16:52:59" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="6edbc3ebe7e9316f230cecf97b1346e78142b0ee" CHECKSUMTYPE="SHA-1" SIZE="5103128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T16:53:26" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="65425fd2700b127e41383f35b13b07a023d7bc6e" CHECKSUMTYPE="SHA-1" SIZE="5018525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T16:53:52" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="b8df4520a473c7a8d77edbf5cd571866412297a7" CHECKSUMTYPE="SHA-1" SIZE="5112127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T16:54:17" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="855f0ddd28d7d0592c2c77c0ec88d34891d4b28e" CHECKSUMTYPE="SHA-1" SIZE="5015803">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T16:54:43" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="faba2f7fb40fac5c7e9f9cd1e97c9272195da1e0" CHECKSUMTYPE="SHA-1" SIZE="5112125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T16:55:10" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="aa417093187142db4f573da5b6a5efa832e82a5f" CHECKSUMTYPE="SHA-1" SIZE="5014018">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T16:55:37" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="8309253b063dbd24935713ac27c20bb5df8cc9ee" CHECKSUMTYPE="SHA-1" SIZE="5084229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T16:56:00" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="06d9c8b300cbbe80e5d6e417d343081f954b969c" CHECKSUMTYPE="SHA-1" SIZE="5006661">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T16:56:28" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="4e800eed5c12b1bfdbca04b11a12834b61813372" CHECKSUMTYPE="SHA-1" SIZE="5066220">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T16:56:54" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="e33207ecf84de837b1ec10d462d2eb1ddf5fdb98" CHECKSUMTYPE="SHA-1" SIZE="5005927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T16:57:23" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="5caca6928803e1ed884d6ec8f8e76c2b41b760ef" CHECKSUMTYPE="SHA-1" SIZE="5045526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T16:57:49" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="5057495a9d05f3df49cd9b026e0537ec07638eed" CHECKSUMTYPE="SHA-1" SIZE="5000529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T16:58:17" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="eef56d34ce81115827ad2800e27d9821d4182039" CHECKSUMTYPE="SHA-1" SIZE="5007724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T16:58:41" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="53bbc6b0c909f0dbaeb2919f572a2cb3ef38b6d3" CHECKSUMTYPE="SHA-1" SIZE="5000524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T16:59:07" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="fe571090a5708bdd06524d8b4f466524969d0fb9" CHECKSUMTYPE="SHA-1" SIZE="4993311">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T16:59:33" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="f261c66974d0112d41b15e16570e7a9a6b5d3f66" CHECKSUMTYPE="SHA-1" SIZE="4987925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T17:00:02" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="ddb498a55aad76856d6c663e1c0ab54660ce6315" CHECKSUMTYPE="SHA-1" SIZE="4990620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T17:00:26" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="4fb4be399795214ec9c6294da223cb730ba7db74" CHECKSUMTYPE="SHA-1" SIZE="4983410">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T17:00:53" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="bf28f18a9f6138440b8806a87d30944eb7768c43" CHECKSUMTYPE="SHA-1" SIZE="4984054">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T17:01:18" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="01de025f6d04c5137eb369b30b6f1e0a42c1809f" CHECKSUMTYPE="SHA-1" SIZE="4991447">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T17:01:45" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="c8a32b7064a36a9a17c3388c576a787c9a9cc4ce" CHECKSUMTYPE="SHA-1" SIZE="4994228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T17:02:09" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="2f985de42c120d7fc5d9466930560bcc1974df4c" CHECKSUMTYPE="SHA-1" SIZE="5005016">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T17:02:41" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="1001636565d8efd3bdbb0ff51547a16a50efea35" CHECKSUMTYPE="SHA-1" SIZE="4948245">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:03:04" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="244d8173eebce7cd847053b8ec8d45fc36133672" CHECKSUMTYPE="SHA-1" SIZE="4967228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:03:30" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="4522831759e11fe1287bbe2585a1689d103a9757" CHECKSUMTYPE="SHA-1" SIZE="4933014">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:04:00" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="3a5f612be39037b08396d5d90506f787c8483e3b" CHECKSUMTYPE="SHA-1" SIZE="4960899">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:04:27" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="a8f77e795a704923305f8591599d506213853686" CHECKSUMTYPE="SHA-1" SIZE="4932116">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:04:56" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="df27c64c5773dc4e1bcf3d07ab29ff23e3ca88a5" CHECKSUMTYPE="SHA-1" SIZE="4985874">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:05:21" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="b7d62b63be6b6cc66cc78fb23457b76b58a4c9d1" CHECKSUMTYPE="SHA-1" SIZE="4968069">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:05:46" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="bff204d0e73fe13f41fe48880a1ee71c7fcf0141" CHECKSUMTYPE="SHA-1" SIZE="4988820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:06:11" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="6e64315576e5b733a3aa61552b433a5a40562b97" CHECKSUMTYPE="SHA-1" SIZE="4927612">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:06:38" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="f91d5fd07c892218fa7de8b611223b62f5062a30" CHECKSUMTYPE="SHA-1" SIZE="4986127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:07:06" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="065e8e064ba9d4e66199f6f90dfefabfeb739551" CHECKSUMTYPE="SHA-1" SIZE="4918533">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:07:33" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="95c3e7bc50e3660711d14997a3f5432d06efd52a" CHECKSUMTYPE="SHA-1" SIZE="5064269">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:08:00" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="f053d74912e7f211fd2e6bd9c5e3b4461f5ac8df" CHECKSUMTYPE="SHA-1" SIZE="4939303">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:08:25" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="867676a2163dcafe42324cf27960a758d158c332" CHECKSUMTYPE="SHA-1" SIZE="4948328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:08:48" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="f64d3ff1f862c8b6ca0dffcdbdee3a964c77c36c" CHECKSUMTYPE="SHA-1" SIZE="4939328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:09:11" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="1ba27fa03819721cb7f0334174ac4c62d7be86b0" CHECKSUMTYPE="SHA-1" SIZE="4977116">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T17:09:40" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="07f1cad069da83d2238c6ba91ae02184601b92d8" CHECKSUMTYPE="SHA-1" SIZE="4969026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0094.jp2"/>
+			</file>
+			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T17:10:06" MIMETYPE="image/jp2" SEQ="95" CHECKSUM="b3a3fefea1ed6734fa1122fe6669a903ca710fc3" CHECKSUMTYPE="SHA-1" SIZE="5032028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0095.jp2"/>
+			</file>
+			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T17:10:31" MIMETYPE="image/jp2" SEQ="96" CHECKSUM="4b3463e0421b303e58cc84155457ba4672c009fd" CHECKSUMTYPE="SHA-1" SIZE="4943821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0096.jp2"/>
+			</file>
+			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T17:10:56" MIMETYPE="image/jp2" SEQ="97" CHECKSUM="e1f3978a97b515522e86470ba9fbf349da5cd919" CHECKSUMTYPE="SHA-1" SIZE="4954619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0097.jp2"/>
+			</file>
+			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T17:11:20" MIMETYPE="image/jp2" SEQ="98" CHECKSUM="2e44ec58e85072b7cb79b33d4134322e12ff1df4" CHECKSUMTYPE="SHA-1" SIZE="4918625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0098.jp2"/>
+			</file>
+			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T17:11:44" MIMETYPE="image/jp2" SEQ="99" CHECKSUM="0189f0e0582e82082e992790b25bb8331b5ac10b" CHECKSUMTYPE="SHA-1" SIZE="4985229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0099.jp2"/>
+			</file>
+			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T17:12:12" MIMETYPE="image/jp2" SEQ="100" CHECKSUM="e27a7b6b467adbc61d87ff8969a40cd95664efd8" CHECKSUMTYPE="SHA-1" SIZE="4945628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0100.jp2"/>
+			</file>
+			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T17:12:36" MIMETYPE="image/jp2" SEQ="101" CHECKSUM="2342058b6cc6cc44cf47568020ad9f83b78a26c6" CHECKSUMTYPE="SHA-1" SIZE="4966316">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0101.jp2"/>
+			</file>
+			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T17:13:03" MIMETYPE="image/jp2" SEQ="102" CHECKSUM="96a92d256101b462a73fb8a6ca31bf46958db35b" CHECKSUMTYPE="SHA-1" SIZE="4960860">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0102.jp2"/>
+			</file>
+			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T17:13:28" MIMETYPE="image/jp2" SEQ="103" CHECKSUM="97afa8aaf0d1046ff08c7bf8ae1b3bb970fd11ea" CHECKSUMTYPE="SHA-1" SIZE="4977128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0103.jp2"/>
+			</file>
+			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T17:13:53" MIMETYPE="image/jp2" SEQ="104" CHECKSUM="3d8e797bce7e7a2b0499a0ffc50fa514f3db70a2" CHECKSUMTYPE="SHA-1" SIZE="4996929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0104.jp2"/>
+			</file>
+			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T17:14:21" MIMETYPE="image/jp2" SEQ="105" CHECKSUM="48bc4a346c2c7905ee89ec1d4a2f440e06419eac" CHECKSUMTYPE="SHA-1" SIZE="4983428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0105.jp2"/>
+			</file>
+			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T17:14:49" MIMETYPE="image/jp2" SEQ="106" CHECKSUM="ff8f50bb58030beba0c33856a3cddb298d65372e" CHECKSUMTYPE="SHA-1" SIZE="4998728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0106.jp2"/>
+			</file>
+			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T17:15:14" MIMETYPE="image/jp2" SEQ="107" CHECKSUM="566103317b45cbfebecde5f63295bce99b99601b" CHECKSUMTYPE="SHA-1" SIZE="4993326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0107.jp2"/>
+			</file>
+			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T17:15:41" MIMETYPE="image/jp2" SEQ="108" CHECKSUM="e119c79864d6ca334c8d191b82d9beb99ce11a78" CHECKSUMTYPE="SHA-1" SIZE="5033817">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0108.jp2"/>
+			</file>
+			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T17:16:08" MIMETYPE="image/jp2" SEQ="109" CHECKSUM="e9fb4223dc1eba9e7f35be961ba21e2b023b70fe" CHECKSUMTYPE="SHA-1" SIZE="4987929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0109.jp2"/>
+			</file>
+			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T17:16:35" MIMETYPE="image/jp2" SEQ="110" CHECKSUM="6ee5d54d57929860ab84e35be0083406c598b103" CHECKSUMTYPE="SHA-1" SIZE="4987020">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/delivery/bmtnabe_1896-02_01_0110.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T17:16:51" MIMETYPE="text/xml" CHECKSUM="82ff28dd9ec80b64d0d55b7e7155c92104bf3547"
-				CHECKSUMTYPE="SHA-1" SIZE="2113">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T17:16:51" MIMETYPE="text/xml" CHECKSUM="82ff28dd9ec80b64d0d55b7e7155c92104bf3547" CHECKSUMTYPE="SHA-1" SIZE="2113">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T17:16:51" MIMETYPE="text/xml" CHECKSUM="6eb058e62d3c3baa8372b675aa6955abcf81167c"
-				CHECKSUMTYPE="SHA-1" SIZE="26532">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T17:16:51" MIMETYPE="text/xml" CHECKSUM="6eb058e62d3c3baa8372b675aa6955abcf81167c" CHECKSUMTYPE="SHA-1" SIZE="26532">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T17:16:51" MIMETYPE="text/xml" CHECKSUM="139bf4c6a006760cbb621a20b7233addf3bf77a7"
-				CHECKSUMTYPE="SHA-1" SIZE="4714">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T17:16:51" MIMETYPE="text/xml" CHECKSUM="139bf4c6a006760cbb621a20b7233addf3bf77a7" CHECKSUMTYPE="SHA-1" SIZE="4714">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T17:16:52" MIMETYPE="text/xml" CHECKSUM="e4ffb163cfabc205eb5af81ff3df170aa2865d5b"
-				CHECKSUMTYPE="SHA-1" SIZE="1998">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T17:16:52" MIMETYPE="text/xml" CHECKSUM="e4ffb163cfabc205eb5af81ff3df170aa2865d5b" CHECKSUMTYPE="SHA-1" SIZE="1998">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T17:16:52" MIMETYPE="text/xml" CHECKSUM="550d9034bae7bd03d2755454c74e8192a080daa2"
-				CHECKSUMTYPE="SHA-1" SIZE="43353">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T17:16:52" MIMETYPE="text/xml" CHECKSUM="550d9034bae7bd03d2755454c74e8192a080daa2" CHECKSUMTYPE="SHA-1" SIZE="43353">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T17:16:52" MIMETYPE="text/xml" CHECKSUM="fd2c99ff2a7b26a6951101331e4ccdcd027e5807"
-				CHECKSUMTYPE="SHA-1" SIZE="76798">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T17:16:52" MIMETYPE="text/xml" CHECKSUM="fd2c99ff2a7b26a6951101331e4ccdcd027e5807" CHECKSUMTYPE="SHA-1" SIZE="76798">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T17:16:53" MIMETYPE="text/xml" CHECKSUM="3180e3a8d8c0c1d43d5cc262bef4b2667e3fa0ec"
-				CHECKSUMTYPE="SHA-1" SIZE="89824">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T17:16:53" MIMETYPE="text/xml" CHECKSUM="3180e3a8d8c0c1d43d5cc262bef4b2667e3fa0ec" CHECKSUMTYPE="SHA-1" SIZE="89824">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T17:16:53" MIMETYPE="text/xml" CHECKSUM="42380d5e02a97dd047f3479b035489b1dd6804ba"
-				CHECKSUMTYPE="SHA-1" SIZE="90758">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T17:16:53" MIMETYPE="text/xml" CHECKSUM="42380d5e02a97dd047f3479b035489b1dd6804ba" CHECKSUMTYPE="SHA-1" SIZE="90758">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T17:16:53" MIMETYPE="text/xml" CHECKSUM="c4f0fa68e05b606b69e0b6a660b4f4a53fb38230"
-				CHECKSUMTYPE="SHA-1" SIZE="5518">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T17:16:53" MIMETYPE="text/xml" CHECKSUM="c4f0fa68e05b606b69e0b6a660b4f4a53fb38230" CHECKSUMTYPE="SHA-1" SIZE="5518">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T17:16:54" MIMETYPE="text/xml"
-				CHECKSUM="a1c9caa3ee614905fa3350af18090f84bdd955c3" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T17:16:54" MIMETYPE="text/xml" CHECKSUM="a1c9caa3ee614905fa3350af18090f84bdd955c3" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T17:16:54" MIMETYPE="text/xml"
-				CHECKSUM="8e6e7e7a203b374057119ecd69c8a069697c213e" CHECKSUMTYPE="SHA-1" SIZE="21140">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T17:16:54" MIMETYPE="text/xml" CHECKSUM="8e6e7e7a203b374057119ecd69c8a069697c213e" CHECKSUMTYPE="SHA-1" SIZE="21140">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T17:16:54" MIMETYPE="text/xml"
-				CHECKSUM="000bad86fd4b2f338eec3bcfe5da876fb360d55f" CHECKSUMTYPE="SHA-1" SIZE="135626">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T17:16:54" MIMETYPE="text/xml" CHECKSUM="000bad86fd4b2f338eec3bcfe5da876fb360d55f" CHECKSUMTYPE="SHA-1" SIZE="135626">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T17:16:54" MIMETYPE="text/xml"
-				CHECKSUM="139fab0d3891781c2894a0b6189248ec34f4a356" CHECKSUMTYPE="SHA-1" SIZE="217931">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T17:16:54" MIMETYPE="text/xml" CHECKSUM="139fab0d3891781c2894a0b6189248ec34f4a356" CHECKSUMTYPE="SHA-1" SIZE="217931">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T17:16:55" MIMETYPE="text/xml"
-				CHECKSUM="2e7ff1f12a9d6564b716f2d44480ff0779744ed5" CHECKSUMTYPE="SHA-1" SIZE="214161">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T17:16:55" MIMETYPE="text/xml" CHECKSUM="2e7ff1f12a9d6564b716f2d44480ff0779744ed5" CHECKSUMTYPE="SHA-1" SIZE="214161">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T17:16:55" MIMETYPE="text/xml"
-				CHECKSUM="3d1cd15388da3796d3f87461c8518875da06b9e0" CHECKSUMTYPE="SHA-1" SIZE="4502">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T17:16:55" MIMETYPE="text/xml" CHECKSUM="3d1cd15388da3796d3f87461c8518875da06b9e0" CHECKSUMTYPE="SHA-1" SIZE="4502">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T17:16:55" MIMETYPE="text/xml"
-				CHECKSUM="8f84a480e09f777ca0de8a8301d7f3306b80fd1a" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T17:16:55" MIMETYPE="text/xml" CHECKSUM="8f84a480e09f777ca0de8a8301d7f3306b80fd1a" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T17:16:56" MIMETYPE="text/xml"
-				CHECKSUM="65cf50bd368fdef1d7d88529355c33bd81fa9f00" CHECKSUMTYPE="SHA-1" SIZE="200947">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T17:16:56" MIMETYPE="text/xml" CHECKSUM="65cf50bd368fdef1d7d88529355c33bd81fa9f00" CHECKSUMTYPE="SHA-1" SIZE="200947">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T17:16:56" MIMETYPE="text/xml"
-				CHECKSUM="b65491d8ab4f8e6c553460530f76a89e35c9151b" CHECKSUMTYPE="SHA-1" SIZE="199238">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T17:16:56" MIMETYPE="text/xml" CHECKSUM="b65491d8ab4f8e6c553460530f76a89e35c9151b" CHECKSUMTYPE="SHA-1" SIZE="199238">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T17:16:57" MIMETYPE="text/xml"
-				CHECKSUM="203e3d24718847cc327b7de83aa272d52bc239c6" CHECKSUMTYPE="SHA-1" SIZE="209601">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T17:16:57" MIMETYPE="text/xml" CHECKSUM="203e3d24718847cc327b7de83aa272d52bc239c6" CHECKSUMTYPE="SHA-1" SIZE="209601">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T17:16:57" MIMETYPE="text/xml"
-				CHECKSUM="fbcd53325908ee1eb93ad34a1ba8dced92332c79" CHECKSUMTYPE="SHA-1" SIZE="216365">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T17:16:57" MIMETYPE="text/xml" CHECKSUM="fbcd53325908ee1eb93ad34a1ba8dced92332c79" CHECKSUMTYPE="SHA-1" SIZE="216365">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T17:16:57" MIMETYPE="text/xml"
-				CHECKSUM="d0ae64adf96300b1fc1c43987705f3adfa639e26" CHECKSUMTYPE="SHA-1" SIZE="217570">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T17:16:57" MIMETYPE="text/xml" CHECKSUM="d0ae64adf96300b1fc1c43987705f3adfa639e26" CHECKSUMTYPE="SHA-1" SIZE="217570">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T17:16:58" MIMETYPE="text/xml"
-				CHECKSUM="5530f215061ae270679795435b2a5d619bdb7ab8" CHECKSUMTYPE="SHA-1" SIZE="193793">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T17:16:58" MIMETYPE="text/xml" CHECKSUM="5530f215061ae270679795435b2a5d619bdb7ab8" CHECKSUMTYPE="SHA-1" SIZE="193793">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T17:16:59" MIMETYPE="text/xml"
-				CHECKSUM="cdfb2426e86a41988a28c727759c1558d554f647" CHECKSUMTYPE="SHA-1" SIZE="208727">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T17:16:59" MIMETYPE="text/xml" CHECKSUM="cdfb2426e86a41988a28c727759c1558d554f647" CHECKSUMTYPE="SHA-1" SIZE="208727">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T17:16:59" MIMETYPE="text/xml"
-				CHECKSUM="718dbe45dace1b2eb9d38ddfc602bb01669542bd" CHECKSUMTYPE="SHA-1" SIZE="204258">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T17:16:59" MIMETYPE="text/xml" CHECKSUM="718dbe45dace1b2eb9d38ddfc602bb01669542bd" CHECKSUMTYPE="SHA-1" SIZE="204258">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T17:17:00" MIMETYPE="text/xml"
-				CHECKSUM="ffd2d592e25d07e9fd19eed9c8c5392980e8b339" CHECKSUMTYPE="SHA-1" SIZE="4414">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T17:17:00" MIMETYPE="text/xml" CHECKSUM="ffd2d592e25d07e9fd19eed9c8c5392980e8b339" CHECKSUMTYPE="SHA-1" SIZE="4414">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T17:17:00" MIMETYPE="text/xml"
-				CHECKSUM="3c1cb52ce05ce0b32d17ab099fb2088b686e47b8" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T17:17:00" MIMETYPE="text/xml" CHECKSUM="3c1cb52ce05ce0b32d17ab099fb2088b686e47b8" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T17:17:00" MIMETYPE="text/xml"
-				CHECKSUM="6fbb792dddd1c7de4b99711e60033cc09ecddd42" CHECKSUMTYPE="SHA-1" SIZE="200319">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T17:17:00" MIMETYPE="text/xml" CHECKSUM="6fbb792dddd1c7de4b99711e60033cc09ecddd42" CHECKSUMTYPE="SHA-1" SIZE="200319">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T17:17:00" MIMETYPE="text/xml"
-				CHECKSUM="921a18bd5c0d426d331fe334946bc35ce51e986d" CHECKSUMTYPE="SHA-1" SIZE="194960">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T17:17:00" MIMETYPE="text/xml" CHECKSUM="921a18bd5c0d426d331fe334946bc35ce51e986d" CHECKSUMTYPE="SHA-1" SIZE="194960">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T17:17:01" MIMETYPE="text/xml"
-				CHECKSUM="e28741c6124fc0f69f62c42dac35a8477136c325" CHECKSUMTYPE="SHA-1" SIZE="190313">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T17:17:01" MIMETYPE="text/xml" CHECKSUM="e28741c6124fc0f69f62c42dac35a8477136c325" CHECKSUMTYPE="SHA-1" SIZE="190313">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T17:17:01" MIMETYPE="text/xml"
-				CHECKSUM="0e2f1e9197a21bdf3da73fe3828d6031aef0d67b" CHECKSUMTYPE="SHA-1" SIZE="198177">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T17:17:01" MIMETYPE="text/xml" CHECKSUM="0e2f1e9197a21bdf3da73fe3828d6031aef0d67b" CHECKSUMTYPE="SHA-1" SIZE="198177">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T17:17:02" MIMETYPE="text/xml"
-				CHECKSUM="0d5c9735af8be52b69ec5625526b31e36f2e74f9" CHECKSUMTYPE="SHA-1" SIZE="199330">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T17:17:02" MIMETYPE="text/xml" CHECKSUM="0d5c9735af8be52b69ec5625526b31e36f2e74f9" CHECKSUMTYPE="SHA-1" SIZE="199330">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T17:17:02" MIMETYPE="text/xml"
-				CHECKSUM="e9e53691a6ade65245280dae88be2299b0eb9314" CHECKSUMTYPE="SHA-1" SIZE="193408">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T17:17:02" MIMETYPE="text/xml" CHECKSUM="e9e53691a6ade65245280dae88be2299b0eb9314" CHECKSUMTYPE="SHA-1" SIZE="193408">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T17:17:02" MIMETYPE="text/xml"
-				CHECKSUM="53e0647e7e025b4665b30cbd4c6d2bd879c606a7" CHECKSUMTYPE="SHA-1" SIZE="85272">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T17:17:02" MIMETYPE="text/xml" CHECKSUM="53e0647e7e025b4665b30cbd4c6d2bd879c606a7" CHECKSUMTYPE="SHA-1" SIZE="85272">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T17:17:03" MIMETYPE="text/xml"
-				CHECKSUM="abe58b89c1ea5dbc679bd336626fd7fd710f9f45" CHECKSUMTYPE="SHA-1" SIZE="17306">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T17:17:03" MIMETYPE="text/xml" CHECKSUM="abe58b89c1ea5dbc679bd336626fd7fd710f9f45" CHECKSUMTYPE="SHA-1" SIZE="17306">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T17:17:03" MIMETYPE="text/xml"
-				CHECKSUM="9b2f79b9829dc6e766b05c96016b6682140cfe7b" CHECKSUMTYPE="SHA-1" SIZE="4467">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T17:17:03" MIMETYPE="text/xml" CHECKSUM="9b2f79b9829dc6e766b05c96016b6682140cfe7b" CHECKSUMTYPE="SHA-1" SIZE="4467">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T17:17:03" MIMETYPE="text/xml"
-				CHECKSUM="3c406a0bd15e03c3a7b09fc4042f90dd50ea7612" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T17:17:03" MIMETYPE="text/xml" CHECKSUM="3c406a0bd15e03c3a7b09fc4042f90dd50ea7612" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T17:17:03" MIMETYPE="text/xml"
-				CHECKSUM="8c2d538f2d0305ab519bc4f1e110be2008ec9223" CHECKSUMTYPE="SHA-1" SIZE="55894">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T17:17:03" MIMETYPE="text/xml" CHECKSUM="8c2d538f2d0305ab519bc4f1e110be2008ec9223" CHECKSUMTYPE="SHA-1" SIZE="55894">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T17:17:04" MIMETYPE="text/xml"
-				CHECKSUM="a6252864cbc1670b718c952db17b69366481409a" CHECKSUMTYPE="SHA-1" SIZE="72615">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T17:17:04" MIMETYPE="text/xml" CHECKSUM="a6252864cbc1670b718c952db17b69366481409a" CHECKSUMTYPE="SHA-1" SIZE="72615">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T17:17:04" MIMETYPE="text/xml"
-				CHECKSUM="d4bb09331c36d9940ea079f9fb0b771abbc1f1f0" CHECKSUMTYPE="SHA-1" SIZE="47917">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T17:17:04" MIMETYPE="text/xml" CHECKSUM="d4bb09331c36d9940ea079f9fb0b771abbc1f1f0" CHECKSUMTYPE="SHA-1" SIZE="47917">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T17:17:04" MIMETYPE="text/xml"
-				CHECKSUM="e2591a38bfc05095f07dfef998d77b270caf9a5c" CHECKSUMTYPE="SHA-1" SIZE="101960">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T17:17:04" MIMETYPE="text/xml" CHECKSUM="e2591a38bfc05095f07dfef998d77b270caf9a5c" CHECKSUMTYPE="SHA-1" SIZE="101960">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T17:17:05" MIMETYPE="text/xml"
-				CHECKSUM="33c05ed3d2d6c391fa0d40dfb8baba93a85708db" CHECKSUMTYPE="SHA-1" SIZE="201153">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T17:17:05" MIMETYPE="text/xml" CHECKSUM="33c05ed3d2d6c391fa0d40dfb8baba93a85708db" CHECKSUMTYPE="SHA-1" SIZE="201153">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T17:17:05" MIMETYPE="text/xml"
-				CHECKSUM="646965cbe5f0adf8a53c05042541c026154d376d" CHECKSUMTYPE="SHA-1" SIZE="198124">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T17:17:05" MIMETYPE="text/xml" CHECKSUM="646965cbe5f0adf8a53c05042541c026154d376d" CHECKSUMTYPE="SHA-1" SIZE="198124">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T17:17:05" MIMETYPE="text/xml"
-				CHECKSUM="f6ec4de008d9dc38affa8858cf9ddf5dd910315f" CHECKSUMTYPE="SHA-1" SIZE="199877">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T17:17:05" MIMETYPE="text/xml" CHECKSUM="f6ec4de008d9dc38affa8858cf9ddf5dd910315f" CHECKSUMTYPE="SHA-1" SIZE="199877">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T17:17:06" MIMETYPE="text/xml"
-				CHECKSUM="befc159e8da78adaff6bedc734e289d20b48841d" CHECKSUMTYPE="SHA-1" SIZE="43277">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T17:17:06" MIMETYPE="text/xml" CHECKSUM="befc159e8da78adaff6bedc734e289d20b48841d" CHECKSUMTYPE="SHA-1" SIZE="43277">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T17:17:06" MIMETYPE="text/xml"
-				CHECKSUM="0c1253414b4fffb4f154213a64639ad568d21e38" CHECKSUMTYPE="SHA-1" SIZE="13039">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T17:17:06" MIMETYPE="text/xml" CHECKSUM="0c1253414b4fffb4f154213a64639ad568d21e38" CHECKSUMTYPE="SHA-1" SIZE="13039">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T17:17:06" MIMETYPE="text/xml"
-				CHECKSUM="883cb58dc20a49d3fbf5e158ce7a0f84d963c131" CHECKSUMTYPE="SHA-1" SIZE="39680">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T17:17:06" MIMETYPE="text/xml" CHECKSUM="883cb58dc20a49d3fbf5e158ce7a0f84d963c131" CHECKSUMTYPE="SHA-1" SIZE="39680">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T17:17:06" MIMETYPE="text/xml"
-				CHECKSUM="ea5464e9ce5342c1761ead1b3a46ec198c26e971" CHECKSUMTYPE="SHA-1" SIZE="110940">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T17:17:06" MIMETYPE="text/xml" CHECKSUM="ea5464e9ce5342c1761ead1b3a46ec198c26e971" CHECKSUMTYPE="SHA-1" SIZE="110940">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T17:17:07" MIMETYPE="text/xml"
-				CHECKSUM="8413480f60a7cf3b670b85cdcee28c01ddddab57" CHECKSUMTYPE="SHA-1" SIZE="201449">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T17:17:07" MIMETYPE="text/xml" CHECKSUM="8413480f60a7cf3b670b85cdcee28c01ddddab57" CHECKSUMTYPE="SHA-1" SIZE="201449">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T17:17:07" MIMETYPE="text/xml"
-				CHECKSUM="45906ff08e1741cca832bec6872e6aa8305ff726" CHECKSUMTYPE="SHA-1" SIZE="202347">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T17:17:07" MIMETYPE="text/xml" CHECKSUM="45906ff08e1741cca832bec6872e6aa8305ff726" CHECKSUMTYPE="SHA-1" SIZE="202347">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T17:17:08" MIMETYPE="text/xml"
-				CHECKSUM="0d37956eb20dd0495fb04408bbd0ea89a0186136" CHECKSUMTYPE="SHA-1" SIZE="25773">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T17:17:08" MIMETYPE="text/xml" CHECKSUM="0d37956eb20dd0495fb04408bbd0ea89a0186136" CHECKSUMTYPE="SHA-1" SIZE="25773">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T17:17:08" MIMETYPE="text/xml"
-				CHECKSUM="f0f4aebb76847b5f57657a836532b495919e98c9" CHECKSUMTYPE="SHA-1" SIZE="50896">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T17:17:08" MIMETYPE="text/xml" CHECKSUM="f0f4aebb76847b5f57657a836532b495919e98c9" CHECKSUMTYPE="SHA-1" SIZE="50896">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T17:17:08" MIMETYPE="text/xml"
-				CHECKSUM="d3ac998f92c12bb53786488e3934c0f1bd56eb31" CHECKSUMTYPE="SHA-1" SIZE="26335">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T17:17:08" MIMETYPE="text/xml" CHECKSUM="d3ac998f92c12bb53786488e3934c0f1bd56eb31" CHECKSUMTYPE="SHA-1" SIZE="26335">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T17:17:09" MIMETYPE="text/xml"
-				CHECKSUM="2ef85cebc42eafbef77b2b60f3c76e5f444d07c1" CHECKSUMTYPE="SHA-1" SIZE="4282">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T17:17:09" MIMETYPE="text/xml" CHECKSUM="2ef85cebc42eafbef77b2b60f3c76e5f444d07c1" CHECKSUMTYPE="SHA-1" SIZE="4282">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T17:17:09" MIMETYPE="text/xml"
-				CHECKSUM="2c8b88ff5466c47be2e55ed33b3f0ab772bea4da" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T17:17:09" MIMETYPE="text/xml" CHECKSUM="2c8b88ff5466c47be2e55ed33b3f0ab772bea4da" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T17:17:09" MIMETYPE="text/xml"
-				CHECKSUM="bad300599599fc8ce1399ed60c41f6bbb27d4443" CHECKSUMTYPE="SHA-1" SIZE="73618">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T17:17:09" MIMETYPE="text/xml" CHECKSUM="bad300599599fc8ce1399ed60c41f6bbb27d4443" CHECKSUMTYPE="SHA-1" SIZE="73618">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T17:17:09" MIMETYPE="text/xml"
-				CHECKSUM="f99329b305f19895ac87d6c6805aaa1643deac1f" CHECKSUMTYPE="SHA-1" SIZE="99296">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T17:17:09" MIMETYPE="text/xml" CHECKSUM="f99329b305f19895ac87d6c6805aaa1643deac1f" CHECKSUMTYPE="SHA-1" SIZE="99296">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T17:17:10" MIMETYPE="text/xml"
-				CHECKSUM="56a06666b5b0064e44179a67cf8f1cbe03385b23" CHECKSUMTYPE="SHA-1" SIZE="76826">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T17:17:10" MIMETYPE="text/xml" CHECKSUM="56a06666b5b0064e44179a67cf8f1cbe03385b23" CHECKSUMTYPE="SHA-1" SIZE="76826">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T17:17:10" MIMETYPE="text/xml"
-				CHECKSUM="97cd5463b4d69e88c408097163a094395ab4e380" CHECKSUMTYPE="SHA-1" SIZE="107301">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T17:17:10" MIMETYPE="text/xml" CHECKSUM="97cd5463b4d69e88c408097163a094395ab4e380" CHECKSUMTYPE="SHA-1" SIZE="107301">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T17:17:10" MIMETYPE="text/xml"
-				CHECKSUM="ea95892d2c1c374a9b30ef4ae587b286dab295be" CHECKSUMTYPE="SHA-1" SIZE="27371">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T17:17:10" MIMETYPE="text/xml" CHECKSUM="ea95892d2c1c374a9b30ef4ae587b286dab295be" CHECKSUMTYPE="SHA-1" SIZE="27371">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T17:17:10" MIMETYPE="text/xml"
-				CHECKSUM="ea02958ffb60af1c7f2aaa12befdd7c6d70fa661" CHECKSUMTYPE="SHA-1" SIZE="65457">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T17:17:10" MIMETYPE="text/xml" CHECKSUM="ea02958ffb60af1c7f2aaa12befdd7c6d70fa661" CHECKSUMTYPE="SHA-1" SIZE="65457">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T17:17:11" MIMETYPE="text/xml"
-				CHECKSUM="865d90b8d9c301c6d1b6f58ae6507a38a7973d7d" CHECKSUMTYPE="SHA-1" SIZE="5941">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T17:17:11" MIMETYPE="text/xml" CHECKSUM="865d90b8d9c301c6d1b6f58ae6507a38a7973d7d" CHECKSUMTYPE="SHA-1" SIZE="5941">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T17:17:11" MIMETYPE="text/xml"
-				CHECKSUM="dcfdeb98ad8c0e6dab47bb0b9904f1e4e01479eb" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T17:17:11" MIMETYPE="text/xml" CHECKSUM="dcfdeb98ad8c0e6dab47bb0b9904f1e4e01479eb" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T17:17:11" MIMETYPE="text/xml"
-				CHECKSUM="eed474e1a70812ba681408e2c481ca088638057d" CHECKSUMTYPE="SHA-1" SIZE="96659">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T17:17:11" MIMETYPE="text/xml" CHECKSUM="eed474e1a70812ba681408e2c481ca088638057d" CHECKSUMTYPE="SHA-1" SIZE="96659">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T17:17:11" MIMETYPE="text/xml"
-				CHECKSUM="0050aa1a172178d4a0ea3e87c94b6adc919fca9a" CHECKSUMTYPE="SHA-1" SIZE="140465">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T17:17:11" MIMETYPE="text/xml" CHECKSUM="0050aa1a172178d4a0ea3e87c94b6adc919fca9a" CHECKSUMTYPE="SHA-1" SIZE="140465">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T17:17:12" MIMETYPE="text/xml"
-				CHECKSUM="64894c7174c2def22d7d0617d09a836fc3d02bec" CHECKSUMTYPE="SHA-1" SIZE="99760">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T17:17:12" MIMETYPE="text/xml" CHECKSUM="64894c7174c2def22d7d0617d09a836fc3d02bec" CHECKSUMTYPE="SHA-1" SIZE="99760">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T17:17:12" MIMETYPE="text/xml"
-				CHECKSUM="bb602324b28dc5476fa9951e85b51da3866c8011" CHECKSUMTYPE="SHA-1" SIZE="142962">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T17:17:12" MIMETYPE="text/xml" CHECKSUM="bb602324b28dc5476fa9951e85b51da3866c8011" CHECKSUMTYPE="SHA-1" SIZE="142962">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T17:17:12" MIMETYPE="text/xml"
-				CHECKSUM="3d9de838943baa21d65fd25045dc9b1e5d67192e" CHECKSUMTYPE="SHA-1" SIZE="142457">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T17:17:12" MIMETYPE="text/xml" CHECKSUM="3d9de838943baa21d65fd25045dc9b1e5d67192e" CHECKSUMTYPE="SHA-1" SIZE="142457">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T17:17:13" MIMETYPE="text/xml"
-				CHECKSUM="dc5c912af19b561369f6ba55c41a61c6d70bb4fa" CHECKSUMTYPE="SHA-1" SIZE="87920">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T17:17:13" MIMETYPE="text/xml" CHECKSUM="dc5c912af19b561369f6ba55c41a61c6d70bb4fa" CHECKSUMTYPE="SHA-1" SIZE="87920">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T17:17:13" MIMETYPE="text/xml"
-				CHECKSUM="e36e50dd8de257addffde933cffba62641ccee44" CHECKSUMTYPE="SHA-1" SIZE="98670">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T17:17:13" MIMETYPE="text/xml" CHECKSUM="e36e50dd8de257addffde933cffba62641ccee44" CHECKSUMTYPE="SHA-1" SIZE="98670">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T17:17:13" MIMETYPE="text/xml"
-				CHECKSUM="5307aa584c1b7f0627e7db2aed1fef2e4293e0af" CHECKSUMTYPE="SHA-1" SIZE="72098">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T17:17:13" MIMETYPE="text/xml" CHECKSUM="5307aa584c1b7f0627e7db2aed1fef2e4293e0af" CHECKSUMTYPE="SHA-1" SIZE="72098">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T17:17:14" MIMETYPE="text/xml"
-				CHECKSUM="30a0f9a3fdd883375673830d9a888aed06a48f3b" CHECKSUMTYPE="SHA-1" SIZE="5846">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T17:17:14" MIMETYPE="text/xml" CHECKSUM="30a0f9a3fdd883375673830d9a888aed06a48f3b" CHECKSUMTYPE="SHA-1" SIZE="5846">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T17:17:14" MIMETYPE="text/xml"
-				CHECKSUM="0a57e6a9f52f5c6cd8455ac4d213f1406916c8e6" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T17:17:14" MIMETYPE="text/xml" CHECKSUM="0a57e6a9f52f5c6cd8455ac4d213f1406916c8e6" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T17:17:14" MIMETYPE="text/xml"
-				CHECKSUM="724701a315b283e283c23b9a4a51b69cda39a094" CHECKSUMTYPE="SHA-1" SIZE="97900">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T17:17:14" MIMETYPE="text/xml" CHECKSUM="724701a315b283e283c23b9a4a51b69cda39a094" CHECKSUMTYPE="SHA-1" SIZE="97900">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T17:17:15" MIMETYPE="text/xml"
-				CHECKSUM="f6a9f91053fe1b150a2a210fddcaf3dac60ee7e4" CHECKSUMTYPE="SHA-1" SIZE="124861">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T17:17:15" MIMETYPE="text/xml" CHECKSUM="f6a9f91053fe1b150a2a210fddcaf3dac60ee7e4" CHECKSUMTYPE="SHA-1" SIZE="124861">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T17:17:15" MIMETYPE="text/xml"
-				CHECKSUM="bff3713da75e7e6db4075e02841133fcb2351dd8" CHECKSUMTYPE="SHA-1" SIZE="92892">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T17:17:15" MIMETYPE="text/xml" CHECKSUM="bff3713da75e7e6db4075e02841133fcb2351dd8" CHECKSUMTYPE="SHA-1" SIZE="92892">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T17:17:16" MIMETYPE="text/xml"
-				CHECKSUM="d1bd864ef0b8700d21ffb52a331da2820681d919" CHECKSUMTYPE="SHA-1" SIZE="148718">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T17:17:16" MIMETYPE="text/xml" CHECKSUM="d1bd864ef0b8700d21ffb52a331da2820681d919" CHECKSUMTYPE="SHA-1" SIZE="148718">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T17:17:16" MIMETYPE="text/xml"
-				CHECKSUM="1009073ee4c64abc24b5ce6d2d2a18eaa81cadbd" CHECKSUMTYPE="SHA-1" SIZE="2403">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T17:17:16" MIMETYPE="text/xml" CHECKSUM="1009073ee4c64abc24b5ce6d2d2a18eaa81cadbd" CHECKSUMTYPE="SHA-1" SIZE="2403">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T17:17:16" MIMETYPE="text/xml"
-				CHECKSUM="168a5d77396281e22d26d0a44e6ca7642e5cc6e6" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T17:17:16" MIMETYPE="text/xml" CHECKSUM="168a5d77396281e22d26d0a44e6ca7642e5cc6e6" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T17:17:16" MIMETYPE="text/xml"
-				CHECKSUM="a968c927dda767cffe59766bffb3af9eb7e1420e" CHECKSUMTYPE="SHA-1" SIZE="106780">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T17:17:16" MIMETYPE="text/xml" CHECKSUM="a968c927dda767cffe59766bffb3af9eb7e1420e" CHECKSUMTYPE="SHA-1" SIZE="106780">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T17:17:17" MIMETYPE="text/xml"
-				CHECKSUM="144287532546141c022daf0f0a215050bf804bef" CHECKSUMTYPE="SHA-1" SIZE="86856">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T17:17:17" MIMETYPE="text/xml" CHECKSUM="144287532546141c022daf0f0a215050bf804bef" CHECKSUMTYPE="SHA-1" SIZE="86856">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T17:17:17" MIMETYPE="text/xml"
-				CHECKSUM="c9cbbe03ffba26bb35c4185c3ce23715cc8505f3" CHECKSUMTYPE="SHA-1" SIZE="82829">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T17:17:17" MIMETYPE="text/xml" CHECKSUM="c9cbbe03ffba26bb35c4185c3ce23715cc8505f3" CHECKSUMTYPE="SHA-1" SIZE="82829">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T17:17:17" MIMETYPE="text/xml"
-				CHECKSUM="4380627c7e6abc7c6d86b0c24eb34b7265fce43e" CHECKSUMTYPE="SHA-1" SIZE="109348">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T17:17:17" MIMETYPE="text/xml" CHECKSUM="4380627c7e6abc7c6d86b0c24eb34b7265fce43e" CHECKSUMTYPE="SHA-1" SIZE="109348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T17:17:18" MIMETYPE="text/xml"
-				CHECKSUM="f1e761b444ef1727a2a0dfa45215dc306e9fc290" CHECKSUMTYPE="SHA-1" SIZE="115817">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T17:17:18" MIMETYPE="text/xml" CHECKSUM="f1e761b444ef1727a2a0dfa45215dc306e9fc290" CHECKSUMTYPE="SHA-1" SIZE="115817">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T17:17:18" MIMETYPE="text/xml"
-				CHECKSUM="ab800af3cae9e8672d20d06fcc04de2bba25f19c" CHECKSUMTYPE="SHA-1" SIZE="87017">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T17:17:18" MIMETYPE="text/xml" CHECKSUM="ab800af3cae9e8672d20d06fcc04de2bba25f19c" CHECKSUMTYPE="SHA-1" SIZE="87017">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T17:17:19" MIMETYPE="text/xml"
-				CHECKSUM="0d6955d8e83849c0a52449485e99124e0e10f16d" CHECKSUMTYPE="SHA-1" SIZE="125128">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T17:17:19" MIMETYPE="text/xml" CHECKSUM="0d6955d8e83849c0a52449485e99124e0e10f16d" CHECKSUMTYPE="SHA-1" SIZE="125128">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T17:17:19" MIMETYPE="text/xml"
-				CHECKSUM="d0c1c9aee887c3b04e09ecbef67290c6250905cf" CHECKSUMTYPE="SHA-1" SIZE="163920">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T17:17:19" MIMETYPE="text/xml" CHECKSUM="d0c1c9aee887c3b04e09ecbef67290c6250905cf" CHECKSUMTYPE="SHA-1" SIZE="163920">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T17:17:20" MIMETYPE="text/xml"
-				CHECKSUM="7ae25138d3cd232e96286dc84332591383eaf5e8" CHECKSUMTYPE="SHA-1" SIZE="52119">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T17:17:20" MIMETYPE="text/xml" CHECKSUM="7ae25138d3cd232e96286dc84332591383eaf5e8" CHECKSUMTYPE="SHA-1" SIZE="52119">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T17:17:20" MIMETYPE="text/xml"
-				CHECKSUM="166bc09ffebdf136fc6e72aaa4121d434d1a56f2" CHECKSUMTYPE="SHA-1" SIZE="72636">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T17:17:20" MIMETYPE="text/xml" CHECKSUM="166bc09ffebdf136fc6e72aaa4121d434d1a56f2" CHECKSUMTYPE="SHA-1" SIZE="72636">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T17:17:20" MIMETYPE="text/xml"
-				CHECKSUM="8db758adc0f1e31fd3d476c5947c742202508e3e" CHECKSUMTYPE="SHA-1" SIZE="4496">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T17:17:20" MIMETYPE="text/xml" CHECKSUM="8db758adc0f1e31fd3d476c5947c742202508e3e" CHECKSUMTYPE="SHA-1" SIZE="4496">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T17:17:21" MIMETYPE="text/xml"
-				CHECKSUM="d5adee632e5e92adfd0212a94359c1b22f105df6" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T17:17:21" MIMETYPE="text/xml" CHECKSUM="d5adee632e5e92adfd0212a94359c1b22f105df6" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T17:17:21" MIMETYPE="text/xml"
-				CHECKSUM="5fc6e75b9d27dead2f9c999acd473f3a847d229d" CHECKSUMTYPE="SHA-1" SIZE="142531">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T17:17:21" MIMETYPE="text/xml" CHECKSUM="5fc6e75b9d27dead2f9c999acd473f3a847d229d" CHECKSUMTYPE="SHA-1" SIZE="142531">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T17:17:21" MIMETYPE="text/xml"
-				CHECKSUM="95b9e1439fdb4a318deb26be5a90489d27e005b3" CHECKSUMTYPE="SHA-1" SIZE="2403">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T17:17:21" MIMETYPE="text/xml" CHECKSUM="95b9e1439fdb4a318deb26be5a90489d27e005b3" CHECKSUMTYPE="SHA-1" SIZE="2403">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T17:17:22" MIMETYPE="text/xml"
-				CHECKSUM="adf42a5eb66fcbf6dbc025c8491b077cb0c9719b" CHECKSUMTYPE="SHA-1" SIZE="72722">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T17:17:22" MIMETYPE="text/xml" CHECKSUM="adf42a5eb66fcbf6dbc025c8491b077cb0c9719b" CHECKSUMTYPE="SHA-1" SIZE="72722">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T17:17:22" MIMETYPE="text/xml"
-				CHECKSUM="0786f054fed2afcd422cc116f51b6105a7d5f285" CHECKSUMTYPE="SHA-1" SIZE="79044">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T17:17:22" MIMETYPE="text/xml" CHECKSUM="0786f054fed2afcd422cc116f51b6105a7d5f285" CHECKSUMTYPE="SHA-1" SIZE="79044">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0094.alto.xml"/>
 			</file>
-			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T17:17:22" MIMETYPE="text/xml"
-				CHECKSUM="6dfea3708ce425792662c551de6a101c9c061994" CHECKSUMTYPE="SHA-1" SIZE="94779">
+			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T17:17:22" MIMETYPE="text/xml" CHECKSUM="6dfea3708ce425792662c551de6a101c9c061994" CHECKSUMTYPE="SHA-1" SIZE="94779">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0095.alto.xml"/>
 			</file>
-			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T17:17:23" MIMETYPE="text/xml"
-				CHECKSUM="9c2e34050644707b4515cb3df786616f409e3d29" CHECKSUMTYPE="SHA-1" SIZE="83251">
+			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T17:17:23" MIMETYPE="text/xml" CHECKSUM="9c2e34050644707b4515cb3df786616f409e3d29" CHECKSUMTYPE="SHA-1" SIZE="83251">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0096.alto.xml"/>
 			</file>
-			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T17:17:23" MIMETYPE="text/xml"
-				CHECKSUM="3af03dabe0d0a2ca578132d88fb4a0637599fe44" CHECKSUMTYPE="SHA-1" SIZE="56895">
+			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T17:17:23" MIMETYPE="text/xml" CHECKSUM="3af03dabe0d0a2ca578132d88fb4a0637599fe44" CHECKSUMTYPE="SHA-1" SIZE="56895">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0097.alto.xml"/>
 			</file>
-			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T17:17:23" MIMETYPE="text/xml"
-				CHECKSUM="4a0f96677077b7cb2a2fecb5a303b62340b46d5b" CHECKSUMTYPE="SHA-1" SIZE="35677">
+			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T17:17:23" MIMETYPE="text/xml" CHECKSUM="4a0f96677077b7cb2a2fecb5a303b62340b46d5b" CHECKSUMTYPE="SHA-1" SIZE="35677">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0098.alto.xml"/>
 			</file>
-			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T17:17:24" MIMETYPE="text/xml"
-				CHECKSUM="0e9dc325fb76774326457eed047d8a0381595a69" CHECKSUMTYPE="SHA-1" SIZE="2012">
+			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T17:17:24" MIMETYPE="text/xml" CHECKSUM="0e9dc325fb76774326457eed047d8a0381595a69" CHECKSUMTYPE="SHA-1" SIZE="2012">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0099.alto.xml"/>
 			</file>
-			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T17:17:24" MIMETYPE="text/xml"
-				CHECKSUM="8ddf72b7ce3a1848f9e219d707cff13fce350d87" CHECKSUMTYPE="SHA-1" SIZE="2019">
+			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T17:17:24" MIMETYPE="text/xml" CHECKSUM="8ddf72b7ce3a1848f9e219d707cff13fce350d87" CHECKSUMTYPE="SHA-1" SIZE="2019">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0100.alto.xml"/>
 			</file>
-			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T17:17:24" MIMETYPE="text/xml"
-				CHECKSUM="ab5d39df36df54847922910ee3e75e7517347b8a" CHECKSUMTYPE="SHA-1" SIZE="44331">
+			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T17:17:24" MIMETYPE="text/xml" CHECKSUM="ab5d39df36df54847922910ee3e75e7517347b8a" CHECKSUMTYPE="SHA-1" SIZE="44331">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0101.alto.xml"/>
 			</file>
-			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T17:17:24" MIMETYPE="text/xml"
-				CHECKSUM="f51a305b0ed5088ce1de953db43a1c5ef8daa285" CHECKSUMTYPE="SHA-1" SIZE="50718">
+			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T17:17:24" MIMETYPE="text/xml" CHECKSUM="f51a305b0ed5088ce1de953db43a1c5ef8daa285" CHECKSUMTYPE="SHA-1" SIZE="50718">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0102.alto.xml"/>
 			</file>
-			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T17:17:25" MIMETYPE="text/xml"
-				CHECKSUM="1968b43574ecc9a19deb405c86b1f3cde62bc67d" CHECKSUMTYPE="SHA-1" SIZE="89801">
+			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T17:17:25" MIMETYPE="text/xml" CHECKSUM="1968b43574ecc9a19deb405c86b1f3cde62bc67d" CHECKSUMTYPE="SHA-1" SIZE="89801">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0103.alto.xml"/>
 			</file>
-			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T17:17:26" MIMETYPE="text/xml"
-				CHECKSUM="a4c4535a6ef9829845e2c1a827b0a84001800850" CHECKSUMTYPE="SHA-1" SIZE="111093">
+			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T17:17:26" MIMETYPE="text/xml" CHECKSUM="a4c4535a6ef9829845e2c1a827b0a84001800850" CHECKSUMTYPE="SHA-1" SIZE="111093">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0104.alto.xml"/>
 			</file>
-			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T17:17:26" MIMETYPE="text/xml"
-				CHECKSUM="79b42b3b39dd9314ff5901664ac3c5d67ebd7036" CHECKSUMTYPE="SHA-1" SIZE="113644">
+			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T17:17:26" MIMETYPE="text/xml" CHECKSUM="79b42b3b39dd9314ff5901664ac3c5d67ebd7036" CHECKSUMTYPE="SHA-1" SIZE="113644">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0105.alto.xml"/>
 			</file>
-			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T17:17:26" MIMETYPE="text/xml"
-				CHECKSUM="15aed4e7d84d3498e2aae80db08ccc46c70fe314" CHECKSUMTYPE="SHA-1" SIZE="110138">
+			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T17:17:26" MIMETYPE="text/xml" CHECKSUM="15aed4e7d84d3498e2aae80db08ccc46c70fe314" CHECKSUMTYPE="SHA-1" SIZE="110138">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0106.alto.xml"/>
 			</file>
-			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T17:17:27" MIMETYPE="text/xml"
-				CHECKSUM="ff725fbb28c8b58e576ce205eb84a173e22dd7b9" CHECKSUMTYPE="SHA-1" SIZE="62675">
+			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T17:17:27" MIMETYPE="text/xml" CHECKSUM="ff725fbb28c8b58e576ce205eb84a173e22dd7b9" CHECKSUMTYPE="SHA-1" SIZE="62675">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0107.alto.xml"/>
 			</file>
-			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T17:17:27" MIMETYPE="text/xml"
-				CHECKSUM="4cb3af1c72b6d0536ffb34f94a208145cb512687" CHECKSUMTYPE="SHA-1" SIZE="2412">
+			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T17:17:27" MIMETYPE="text/xml" CHECKSUM="4cb3af1c72b6d0536ffb34f94a208145cb512687" CHECKSUMTYPE="SHA-1" SIZE="2412">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0108.alto.xml"/>
 			</file>
-			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T17:17:27" MIMETYPE="text/xml"
-				CHECKSUM="521a8010cca200e759627dc210dcd537dd1b6129" CHECKSUMTYPE="SHA-1" SIZE="2018">
+			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T17:17:27" MIMETYPE="text/xml" CHECKSUM="521a8010cca200e759627dc210dcd537dd1b6129" CHECKSUMTYPE="SHA-1" SIZE="2018">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0109.alto.xml"/>
 			</file>
-			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T17:17:27" MIMETYPE="text/xml"
-				CHECKSUM="2c8224cfbb654a8d853474e8a125d565e2b9d0cb" CHECKSUMTYPE="SHA-1" SIZE="3906">
+			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T17:17:27" MIMETYPE="text/xml" CHECKSUM="2c8224cfbb654a8d853474e8a125d565e2b9d0cb" CHECKSUMTYPE="SHA-1" SIZE="3906">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-02_01_0110.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T17:21:29" MIMETYPE="application/pdf" CHECKSUM="87849d2dc4f72f4cc89a740db29d4465c2a03922"
-				CHECKSUMTYPE="SHA-1" SIZE="57513738">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/bmtnabe_1896-02_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T17:21:29" MIMETYPE="application/pdf" CHECKSUM="87849d2dc4f72f4cc89a740db29d4465c2a03922" CHECKSUMTYPE="SHA-1" SIZE="57513738">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/02_01/bmtnabe_1896-02_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>

--- a/metadata/periodicals/bmtnabe/issues/1896/07_01/bmtnabe_1896-07_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1896/07_01/bmtnabe_1896-07_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1896-07_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1896-07_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-07_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-07_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1896-07_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1896-07_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-07_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -10525,1112 +10521,744 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T16:27:29" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="da42f247daef487292fc47ad9814281065d20169" CHECKSUMTYPE="SHA-1" SIZE="4888883">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T16:27:54" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="65a4ba3d4f85641b7b695916afbc35076005ccdd" CHECKSUMTYPE="SHA-1" SIZE="5054515">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T16:28:20" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="97f530a19efdd15d98c5dde843716600bbb81da7" CHECKSUMTYPE="SHA-1" SIZE="4888903">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T16:28:44" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="680052234cb30e53cf7caf128a70c3c3ae1055c9" CHECKSUMTYPE="SHA-1" SIZE="5054490">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T16:29:10" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="982520aa66ed0a02c3d5152f4581a6d43bed717d" CHECKSUMTYPE="SHA-1" SIZE="4888916">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T16:29:35" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="a26dda56d2d0a97108f22585698c15622a4124cb" CHECKSUMTYPE="SHA-1" SIZE="5089445">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T16:30:00" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="87ae1e066c99144f2bd90aec4b3b24a06d0598bd" CHECKSUMTYPE="SHA-1" SIZE="4820429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T16:30:23" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="411b97784d3ba687fc6a5ba4bbcf502087b42853" CHECKSUMTYPE="SHA-1" SIZE="5089605">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T16:30:50" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="1e817a7b6adebb7fd19b9af21965a43ec2c62f91" CHECKSUMTYPE="SHA-1" SIZE="4792629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T16:31:14" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="9689d3f4f73bd501b7cdf67ba854ee1c940be221" CHECKSUMTYPE="SHA-1" SIZE="5089608">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T16:31:40" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="0ae24d1013350427fc2b099a4b1db0e3b05f38f3" CHECKSUMTYPE="SHA-1" SIZE="4792616">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T16:32:04" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="4b924b12e5bdfdbb8090d90818772f9d59222a2b" CHECKSUMTYPE="SHA-1" SIZE="5089626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T16:32:29" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="e8c8528e0cdd0ef2d45ff16d03e5fc73b4b78d92" CHECKSUMTYPE="SHA-1" SIZE="4802508">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T16:32:53" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="db9c3e8a59e86c1ce641597e7ccd08dd87158583" CHECKSUMTYPE="SHA-1" SIZE="5097729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T16:33:17" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="5be9d87da38fbcf5721124123668e944d148c82f" CHECKSUMTYPE="SHA-1" SIZE="4802527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T16:33:41" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="7ed60aee52c6a82fa502afde1526be46fcc9bb0d" CHECKSUMTYPE="SHA-1" SIZE="5097723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T16:34:05" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="a22e26b7b9897bddc2695d2a7503f2d8cf037f8a" CHECKSUMTYPE="SHA-1" SIZE="4802529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T16:34:34" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="ed76f7278435a0674734464c69ba41f00349cc97" CHECKSUMTYPE="SHA-1" SIZE="5097720">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T16:35:00" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="eea75b47ef1eee7fd8c7294a34d13a4a1e45f5f6" CHECKSUMTYPE="SHA-1" SIZE="4802489">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T16:35:24" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="8148fb77a9affc189e2f47df9b5dd784ffc7723e" CHECKSUMTYPE="SHA-1" SIZE="5097700">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T16:35:47" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="497c77ea14ae44bfc7405760190bbccbe78d9999" CHECKSUMTYPE="SHA-1" SIZE="4776356">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T16:36:10" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="8bd514533370ee79076567c4d815022158093880" CHECKSUMTYPE="SHA-1" SIZE="5121121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T16:36:38" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="5ca6a0fd36a4068bcd8cd5ad2ce3525649a3fb05" CHECKSUMTYPE="SHA-1" SIZE="4776429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T16:37:06" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="4ab5f1a4c058ef8332749a05cba9f18dfe9d5788" CHECKSUMTYPE="SHA-1" SIZE="5121093">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T16:37:32" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="58f1536299ba7899172793c4d0fdd3f85b847d09" CHECKSUMTYPE="SHA-1" SIZE="4873626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T16:37:56" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="8adb7eb2ebd291fae0045c1551c25e89edc00315" CHECKSUMTYPE="SHA-1" SIZE="5121129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T16:38:21" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="136b82c2c897d60f3454d46e4a35a17610f43820" CHECKSUMTYPE="SHA-1" SIZE="4795309">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T16:38:47" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="ab81049e1cc3f370d6a2a0150fd2f842e36ddec2" CHECKSUMTYPE="SHA-1" SIZE="5121127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T16:39:12" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="51552b44fab075d9806fa963d0979a8a0d571f3e" CHECKSUMTYPE="SHA-1" SIZE="4873627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T16:39:39" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="b9eb8064b7796fb3317854e45624555266e0ec6d" CHECKSUMTYPE="SHA-1" SIZE="5121128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T16:40:04" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="582c06581bb51f1c692d2a4e2116dcead4a0b305" CHECKSUMTYPE="SHA-1" SIZE="4767427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T16:40:29" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="99dd2e5a7bf134d377b7cf157d8963026d4e271c" CHECKSUMTYPE="SHA-1" SIZE="5121088">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T16:40:54" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="175df9e507ba0f9b21545e44aeaf473546bb7224" CHECKSUMTYPE="SHA-1" SIZE="4767427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T16:41:17" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="c1295858fe92d403d4f4f7a36b65f883160b060e" CHECKSUMTYPE="SHA-1" SIZE="5144526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T16:41:43" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="7f4feeb46e3d05527f8efc60991618afac38d7dc" CHECKSUMTYPE="SHA-1" SIZE="4767423">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T16:42:07" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="85da77889cd6fe6f8bc4ffd7af9b3bdac51a5256" CHECKSUMTYPE="SHA-1" SIZE="5125629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T16:42:32" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="ff219aa97da6e4b07c733d7b6923b1b5d2c5ebba" CHECKSUMTYPE="SHA-1" SIZE="4767412">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T16:42:57" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="b566c5ccdcbd318aa47b50a106d68f6095d4391b" CHECKSUMTYPE="SHA-1" SIZE="5125579">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T16:43:21" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="b17d60da3f56336460f509073221d0aee71c6e0a" CHECKSUMTYPE="SHA-1" SIZE="4767157">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T16:43:47" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="9442f24568342dafed1fd870208fab213bb522b7" CHECKSUMTYPE="SHA-1" SIZE="5138205">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T16:44:12" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="3a5e101257122f4b8f52c59bc02140bd8b5921ce" CHECKSUMTYPE="SHA-1" SIZE="4903325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T16:44:36" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="0d316fec42f437d72c73d05d8a64b6153b844cf3" CHECKSUMTYPE="SHA-1" SIZE="5138227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T16:45:00" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="27525441db666435d3aa075472a4739e78ebb65c" CHECKSUMTYPE="SHA-1" SIZE="4781821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T16:45:26" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="9790b8950a9b457eee7003f86d1011d394fd39a1" CHECKSUMTYPE="SHA-1" SIZE="5138214">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T16:45:53" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="fecb344fb3e3477f42e6e30fefa90cf03efe90d6" CHECKSUMTYPE="SHA-1" SIZE="4913199">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T16:46:19" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="64c9daecc68992ad43835e435c8a0d1638b53c0f" CHECKSUMTYPE="SHA-1" SIZE="5138166">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T16:46:45" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="7ad6157ae8346c38f1813196d2c3d87cafab2cdc" CHECKSUMTYPE="SHA-1" SIZE="4776428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T16:47:10" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="af7473b0c4644cb9e54eca5de0aa9594c6b22e0a" CHECKSUMTYPE="SHA-1" SIZE="5155318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T16:47:37" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="71880c1dd08d0dfd032642d07d217dea1c509add" CHECKSUMTYPE="SHA-1" SIZE="4834916">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T16:48:03" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="313bfee49040243e717c1ba6a8237a9f98726f1a" CHECKSUMTYPE="SHA-1" SIZE="5155327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T16:48:28" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="dd71db74c0f443dd9562171a2d8c532ff7646d92" CHECKSUMTYPE="SHA-1" SIZE="4834861">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T16:48:54" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="385bef704d60a95eb4ecda78e8c4504448a20fd1" CHECKSUMTYPE="SHA-1" SIZE="5267818">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T16:49:20" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="4c048d325e7269af5279432f2f9fbf61cc61f4fb" CHECKSUMTYPE="SHA-1" SIZE="4808824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T16:49:45" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="8ad5ecd021fd893c196c801ae459b2ad81ee21f5" CHECKSUMTYPE="SHA-1" SIZE="5179627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T16:50:10" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="41ea8c16d30d4e9ec6e7462aef10573e3f4c7996" CHECKSUMTYPE="SHA-1" SIZE="4808822">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T16:50:33" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="13782650e5778dbbc15468408a1c22d675ec3a82" CHECKSUMTYPE="SHA-1" SIZE="5197628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T16:50:59" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="61131df087e40ee5e7095b8853f3597fb15c2d2e" CHECKSUMTYPE="SHA-1" SIZE="4808820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T16:51:24" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="3993d59fb4970879b873481823305e3e8ada5255" CHECKSUMTYPE="SHA-1" SIZE="5171516">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T16:51:50" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="15e09db42dfd111039346608bc62da3c6ec4a3e3" CHECKSUMTYPE="SHA-1" SIZE="4808787">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T16:52:14" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="b83982bff46ddfc68ff872001941bf76ed2cd360" CHECKSUMTYPE="SHA-1" SIZE="5172391">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T16:52:38" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="34da4f01f9a56e8534426627bb35b7a8485fbf10" CHECKSUMTYPE="SHA-1" SIZE="4834923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T16:53:03" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="c072f78e8a94849e2fec3a730464be1ad5e9cceb" CHECKSUMTYPE="SHA-1" SIZE="5167901">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T16:53:29" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="46e9f09f34581bbfc893f29712599e8eebb11c3a" CHECKSUMTYPE="SHA-1" SIZE="4958226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T16:53:54" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="001067464c5c16f2ee8e7b71fdfdfc6112c28d69" CHECKSUMTYPE="SHA-1" SIZE="5185022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T16:54:21" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="ccafb6d14924d35f8fd498995c369cde51d43cb3" CHECKSUMTYPE="SHA-1" SIZE="4990624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T16:54:46" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="e39576ac247f1e9e55458b65a9e819d645082f16" CHECKSUMTYPE="SHA-1" SIZE="5188628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T16:55:12" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="3f613b6f407e72c05b7814eb27941cb7248517f4" CHECKSUMTYPE="SHA-1" SIZE="4814124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T16:55:39" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="af9b2ac8a9945c16e6719a619a586fb19f93fc80" CHECKSUMTYPE="SHA-1" SIZE="5241705">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T16:56:04" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="381863e9cc1cb4bb4593a60ec3fbdbaef97cda8d" CHECKSUMTYPE="SHA-1" SIZE="4858314">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T16:56:29" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="33925eeeef710cb1faffa90449f609d7a0c89804" CHECKSUMTYPE="SHA-1" SIZE="5239920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T16:56:54" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="cae83b862570d42168851a068a1dfb7ae13c293c" CHECKSUMTYPE="SHA-1" SIZE="4858313">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T16:57:19" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="72ff5d7dd795b06fb02e3f51b899259f11cbb819" CHECKSUMTYPE="SHA-1" SIZE="5249753">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T16:57:45" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="12e7cfcc452535f9624384b9386df7a3fd0ae028" CHECKSUMTYPE="SHA-1" SIZE="4878128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T16:58:09" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="0e688fbcfd2a5a78af0dabb88e600d87fc04b087" CHECKSUMTYPE="SHA-1" SIZE="5257925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T16:58:35" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="0c09dc9ec81f9cb08e5ec51020641eec825a67cc" CHECKSUMTYPE="SHA-1" SIZE="4900624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T16:59:00" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="685d896377c54755d95c619a3c7a24b208c06dd4" CHECKSUMTYPE="SHA-1" SIZE="5259728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T16:59:26" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="8150783a0409cda99d5c52968c5a04120c39ab24" CHECKSUMTYPE="SHA-1" SIZE="4900622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T16:59:52" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="88619d2f0e69bb97587fd6e900a14e03f3936ddd" CHECKSUMTYPE="SHA-1" SIZE="5248014">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:00:20" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="cb81d73a718ce4aad2969d0d0527f87a2a2e5f8b" CHECKSUMTYPE="SHA-1" SIZE="4900627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:00:46" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="786ec1da009472ab1cd54115f6cee7b3c2776345" CHECKSUMTYPE="SHA-1" SIZE="5217415">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:01:10" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="7349c6e6237416475315924164e2a1b95240559b" CHECKSUMTYPE="SHA-1" SIZE="4900594">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:01:38" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="6f4fa706e81c174cc070c2b68a67c2784b309f81" CHECKSUMTYPE="SHA-1" SIZE="5244373">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:02:04" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="09f1d51190ded831c029152c0da6aec220886bce" CHECKSUMTYPE="SHA-1" SIZE="4900421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:02:30" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="f100370d6f2be6e86c605b7e3c61d9652e74f01f" CHECKSUMTYPE="SHA-1" SIZE="5248927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:02:55" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="1e07a414b0f4179e8332285395f206fefd9dfe74" CHECKSUMTYPE="SHA-1" SIZE="4900575">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:03:22" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="65959ae5f127d964b89515755ce3c20304a91234" CHECKSUMTYPE="SHA-1" SIZE="5256075">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:03:45" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="eae389546ed6f90820d69bdd482522c517c42b4c" CHECKSUMTYPE="SHA-1" SIZE="4900522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:04:10" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="f08702e234276645833492d9494f062e36b25ac0" CHECKSUMTYPE="SHA-1" SIZE="5236324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:04:35" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="3d6155212352cde0d4536bc439f2538565b26e52" CHECKSUMTYPE="SHA-1" SIZE="4900629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:04:59" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="afc54e50bef3d5668634d825b6867cf2fe9ffebf" CHECKSUMTYPE="SHA-1" SIZE="5254310">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:05:26" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="1f0d7da3754f3e433e8a7437c9a28a63e2ff2aee" CHECKSUMTYPE="SHA-1" SIZE="4900602">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:05:52" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="1cc32197a5fa78ba78649fd4441f44567f554c83" CHECKSUMTYPE="SHA-1" SIZE="5294827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:06:16" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="b3f874744fb6b5d4ca7bb76e29e4a96d5c3360ce" CHECKSUMTYPE="SHA-1" SIZE="4906926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T17:06:43" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="42ca9984c00ef3113904c393f6e2bc138e64805d" CHECKSUMTYPE="SHA-1" SIZE="5256105">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0094.jp2"/>
-			</file>
-			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T17:07:08" MIMETYPE="image/jp2" SEQ="95"
-				CHECKSUM="8e12ffbb1f533afb73c03459fc563f5031d0f35f" CHECKSUMTYPE="SHA-1" SIZE="5040126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0095.jp2"/>
-			</file>
-			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T17:07:33" MIMETYPE="image/jp2" SEQ="96"
-				CHECKSUM="3f2ab7ccb065ca802f4f687c691d55cd54303f5c" CHECKSUMTYPE="SHA-1" SIZE="5276812">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0096.jp2"/>
-			</file>
-			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T17:07:58" MIMETYPE="image/jp2" SEQ="97"
-				CHECKSUM="b9082735be13c56644472032d93df1ee0c9e5c2d" CHECKSUMTYPE="SHA-1" SIZE="4906922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0097.jp2"/>
-			</file>
-			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T17:08:26" MIMETYPE="image/jp2" SEQ="98"
-				CHECKSUM="7c2dc441da343ee0f93e9e0bfad4e476088ccb36" CHECKSUMTYPE="SHA-1" SIZE="5277723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0098.jp2"/>
-			</file>
-			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T17:08:50" MIMETYPE="image/jp2" SEQ="99"
-				CHECKSUM="899136b26a851dd0c8395fa3e6675aa9e39db51a" CHECKSUMTYPE="SHA-1" SIZE="4906923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0099.jp2"/>
-			</file>
-			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T17:09:15" MIMETYPE="image/jp2" SEQ="100"
-				CHECKSUM="bb90486509cf6accd4ce34d32b74212f0c8aafd3" CHECKSUMTYPE="SHA-1" SIZE="5284007">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0100.jp2"/>
-			</file>
-			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T17:09:42" MIMETYPE="image/jp2" SEQ="101"
-				CHECKSUM="5d1c8322e780fd5efad52eaa29bf9176d71e37a9" CHECKSUMTYPE="SHA-1" SIZE="5049108">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0101.jp2"/>
-			</file>
-			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T17:10:09" MIMETYPE="image/jp2" SEQ="102"
-				CHECKSUM="588e5e9109b09a2c5255a5005b31a4a8b8ed56f1" CHECKSUMTYPE="SHA-1" SIZE="5329928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0102.jp2"/>
-			</file>
-			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T17:10:35" MIMETYPE="image/jp2" SEQ="103"
-				CHECKSUM="59e1d64b3696c102b3137d57447f3c74f7ee70d1" CHECKSUMTYPE="SHA-1" SIZE="4936625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0103.jp2"/>
-			</file>
-			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T17:10:59" MIMETYPE="image/jp2" SEQ="104"
-				CHECKSUM="601de849bcfabc3c9263dc1e447ece1e56140dc9" CHECKSUMTYPE="SHA-1" SIZE="5297527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0104.jp2"/>
-			</file>
-			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T17:11:26" MIMETYPE="image/jp2" SEQ="105"
-				CHECKSUM="ec11fc42e1195b96ea7ac4d1edae53eb6736de6e" CHECKSUMTYPE="SHA-1" SIZE="4936593">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0105.jp2"/>
-			</file>
-			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T17:11:52" MIMETYPE="image/jp2" SEQ="106"
-				CHECKSUM="ba620c4f9ac2a75077eb168babaaff0a617878ad" CHECKSUMTYPE="SHA-1" SIZE="5325429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0106.jp2"/>
-			</file>
-			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T17:12:20" MIMETYPE="image/jp2" SEQ="107"
-				CHECKSUM="0d4c0b2047a7ab720703876d895afca9d565927b" CHECKSUMTYPE="SHA-1" SIZE="4936610">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0107.jp2"/>
-			</file>
-			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T17:12:43" MIMETYPE="image/jp2" SEQ="108"
-				CHECKSUM="ec9c7ce1b0f38679521fe9528a05c03da8ad4a4f" CHECKSUMTYPE="SHA-1" SIZE="5363223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0108.jp2"/>
-			</file>
-			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T17:13:09" MIMETYPE="image/jp2" SEQ="109"
-				CHECKSUM="4a33cbf76874505cac0db58cf7784503db62ea42" CHECKSUMTYPE="SHA-1" SIZE="4982525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0109.jp2"/>
-			</file>
-			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T17:13:36" MIMETYPE="image/jp2" SEQ="110"
-				CHECKSUM="334a6739c8ce07e5c00d92e08a737d9c03f758a9" CHECKSUMTYPE="SHA-1" SIZE="5377622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0110.jp2"/>
-			</file>
-			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-07-30T17:14:04" MIMETYPE="image/jp2" SEQ="111"
-				CHECKSUM="316dd88173b6df5985a48a21efe3f3a55656be3b" CHECKSUMTYPE="SHA-1" SIZE="4982525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0111.jp2"/>
-			</file>
-			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-07-30T17:14:30" MIMETYPE="image/jp2" SEQ="112"
-				CHECKSUM="878df1280c08e3baf397572c9ff514c75d73cdb9" CHECKSUMTYPE="SHA-1" SIZE="5373101">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0112.jp2"/>
-			</file>
-			<file ID="IMG00113" ADMID="techmd113" GROUPID="page113" CREATED="2015-07-30T17:14:56" MIMETYPE="image/jp2" SEQ="113"
-				CHECKSUM="f82f99e37a84bae2a3dcb68c81ef4a95e2fbe1e2" CHECKSUMTYPE="SHA-1" SIZE="4982529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0113.jp2"/>
-			</file>
-			<file ID="IMG00114" ADMID="techmd114" GROUPID="page114" CREATED="2015-07-30T17:15:23" MIMETYPE="image/jp2" SEQ="114"
-				CHECKSUM="accc6314eb77fb79e147833d6a79526df675975c" CHECKSUMTYPE="SHA-1" SIZE="5341620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0114.jp2"/>
-			</file>
-			<file ID="IMG00115" ADMID="techmd115" GROUPID="page115" CREATED="2015-07-30T17:15:51" MIMETYPE="image/jp2" SEQ="115"
-				CHECKSUM="39574209a86f852d83afc7406a11f797a3599163" CHECKSUMTYPE="SHA-1" SIZE="4982517">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0115.jp2"/>
-			</file>
-			<file ID="IMG00116" ADMID="techmd116" GROUPID="page116" CREATED="2015-07-30T17:16:15" MIMETYPE="image/jp2" SEQ="116"
-				CHECKSUM="78c3e184158adc82a5dbfca442204798de7b3787" CHECKSUMTYPE="SHA-1" SIZE="5386628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0116.jp2"/>
-			</file>
-			<file ID="IMG00117" ADMID="techmd117" GROUPID="page117" CREATED="2015-07-30T17:16:42" MIMETYPE="image/jp2" SEQ="117"
-				CHECKSUM="311d7129906147b020fa5e2166281ad9aa210018" CHECKSUMTYPE="SHA-1" SIZE="5008612">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0117.jp2"/>
-			</file>
-			<file ID="IMG00118" ADMID="techmd118" GROUPID="page118" CREATED="2015-07-30T17:17:07" MIMETYPE="image/jp2" SEQ="118"
-				CHECKSUM="6c1d060ea332413d3133fe9d22158d5ed9cdb223" CHECKSUMTYPE="SHA-1" SIZE="5386611">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0118.jp2"/>
-			</file>
-			<file ID="IMG00119" ADMID="techmd119" GROUPID="page119" CREATED="2015-07-30T17:17:33" MIMETYPE="image/jp2" SEQ="119"
-				CHECKSUM="2668ed1d3298e42ce9a674b7820c3c33ffb8330b" CHECKSUMTYPE="SHA-1" SIZE="5008488">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0119.jp2"/>
-			</file>
-			<file ID="IMG00120" ADMID="techmd120" GROUPID="page120" CREATED="2015-07-30T17:17:57" MIMETYPE="image/jp2" SEQ="120"
-				CHECKSUM="4f6785f11c8138e799dde9514c994a5a2661ceb3" CHECKSUMTYPE="SHA-1" SIZE="5386600">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0120.jp2"/>
-			</file>
-			<file ID="IMG00121" ADMID="techmd121" GROUPID="page121" CREATED="2015-07-30T17:18:24" MIMETYPE="image/jp2" SEQ="121"
-				CHECKSUM="b61054ad5ee82f1101771ebe3e0d5794c8bd607d" CHECKSUMTYPE="SHA-1" SIZE="5008628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0121.jp2"/>
-			</file>
-			<file ID="IMG00122" ADMID="techmd122" GROUPID="page122" CREATED="2015-07-30T17:18:51" MIMETYPE="image/jp2" SEQ="122"
-				CHECKSUM="d351336f62947b6896b29f66fca74ecd1704424b" CHECKSUMTYPE="SHA-1" SIZE="5386629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0122.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T16:27:29" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="da42f247daef487292fc47ad9814281065d20169" CHECKSUMTYPE="SHA-1" SIZE="4888883">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T16:27:54" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="65a4ba3d4f85641b7b695916afbc35076005ccdd" CHECKSUMTYPE="SHA-1" SIZE="5054515">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T16:28:20" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="97f530a19efdd15d98c5dde843716600bbb81da7" CHECKSUMTYPE="SHA-1" SIZE="4888903">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T16:28:44" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="680052234cb30e53cf7caf128a70c3c3ae1055c9" CHECKSUMTYPE="SHA-1" SIZE="5054490">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T16:29:10" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="982520aa66ed0a02c3d5152f4581a6d43bed717d" CHECKSUMTYPE="SHA-1" SIZE="4888916">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T16:29:35" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="a26dda56d2d0a97108f22585698c15622a4124cb" CHECKSUMTYPE="SHA-1" SIZE="5089445">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T16:30:00" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="87ae1e066c99144f2bd90aec4b3b24a06d0598bd" CHECKSUMTYPE="SHA-1" SIZE="4820429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T16:30:23" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="411b97784d3ba687fc6a5ba4bbcf502087b42853" CHECKSUMTYPE="SHA-1" SIZE="5089605">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T16:30:50" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="1e817a7b6adebb7fd19b9af21965a43ec2c62f91" CHECKSUMTYPE="SHA-1" SIZE="4792629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T16:31:14" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="9689d3f4f73bd501b7cdf67ba854ee1c940be221" CHECKSUMTYPE="SHA-1" SIZE="5089608">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T16:31:40" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="0ae24d1013350427fc2b099a4b1db0e3b05f38f3" CHECKSUMTYPE="SHA-1" SIZE="4792616">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T16:32:04" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="4b924b12e5bdfdbb8090d90818772f9d59222a2b" CHECKSUMTYPE="SHA-1" SIZE="5089626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T16:32:29" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="e8c8528e0cdd0ef2d45ff16d03e5fc73b4b78d92" CHECKSUMTYPE="SHA-1" SIZE="4802508">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T16:32:53" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="db9c3e8a59e86c1ce641597e7ccd08dd87158583" CHECKSUMTYPE="SHA-1" SIZE="5097729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T16:33:17" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="5be9d87da38fbcf5721124123668e944d148c82f" CHECKSUMTYPE="SHA-1" SIZE="4802527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T16:33:41" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="7ed60aee52c6a82fa502afde1526be46fcc9bb0d" CHECKSUMTYPE="SHA-1" SIZE="5097723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T16:34:05" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="a22e26b7b9897bddc2695d2a7503f2d8cf037f8a" CHECKSUMTYPE="SHA-1" SIZE="4802529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T16:34:34" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="ed76f7278435a0674734464c69ba41f00349cc97" CHECKSUMTYPE="SHA-1" SIZE="5097720">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T16:35:00" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="eea75b47ef1eee7fd8c7294a34d13a4a1e45f5f6" CHECKSUMTYPE="SHA-1" SIZE="4802489">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T16:35:24" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="8148fb77a9affc189e2f47df9b5dd784ffc7723e" CHECKSUMTYPE="SHA-1" SIZE="5097700">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T16:35:47" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="497c77ea14ae44bfc7405760190bbccbe78d9999" CHECKSUMTYPE="SHA-1" SIZE="4776356">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T16:36:10" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="8bd514533370ee79076567c4d815022158093880" CHECKSUMTYPE="SHA-1" SIZE="5121121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T16:36:38" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="5ca6a0fd36a4068bcd8cd5ad2ce3525649a3fb05" CHECKSUMTYPE="SHA-1" SIZE="4776429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T16:37:06" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="4ab5f1a4c058ef8332749a05cba9f18dfe9d5788" CHECKSUMTYPE="SHA-1" SIZE="5121093">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T16:37:32" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="58f1536299ba7899172793c4d0fdd3f85b847d09" CHECKSUMTYPE="SHA-1" SIZE="4873626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T16:37:56" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="8adb7eb2ebd291fae0045c1551c25e89edc00315" CHECKSUMTYPE="SHA-1" SIZE="5121129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T16:38:21" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="136b82c2c897d60f3454d46e4a35a17610f43820" CHECKSUMTYPE="SHA-1" SIZE="4795309">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T16:38:47" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="ab81049e1cc3f370d6a2a0150fd2f842e36ddec2" CHECKSUMTYPE="SHA-1" SIZE="5121127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T16:39:12" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="51552b44fab075d9806fa963d0979a8a0d571f3e" CHECKSUMTYPE="SHA-1" SIZE="4873627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T16:39:39" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="b9eb8064b7796fb3317854e45624555266e0ec6d" CHECKSUMTYPE="SHA-1" SIZE="5121128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T16:40:04" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="582c06581bb51f1c692d2a4e2116dcead4a0b305" CHECKSUMTYPE="SHA-1" SIZE="4767427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T16:40:29" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="99dd2e5a7bf134d377b7cf157d8963026d4e271c" CHECKSUMTYPE="SHA-1" SIZE="5121088">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T16:40:54" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="175df9e507ba0f9b21545e44aeaf473546bb7224" CHECKSUMTYPE="SHA-1" SIZE="4767427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T16:41:17" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="c1295858fe92d403d4f4f7a36b65f883160b060e" CHECKSUMTYPE="SHA-1" SIZE="5144526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T16:41:43" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="7f4feeb46e3d05527f8efc60991618afac38d7dc" CHECKSUMTYPE="SHA-1" SIZE="4767423">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T16:42:07" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="85da77889cd6fe6f8bc4ffd7af9b3bdac51a5256" CHECKSUMTYPE="SHA-1" SIZE="5125629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T16:42:32" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="ff219aa97da6e4b07c733d7b6923b1b5d2c5ebba" CHECKSUMTYPE="SHA-1" SIZE="4767412">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T16:42:57" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="b566c5ccdcbd318aa47b50a106d68f6095d4391b" CHECKSUMTYPE="SHA-1" SIZE="5125579">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T16:43:21" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="b17d60da3f56336460f509073221d0aee71c6e0a" CHECKSUMTYPE="SHA-1" SIZE="4767157">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T16:43:47" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="9442f24568342dafed1fd870208fab213bb522b7" CHECKSUMTYPE="SHA-1" SIZE="5138205">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T16:44:12" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="3a5e101257122f4b8f52c59bc02140bd8b5921ce" CHECKSUMTYPE="SHA-1" SIZE="4903325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T16:44:36" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="0d316fec42f437d72c73d05d8a64b6153b844cf3" CHECKSUMTYPE="SHA-1" SIZE="5138227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T16:45:00" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="27525441db666435d3aa075472a4739e78ebb65c" CHECKSUMTYPE="SHA-1" SIZE="4781821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T16:45:26" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="9790b8950a9b457eee7003f86d1011d394fd39a1" CHECKSUMTYPE="SHA-1" SIZE="5138214">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T16:45:53" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="fecb344fb3e3477f42e6e30fefa90cf03efe90d6" CHECKSUMTYPE="SHA-1" SIZE="4913199">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T16:46:19" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="64c9daecc68992ad43835e435c8a0d1638b53c0f" CHECKSUMTYPE="SHA-1" SIZE="5138166">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T16:46:45" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="7ad6157ae8346c38f1813196d2c3d87cafab2cdc" CHECKSUMTYPE="SHA-1" SIZE="4776428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T16:47:10" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="af7473b0c4644cb9e54eca5de0aa9594c6b22e0a" CHECKSUMTYPE="SHA-1" SIZE="5155318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T16:47:37" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="71880c1dd08d0dfd032642d07d217dea1c509add" CHECKSUMTYPE="SHA-1" SIZE="4834916">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T16:48:03" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="313bfee49040243e717c1ba6a8237a9f98726f1a" CHECKSUMTYPE="SHA-1" SIZE="5155327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T16:48:28" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="dd71db74c0f443dd9562171a2d8c532ff7646d92" CHECKSUMTYPE="SHA-1" SIZE="4834861">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T16:48:54" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="385bef704d60a95eb4ecda78e8c4504448a20fd1" CHECKSUMTYPE="SHA-1" SIZE="5267818">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T16:49:20" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="4c048d325e7269af5279432f2f9fbf61cc61f4fb" CHECKSUMTYPE="SHA-1" SIZE="4808824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T16:49:45" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="8ad5ecd021fd893c196c801ae459b2ad81ee21f5" CHECKSUMTYPE="SHA-1" SIZE="5179627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T16:50:10" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="41ea8c16d30d4e9ec6e7462aef10573e3f4c7996" CHECKSUMTYPE="SHA-1" SIZE="4808822">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T16:50:33" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="13782650e5778dbbc15468408a1c22d675ec3a82" CHECKSUMTYPE="SHA-1" SIZE="5197628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T16:50:59" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="61131df087e40ee5e7095b8853f3597fb15c2d2e" CHECKSUMTYPE="SHA-1" SIZE="4808820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T16:51:24" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="3993d59fb4970879b873481823305e3e8ada5255" CHECKSUMTYPE="SHA-1" SIZE="5171516">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T16:51:50" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="15e09db42dfd111039346608bc62da3c6ec4a3e3" CHECKSUMTYPE="SHA-1" SIZE="4808787">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T16:52:14" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="b83982bff46ddfc68ff872001941bf76ed2cd360" CHECKSUMTYPE="SHA-1" SIZE="5172391">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T16:52:38" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="34da4f01f9a56e8534426627bb35b7a8485fbf10" CHECKSUMTYPE="SHA-1" SIZE="4834923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T16:53:03" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="c072f78e8a94849e2fec3a730464be1ad5e9cceb" CHECKSUMTYPE="SHA-1" SIZE="5167901">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T16:53:29" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="46e9f09f34581bbfc893f29712599e8eebb11c3a" CHECKSUMTYPE="SHA-1" SIZE="4958226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T16:53:54" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="001067464c5c16f2ee8e7b71fdfdfc6112c28d69" CHECKSUMTYPE="SHA-1" SIZE="5185022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T16:54:21" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="ccafb6d14924d35f8fd498995c369cde51d43cb3" CHECKSUMTYPE="SHA-1" SIZE="4990624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T16:54:46" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="e39576ac247f1e9e55458b65a9e819d645082f16" CHECKSUMTYPE="SHA-1" SIZE="5188628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T16:55:12" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="3f613b6f407e72c05b7814eb27941cb7248517f4" CHECKSUMTYPE="SHA-1" SIZE="4814124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T16:55:39" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="af9b2ac8a9945c16e6719a619a586fb19f93fc80" CHECKSUMTYPE="SHA-1" SIZE="5241705">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T16:56:04" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="381863e9cc1cb4bb4593a60ec3fbdbaef97cda8d" CHECKSUMTYPE="SHA-1" SIZE="4858314">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T16:56:29" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="33925eeeef710cb1faffa90449f609d7a0c89804" CHECKSUMTYPE="SHA-1" SIZE="5239920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T16:56:54" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="cae83b862570d42168851a068a1dfb7ae13c293c" CHECKSUMTYPE="SHA-1" SIZE="4858313">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T16:57:19" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="72ff5d7dd795b06fb02e3f51b899259f11cbb819" CHECKSUMTYPE="SHA-1" SIZE="5249753">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T16:57:45" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="12e7cfcc452535f9624384b9386df7a3fd0ae028" CHECKSUMTYPE="SHA-1" SIZE="4878128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T16:58:09" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="0e688fbcfd2a5a78af0dabb88e600d87fc04b087" CHECKSUMTYPE="SHA-1" SIZE="5257925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T16:58:35" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="0c09dc9ec81f9cb08e5ec51020641eec825a67cc" CHECKSUMTYPE="SHA-1" SIZE="4900624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T16:59:00" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="685d896377c54755d95c619a3c7a24b208c06dd4" CHECKSUMTYPE="SHA-1" SIZE="5259728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T16:59:26" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="8150783a0409cda99d5c52968c5a04120c39ab24" CHECKSUMTYPE="SHA-1" SIZE="4900622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T16:59:52" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="88619d2f0e69bb97587fd6e900a14e03f3936ddd" CHECKSUMTYPE="SHA-1" SIZE="5248014">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:00:20" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="cb81d73a718ce4aad2969d0d0527f87a2a2e5f8b" CHECKSUMTYPE="SHA-1" SIZE="4900627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:00:46" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="786ec1da009472ab1cd54115f6cee7b3c2776345" CHECKSUMTYPE="SHA-1" SIZE="5217415">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:01:10" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="7349c6e6237416475315924164e2a1b95240559b" CHECKSUMTYPE="SHA-1" SIZE="4900594">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:01:38" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="6f4fa706e81c174cc070c2b68a67c2784b309f81" CHECKSUMTYPE="SHA-1" SIZE="5244373">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:02:04" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="09f1d51190ded831c029152c0da6aec220886bce" CHECKSUMTYPE="SHA-1" SIZE="4900421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:02:30" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="f100370d6f2be6e86c605b7e3c61d9652e74f01f" CHECKSUMTYPE="SHA-1" SIZE="5248927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:02:55" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="1e07a414b0f4179e8332285395f206fefd9dfe74" CHECKSUMTYPE="SHA-1" SIZE="4900575">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:03:22" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="65959ae5f127d964b89515755ce3c20304a91234" CHECKSUMTYPE="SHA-1" SIZE="5256075">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:03:45" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="eae389546ed6f90820d69bdd482522c517c42b4c" CHECKSUMTYPE="SHA-1" SIZE="4900522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:04:10" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="f08702e234276645833492d9494f062e36b25ac0" CHECKSUMTYPE="SHA-1" SIZE="5236324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:04:35" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="3d6155212352cde0d4536bc439f2538565b26e52" CHECKSUMTYPE="SHA-1" SIZE="4900629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:04:59" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="afc54e50bef3d5668634d825b6867cf2fe9ffebf" CHECKSUMTYPE="SHA-1" SIZE="5254310">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:05:26" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="1f0d7da3754f3e433e8a7437c9a28a63e2ff2aee" CHECKSUMTYPE="SHA-1" SIZE="4900602">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:05:52" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="1cc32197a5fa78ba78649fd4441f44567f554c83" CHECKSUMTYPE="SHA-1" SIZE="5294827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:06:16" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="b3f874744fb6b5d4ca7bb76e29e4a96d5c3360ce" CHECKSUMTYPE="SHA-1" SIZE="4906926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T17:06:43" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="42ca9984c00ef3113904c393f6e2bc138e64805d" CHECKSUMTYPE="SHA-1" SIZE="5256105">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0094.jp2"/>
+			</file>
+			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T17:07:08" MIMETYPE="image/jp2" SEQ="95" CHECKSUM="8e12ffbb1f533afb73c03459fc563f5031d0f35f" CHECKSUMTYPE="SHA-1" SIZE="5040126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0095.jp2"/>
+			</file>
+			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T17:07:33" MIMETYPE="image/jp2" SEQ="96" CHECKSUM="3f2ab7ccb065ca802f4f687c691d55cd54303f5c" CHECKSUMTYPE="SHA-1" SIZE="5276812">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0096.jp2"/>
+			</file>
+			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T17:07:58" MIMETYPE="image/jp2" SEQ="97" CHECKSUM="b9082735be13c56644472032d93df1ee0c9e5c2d" CHECKSUMTYPE="SHA-1" SIZE="4906922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0097.jp2"/>
+			</file>
+			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T17:08:26" MIMETYPE="image/jp2" SEQ="98" CHECKSUM="7c2dc441da343ee0f93e9e0bfad4e476088ccb36" CHECKSUMTYPE="SHA-1" SIZE="5277723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0098.jp2"/>
+			</file>
+			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T17:08:50" MIMETYPE="image/jp2" SEQ="99" CHECKSUM="899136b26a851dd0c8395fa3e6675aa9e39db51a" CHECKSUMTYPE="SHA-1" SIZE="4906923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0099.jp2"/>
+			</file>
+			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T17:09:15" MIMETYPE="image/jp2" SEQ="100" CHECKSUM="bb90486509cf6accd4ce34d32b74212f0c8aafd3" CHECKSUMTYPE="SHA-1" SIZE="5284007">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0100.jp2"/>
+			</file>
+			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T17:09:42" MIMETYPE="image/jp2" SEQ="101" CHECKSUM="5d1c8322e780fd5efad52eaa29bf9176d71e37a9" CHECKSUMTYPE="SHA-1" SIZE="5049108">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0101.jp2"/>
+			</file>
+			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T17:10:09" MIMETYPE="image/jp2" SEQ="102" CHECKSUM="588e5e9109b09a2c5255a5005b31a4a8b8ed56f1" CHECKSUMTYPE="SHA-1" SIZE="5329928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0102.jp2"/>
+			</file>
+			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T17:10:35" MIMETYPE="image/jp2" SEQ="103" CHECKSUM="59e1d64b3696c102b3137d57447f3c74f7ee70d1" CHECKSUMTYPE="SHA-1" SIZE="4936625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0103.jp2"/>
+			</file>
+			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T17:10:59" MIMETYPE="image/jp2" SEQ="104" CHECKSUM="601de849bcfabc3c9263dc1e447ece1e56140dc9" CHECKSUMTYPE="SHA-1" SIZE="5297527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0104.jp2"/>
+			</file>
+			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T17:11:26" MIMETYPE="image/jp2" SEQ="105" CHECKSUM="ec11fc42e1195b96ea7ac4d1edae53eb6736de6e" CHECKSUMTYPE="SHA-1" SIZE="4936593">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0105.jp2"/>
+			</file>
+			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T17:11:52" MIMETYPE="image/jp2" SEQ="106" CHECKSUM="ba620c4f9ac2a75077eb168babaaff0a617878ad" CHECKSUMTYPE="SHA-1" SIZE="5325429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0106.jp2"/>
+			</file>
+			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T17:12:20" MIMETYPE="image/jp2" SEQ="107" CHECKSUM="0d4c0b2047a7ab720703876d895afca9d565927b" CHECKSUMTYPE="SHA-1" SIZE="4936610">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0107.jp2"/>
+			</file>
+			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T17:12:43" MIMETYPE="image/jp2" SEQ="108" CHECKSUM="ec9c7ce1b0f38679521fe9528a05c03da8ad4a4f" CHECKSUMTYPE="SHA-1" SIZE="5363223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0108.jp2"/>
+			</file>
+			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T17:13:09" MIMETYPE="image/jp2" SEQ="109" CHECKSUM="4a33cbf76874505cac0db58cf7784503db62ea42" CHECKSUMTYPE="SHA-1" SIZE="4982525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0109.jp2"/>
+			</file>
+			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T17:13:36" MIMETYPE="image/jp2" SEQ="110" CHECKSUM="334a6739c8ce07e5c00d92e08a737d9c03f758a9" CHECKSUMTYPE="SHA-1" SIZE="5377622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0110.jp2"/>
+			</file>
+			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-07-30T17:14:04" MIMETYPE="image/jp2" SEQ="111" CHECKSUM="316dd88173b6df5985a48a21efe3f3a55656be3b" CHECKSUMTYPE="SHA-1" SIZE="4982525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0111.jp2"/>
+			</file>
+			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-07-30T17:14:30" MIMETYPE="image/jp2" SEQ="112" CHECKSUM="878df1280c08e3baf397572c9ff514c75d73cdb9" CHECKSUMTYPE="SHA-1" SIZE="5373101">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0112.jp2"/>
+			</file>
+			<file ID="IMG00113" ADMID="techmd113" GROUPID="page113" CREATED="2015-07-30T17:14:56" MIMETYPE="image/jp2" SEQ="113" CHECKSUM="f82f99e37a84bae2a3dcb68c81ef4a95e2fbe1e2" CHECKSUMTYPE="SHA-1" SIZE="4982529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0113.jp2"/>
+			</file>
+			<file ID="IMG00114" ADMID="techmd114" GROUPID="page114" CREATED="2015-07-30T17:15:23" MIMETYPE="image/jp2" SEQ="114" CHECKSUM="accc6314eb77fb79e147833d6a79526df675975c" CHECKSUMTYPE="SHA-1" SIZE="5341620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0114.jp2"/>
+			</file>
+			<file ID="IMG00115" ADMID="techmd115" GROUPID="page115" CREATED="2015-07-30T17:15:51" MIMETYPE="image/jp2" SEQ="115" CHECKSUM="39574209a86f852d83afc7406a11f797a3599163" CHECKSUMTYPE="SHA-1" SIZE="4982517">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0115.jp2"/>
+			</file>
+			<file ID="IMG00116" ADMID="techmd116" GROUPID="page116" CREATED="2015-07-30T17:16:15" MIMETYPE="image/jp2" SEQ="116" CHECKSUM="78c3e184158adc82a5dbfca442204798de7b3787" CHECKSUMTYPE="SHA-1" SIZE="5386628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0116.jp2"/>
+			</file>
+			<file ID="IMG00117" ADMID="techmd117" GROUPID="page117" CREATED="2015-07-30T17:16:42" MIMETYPE="image/jp2" SEQ="117" CHECKSUM="311d7129906147b020fa5e2166281ad9aa210018" CHECKSUMTYPE="SHA-1" SIZE="5008612">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0117.jp2"/>
+			</file>
+			<file ID="IMG00118" ADMID="techmd118" GROUPID="page118" CREATED="2015-07-30T17:17:07" MIMETYPE="image/jp2" SEQ="118" CHECKSUM="6c1d060ea332413d3133fe9d22158d5ed9cdb223" CHECKSUMTYPE="SHA-1" SIZE="5386611">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0118.jp2"/>
+			</file>
+			<file ID="IMG00119" ADMID="techmd119" GROUPID="page119" CREATED="2015-07-30T17:17:33" MIMETYPE="image/jp2" SEQ="119" CHECKSUM="2668ed1d3298e42ce9a674b7820c3c33ffb8330b" CHECKSUMTYPE="SHA-1" SIZE="5008488">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0119.jp2"/>
+			</file>
+			<file ID="IMG00120" ADMID="techmd120" GROUPID="page120" CREATED="2015-07-30T17:17:57" MIMETYPE="image/jp2" SEQ="120" CHECKSUM="4f6785f11c8138e799dde9514c994a5a2661ceb3" CHECKSUMTYPE="SHA-1" SIZE="5386600">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0120.jp2"/>
+			</file>
+			<file ID="IMG00121" ADMID="techmd121" GROUPID="page121" CREATED="2015-07-30T17:18:24" MIMETYPE="image/jp2" SEQ="121" CHECKSUM="b61054ad5ee82f1101771ebe3e0d5794c8bd607d" CHECKSUMTYPE="SHA-1" SIZE="5008628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0121.jp2"/>
+			</file>
+			<file ID="IMG00122" ADMID="techmd122" GROUPID="page122" CREATED="2015-07-30T17:18:51" MIMETYPE="image/jp2" SEQ="122" CHECKSUM="d351336f62947b6896b29f66fca74ecd1704424b" CHECKSUMTYPE="SHA-1" SIZE="5386629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/delivery/bmtnabe_1896-07_01_0122.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T17:19:09" MIMETYPE="text/xml" CHECKSUM="c6d6369a0abc790a1bb23c6d7363f2138aa72212"
-				CHECKSUMTYPE="SHA-1" SIZE="2110">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T17:19:09" MIMETYPE="text/xml" CHECKSUM="c6d6369a0abc790a1bb23c6d7363f2138aa72212" CHECKSUMTYPE="SHA-1" SIZE="2110">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T17:19:09" MIMETYPE="text/xml" CHECKSUM="ccc16d1bdde40bb05b676773adfcb14497a21185"
-				CHECKSUMTYPE="SHA-1" SIZE="1714">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T17:19:09" MIMETYPE="text/xml" CHECKSUM="ccc16d1bdde40bb05b676773adfcb14497a21185" CHECKSUMTYPE="SHA-1" SIZE="1714">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T17:19:09" MIMETYPE="text/xml" CHECKSUM="909512f7cc60e46a5ad30100991006afb9112f55"
-				CHECKSUMTYPE="SHA-1" SIZE="1714">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T17:19:09" MIMETYPE="text/xml" CHECKSUM="909512f7cc60e46a5ad30100991006afb9112f55" CHECKSUMTYPE="SHA-1" SIZE="1714">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T17:19:09" MIMETYPE="text/xml" CHECKSUM="e5b6a31f7c1c08b1587939e9f8b86f2ddad76e87"
-				CHECKSUMTYPE="SHA-1" SIZE="1715">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T17:19:09" MIMETYPE="text/xml" CHECKSUM="e5b6a31f7c1c08b1587939e9f8b86f2ddad76e87" CHECKSUMTYPE="SHA-1" SIZE="1715">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T17:19:10" MIMETYPE="text/xml" CHECKSUM="566a5517c53ca68816f41e08afd19fad5aa3bf1a"
-				CHECKSUMTYPE="SHA-1" SIZE="12492">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T17:19:10" MIMETYPE="text/xml" CHECKSUM="566a5517c53ca68816f41e08afd19fad5aa3bf1a" CHECKSUMTYPE="SHA-1" SIZE="12492">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T17:19:10" MIMETYPE="text/xml" CHECKSUM="1ba28fc1279007abf453ec3ebd3f44756f0755e4"
-				CHECKSUMTYPE="SHA-1" SIZE="1715">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T17:19:10" MIMETYPE="text/xml" CHECKSUM="1ba28fc1279007abf453ec3ebd3f44756f0755e4" CHECKSUMTYPE="SHA-1" SIZE="1715">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T17:19:10" MIMETYPE="text/xml" CHECKSUM="a765620b219b64a455d8a2261c03672f0fb1d5b1"
-				CHECKSUMTYPE="SHA-1" SIZE="1714">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T17:19:10" MIMETYPE="text/xml" CHECKSUM="a765620b219b64a455d8a2261c03672f0fb1d5b1" CHECKSUMTYPE="SHA-1" SIZE="1714">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T17:19:11" MIMETYPE="text/xml" CHECKSUM="57ad35735f910040fa3e475bd7e6fbdeb65433c0"
-				CHECKSUMTYPE="SHA-1" SIZE="4723">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T17:19:11" MIMETYPE="text/xml" CHECKSUM="57ad35735f910040fa3e475bd7e6fbdeb65433c0" CHECKSUMTYPE="SHA-1" SIZE="4723">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T17:19:11" MIMETYPE="text/xml" CHECKSUM="9812435d2cdb431d6b1d595992dbddcab69d0bd4"
-				CHECKSUMTYPE="SHA-1" SIZE="39475">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T17:19:11" MIMETYPE="text/xml" CHECKSUM="9812435d2cdb431d6b1d595992dbddcab69d0bd4" CHECKSUMTYPE="SHA-1" SIZE="39475">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T17:19:11" MIMETYPE="text/xml"
-				CHECKSUM="3e0f5cd121d6d78c94f150d23e0373a51822912e" CHECKSUMTYPE="SHA-1" SIZE="69340">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T17:19:11" MIMETYPE="text/xml" CHECKSUM="3e0f5cd121d6d78c94f150d23e0373a51822912e" CHECKSUMTYPE="SHA-1" SIZE="69340">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T17:19:11" MIMETYPE="text/xml"
-				CHECKSUM="ee8ffc55ba3a3238a0f252edd5a6a446449047d7" CHECKSUMTYPE="SHA-1" SIZE="4826">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T17:19:11" MIMETYPE="text/xml" CHECKSUM="ee8ffc55ba3a3238a0f252edd5a6a446449047d7" CHECKSUMTYPE="SHA-1" SIZE="4826">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T17:19:12" MIMETYPE="text/xml"
-				CHECKSUM="5f38f8c92d0dfb950e57a00abdb8a021b3660403" CHECKSUMTYPE="SHA-1" SIZE="2016">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T17:19:12" MIMETYPE="text/xml" CHECKSUM="5f38f8c92d0dfb950e57a00abdb8a021b3660403" CHECKSUMTYPE="SHA-1" SIZE="2016">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T17:19:12" MIMETYPE="text/xml"
-				CHECKSUM="70d6f665e4757896bb6a85bb1fa6b5b7a08a8fcf" CHECKSUMTYPE="SHA-1" SIZE="28858">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T17:19:12" MIMETYPE="text/xml" CHECKSUM="70d6f665e4757896bb6a85bb1fa6b5b7a08a8fcf" CHECKSUMTYPE="SHA-1" SIZE="28858">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T17:19:12" MIMETYPE="text/xml"
-				CHECKSUM="9d5b70c42ef2f3743fc8bcd1669a33a0acd2a103" CHECKSUMTYPE="SHA-1" SIZE="66281">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T17:19:12" MIMETYPE="text/xml" CHECKSUM="9d5b70c42ef2f3743fc8bcd1669a33a0acd2a103" CHECKSUMTYPE="SHA-1" SIZE="66281">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T17:19:12" MIMETYPE="text/xml"
-				CHECKSUM="692d81b306c3a7dafd84998b38fde30cacec9369" CHECKSUMTYPE="SHA-1" SIZE="55822">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T17:19:12" MIMETYPE="text/xml" CHECKSUM="692d81b306c3a7dafd84998b38fde30cacec9369" CHECKSUMTYPE="SHA-1" SIZE="55822">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T17:19:13" MIMETYPE="text/xml"
-				CHECKSUM="17afa4ecfec8e6dc9f38f4ad3a7b44ded46945ac" CHECKSUMTYPE="SHA-1" SIZE="32917">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T17:19:13" MIMETYPE="text/xml" CHECKSUM="17afa4ecfec8e6dc9f38f4ad3a7b44ded46945ac" CHECKSUMTYPE="SHA-1" SIZE="32917">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T17:19:13" MIMETYPE="text/xml"
-				CHECKSUM="94ce1ad45925e4d76cfbd5148f0655627811ab8c" CHECKSUMTYPE="SHA-1" SIZE="4815">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T17:19:13" MIMETYPE="text/xml" CHECKSUM="94ce1ad45925e4d76cfbd5148f0655627811ab8c" CHECKSUMTYPE="SHA-1" SIZE="4815">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T17:19:13" MIMETYPE="text/xml"
-				CHECKSUM="447427bf4b4e40b3bdc23002f4cdfb2f88275ce3" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T17:19:13" MIMETYPE="text/xml" CHECKSUM="447427bf4b4e40b3bdc23002f4cdfb2f88275ce3" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T17:19:13" MIMETYPE="text/xml"
-				CHECKSUM="bdcf17d1a6f4f4f60fac0bd0130fb95b9c38d082" CHECKSUMTYPE="SHA-1" SIZE="16498">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T17:19:13" MIMETYPE="text/xml" CHECKSUM="bdcf17d1a6f4f4f60fac0bd0130fb95b9c38d082" CHECKSUMTYPE="SHA-1" SIZE="16498">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T17:19:14" MIMETYPE="text/xml"
-				CHECKSUM="f35c22c05d22e92e757b699212ea45815c99facf" CHECKSUMTYPE="SHA-1" SIZE="21000">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T17:19:14" MIMETYPE="text/xml" CHECKSUM="f35c22c05d22e92e757b699212ea45815c99facf" CHECKSUMTYPE="SHA-1" SIZE="21000">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T17:19:14" MIMETYPE="text/xml"
-				CHECKSUM="1cc155bd66a7a6628de1c3f236dd22cf3602245b" CHECKSUMTYPE="SHA-1" SIZE="5403">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T17:19:14" MIMETYPE="text/xml" CHECKSUM="1cc155bd66a7a6628de1c3f236dd22cf3602245b" CHECKSUMTYPE="SHA-1" SIZE="5403">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T17:19:14" MIMETYPE="text/xml"
-				CHECKSUM="122eb0ae198a76d3767d196d0c5c09fd40b40793" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T17:19:14" MIMETYPE="text/xml" CHECKSUM="122eb0ae198a76d3767d196d0c5c09fd40b40793" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T17:19:14" MIMETYPE="text/xml"
-				CHECKSUM="756eefaff87560949b384db6690f8e457846367f" CHECKSUMTYPE="SHA-1" SIZE="85546">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T17:19:14" MIMETYPE="text/xml" CHECKSUM="756eefaff87560949b384db6690f8e457846367f" CHECKSUMTYPE="SHA-1" SIZE="85546">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T17:19:15" MIMETYPE="text/xml"
-				CHECKSUM="55e64e283006bb0116a8285eb731fc8a8820ef71" CHECKSUMTYPE="SHA-1" SIZE="151904">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T17:19:15" MIMETYPE="text/xml" CHECKSUM="55e64e283006bb0116a8285eb731fc8a8820ef71" CHECKSUMTYPE="SHA-1" SIZE="151904">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T17:19:15" MIMETYPE="text/xml"
-				CHECKSUM="42451d60eb1d11b4361df17f42a990d8245b9bd2" CHECKSUMTYPE="SHA-1" SIZE="153965">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T17:19:15" MIMETYPE="text/xml" CHECKSUM="42451d60eb1d11b4361df17f42a990d8245b9bd2" CHECKSUMTYPE="SHA-1" SIZE="153965">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T17:19:15" MIMETYPE="text/xml"
-				CHECKSUM="951adff16e8ac1ac62671535b51cf378d1a46e62" CHECKSUMTYPE="SHA-1" SIZE="153320">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T17:19:15" MIMETYPE="text/xml" CHECKSUM="951adff16e8ac1ac62671535b51cf378d1a46e62" CHECKSUMTYPE="SHA-1" SIZE="153320">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T17:19:16" MIMETYPE="text/xml"
-				CHECKSUM="3e31a0f844805ae41e52fa37929d9e5371cd32fa" CHECKSUMTYPE="SHA-1" SIZE="145970">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T17:19:16" MIMETYPE="text/xml" CHECKSUM="3e31a0f844805ae41e52fa37929d9e5371cd32fa" CHECKSUMTYPE="SHA-1" SIZE="145970">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T17:19:16" MIMETYPE="text/xml"
-				CHECKSUM="c533ff003b11d216720fe635a15a6515467fd0b8" CHECKSUMTYPE="SHA-1" SIZE="149130">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T17:19:16" MIMETYPE="text/xml" CHECKSUM="c533ff003b11d216720fe635a15a6515467fd0b8" CHECKSUMTYPE="SHA-1" SIZE="149130">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T17:19:16" MIMETYPE="text/xml"
-				CHECKSUM="a4e8f4eb20385cc38296ea6bc10754e3cb479fd2" CHECKSUMTYPE="SHA-1" SIZE="151592">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T17:19:16" MIMETYPE="text/xml" CHECKSUM="a4e8f4eb20385cc38296ea6bc10754e3cb479fd2" CHECKSUMTYPE="SHA-1" SIZE="151592">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T17:19:17" MIMETYPE="text/xml"
-				CHECKSUM="b336ddc84967cb523628459a0e1d2358e7d963f5" CHECKSUMTYPE="SHA-1" SIZE="162375">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T17:19:17" MIMETYPE="text/xml" CHECKSUM="b336ddc84967cb523628459a0e1d2358e7d963f5" CHECKSUMTYPE="SHA-1" SIZE="162375">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T17:19:17" MIMETYPE="text/xml"
-				CHECKSUM="c13fc30928115569f8397e34723e43a79afac210" CHECKSUMTYPE="SHA-1" SIZE="149727">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T17:19:17" MIMETYPE="text/xml" CHECKSUM="c13fc30928115569f8397e34723e43a79afac210" CHECKSUMTYPE="SHA-1" SIZE="149727">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T17:19:17" MIMETYPE="text/xml"
-				CHECKSUM="4f141c803daa7aea9d4f7ebfad6bab62a2fd7798" CHECKSUMTYPE="SHA-1" SIZE="147219">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T17:19:17" MIMETYPE="text/xml" CHECKSUM="4f141c803daa7aea9d4f7ebfad6bab62a2fd7798" CHECKSUMTYPE="SHA-1" SIZE="147219">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T17:19:17" MIMETYPE="text/xml"
-				CHECKSUM="5eef691181f21ad47e161f0dfa556e817c5f4ca7" CHECKSUMTYPE="SHA-1" SIZE="33735">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T17:19:17" MIMETYPE="text/xml" CHECKSUM="5eef691181f21ad47e161f0dfa556e817c5f4ca7" CHECKSUMTYPE="SHA-1" SIZE="33735">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T17:19:18" MIMETYPE="text/xml"
-				CHECKSUM="af08542d40aae4a304061ce364c9ba40354bc7eb" CHECKSUMTYPE="SHA-1" SIZE="25172">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T17:19:18" MIMETYPE="text/xml" CHECKSUM="af08542d40aae4a304061ce364c9ba40354bc7eb" CHECKSUMTYPE="SHA-1" SIZE="25172">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T17:19:18" MIMETYPE="text/xml"
-				CHECKSUM="fe0a3f1c318499c1df3ac3c9d15bd4748bdf680c" CHECKSUMTYPE="SHA-1" SIZE="5085">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T17:19:18" MIMETYPE="text/xml" CHECKSUM="fe0a3f1c318499c1df3ac3c9d15bd4748bdf680c" CHECKSUMTYPE="SHA-1" SIZE="5085">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T17:19:18" MIMETYPE="text/xml"
-				CHECKSUM="de37ae32c2e966727c1aa00755ef66c4c71f2699" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T17:19:18" MIMETYPE="text/xml" CHECKSUM="de37ae32c2e966727c1aa00755ef66c4c71f2699" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T17:19:19" MIMETYPE="text/xml"
-				CHECKSUM="0f606d8588ee22df412102e0584393574be3b776" CHECKSUMTYPE="SHA-1" SIZE="39300">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T17:19:19" MIMETYPE="text/xml" CHECKSUM="0f606d8588ee22df412102e0584393574be3b776" CHECKSUMTYPE="SHA-1" SIZE="39300">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T17:19:19" MIMETYPE="text/xml"
-				CHECKSUM="342881652cb88725c65da9128fc94dc2b310c9b0" CHECKSUMTYPE="SHA-1" SIZE="41621">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T17:19:19" MIMETYPE="text/xml" CHECKSUM="342881652cb88725c65da9128fc94dc2b310c9b0" CHECKSUMTYPE="SHA-1" SIZE="41621">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T17:19:19" MIMETYPE="text/xml"
-				CHECKSUM="7011d18a9593ad7adb8e5f8816da8485add0b81d" CHECKSUMTYPE="SHA-1" SIZE="40129">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T17:19:19" MIMETYPE="text/xml" CHECKSUM="7011d18a9593ad7adb8e5f8816da8485add0b81d" CHECKSUMTYPE="SHA-1" SIZE="40129">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T17:19:20" MIMETYPE="text/xml"
-				CHECKSUM="3d5c8c88232a429d99b8eafba5b00e21d04dbe73" CHECKSUMTYPE="SHA-1" SIZE="37029">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T17:19:20" MIMETYPE="text/xml" CHECKSUM="3d5c8c88232a429d99b8eafba5b00e21d04dbe73" CHECKSUMTYPE="SHA-1" SIZE="37029">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T17:19:20" MIMETYPE="text/xml"
-				CHECKSUM="e91363d6be686411aba4afe338f0679aa45e38bf" CHECKSUMTYPE="SHA-1" SIZE="23338">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T17:19:20" MIMETYPE="text/xml" CHECKSUM="e91363d6be686411aba4afe338f0679aa45e38bf" CHECKSUMTYPE="SHA-1" SIZE="23338">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T17:19:20" MIMETYPE="text/xml"
-				CHECKSUM="99fd62175f3e6cec5b6cdce6af5aa333cc9e196b" CHECKSUMTYPE="SHA-1" SIZE="23060">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T17:19:20" MIMETYPE="text/xml" CHECKSUM="99fd62175f3e6cec5b6cdce6af5aa333cc9e196b" CHECKSUMTYPE="SHA-1" SIZE="23060">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T17:19:20" MIMETYPE="text/xml"
-				CHECKSUM="574e4948d149bf29b1f95120ca250e95f760e435" CHECKSUMTYPE="SHA-1" SIZE="4977">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T17:19:20" MIMETYPE="text/xml" CHECKSUM="574e4948d149bf29b1f95120ca250e95f760e435" CHECKSUMTYPE="SHA-1" SIZE="4977">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T17:19:21" MIMETYPE="text/xml"
-				CHECKSUM="1cc1cbeba0faab17a14106c5b38692de7ca5ffb1" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T17:19:21" MIMETYPE="text/xml" CHECKSUM="1cc1cbeba0faab17a14106c5b38692de7ca5ffb1" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T17:19:21" MIMETYPE="text/xml"
-				CHECKSUM="6cf3874b9d95bfb898dc301176f0d456b3531260" CHECKSUMTYPE="SHA-1" SIZE="116447">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T17:19:21" MIMETYPE="text/xml" CHECKSUM="6cf3874b9d95bfb898dc301176f0d456b3531260" CHECKSUMTYPE="SHA-1" SIZE="116447">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T17:19:21" MIMETYPE="text/xml"
-				CHECKSUM="a0026eef418b20bab9b4840e9fcbf351b2da96b4" CHECKSUMTYPE="SHA-1" SIZE="194682">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T17:19:21" MIMETYPE="text/xml" CHECKSUM="a0026eef418b20bab9b4840e9fcbf351b2da96b4" CHECKSUMTYPE="SHA-1" SIZE="194682">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T17:19:22" MIMETYPE="text/xml"
-				CHECKSUM="0db4f84f06334531e24e95c3f86e470a7a06ba44" CHECKSUMTYPE="SHA-1" SIZE="197170">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T17:19:22" MIMETYPE="text/xml" CHECKSUM="0db4f84f06334531e24e95c3f86e470a7a06ba44" CHECKSUMTYPE="SHA-1" SIZE="197170">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T17:19:22" MIMETYPE="text/xml"
-				CHECKSUM="6e8fa20b1bfa48e44e156b1bf2f7875d89126a15" CHECKSUMTYPE="SHA-1" SIZE="194140">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T17:19:22" MIMETYPE="text/xml" CHECKSUM="6e8fa20b1bfa48e44e156b1bf2f7875d89126a15" CHECKSUMTYPE="SHA-1" SIZE="194140">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T17:19:22" MIMETYPE="text/xml"
-				CHECKSUM="efdeb3741129e43c5b478dcf72055a82d3832453" CHECKSUMTYPE="SHA-1" SIZE="195148">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T17:19:22" MIMETYPE="text/xml" CHECKSUM="efdeb3741129e43c5b478dcf72055a82d3832453" CHECKSUMTYPE="SHA-1" SIZE="195148">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T17:19:23" MIMETYPE="text/xml"
-				CHECKSUM="9535430bcf2799bcce78230f90c48034a2a903de" CHECKSUMTYPE="SHA-1" SIZE="193853">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T17:19:23" MIMETYPE="text/xml" CHECKSUM="9535430bcf2799bcce78230f90c48034a2a903de" CHECKSUMTYPE="SHA-1" SIZE="193853">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T17:19:23" MIMETYPE="text/xml"
-				CHECKSUM="6b4a5bf8f6ef45b88fde4d86d48a5c4ce59b5cdd" CHECKSUMTYPE="SHA-1" SIZE="4922">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T17:19:23" MIMETYPE="text/xml" CHECKSUM="6b4a5bf8f6ef45b88fde4d86d48a5c4ce59b5cdd" CHECKSUMTYPE="SHA-1" SIZE="4922">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T17:19:23" MIMETYPE="text/xml"
-				CHECKSUM="ce20567ccc566811668e04704917dd756d04b59c" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T17:19:23" MIMETYPE="text/xml" CHECKSUM="ce20567ccc566811668e04704917dd756d04b59c" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T17:19:23" MIMETYPE="text/xml"
-				CHECKSUM="65ab04be0fd034f953ba9447df9a35348e9d5116" CHECKSUMTYPE="SHA-1" SIZE="103750">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T17:19:23" MIMETYPE="text/xml" CHECKSUM="65ab04be0fd034f953ba9447df9a35348e9d5116" CHECKSUMTYPE="SHA-1" SIZE="103750">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T17:19:24" MIMETYPE="text/xml"
-				CHECKSUM="8342667c43904b16e5e1f6f69b110b027d255eec" CHECKSUMTYPE="SHA-1" SIZE="182687">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T17:19:24" MIMETYPE="text/xml" CHECKSUM="8342667c43904b16e5e1f6f69b110b027d255eec" CHECKSUMTYPE="SHA-1" SIZE="182687">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T17:19:24" MIMETYPE="text/xml"
-				CHECKSUM="35381e3ec385bfc841b4247cea70d059ce33af62" CHECKSUMTYPE="SHA-1" SIZE="183930">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T17:19:24" MIMETYPE="text/xml" CHECKSUM="35381e3ec385bfc841b4247cea70d059ce33af62" CHECKSUMTYPE="SHA-1" SIZE="183930">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T17:19:25" MIMETYPE="text/xml"
-				CHECKSUM="65ca17ab838babe370dee6ef22f386feec771c1e" CHECKSUMTYPE="SHA-1" SIZE="189724">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T17:19:25" MIMETYPE="text/xml" CHECKSUM="65ca17ab838babe370dee6ef22f386feec771c1e" CHECKSUMTYPE="SHA-1" SIZE="189724">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T17:19:25" MIMETYPE="text/xml"
-				CHECKSUM="15e8c78a53a97cdd33cb7c617f38a13613e117b9" CHECKSUMTYPE="SHA-1" SIZE="187837">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T17:19:25" MIMETYPE="text/xml" CHECKSUM="15e8c78a53a97cdd33cb7c617f38a13613e117b9" CHECKSUMTYPE="SHA-1" SIZE="187837">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T17:19:26" MIMETYPE="text/xml"
-				CHECKSUM="58a3f60787ed9fdf2c07f175db8a4ba453e225a2" CHECKSUMTYPE="SHA-1" SIZE="175001">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T17:19:26" MIMETYPE="text/xml" CHECKSUM="58a3f60787ed9fdf2c07f175db8a4ba453e225a2" CHECKSUMTYPE="SHA-1" SIZE="175001">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T17:19:26" MIMETYPE="text/xml"
-				CHECKSUM="fcd1004fdf6788ee6814245d834262c9ea2d6719" CHECKSUMTYPE="SHA-1" SIZE="180192">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T17:19:26" MIMETYPE="text/xml" CHECKSUM="fcd1004fdf6788ee6814245d834262c9ea2d6719" CHECKSUMTYPE="SHA-1" SIZE="180192">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T17:19:26" MIMETYPE="text/xml"
-				CHECKSUM="7b2cfe36f1fe5da348a9064c5027994b35ae3e71" CHECKSUMTYPE="SHA-1" SIZE="112461">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T17:19:26" MIMETYPE="text/xml" CHECKSUM="7b2cfe36f1fe5da348a9064c5027994b35ae3e71" CHECKSUMTYPE="SHA-1" SIZE="112461">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T17:19:27" MIMETYPE="text/xml"
-				CHECKSUM="6ae8d7d3e8f6bff1b948d0844b16a984181d885a" CHECKSUMTYPE="SHA-1" SIZE="4437">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T17:19:27" MIMETYPE="text/xml" CHECKSUM="6ae8d7d3e8f6bff1b948d0844b16a984181d885a" CHECKSUMTYPE="SHA-1" SIZE="4437">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T17:19:27" MIMETYPE="text/xml"
-				CHECKSUM="9b0babcb7c401119d3fc3a79afeca4405e4aca8b" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T17:19:27" MIMETYPE="text/xml" CHECKSUM="9b0babcb7c401119d3fc3a79afeca4405e4aca8b" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T17:19:27" MIMETYPE="text/xml"
-				CHECKSUM="a94e2d9da23a96abef480a8cb557311d99b8c28a" CHECKSUMTYPE="SHA-1" SIZE="75074">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T17:19:27" MIMETYPE="text/xml" CHECKSUM="a94e2d9da23a96abef480a8cb557311d99b8c28a" CHECKSUMTYPE="SHA-1" SIZE="75074">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T17:19:28" MIMETYPE="text/xml"
-				CHECKSUM="f6a01ecc8cb000d08658d924b328f3c7010d7701" CHECKSUMTYPE="SHA-1" SIZE="203218">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T17:19:28" MIMETYPE="text/xml" CHECKSUM="f6a01ecc8cb000d08658d924b328f3c7010d7701" CHECKSUMTYPE="SHA-1" SIZE="203218">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T17:19:29" MIMETYPE="text/xml"
-				CHECKSUM="69fb6786c07b18a5fe2965a87f0b43e90f1fb950" CHECKSUMTYPE="SHA-1" SIZE="197285">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T17:19:29" MIMETYPE="text/xml" CHECKSUM="69fb6786c07b18a5fe2965a87f0b43e90f1fb950" CHECKSUMTYPE="SHA-1" SIZE="197285">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T17:19:30" MIMETYPE="text/xml"
-				CHECKSUM="4c67018323d34ea967b86a5056da63c853108107" CHECKSUMTYPE="SHA-1" SIZE="63737">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T17:19:30" MIMETYPE="text/xml" CHECKSUM="4c67018323d34ea967b86a5056da63c853108107" CHECKSUMTYPE="SHA-1" SIZE="63737">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T17:19:30" MIMETYPE="text/xml"
-				CHECKSUM="d6efb6bae4896e9020ce166e58dc03ae6d47aa87" CHECKSUMTYPE="SHA-1" SIZE="4631">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T17:19:30" MIMETYPE="text/xml" CHECKSUM="d6efb6bae4896e9020ce166e58dc03ae6d47aa87" CHECKSUMTYPE="SHA-1" SIZE="4631">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T17:19:31" MIMETYPE="text/xml"
-				CHECKSUM="48b056509530900c735113f420972fce5b8b2c36" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T17:19:31" MIMETYPE="text/xml" CHECKSUM="48b056509530900c735113f420972fce5b8b2c36" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T17:19:31" MIMETYPE="text/xml"
-				CHECKSUM="e1495271cb054092774eea39f09471dd8e51a4de" CHECKSUMTYPE="SHA-1" SIZE="87396">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T17:19:31" MIMETYPE="text/xml" CHECKSUM="e1495271cb054092774eea39f09471dd8e51a4de" CHECKSUMTYPE="SHA-1" SIZE="87396">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T17:19:31" MIMETYPE="text/xml"
-				CHECKSUM="6d483e0027f18534c7f481fa346788d11673a607" CHECKSUMTYPE="SHA-1" SIZE="200393">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T17:19:31" MIMETYPE="text/xml" CHECKSUM="6d483e0027f18534c7f481fa346788d11673a607" CHECKSUMTYPE="SHA-1" SIZE="200393">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T17:19:32" MIMETYPE="text/xml"
-				CHECKSUM="5871ddcceb3f544c6211af39d42ea111cb4c2fdb" CHECKSUMTYPE="SHA-1" SIZE="199262">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T17:19:32" MIMETYPE="text/xml" CHECKSUM="5871ddcceb3f544c6211af39d42ea111cb4c2fdb" CHECKSUMTYPE="SHA-1" SIZE="199262">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T17:19:32" MIMETYPE="text/xml"
-				CHECKSUM="1e6d423b9d012f344606791fd7f3437649141365" CHECKSUMTYPE="SHA-1" SIZE="190805">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T17:19:32" MIMETYPE="text/xml" CHECKSUM="1e6d423b9d012f344606791fd7f3437649141365" CHECKSUMTYPE="SHA-1" SIZE="190805">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T17:19:33" MIMETYPE="text/xml"
-				CHECKSUM="e47fc216815954053c9ca83863003f9404c6f830" CHECKSUMTYPE="SHA-1" SIZE="4595">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T17:19:33" MIMETYPE="text/xml" CHECKSUM="e47fc216815954053c9ca83863003f9404c6f830" CHECKSUMTYPE="SHA-1" SIZE="4595">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T17:19:33" MIMETYPE="text/xml"
-				CHECKSUM="ad0d83efecec20f475dd57c2c9a5110b5d663ce2" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T17:19:33" MIMETYPE="text/xml" CHECKSUM="ad0d83efecec20f475dd57c2c9a5110b5d663ce2" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T17:19:33" MIMETYPE="text/xml"
-				CHECKSUM="a6557ff0889b4fbd80db7f40bbee5a193e0cac1b" CHECKSUMTYPE="SHA-1" SIZE="69111">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T17:19:33" MIMETYPE="text/xml" CHECKSUM="a6557ff0889b4fbd80db7f40bbee5a193e0cac1b" CHECKSUMTYPE="SHA-1" SIZE="69111">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T17:19:33" MIMETYPE="text/xml"
-				CHECKSUM="c7d84f9f234c2808b61a4105e93e13870bb1cdc9" CHECKSUMTYPE="SHA-1" SIZE="35788">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T17:19:33" MIMETYPE="text/xml" CHECKSUM="c7d84f9f234c2808b61a4105e93e13870bb1cdc9" CHECKSUMTYPE="SHA-1" SIZE="35788">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T17:19:34" MIMETYPE="text/xml"
-				CHECKSUM="9119a86af3744deea6a696c8dc6dabc681dd8fd0" CHECKSUMTYPE="SHA-1" SIZE="75187">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T17:19:34" MIMETYPE="text/xml" CHECKSUM="9119a86af3744deea6a696c8dc6dabc681dd8fd0" CHECKSUMTYPE="SHA-1" SIZE="75187">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T17:19:34" MIMETYPE="text/xml"
-				CHECKSUM="bda226c1a9b46085398c12675714475e736dade3" CHECKSUMTYPE="SHA-1" SIZE="92398">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T17:19:34" MIMETYPE="text/xml" CHECKSUM="bda226c1a9b46085398c12675714475e736dade3" CHECKSUMTYPE="SHA-1" SIZE="92398">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T17:19:34" MIMETYPE="text/xml"
-				CHECKSUM="6e10c688928ac83525e4aff41a126fa215cefc12" CHECKSUMTYPE="SHA-1" SIZE="92758">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T17:19:34" MIMETYPE="text/xml" CHECKSUM="6e10c688928ac83525e4aff41a126fa215cefc12" CHECKSUMTYPE="SHA-1" SIZE="92758">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T17:19:34" MIMETYPE="text/xml"
-				CHECKSUM="bf52865ee346d531e4e24eb85c7e7d61b65d3525" CHECKSUMTYPE="SHA-1" SIZE="136713">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T17:19:34" MIMETYPE="text/xml" CHECKSUM="bf52865ee346d531e4e24eb85c7e7d61b65d3525" CHECKSUMTYPE="SHA-1" SIZE="136713">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T17:19:35" MIMETYPE="text/xml"
-				CHECKSUM="aada7f2d2268d6165991dbfdfef39653f7d5f1ac" CHECKSUMTYPE="SHA-1" SIZE="5333">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T17:19:35" MIMETYPE="text/xml" CHECKSUM="aada7f2d2268d6165991dbfdfef39653f7d5f1ac" CHECKSUMTYPE="SHA-1" SIZE="5333">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T17:19:35" MIMETYPE="text/xml"
-				CHECKSUM="4f00063e51ea4f65e77fa4a3080a89ab6573572f" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T17:19:35" MIMETYPE="text/xml" CHECKSUM="4f00063e51ea4f65e77fa4a3080a89ab6573572f" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T17:19:36" MIMETYPE="text/xml"
-				CHECKSUM="ac450bb2ffd3025eacdb93f4c3ff98413e6b02df" CHECKSUMTYPE="SHA-1" SIZE="128208">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T17:19:36" MIMETYPE="text/xml" CHECKSUM="ac450bb2ffd3025eacdb93f4c3ff98413e6b02df" CHECKSUMTYPE="SHA-1" SIZE="128208">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T17:19:36" MIMETYPE="text/xml"
-				CHECKSUM="9b27e8004be2233bd797112cb9dc4e1bcfd89fae" CHECKSUMTYPE="SHA-1" SIZE="102782">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T17:19:36" MIMETYPE="text/xml" CHECKSUM="9b27e8004be2233bd797112cb9dc4e1bcfd89fae" CHECKSUMTYPE="SHA-1" SIZE="102782">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T17:19:36" MIMETYPE="text/xml"
-				CHECKSUM="7e43932a555be80a990943209ee1dc1e66b1a00e" CHECKSUMTYPE="SHA-1" SIZE="4921">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T17:19:36" MIMETYPE="text/xml" CHECKSUM="7e43932a555be80a990943209ee1dc1e66b1a00e" CHECKSUMTYPE="SHA-1" SIZE="4921">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T17:19:36" MIMETYPE="text/xml"
-				CHECKSUM="1f2aa4a98366b8cbcca2e665ff0c8eb5cb0c823a" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T17:19:36" MIMETYPE="text/xml" CHECKSUM="1f2aa4a98366b8cbcca2e665ff0c8eb5cb0c823a" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T17:19:37" MIMETYPE="text/xml"
-				CHECKSUM="00799412c3ead4e2d9397d569376debd5b6e4328" CHECKSUMTYPE="SHA-1" SIZE="93250">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T17:19:37" MIMETYPE="text/xml" CHECKSUM="00799412c3ead4e2d9397d569376debd5b6e4328" CHECKSUMTYPE="SHA-1" SIZE="93250">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T17:19:37" MIMETYPE="text/xml"
-				CHECKSUM="7f930f1177ceee1f7ef6b6d9bc617267c2412ab2" CHECKSUMTYPE="SHA-1" SIZE="177900">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T17:19:37" MIMETYPE="text/xml" CHECKSUM="7f930f1177ceee1f7ef6b6d9bc617267c2412ab2" CHECKSUMTYPE="SHA-1" SIZE="177900">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T17:19:37" MIMETYPE="text/xml"
-				CHECKSUM="07036ca3c89b02eb1a981e6ea2bd0fb9882e44f8" CHECKSUMTYPE="SHA-1" SIZE="176376">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T17:19:37" MIMETYPE="text/xml" CHECKSUM="07036ca3c89b02eb1a981e6ea2bd0fb9882e44f8" CHECKSUMTYPE="SHA-1" SIZE="176376">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T17:19:38" MIMETYPE="text/xml"
-				CHECKSUM="456ce81ff6f9be40373c03d987fba08d43f10a8b" CHECKSUMTYPE="SHA-1" SIZE="76213">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T17:19:38" MIMETYPE="text/xml" CHECKSUM="456ce81ff6f9be40373c03d987fba08d43f10a8b" CHECKSUMTYPE="SHA-1" SIZE="76213">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T17:19:38" MIMETYPE="text/xml"
-				CHECKSUM="f3b7e5da50c9d8c864476a3445bd94df3a850642" CHECKSUMTYPE="SHA-1" SIZE="5214">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T17:19:38" MIMETYPE="text/xml" CHECKSUM="f3b7e5da50c9d8c864476a3445bd94df3a850642" CHECKSUMTYPE="SHA-1" SIZE="5214">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T17:19:38" MIMETYPE="text/xml"
-				CHECKSUM="1dbda5b4dac144a4a891bbfcf7d37d71e27ddce3" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T17:19:38" MIMETYPE="text/xml" CHECKSUM="1dbda5b4dac144a4a891bbfcf7d37d71e27ddce3" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T17:19:38" MIMETYPE="text/xml"
-				CHECKSUM="d52220d0a372c4be6fee3558e08c789cc9efe6fc" CHECKSUMTYPE="SHA-1" SIZE="89984">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T17:19:38" MIMETYPE="text/xml" CHECKSUM="d52220d0a372c4be6fee3558e08c789cc9efe6fc" CHECKSUMTYPE="SHA-1" SIZE="89984">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T17:19:39" MIMETYPE="text/xml"
-				CHECKSUM="8ac3dcae3484282b1933ea272204eb2f3e303f8f" CHECKSUMTYPE="SHA-1" SIZE="197710">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T17:19:39" MIMETYPE="text/xml" CHECKSUM="8ac3dcae3484282b1933ea272204eb2f3e303f8f" CHECKSUMTYPE="SHA-1" SIZE="197710">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0094.alto.xml"/>
 			</file>
-			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T17:19:39" MIMETYPE="text/xml"
-				CHECKSUM="48e82c5de1973b29a941060c340388c234a119b7" CHECKSUMTYPE="SHA-1" SIZE="133829">
+			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T17:19:39" MIMETYPE="text/xml" CHECKSUM="48e82c5de1973b29a941060c340388c234a119b7" CHECKSUMTYPE="SHA-1" SIZE="133829">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0095.alto.xml"/>
 			</file>
-			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T17:19:40" MIMETYPE="text/xml"
-				CHECKSUM="75c3a5bc91e99c17cbf61154a8127bec6b01436d" CHECKSUMTYPE="SHA-1" SIZE="110473">
+			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T17:19:40" MIMETYPE="text/xml" CHECKSUM="75c3a5bc91e99c17cbf61154a8127bec6b01436d" CHECKSUMTYPE="SHA-1" SIZE="110473">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0096.alto.xml"/>
 			</file>
-			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T17:19:40" MIMETYPE="text/xml"
-				CHECKSUM="3fc3bab519227467ddf82cbc14385be9db9f051c" CHECKSUMTYPE="SHA-1" SIZE="182412">
+			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T17:19:40" MIMETYPE="text/xml" CHECKSUM="3fc3bab519227467ddf82cbc14385be9db9f051c" CHECKSUMTYPE="SHA-1" SIZE="182412">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0097.alto.xml"/>
 			</file>
-			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T17:19:40" MIMETYPE="text/xml"
-				CHECKSUM="24589f65335537cc0edbbb5a42b17f44f582746e" CHECKSUMTYPE="SHA-1" SIZE="177509">
+			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T17:19:40" MIMETYPE="text/xml" CHECKSUM="24589f65335537cc0edbbb5a42b17f44f582746e" CHECKSUMTYPE="SHA-1" SIZE="177509">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0098.alto.xml"/>
 			</file>
-			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T17:19:41" MIMETYPE="text/xml"
-				CHECKSUM="945cfd1f619564e5f9ed024a574d44243e83ce65" CHECKSUMTYPE="SHA-1" SIZE="192763">
+			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T17:19:41" MIMETYPE="text/xml" CHECKSUM="945cfd1f619564e5f9ed024a574d44243e83ce65" CHECKSUMTYPE="SHA-1" SIZE="192763">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0099.alto.xml"/>
 			</file>
-			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T17:19:41" MIMETYPE="text/xml"
-				CHECKSUM="4260d6ce18d06265de35b3964daa4ee8bdec1a73" CHECKSUMTYPE="SHA-1" SIZE="161425">
+			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T17:19:41" MIMETYPE="text/xml" CHECKSUM="4260d6ce18d06265de35b3964daa4ee8bdec1a73" CHECKSUMTYPE="SHA-1" SIZE="161425">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0100.alto.xml"/>
 			</file>
-			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T17:19:41" MIMETYPE="text/xml"
-				CHECKSUM="e44d495433eb1fbb17e97b057ca54116cfb3f20c" CHECKSUMTYPE="SHA-1" SIZE="4778">
+			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T17:19:41" MIMETYPE="text/xml" CHECKSUM="e44d495433eb1fbb17e97b057ca54116cfb3f20c" CHECKSUMTYPE="SHA-1" SIZE="4778">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0101.alto.xml"/>
 			</file>
-			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T17:19:42" MIMETYPE="text/xml"
-				CHECKSUM="9ee8f29c9f27252d8efeafad714627ddcce5d3df" CHECKSUMTYPE="SHA-1" SIZE="2022">
+			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T17:19:42" MIMETYPE="text/xml" CHECKSUM="9ee8f29c9f27252d8efeafad714627ddcce5d3df" CHECKSUMTYPE="SHA-1" SIZE="2022">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0102.alto.xml"/>
 			</file>
-			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T17:19:42" MIMETYPE="text/xml"
-				CHECKSUM="7577e86b61330ccb106ed4944ba852747d66e60c" CHECKSUMTYPE="SHA-1" SIZE="79084">
+			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T17:19:42" MIMETYPE="text/xml" CHECKSUM="7577e86b61330ccb106ed4944ba852747d66e60c" CHECKSUMTYPE="SHA-1" SIZE="79084">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0103.alto.xml"/>
 			</file>
-			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T17:19:42" MIMETYPE="text/xml"
-				CHECKSUM="fa4470a7bd08fc04270d19dcbf4514985521bbd4" CHECKSUMTYPE="SHA-1" SIZE="188585">
+			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T17:19:42" MIMETYPE="text/xml" CHECKSUM="fa4470a7bd08fc04270d19dcbf4514985521bbd4" CHECKSUMTYPE="SHA-1" SIZE="188585">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0104.alto.xml"/>
 			</file>
-			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T17:19:43" MIMETYPE="text/xml"
-				CHECKSUM="edbb866054257ec70e87a341eb7f26cb4fd6e17e" CHECKSUMTYPE="SHA-1" SIZE="193490">
+			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T17:19:43" MIMETYPE="text/xml" CHECKSUM="edbb866054257ec70e87a341eb7f26cb4fd6e17e" CHECKSUMTYPE="SHA-1" SIZE="193490">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0105.alto.xml"/>
 			</file>
-			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T17:19:43" MIMETYPE="text/xml"
-				CHECKSUM="3e31c9a51134046d2adfd9a9548aad46d3047355" CHECKSUMTYPE="SHA-1" SIZE="182925">
+			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T17:19:43" MIMETYPE="text/xml" CHECKSUM="3e31c9a51134046d2adfd9a9548aad46d3047355" CHECKSUMTYPE="SHA-1" SIZE="182925">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0106.alto.xml"/>
 			</file>
-			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T17:19:44" MIMETYPE="text/xml"
-				CHECKSUM="a005a36830ed80c2f3b76bda3b9ea1b050730209" CHECKSUMTYPE="SHA-1" SIZE="192449">
+			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T17:19:44" MIMETYPE="text/xml" CHECKSUM="a005a36830ed80c2f3b76bda3b9ea1b050730209" CHECKSUMTYPE="SHA-1" SIZE="192449">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0107.alto.xml"/>
 			</file>
-			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T17:19:44" MIMETYPE="text/xml"
-				CHECKSUM="5bfc6176018f9c5a764ae3d322ad83164563697b" CHECKSUMTYPE="SHA-1" SIZE="188304">
+			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T17:19:44" MIMETYPE="text/xml" CHECKSUM="5bfc6176018f9c5a764ae3d322ad83164563697b" CHECKSUMTYPE="SHA-1" SIZE="188304">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0108.alto.xml"/>
 			</file>
-			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T17:19:44" MIMETYPE="text/xml"
-				CHECKSUM="825fc2ada932e12b7961ec5d069a562ee8f23945" CHECKSUMTYPE="SHA-1" SIZE="187040">
+			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T17:19:44" MIMETYPE="text/xml" CHECKSUM="825fc2ada932e12b7961ec5d069a562ee8f23945" CHECKSUMTYPE="SHA-1" SIZE="187040">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0109.alto.xml"/>
 			</file>
-			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T17:19:45" MIMETYPE="text/xml"
-				CHECKSUM="0c1ba14bd0d56919364481c660ad9439339226ed" CHECKSUMTYPE="SHA-1" SIZE="203972">
+			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T17:19:45" MIMETYPE="text/xml" CHECKSUM="0c1ba14bd0d56919364481c660ad9439339226ed" CHECKSUMTYPE="SHA-1" SIZE="203972">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0110.alto.xml"/>
 			</file>
-			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-07-30T17:19:45" MIMETYPE="text/xml"
-				CHECKSUM="bb15e35fcf14478e3ede43f9da8c187f27bd0425" CHECKSUMTYPE="SHA-1" SIZE="206737">
+			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-07-30T17:19:45" MIMETYPE="text/xml" CHECKSUM="bb15e35fcf14478e3ede43f9da8c187f27bd0425" CHECKSUMTYPE="SHA-1" SIZE="206737">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0111.alto.xml"/>
 			</file>
-			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-07-30T17:19:45" MIMETYPE="text/xml"
-				CHECKSUM="713c25b296337af899b440dd0130f9e7c025a0cb" CHECKSUMTYPE="SHA-1" SIZE="2938">
+			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-07-30T17:19:45" MIMETYPE="text/xml" CHECKSUM="713c25b296337af899b440dd0130f9e7c025a0cb" CHECKSUMTYPE="SHA-1" SIZE="2938">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0112.alto.xml"/>
 			</file>
-			<file ID="ALTO00113" GROUPID="page113" CREATED="2015-07-30T17:19:46" MIMETYPE="text/xml"
-				CHECKSUM="a59e68a61542eceff8f9d88d640c51855d2dc93f" CHECKSUMTYPE="SHA-1" SIZE="5578">
+			<file ID="ALTO00113" GROUPID="page113" CREATED="2015-07-30T17:19:46" MIMETYPE="text/xml" CHECKSUM="a59e68a61542eceff8f9d88d640c51855d2dc93f" CHECKSUMTYPE="SHA-1" SIZE="5578">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0113.alto.xml"/>
 			</file>
-			<file ID="ALTO00114" GROUPID="page114" CREATED="2015-07-30T17:19:46" MIMETYPE="text/xml"
-				CHECKSUM="c9f2a06434e1c0b44d27244a35d18e0eb37fb38a" CHECKSUMTYPE="SHA-1" SIZE="2022">
+			<file ID="ALTO00114" GROUPID="page114" CREATED="2015-07-30T17:19:46" MIMETYPE="text/xml" CHECKSUM="c9f2a06434e1c0b44d27244a35d18e0eb37fb38a" CHECKSUMTYPE="SHA-1" SIZE="2022">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0114.alto.xml"/>
 			</file>
-			<file ID="ALTO00115" GROUPID="page115" CREATED="2015-07-30T17:19:46" MIMETYPE="text/xml"
-				CHECKSUM="f52af8e177644d5243f059f39dd55c94ec11674f" CHECKSUMTYPE="SHA-1" SIZE="65991">
+			<file ID="ALTO00115" GROUPID="page115" CREATED="2015-07-30T17:19:46" MIMETYPE="text/xml" CHECKSUM="f52af8e177644d5243f059f39dd55c94ec11674f" CHECKSUMTYPE="SHA-1" SIZE="65991">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0115.alto.xml"/>
 			</file>
-			<file ID="ALTO00116" GROUPID="page116" CREATED="2015-07-30T17:19:46" MIMETYPE="text/xml"
-				CHECKSUM="2291e89702f2b1011606429a03faee2e197ed2ee" CHECKSUMTYPE="SHA-1" SIZE="3023">
+			<file ID="ALTO00116" GROUPID="page116" CREATED="2015-07-30T17:19:46" MIMETYPE="text/xml" CHECKSUM="2291e89702f2b1011606429a03faee2e197ed2ee" CHECKSUMTYPE="SHA-1" SIZE="3023">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0116.alto.xml"/>
 			</file>
-			<file ID="ALTO00117" GROUPID="page117" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml"
-				CHECKSUM="6cfcab4f21fc25aed8920297e172f1176835dc14" CHECKSUMTYPE="SHA-1" SIZE="58065">
+			<file ID="ALTO00117" GROUPID="page117" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml" CHECKSUM="6cfcab4f21fc25aed8920297e172f1176835dc14" CHECKSUMTYPE="SHA-1" SIZE="58065">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0117.alto.xml"/>
 			</file>
-			<file ID="ALTO00118" GROUPID="page118" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml"
-				CHECKSUM="e3b4a2d355ab90960ba14c598118f19b83e2b24c" CHECKSUMTYPE="SHA-1" SIZE="30567">
+			<file ID="ALTO00118" GROUPID="page118" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml" CHECKSUM="e3b4a2d355ab90960ba14c598118f19b83e2b24c" CHECKSUMTYPE="SHA-1" SIZE="30567">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0118.alto.xml"/>
 			</file>
-			<file ID="ALTO00119" GROUPID="page119" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml"
-				CHECKSUM="5258630ae7f985c5dda723ee444cf8c6ded3bec5" CHECKSUMTYPE="SHA-1" SIZE="23547">
+			<file ID="ALTO00119" GROUPID="page119" CREATED="2015-07-30T17:19:47" MIMETYPE="text/xml" CHECKSUM="5258630ae7f985c5dda723ee444cf8c6ded3bec5" CHECKSUMTYPE="SHA-1" SIZE="23547">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0119.alto.xml"/>
 			</file>
-			<file ID="ALTO00120" GROUPID="page120" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml"
-				CHECKSUM="deef1e33db9d20567c293178f6469b278e6830f2" CHECKSUMTYPE="SHA-1" SIZE="50657">
+			<file ID="ALTO00120" GROUPID="page120" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml" CHECKSUM="deef1e33db9d20567c293178f6469b278e6830f2" CHECKSUMTYPE="SHA-1" SIZE="50657">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0120.alto.xml"/>
 			</file>
-			<file ID="ALTO00121" GROUPID="page121" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml"
-				CHECKSUM="579b4bd2a43cace6ad03adeb9b949639d55ca3dc" CHECKSUMTYPE="SHA-1" SIZE="2018">
+			<file ID="ALTO00121" GROUPID="page121" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml" CHECKSUM="579b4bd2a43cace6ad03adeb9b949639d55ca3dc" CHECKSUMTYPE="SHA-1" SIZE="2018">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0121.alto.xml"/>
 			</file>
-			<file ID="ALTO00122" GROUPID="page122" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml"
-				CHECKSUM="a9beb7117892a71f830cc422b723d750fdd5edf5" CHECKSUMTYPE="SHA-1" SIZE="2416">
+			<file ID="ALTO00122" GROUPID="page122" CREATED="2015-07-30T17:19:48" MIMETYPE="text/xml" CHECKSUM="a9beb7117892a71f830cc422b723d750fdd5edf5" CHECKSUMTYPE="SHA-1" SIZE="2416">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-07_01_0122.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T17:24:21" MIMETYPE="application/pdf" CHECKSUM="967072eeba36bcf96036d6b9c239d6d9e810bff4"
-				CHECKSUMTYPE="SHA-1" SIZE="80171987">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/bmtnabe_1896-07_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T17:24:21" MIMETYPE="application/pdf" CHECKSUM="967072eeba36bcf96036d6b9c239d6d9e810bff4" CHECKSUMTYPE="SHA-1" SIZE="80171987">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/07_01/bmtnabe_1896-07_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -13587,8 +13215,7 @@
 					</div>
 
 				</div>
-				<div ID="L.1.1.23" TYPE="TextContent" ORDER="23" DMDID="c056"
-					LABEL="BERLINER AKADEMIE GEDANKEN BEI DER FEIER IHRES 200 JAEHRIGEN BESTEHENS">
+				<div ID="L.1.1.23" TYPE="TextContent" ORDER="23" DMDID="c056" LABEL="BERLINER AKADEMIE GEDANKEN BEI DER FEIER IHRES 200 JAEHRIGEN BESTEHENS">
 					<div ID="L.1.1.23.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00069" BEGIN="P69_TB00002"/>

--- a/metadata/periodicals/bmtnabe/issues/1896/10_01/bmtnabe_1896-10_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1896/10_01/bmtnabe_1896-10_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1896-10_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1896-10_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-10_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-10_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1896-10_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1896-10_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,7 +46,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-10_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -12117,1274 +12113,852 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-11-17T17:46:36" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="463c36b1b92bcc61b9e301e6dfa410a81c3bc73c" CHECKSUMTYPE="SHA-1" SIZE="5005018">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-11-17T17:47:04" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="ab75e46150dc0fa51812fa413665b67a6a4120ff" CHECKSUMTYPE="SHA-1" SIZE="5347928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-11-17T17:47:31" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="903d6715fd55639d13e9f67ebb7f9a3c211c145f" CHECKSUMTYPE="SHA-1" SIZE="5004996">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-11-17T17:47:56" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="63a6e0f9d64a4bd6a0f3f1dfd3aa89802e471a24" CHECKSUMTYPE="SHA-1" SIZE="5347927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-11-17T17:48:22" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="a795f2fa82703331451af9ee035aba768430c382" CHECKSUMTYPE="SHA-1" SIZE="5005028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-11-17T17:48:46" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="96440e38ed4e9618e92b4e1882e391bcf05a3cc1" CHECKSUMTYPE="SHA-1" SIZE="5347898">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-11-17T17:49:12" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="c1dc8a18b511a82283e26ee2ca62b5a03e3d38ce" CHECKSUMTYPE="SHA-1" SIZE="5004927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-11-17T17:49:35" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="5d567031540c9cb7ca28666978fd7db4f5fcc28c" CHECKSUMTYPE="SHA-1" SIZE="5347918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-11-17T17:49:59" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="5396baf56777e1ff67bc2ccfa9bfd4d216597e0d" CHECKSUMTYPE="SHA-1" SIZE="5004872">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-11-17T17:50:22" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="4dc5eb7e5be6f303543aedf60d98f18b71d3a268" CHECKSUMTYPE="SHA-1" SIZE="5333527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-11-17T17:50:47" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="79cf45a3872b05ce14141312de19efda427aee87" CHECKSUMTYPE="SHA-1" SIZE="5004978">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-11-17T17:51:11" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="01076ba217a946a4e9a644b1edd6e4fcba521b4d" CHECKSUMTYPE="SHA-1" SIZE="5333523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-11-17T17:51:38" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="e6a1bfc4b09981b47bb676e5a8ecfa0f73928474" CHECKSUMTYPE="SHA-1" SIZE="5005025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-11-17T17:52:02" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="a525f61c8e870bfc31e46444fff7c802b7eacb15" CHECKSUMTYPE="SHA-1" SIZE="5333437">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-11-17T17:52:26" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="1da804097475e02719d21b056c29346c2e2fbf32" CHECKSUMTYPE="SHA-1" SIZE="5005027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-11-17T17:52:49" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="5d5de713394b14f9240b4a8cb1e4cb0be1b24b2d" CHECKSUMTYPE="SHA-1" SIZE="5333529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-11-17T17:53:15" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="967f080942c3b8d4a50213b01f849682380402d5" CHECKSUMTYPE="SHA-1" SIZE="5004986">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-11-17T17:53:41" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="17d5626731c228db3276ef4bbb777998fd3b136b" CHECKSUMTYPE="SHA-1" SIZE="5333525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-11-17T17:54:06" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="e721aeeff7fa9e475e0e078bb3831f643d5c5846" CHECKSUMTYPE="SHA-1" SIZE="5005026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-11-17T17:54:33" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="474379d4355047239b50aea9d968354aa864185c" CHECKSUMTYPE="SHA-1" SIZE="5333520">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-11-17T17:55:01" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="b184ef0994bd19cbddd562f078607d3b99817365" CHECKSUMTYPE="SHA-1" SIZE="5005007">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-11-17T17:55:26" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="f686d3d14cf6d7bd689ba0f2749d72f1da826708" CHECKSUMTYPE="SHA-1" SIZE="5333515">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-11-17T17:55:55" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="06d07308b37e0ad03dd90171f9e42862456aaa24" CHECKSUMTYPE="SHA-1" SIZE="5005028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-11-17T17:56:22" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="f7ed91a41b2181f4ace55030b18b25912b431470" CHECKSUMTYPE="SHA-1" SIZE="5333515">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-11-17T17:56:48" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="184a6a7032ca22a4222868a2131f48e289108863" CHECKSUMTYPE="SHA-1" SIZE="5005019">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-11-17T17:57:14" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="e98a2d3306119b6388d24a196a6689fd8418610b" CHECKSUMTYPE="SHA-1" SIZE="5345219">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-11-17T17:57:41" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="f6b935d4ef709156380653d534d291af461fb1a5" CHECKSUMTYPE="SHA-1" SIZE="5004977">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-11-17T17:58:08" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="e72d5301c6cddc2835631cd8d3a9bd247a584c50" CHECKSUMTYPE="SHA-1" SIZE="5345227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-11-17T17:58:35" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="fed0055ceeef9d1b76592a3a818f89f74a5f5c80" CHECKSUMTYPE="SHA-1" SIZE="5005023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-11-17T17:59:03" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="07afa964d77e47fb962edb01d49024d14f0cd6c7" CHECKSUMTYPE="SHA-1" SIZE="5345226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-11-17T17:59:27" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="d3254ca121da940e041001a6b169316069c3f58f" CHECKSUMTYPE="SHA-1" SIZE="5005024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-11-17T17:59:53" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="60cd11364b20fc65419e7d079ae29e3e9ec8edb7" CHECKSUMTYPE="SHA-1" SIZE="5398329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-11-17T18:00:20" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="dc6ac05b2aee79a28bc6c7e584347419f6ae40d9" CHECKSUMTYPE="SHA-1" SIZE="5005026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-11-17T18:00:45" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="b009689973036d129f8b16923930949c550b6b5a" CHECKSUMTYPE="SHA-1" SIZE="5398329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-11-17T18:01:13" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="9552bf2d9d8094bdbcae61b74dfa4e0764aa8078" CHECKSUMTYPE="SHA-1" SIZE="5004969">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-11-17T18:01:39" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="9a10bfd8729bb5cf6a3e0fa152b0a1a074594a03" CHECKSUMTYPE="SHA-1" SIZE="5398329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-11-17T18:02:05" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="438ce5ec50ca4897af9e64ee899fd393005d0b0d" CHECKSUMTYPE="SHA-1" SIZE="5005025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-11-17T18:02:30" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="9b74f215688547b6cb3f90daf3991b16e51cbb56" CHECKSUMTYPE="SHA-1" SIZE="5412718">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-11-17T18:02:58" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="0fd69530c2de565a5209481ee6f4b46a81ac36dd" CHECKSUMTYPE="SHA-1" SIZE="5005026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-11-17T18:03:26" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="7c2432350c6c367261b1018e68b00989f0478878" CHECKSUMTYPE="SHA-1" SIZE="5412728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-11-17T18:03:53" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="6356dc8278210162271d02b2ac957c658fd5d6e1" CHECKSUMTYPE="SHA-1" SIZE="5004996">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-11-17T18:04:20" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="884a4d950c071c6b3a97b7cbc15b6fb8294b1110" CHECKSUMTYPE="SHA-1" SIZE="5412725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-11-17T18:04:48" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="4567b239546478457f776bd0f5f54227107787c2" CHECKSUMTYPE="SHA-1" SIZE="5005022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-11-17T18:05:14" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="0de31ba945daeb03af921c9bddbbbf2e8e107036" CHECKSUMTYPE="SHA-1" SIZE="5412693">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-11-17T18:05:40" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="bcd4a5550f544e5db9b2bb03d1a73b84c63a1362" CHECKSUMTYPE="SHA-1" SIZE="5005002">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-11-17T18:06:06" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="b50de71b5e805d19d6989bb086d6ec1260f37ac9" CHECKSUMTYPE="SHA-1" SIZE="5412725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-11-17T18:06:34" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="000c88e7355a7f748168cd13b9a8c2fd832236cc" CHECKSUMTYPE="SHA-1" SIZE="5005017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-11-17T18:07:00" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="71323122a60254204d47f0ad2f0d3eadd7f7b71a" CHECKSUMTYPE="SHA-1" SIZE="5406299">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-11-17T18:07:28" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="3df2bf77abbc88cb6e3832119119e40b2dcf3566" CHECKSUMTYPE="SHA-1" SIZE="5005018">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-11-17T18:07:55" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="af409eb20517bea1143daf93cc66a47265af2238" CHECKSUMTYPE="SHA-1" SIZE="5412724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-11-17T18:08:23" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="0ac2080c468d0c1173f646ae467de89898d381da" CHECKSUMTYPE="SHA-1" SIZE="5005022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-11-17T18:08:50" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="fe7043791fe0af52b6366c9afc86f2efc47f4117" CHECKSUMTYPE="SHA-1" SIZE="5412702">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-11-17T18:09:16" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="7c6f84982d82f7d424755434d6fc6ac0d971ff5a" CHECKSUMTYPE="SHA-1" SIZE="5004903">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-11-17T18:09:43" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="1071f3e2403511178f0e64bb9729806e3db4bd75" CHECKSUMTYPE="SHA-1" SIZE="5412707">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-11-17T18:10:11" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="813536501d012c3e5e8b13375eabba8648bb983d" CHECKSUMTYPE="SHA-1" SIZE="5005024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-11-17T18:10:38" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="f8162ebc890aa9b88fb31675f6c7308f49d07a03" CHECKSUMTYPE="SHA-1" SIZE="5412716">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-11-17T18:11:06" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="d2021713603f90965cb287f481d501700178a563" CHECKSUMTYPE="SHA-1" SIZE="5005022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-11-17T18:11:34" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="dea9e31e458f7c3c43f9648670afdeef9449a06a" CHECKSUMTYPE="SHA-1" SIZE="5412723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-11-17T18:12:00" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="0e9202d4a8a30b3b1b0c0166cc84d328eede533d" CHECKSUMTYPE="SHA-1" SIZE="5005006">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-11-17T18:12:28" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="f55cd261e0b53c1b0f3a52fc9857f8a583c2f00d" CHECKSUMTYPE="SHA-1" SIZE="5412650">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-11-17T18:12:54" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="c4fa4fa6f776b3b89158c7e87b9f5d6720e627ed" CHECKSUMTYPE="SHA-1" SIZE="5005020">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-11-17T18:13:21" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="60f4c7117be30ac8e7781cfbbf730778bfa23dc6" CHECKSUMTYPE="SHA-1" SIZE="5412706">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-11-17T18:13:49" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="0df8ec9719063225770d0599de13c953ecc94afe" CHECKSUMTYPE="SHA-1" SIZE="5005002">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-11-17T18:14:15" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="6918dfe8984a48f049690a7675b6d045cef0e2a5" CHECKSUMTYPE="SHA-1" SIZE="5430727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-11-17T18:14:43" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="214d7efac593af6ef150f73a47ab82467825f213" CHECKSUMTYPE="SHA-1" SIZE="5004925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-11-17T18:15:12" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="8e7bd713139f1c9ef94e17524be8a15683451cda" CHECKSUMTYPE="SHA-1" SIZE="5430695">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-11-17T18:15:38" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="46eb01b71c09f58dbd9175acf9fc73f2e5159db2" CHECKSUMTYPE="SHA-1" SIZE="5020297">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-11-17T18:16:06" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="684a0ea6c7289e7ee5112937f2f045d899a22ec2" CHECKSUMTYPE="SHA-1" SIZE="5430726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-11-17T18:16:32" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="f6e29df49b2421dc606499cdeefd68d395a1baf4" CHECKSUMTYPE="SHA-1" SIZE="5020322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-11-17T18:16:58" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="6a9c8845533caa5da25ac82e442ba730c34de4e8" CHECKSUMTYPE="SHA-1" SIZE="5430728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-11-17T18:17:27" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="48107aec2ee82cb0875fd4f1d886c7d8d4669cf0" CHECKSUMTYPE="SHA-1" SIZE="5020328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-11-17T18:17:54" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="5d5bb882d7134411b22255f3eb35046169ee25c8" CHECKSUMTYPE="SHA-1" SIZE="5421724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-11-17T18:18:23" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="dd50d0baf9320386898535a27063eb039eed205f" CHECKSUMTYPE="SHA-1" SIZE="5273225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-11-17T18:18:51" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="cf62d4b94ac7515059e5748825ae31cd7a56e88f" CHECKSUMTYPE="SHA-1" SIZE="5430715">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-11-17T18:19:21" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="3b838b09ec774986d26939d51847239651ebd795" CHECKSUMTYPE="SHA-1" SIZE="5078825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-11-17T18:19:51" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="7489d2672ba2046ca8d385a5059df95a905354dc" CHECKSUMTYPE="SHA-1" SIZE="5418931">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-11-17T18:20:22" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="b7b8646f2b215e2b538a5cbcad011d0036312788" CHECKSUMTYPE="SHA-1" SIZE="5092329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-11-17T18:20:52" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="ac62fee8d8e6553763dcc4d3c6f057697c4eb01d" CHECKSUMTYPE="SHA-1" SIZE="5430728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-11-17T18:21:24" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="87f1aa6ff0a76755ae7c082be5b059531d3fe4af" CHECKSUMTYPE="SHA-1" SIZE="5092326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-11-17T18:21:57" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="a06a77b039fd0b39050285cc702a85c1dd87c512" CHECKSUMTYPE="SHA-1" SIZE="5430698">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-11-17T18:22:31" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="7ef30d9c51bd62023f7f748f5823dcb9a219ebc0" CHECKSUMTYPE="SHA-1" SIZE="5118401">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-11-17T18:23:03" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="6b14750c750f8e0aa04c2ec68a1bc3c683aea345" CHECKSUMTYPE="SHA-1" SIZE="5430709">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-11-17T18:23:36" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="b21b67f762a99f4ed2d6efcd0f55e1d9af5301bb" CHECKSUMTYPE="SHA-1" SIZE="5118148">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-11-17T18:24:08" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="09b176b6a7b261bf617e4d1dfe23791001056349" CHECKSUMTYPE="SHA-1" SIZE="5430720">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-11-17T18:24:41" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="a5aa6d73863ce3782b3417cb2a204ad37409143f" CHECKSUMTYPE="SHA-1" SIZE="5136416">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-11-17T18:25:13" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="8066e9bb7ba11979d69aa6eca19ee7dd07ae007b" CHECKSUMTYPE="SHA-1" SIZE="5430722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-11-17T18:25:46" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="d3d578c1de38b728d50ff172fb3f15015be2ae78" CHECKSUMTYPE="SHA-1" SIZE="5136414">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-11-17T18:26:19" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="cec1f4adccb99af48ee38e5290c3341a5d1a72ea" CHECKSUMTYPE="SHA-1" SIZE="5430714">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-11-17T18:26:50" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="42f5e955ed9c94468633e27104477914c719587e" CHECKSUMTYPE="SHA-1" SIZE="5149022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-11-17T18:27:21" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="3b573d2e6618f298c21ebc9a0f76c4c129e9ce70" CHECKSUMTYPE="SHA-1" SIZE="5430710">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-11-17T18:27:54" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="3a0ac4d69dea7fcc2e6d1ea3ed8ad77af3da5bb9" CHECKSUMTYPE="SHA-1" SIZE="5273227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-11-17T18:28:26" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="36fd08ec45bf8bfbe91fae88ef3ef24694d77d56" CHECKSUMTYPE="SHA-1" SIZE="5430728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-11-17T18:28:58" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="c71f6514375136fdc5e4f3ed0c2ef8ec9589c13a" CHECKSUMTYPE="SHA-1" SIZE="5170625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-11-17T18:29:29" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="b481eb954c6bf32a3c8d7f87fdaaf19701116c00" CHECKSUMTYPE="SHA-1" SIZE="5430719">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0094.jp2"/>
-			</file>
-			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-11-17T18:30:01" MIMETYPE="image/jp2" SEQ="95"
-				CHECKSUM="c9e4b263e1b0e55d50975df0820b335ce01d17f3" CHECKSUMTYPE="SHA-1" SIZE="5170627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0095.jp2"/>
-			</file>
-			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-11-17T18:30:35" MIMETYPE="image/jp2" SEQ="96"
-				CHECKSUM="2ddf2c92724c2974cb550736bdb337b93c3536df" CHECKSUMTYPE="SHA-1" SIZE="5430725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0096.jp2"/>
-			</file>
-			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-11-17T18:31:09" MIMETYPE="image/jp2" SEQ="97"
-				CHECKSUM="901d12820dcd85ab8e2cec26863b55e5312d5a53" CHECKSUMTYPE="SHA-1" SIZE="5170586">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0097.jp2"/>
-			</file>
-			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-11-17T18:31:42" MIMETYPE="image/jp2" SEQ="98"
-				CHECKSUM="320eb817715955f57d61c3520d161501c329ae02" CHECKSUMTYPE="SHA-1" SIZE="5430729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0098.jp2"/>
-			</file>
-			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-11-17T18:32:16" MIMETYPE="image/jp2" SEQ="99"
-				CHECKSUM="3f48f6d88138c86f8a9f014b8c3933a832aa9f54" CHECKSUMTYPE="SHA-1" SIZE="5170628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0099.jp2"/>
-			</file>
-			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-11-17T18:32:48" MIMETYPE="image/jp2" SEQ="100"
-				CHECKSUM="24c480cca3fea64f3ed0e4b429456d8a06f4e2e5" CHECKSUMTYPE="SHA-1" SIZE="5409122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0100.jp2"/>
-			</file>
-			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-11-17T18:33:21" MIMETYPE="image/jp2" SEQ="101"
-				CHECKSUM="c173f1fef33b9976f7177da88603efb722d86fab" CHECKSUMTYPE="SHA-1" SIZE="5170598">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0101.jp2"/>
-			</file>
-			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-11-17T18:33:53" MIMETYPE="image/jp2" SEQ="102"
-				CHECKSUM="49426d0631ff96f3c65e30c1094c4df1586d60fc" CHECKSUMTYPE="SHA-1" SIZE="5409120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0102.jp2"/>
-			</file>
-			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-11-17T18:34:25" MIMETYPE="image/jp2" SEQ="103"
-				CHECKSUM="a9610779493d7996c1b6d689a85d39f44dc37107" CHECKSUMTYPE="SHA-1" SIZE="5216511">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0103.jp2"/>
-			</file>
-			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-11-17T18:34:59" MIMETYPE="image/jp2" SEQ="104"
-				CHECKSUM="d05aab68173b529c1541490dc206dfed1f727d46" CHECKSUMTYPE="SHA-1" SIZE="5409029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0104.jp2"/>
-			</file>
-			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-11-17T18:35:29" MIMETYPE="image/jp2" SEQ="105"
-				CHECKSUM="79b4d6600df22ef36c7052b1c556e5e308af1d38" CHECKSUMTYPE="SHA-1" SIZE="5216525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0105.jp2"/>
-			</file>
-			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-11-17T18:36:01" MIMETYPE="image/jp2" SEQ="106"
-				CHECKSUM="8f4bc6ec9849fc74a4779c59481922c5e85cd3a4" CHECKSUMTYPE="SHA-1" SIZE="5409129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0106.jp2"/>
-			</file>
-			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-11-17T18:36:33" MIMETYPE="image/jp2" SEQ="107"
-				CHECKSUM="5acdef5bfcbb7fd8a9d185b9ff8a6d43341ca925" CHECKSUMTYPE="SHA-1" SIZE="5216520">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0107.jp2"/>
-			</file>
-			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-11-17T18:37:06" MIMETYPE="image/jp2" SEQ="108"
-				CHECKSUM="8eecf6c2575da645558ce40f54b2437c310cffea" CHECKSUMTYPE="SHA-1" SIZE="5409079">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0108.jp2"/>
-			</file>
-			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-11-17T18:37:39" MIMETYPE="image/jp2" SEQ="109"
-				CHECKSUM="313a6fe62c9989891f9e2a9beb622d414c2e0a1e" CHECKSUMTYPE="SHA-1" SIZE="5216529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0109.jp2"/>
-			</file>
-			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-11-17T18:38:11" MIMETYPE="image/jp2" SEQ="110"
-				CHECKSUM="7af6d415b058f25852249a530577628b32ef67a5" CHECKSUMTYPE="SHA-1" SIZE="5409129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0110.jp2"/>
-			</file>
-			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-11-17T18:38:44" MIMETYPE="image/jp2" SEQ="111"
-				CHECKSUM="3b6b354d86fa9a21e158834b0ceea072911e4818" CHECKSUMTYPE="SHA-1" SIZE="5216528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0111.jp2"/>
-			</file>
-			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-11-17T18:39:17" MIMETYPE="image/jp2" SEQ="112"
-				CHECKSUM="fbf2819cf8afbc51e8479da62ae6f1b214bae242" CHECKSUMTYPE="SHA-1" SIZE="5409120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0112.jp2"/>
-			</file>
-			<file ID="IMG00113" ADMID="techmd113" GROUPID="page113" CREATED="2015-11-17T18:39:50" MIMETYPE="image/jp2" SEQ="113"
-				CHECKSUM="90af9ae41825741f8ca4be3ad71ee5eee2a2f0b5" CHECKSUMTYPE="SHA-1" SIZE="5250729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0113.jp2"/>
-			</file>
-			<file ID="IMG00114" ADMID="techmd114" GROUPID="page114" CREATED="2015-11-17T18:40:23" MIMETYPE="image/jp2" SEQ="114"
-				CHECKSUM="2b91cf2b534b2b0c58a0709d0eb2557de00366eb" CHECKSUMTYPE="SHA-1" SIZE="5409089">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0114.jp2"/>
-			</file>
-			<file ID="IMG00115" ADMID="techmd115" GROUPID="page115" CREATED="2015-11-17T18:40:56" MIMETYPE="image/jp2" SEQ="115"
-				CHECKSUM="9c53ecaf8096729608a800823fbd2378a43b5a0e" CHECKSUMTYPE="SHA-1" SIZE="5250726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0115.jp2"/>
-			</file>
-			<file ID="IMG00116" ADMID="techmd116" GROUPID="page116" CREATED="2015-11-17T18:41:29" MIMETYPE="image/jp2" SEQ="116"
-				CHECKSUM="abbd7fb9d0b864025a1951cf2b9c3278dc000d81" CHECKSUMTYPE="SHA-1" SIZE="5409129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0116.jp2"/>
-			</file>
-			<file ID="IMG00117" ADMID="techmd117" GROUPID="page117" CREATED="2015-11-17T18:42:02" MIMETYPE="image/jp2" SEQ="117"
-				CHECKSUM="443feb8b056299376d97f9192e3bea1230a610fc" CHECKSUMTYPE="SHA-1" SIZE="5250725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0117.jp2"/>
-			</file>
-			<file ID="IMG00118" ADMID="techmd118" GROUPID="page118" CREATED="2015-11-17T18:42:34" MIMETYPE="image/jp2" SEQ="118"
-				CHECKSUM="7e2ab809293ddda8e5b493eb692f24a44e3ef64c" CHECKSUMTYPE="SHA-1" SIZE="5409098">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0118.jp2"/>
-			</file>
-			<file ID="IMG00119" ADMID="techmd119" GROUPID="page119" CREATED="2015-11-17T18:43:07" MIMETYPE="image/jp2" SEQ="119"
-				CHECKSUM="540283ae2e8df70cd8fe2de9f4109c8426d3860d" CHECKSUMTYPE="SHA-1" SIZE="5275008">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0119.jp2"/>
-			</file>
-			<file ID="IMG00120" ADMID="techmd120" GROUPID="page120" CREATED="2015-11-17T18:43:41" MIMETYPE="image/jp2" SEQ="120"
-				CHECKSUM="10fa4fc6bfab4c2835bc77c3af17394549f7bda4" CHECKSUMTYPE="SHA-1" SIZE="5409125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0120.jp2"/>
-			</file>
-			<file ID="IMG00121" ADMID="techmd121" GROUPID="page121" CREATED="2015-11-17T18:44:14" MIMETYPE="image/jp2" SEQ="121"
-				CHECKSUM="8dae42e5d4917cf9fc2aa0d0f19b48f753d75662" CHECKSUMTYPE="SHA-1" SIZE="5282199">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0121.jp2"/>
-			</file>
-			<file ID="IMG00122" ADMID="techmd122" GROUPID="page122" CREATED="2015-11-17T18:44:47" MIMETYPE="image/jp2" SEQ="122"
-				CHECKSUM="92ad41b54817413b9468fbe331607ace3ec431cf" CHECKSUMTYPE="SHA-1" SIZE="5409122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0122.jp2"/>
-			</file>
-			<file ID="IMG00123" ADMID="techmd123" GROUPID="page123" CREATED="2015-11-17T18:45:18" MIMETYPE="image/jp2" SEQ="123"
-				CHECKSUM="9bfd2e814385b89bbb0ebe2e874aa4904ae4fdef" CHECKSUMTYPE="SHA-1" SIZE="5232725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0123.jp2"/>
-			</file>
-			<file ID="IMG00124" ADMID="techmd124" GROUPID="page124" CREATED="2015-11-17T18:45:50" MIMETYPE="image/jp2" SEQ="124"
-				CHECKSUM="b4d5b0d5c55e97b997cb20d71aec389e1ab36d51" CHECKSUMTYPE="SHA-1" SIZE="5409121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0124.jp2"/>
-			</file>
-			<file ID="IMG00125" ADMID="techmd125" GROUPID="page125" CREATED="2015-11-17T18:46:24" MIMETYPE="image/jp2" SEQ="125"
-				CHECKSUM="256355ebb3d314c02321bd49b132748d140352da" CHECKSUMTYPE="SHA-1" SIZE="5274124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0125.jp2"/>
-			</file>
-			<file ID="IMG00126" ADMID="techmd126" GROUPID="page126" CREATED="2015-11-17T18:46:57" MIMETYPE="image/jp2" SEQ="126"
-				CHECKSUM="9b6b0ef7d52632e46e0033b8656b65f259c8d1ed" CHECKSUMTYPE="SHA-1" SIZE="5409103">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0126.jp2"/>
-			</file>
-			<file ID="IMG00127" ADMID="techmd127" GROUPID="page127" CREATED="2015-11-17T18:47:31" MIMETYPE="image/jp2" SEQ="127"
-				CHECKSUM="1ebb30ab7b76e7c6c957eb125758628178362424" CHECKSUMTYPE="SHA-1" SIZE="5274129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0127.jp2"/>
-			</file>
-			<file ID="IMG00128" ADMID="techmd128" GROUPID="page128" CREATED="2015-11-17T18:48:05" MIMETYPE="image/jp2" SEQ="128"
-				CHECKSUM="600e238da7e4ad55ffbdc5540df5703ad083b906" CHECKSUMTYPE="SHA-1" SIZE="5390225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0128.jp2"/>
-			</file>
-			<file ID="IMG00129" ADMID="techmd129" GROUPID="page129" CREATED="2015-11-17T18:48:39" MIMETYPE="image/jp2" SEQ="129"
-				CHECKSUM="ba2af117fa48b7b629c5ca4f9b05b46b118e4329" CHECKSUMTYPE="SHA-1" SIZE="5274125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0129.jp2"/>
-			</file>
-			<file ID="IMG00130" ADMID="techmd130" GROUPID="page130" CREATED="2015-11-17T18:49:11" MIMETYPE="image/jp2" SEQ="130"
-				CHECKSUM="a76ae04bcb3b761ad0c2a0e3f1934a67f8198a54" CHECKSUMTYPE="SHA-1" SIZE="5390229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0130.jp2"/>
-			</file>
-			<file ID="IMG00131" ADMID="techmd131" GROUPID="page131" CREATED="2015-11-17T18:49:43" MIMETYPE="image/jp2" SEQ="131"
-				CHECKSUM="39aeafafe6c98af3fefda728d6b713f9a639a82a" CHECKSUMTYPE="SHA-1" SIZE="5274129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0131.jp2"/>
-			</file>
-			<file ID="IMG00132" ADMID="techmd132" GROUPID="page132" CREATED="2015-11-17T18:50:15" MIMETYPE="image/jp2" SEQ="132"
-				CHECKSUM="175e7d93bec54493323995a7acd8f08b7a5add50" CHECKSUMTYPE="SHA-1" SIZE="5390226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0132.jp2"/>
-			</file>
-			<file ID="IMG00133" ADMID="techmd133" GROUPID="page133" CREATED="2015-11-17T18:50:48" MIMETYPE="image/jp2" SEQ="133"
-				CHECKSUM="9d96b0b734b5a313a34dec2db14d0043717e87f0" CHECKSUMTYPE="SHA-1" SIZE="5175128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0133.jp2"/>
-			</file>
-			<file ID="IMG00134" ADMID="techmd134" GROUPID="page134" CREATED="2015-11-17T18:51:19" MIMETYPE="image/jp2" SEQ="134"
-				CHECKSUM="fc1370b16cba19fee8d95a51561bc6c12cd26f57" CHECKSUMTYPE="SHA-1" SIZE="5390222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0134.jp2"/>
-			</file>
-			<file ID="IMG00135" ADMID="techmd135" GROUPID="page135" CREATED="2015-11-17T18:51:50" MIMETYPE="image/jp2" SEQ="135"
-				CHECKSUM="ac96f04302b3306ef2dd8d58b9388896de7d3e2f" CHECKSUMTYPE="SHA-1" SIZE="5175129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0135.jp2"/>
-			</file>
-			<file ID="IMG00136" ADMID="techmd136" GROUPID="page136" CREATED="2015-11-17T18:52:22" MIMETYPE="image/jp2" SEQ="136"
-				CHECKSUM="7891abd35725bd2d36b4bb417ea56e15835d4405" CHECKSUMTYPE="SHA-1" SIZE="5390221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0136.jp2"/>
-			</file>
-			<file ID="IMG00137" ADMID="techmd137" GROUPID="page137" CREATED="2015-11-17T18:52:54" MIMETYPE="image/jp2" SEQ="137"
-				CHECKSUM="dac7ff00434859f8bb347f85fa69775b58c7d413" CHECKSUMTYPE="SHA-1" SIZE="5175126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0137.jp2"/>
-			</file>
-			<file ID="IMG00138" ADMID="techmd138" GROUPID="page138" CREATED="2015-11-17T18:53:26" MIMETYPE="image/jp2" SEQ="138"
-				CHECKSUM="d534dd9308729efd779a687d085d5dd01ba7e9fe" CHECKSUMTYPE="SHA-1" SIZE="5390197">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0138.jp2"/>
-			</file>
-			<file ID="IMG00139" ADMID="techmd139" GROUPID="page139" CREATED="2015-11-17T18:53:59" MIMETYPE="image/jp2" SEQ="139"
-				CHECKSUM="9cc9ee62eb15040c969d6b85f1985e2884b8ab09" CHECKSUMTYPE="SHA-1" SIZE="5175127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0139.jp2"/>
-			</file>
-			<file ID="IMG00140" ADMID="techmd140" GROUPID="page140" CREATED="2015-11-17T18:54:33" MIMETYPE="image/jp2" SEQ="140"
-				CHECKSUM="4001070f2e12b0a9f4d05cf1b099ba8840bd468d" CHECKSUMTYPE="SHA-1" SIZE="5390222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0140.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-11-17T17:46:36" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="463c36b1b92bcc61b9e301e6dfa410a81c3bc73c" CHECKSUMTYPE="SHA-1" SIZE="5005018">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-11-17T17:47:04" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="ab75e46150dc0fa51812fa413665b67a6a4120ff" CHECKSUMTYPE="SHA-1" SIZE="5347928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-11-17T17:47:31" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="903d6715fd55639d13e9f67ebb7f9a3c211c145f" CHECKSUMTYPE="SHA-1" SIZE="5004996">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-11-17T17:47:56" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="63a6e0f9d64a4bd6a0f3f1dfd3aa89802e471a24" CHECKSUMTYPE="SHA-1" SIZE="5347927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-11-17T17:48:22" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="a795f2fa82703331451af9ee035aba768430c382" CHECKSUMTYPE="SHA-1" SIZE="5005028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-11-17T17:48:46" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="96440e38ed4e9618e92b4e1882e391bcf05a3cc1" CHECKSUMTYPE="SHA-1" SIZE="5347898">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-11-17T17:49:12" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="c1dc8a18b511a82283e26ee2ca62b5a03e3d38ce" CHECKSUMTYPE="SHA-1" SIZE="5004927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-11-17T17:49:35" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="5d567031540c9cb7ca28666978fd7db4f5fcc28c" CHECKSUMTYPE="SHA-1" SIZE="5347918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-11-17T17:49:59" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="5396baf56777e1ff67bc2ccfa9bfd4d216597e0d" CHECKSUMTYPE="SHA-1" SIZE="5004872">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-11-17T17:50:22" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="4dc5eb7e5be6f303543aedf60d98f18b71d3a268" CHECKSUMTYPE="SHA-1" SIZE="5333527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-11-17T17:50:47" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="79cf45a3872b05ce14141312de19efda427aee87" CHECKSUMTYPE="SHA-1" SIZE="5004978">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-11-17T17:51:11" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="01076ba217a946a4e9a644b1edd6e4fcba521b4d" CHECKSUMTYPE="SHA-1" SIZE="5333523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-11-17T17:51:38" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="e6a1bfc4b09981b47bb676e5a8ecfa0f73928474" CHECKSUMTYPE="SHA-1" SIZE="5005025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-11-17T17:52:02" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="a525f61c8e870bfc31e46444fff7c802b7eacb15" CHECKSUMTYPE="SHA-1" SIZE="5333437">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-11-17T17:52:26" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="1da804097475e02719d21b056c29346c2e2fbf32" CHECKSUMTYPE="SHA-1" SIZE="5005027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-11-17T17:52:49" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="5d5de713394b14f9240b4a8cb1e4cb0be1b24b2d" CHECKSUMTYPE="SHA-1" SIZE="5333529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-11-17T17:53:15" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="967f080942c3b8d4a50213b01f849682380402d5" CHECKSUMTYPE="SHA-1" SIZE="5004986">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-11-17T17:53:41" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="17d5626731c228db3276ef4bbb777998fd3b136b" CHECKSUMTYPE="SHA-1" SIZE="5333525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-11-17T17:54:06" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="e721aeeff7fa9e475e0e078bb3831f643d5c5846" CHECKSUMTYPE="SHA-1" SIZE="5005026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-11-17T17:54:33" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="474379d4355047239b50aea9d968354aa864185c" CHECKSUMTYPE="SHA-1" SIZE="5333520">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-11-17T17:55:01" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="b184ef0994bd19cbddd562f078607d3b99817365" CHECKSUMTYPE="SHA-1" SIZE="5005007">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-11-17T17:55:26" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="f686d3d14cf6d7bd689ba0f2749d72f1da826708" CHECKSUMTYPE="SHA-1" SIZE="5333515">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-11-17T17:55:55" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="06d07308b37e0ad03dd90171f9e42862456aaa24" CHECKSUMTYPE="SHA-1" SIZE="5005028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-11-17T17:56:22" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f7ed91a41b2181f4ace55030b18b25912b431470" CHECKSUMTYPE="SHA-1" SIZE="5333515">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-11-17T17:56:48" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="184a6a7032ca22a4222868a2131f48e289108863" CHECKSUMTYPE="SHA-1" SIZE="5005019">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-11-17T17:57:14" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="e98a2d3306119b6388d24a196a6689fd8418610b" CHECKSUMTYPE="SHA-1" SIZE="5345219">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-11-17T17:57:41" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="f6b935d4ef709156380653d534d291af461fb1a5" CHECKSUMTYPE="SHA-1" SIZE="5004977">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-11-17T17:58:08" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="e72d5301c6cddc2835631cd8d3a9bd247a584c50" CHECKSUMTYPE="SHA-1" SIZE="5345227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-11-17T17:58:35" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="fed0055ceeef9d1b76592a3a818f89f74a5f5c80" CHECKSUMTYPE="SHA-1" SIZE="5005023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-11-17T17:59:03" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="07afa964d77e47fb962edb01d49024d14f0cd6c7" CHECKSUMTYPE="SHA-1" SIZE="5345226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-11-17T17:59:27" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="d3254ca121da940e041001a6b169316069c3f58f" CHECKSUMTYPE="SHA-1" SIZE="5005024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-11-17T17:59:53" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="60cd11364b20fc65419e7d079ae29e3e9ec8edb7" CHECKSUMTYPE="SHA-1" SIZE="5398329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-11-17T18:00:20" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="dc6ac05b2aee79a28bc6c7e584347419f6ae40d9" CHECKSUMTYPE="SHA-1" SIZE="5005026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-11-17T18:00:45" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="b009689973036d129f8b16923930949c550b6b5a" CHECKSUMTYPE="SHA-1" SIZE="5398329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-11-17T18:01:13" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="9552bf2d9d8094bdbcae61b74dfa4e0764aa8078" CHECKSUMTYPE="SHA-1" SIZE="5004969">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-11-17T18:01:39" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="9a10bfd8729bb5cf6a3e0fa152b0a1a074594a03" CHECKSUMTYPE="SHA-1" SIZE="5398329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-11-17T18:02:05" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="438ce5ec50ca4897af9e64ee899fd393005d0b0d" CHECKSUMTYPE="SHA-1" SIZE="5005025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-11-17T18:02:30" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="9b74f215688547b6cb3f90daf3991b16e51cbb56" CHECKSUMTYPE="SHA-1" SIZE="5412718">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-11-17T18:02:58" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="0fd69530c2de565a5209481ee6f4b46a81ac36dd" CHECKSUMTYPE="SHA-1" SIZE="5005026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-11-17T18:03:26" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="7c2432350c6c367261b1018e68b00989f0478878" CHECKSUMTYPE="SHA-1" SIZE="5412728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-11-17T18:03:53" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="6356dc8278210162271d02b2ac957c658fd5d6e1" CHECKSUMTYPE="SHA-1" SIZE="5004996">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-11-17T18:04:20" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="884a4d950c071c6b3a97b7cbc15b6fb8294b1110" CHECKSUMTYPE="SHA-1" SIZE="5412725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-11-17T18:04:48" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="4567b239546478457f776bd0f5f54227107787c2" CHECKSUMTYPE="SHA-1" SIZE="5005022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-11-17T18:05:14" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="0de31ba945daeb03af921c9bddbbbf2e8e107036" CHECKSUMTYPE="SHA-1" SIZE="5412693">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-11-17T18:05:40" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="bcd4a5550f544e5db9b2bb03d1a73b84c63a1362" CHECKSUMTYPE="SHA-1" SIZE="5005002">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-11-17T18:06:06" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="b50de71b5e805d19d6989bb086d6ec1260f37ac9" CHECKSUMTYPE="SHA-1" SIZE="5412725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-11-17T18:06:34" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="000c88e7355a7f748168cd13b9a8c2fd832236cc" CHECKSUMTYPE="SHA-1" SIZE="5005017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-11-17T18:07:00" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="71323122a60254204d47f0ad2f0d3eadd7f7b71a" CHECKSUMTYPE="SHA-1" SIZE="5406299">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-11-17T18:07:28" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="3df2bf77abbc88cb6e3832119119e40b2dcf3566" CHECKSUMTYPE="SHA-1" SIZE="5005018">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-11-17T18:07:55" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="af409eb20517bea1143daf93cc66a47265af2238" CHECKSUMTYPE="SHA-1" SIZE="5412724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-11-17T18:08:23" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="0ac2080c468d0c1173f646ae467de89898d381da" CHECKSUMTYPE="SHA-1" SIZE="5005022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-11-17T18:08:50" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="fe7043791fe0af52b6366c9afc86f2efc47f4117" CHECKSUMTYPE="SHA-1" SIZE="5412702">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-11-17T18:09:16" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="7c6f84982d82f7d424755434d6fc6ac0d971ff5a" CHECKSUMTYPE="SHA-1" SIZE="5004903">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-11-17T18:09:43" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="1071f3e2403511178f0e64bb9729806e3db4bd75" CHECKSUMTYPE="SHA-1" SIZE="5412707">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-11-17T18:10:11" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="813536501d012c3e5e8b13375eabba8648bb983d" CHECKSUMTYPE="SHA-1" SIZE="5005024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-11-17T18:10:38" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="f8162ebc890aa9b88fb31675f6c7308f49d07a03" CHECKSUMTYPE="SHA-1" SIZE="5412716">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-11-17T18:11:06" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="d2021713603f90965cb287f481d501700178a563" CHECKSUMTYPE="SHA-1" SIZE="5005022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-11-17T18:11:34" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="dea9e31e458f7c3c43f9648670afdeef9449a06a" CHECKSUMTYPE="SHA-1" SIZE="5412723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-11-17T18:12:00" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="0e9202d4a8a30b3b1b0c0166cc84d328eede533d" CHECKSUMTYPE="SHA-1" SIZE="5005006">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-11-17T18:12:28" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="f55cd261e0b53c1b0f3a52fc9857f8a583c2f00d" CHECKSUMTYPE="SHA-1" SIZE="5412650">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-11-17T18:12:54" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="c4fa4fa6f776b3b89158c7e87b9f5d6720e627ed" CHECKSUMTYPE="SHA-1" SIZE="5005020">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-11-17T18:13:21" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="60f4c7117be30ac8e7781cfbbf730778bfa23dc6" CHECKSUMTYPE="SHA-1" SIZE="5412706">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-11-17T18:13:49" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="0df8ec9719063225770d0599de13c953ecc94afe" CHECKSUMTYPE="SHA-1" SIZE="5005002">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-11-17T18:14:15" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="6918dfe8984a48f049690a7675b6d045cef0e2a5" CHECKSUMTYPE="SHA-1" SIZE="5430727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-11-17T18:14:43" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="214d7efac593af6ef150f73a47ab82467825f213" CHECKSUMTYPE="SHA-1" SIZE="5004925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-11-17T18:15:12" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="8e7bd713139f1c9ef94e17524be8a15683451cda" CHECKSUMTYPE="SHA-1" SIZE="5430695">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-11-17T18:15:38" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="46eb01b71c09f58dbd9175acf9fc73f2e5159db2" CHECKSUMTYPE="SHA-1" SIZE="5020297">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-11-17T18:16:06" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="684a0ea6c7289e7ee5112937f2f045d899a22ec2" CHECKSUMTYPE="SHA-1" SIZE="5430726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-11-17T18:16:32" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="f6e29df49b2421dc606499cdeefd68d395a1baf4" CHECKSUMTYPE="SHA-1" SIZE="5020322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-11-17T18:16:58" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="6a9c8845533caa5da25ac82e442ba730c34de4e8" CHECKSUMTYPE="SHA-1" SIZE="5430728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-11-17T18:17:27" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="48107aec2ee82cb0875fd4f1d886c7d8d4669cf0" CHECKSUMTYPE="SHA-1" SIZE="5020328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-11-17T18:17:54" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="5d5bb882d7134411b22255f3eb35046169ee25c8" CHECKSUMTYPE="SHA-1" SIZE="5421724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-11-17T18:18:23" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="dd50d0baf9320386898535a27063eb039eed205f" CHECKSUMTYPE="SHA-1" SIZE="5273225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-11-17T18:18:51" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="cf62d4b94ac7515059e5748825ae31cd7a56e88f" CHECKSUMTYPE="SHA-1" SIZE="5430715">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-11-17T18:19:21" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="3b838b09ec774986d26939d51847239651ebd795" CHECKSUMTYPE="SHA-1" SIZE="5078825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-11-17T18:19:51" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="7489d2672ba2046ca8d385a5059df95a905354dc" CHECKSUMTYPE="SHA-1" SIZE="5418931">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-11-17T18:20:22" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="b7b8646f2b215e2b538a5cbcad011d0036312788" CHECKSUMTYPE="SHA-1" SIZE="5092329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-11-17T18:20:52" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="ac62fee8d8e6553763dcc4d3c6f057697c4eb01d" CHECKSUMTYPE="SHA-1" SIZE="5430728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-11-17T18:21:24" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="87f1aa6ff0a76755ae7c082be5b059531d3fe4af" CHECKSUMTYPE="SHA-1" SIZE="5092326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-11-17T18:21:57" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="a06a77b039fd0b39050285cc702a85c1dd87c512" CHECKSUMTYPE="SHA-1" SIZE="5430698">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-11-17T18:22:31" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="7ef30d9c51bd62023f7f748f5823dcb9a219ebc0" CHECKSUMTYPE="SHA-1" SIZE="5118401">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-11-17T18:23:03" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="6b14750c750f8e0aa04c2ec68a1bc3c683aea345" CHECKSUMTYPE="SHA-1" SIZE="5430709">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-11-17T18:23:36" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="b21b67f762a99f4ed2d6efcd0f55e1d9af5301bb" CHECKSUMTYPE="SHA-1" SIZE="5118148">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-11-17T18:24:08" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="09b176b6a7b261bf617e4d1dfe23791001056349" CHECKSUMTYPE="SHA-1" SIZE="5430720">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-11-17T18:24:41" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="a5aa6d73863ce3782b3417cb2a204ad37409143f" CHECKSUMTYPE="SHA-1" SIZE="5136416">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-11-17T18:25:13" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="8066e9bb7ba11979d69aa6eca19ee7dd07ae007b" CHECKSUMTYPE="SHA-1" SIZE="5430722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-11-17T18:25:46" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="d3d578c1de38b728d50ff172fb3f15015be2ae78" CHECKSUMTYPE="SHA-1" SIZE="5136414">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-11-17T18:26:19" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="cec1f4adccb99af48ee38e5290c3341a5d1a72ea" CHECKSUMTYPE="SHA-1" SIZE="5430714">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-11-17T18:26:50" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="42f5e955ed9c94468633e27104477914c719587e" CHECKSUMTYPE="SHA-1" SIZE="5149022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-11-17T18:27:21" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="3b573d2e6618f298c21ebc9a0f76c4c129e9ce70" CHECKSUMTYPE="SHA-1" SIZE="5430710">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-11-17T18:27:54" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="3a0ac4d69dea7fcc2e6d1ea3ed8ad77af3da5bb9" CHECKSUMTYPE="SHA-1" SIZE="5273227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-11-17T18:28:26" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="36fd08ec45bf8bfbe91fae88ef3ef24694d77d56" CHECKSUMTYPE="SHA-1" SIZE="5430728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-11-17T18:28:58" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="c71f6514375136fdc5e4f3ed0c2ef8ec9589c13a" CHECKSUMTYPE="SHA-1" SIZE="5170625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-11-17T18:29:29" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="b481eb954c6bf32a3c8d7f87fdaaf19701116c00" CHECKSUMTYPE="SHA-1" SIZE="5430719">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0094.jp2"/>
+			</file>
+			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-11-17T18:30:01" MIMETYPE="image/jp2" SEQ="95" CHECKSUM="c9e4b263e1b0e55d50975df0820b335ce01d17f3" CHECKSUMTYPE="SHA-1" SIZE="5170627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0095.jp2"/>
+			</file>
+			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-11-17T18:30:35" MIMETYPE="image/jp2" SEQ="96" CHECKSUM="2ddf2c92724c2974cb550736bdb337b93c3536df" CHECKSUMTYPE="SHA-1" SIZE="5430725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0096.jp2"/>
+			</file>
+			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-11-17T18:31:09" MIMETYPE="image/jp2" SEQ="97" CHECKSUM="901d12820dcd85ab8e2cec26863b55e5312d5a53" CHECKSUMTYPE="SHA-1" SIZE="5170586">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0097.jp2"/>
+			</file>
+			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-11-17T18:31:42" MIMETYPE="image/jp2" SEQ="98" CHECKSUM="320eb817715955f57d61c3520d161501c329ae02" CHECKSUMTYPE="SHA-1" SIZE="5430729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0098.jp2"/>
+			</file>
+			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-11-17T18:32:16" MIMETYPE="image/jp2" SEQ="99" CHECKSUM="3f48f6d88138c86f8a9f014b8c3933a832aa9f54" CHECKSUMTYPE="SHA-1" SIZE="5170628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0099.jp2"/>
+			</file>
+			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-11-17T18:32:48" MIMETYPE="image/jp2" SEQ="100" CHECKSUM="24c480cca3fea64f3ed0e4b429456d8a06f4e2e5" CHECKSUMTYPE="SHA-1" SIZE="5409122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0100.jp2"/>
+			</file>
+			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-11-17T18:33:21" MIMETYPE="image/jp2" SEQ="101" CHECKSUM="c173f1fef33b9976f7177da88603efb722d86fab" CHECKSUMTYPE="SHA-1" SIZE="5170598">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0101.jp2"/>
+			</file>
+			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-11-17T18:33:53" MIMETYPE="image/jp2" SEQ="102" CHECKSUM="49426d0631ff96f3c65e30c1094c4df1586d60fc" CHECKSUMTYPE="SHA-1" SIZE="5409120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0102.jp2"/>
+			</file>
+			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-11-17T18:34:25" MIMETYPE="image/jp2" SEQ="103" CHECKSUM="a9610779493d7996c1b6d689a85d39f44dc37107" CHECKSUMTYPE="SHA-1" SIZE="5216511">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0103.jp2"/>
+			</file>
+			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-11-17T18:34:59" MIMETYPE="image/jp2" SEQ="104" CHECKSUM="d05aab68173b529c1541490dc206dfed1f727d46" CHECKSUMTYPE="SHA-1" SIZE="5409029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0104.jp2"/>
+			</file>
+			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-11-17T18:35:29" MIMETYPE="image/jp2" SEQ="105" CHECKSUM="79b4d6600df22ef36c7052b1c556e5e308af1d38" CHECKSUMTYPE="SHA-1" SIZE="5216525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0105.jp2"/>
+			</file>
+			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-11-17T18:36:01" MIMETYPE="image/jp2" SEQ="106" CHECKSUM="8f4bc6ec9849fc74a4779c59481922c5e85cd3a4" CHECKSUMTYPE="SHA-1" SIZE="5409129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0106.jp2"/>
+			</file>
+			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-11-17T18:36:33" MIMETYPE="image/jp2" SEQ="107" CHECKSUM="5acdef5bfcbb7fd8a9d185b9ff8a6d43341ca925" CHECKSUMTYPE="SHA-1" SIZE="5216520">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0107.jp2"/>
+			</file>
+			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-11-17T18:37:06" MIMETYPE="image/jp2" SEQ="108" CHECKSUM="8eecf6c2575da645558ce40f54b2437c310cffea" CHECKSUMTYPE="SHA-1" SIZE="5409079">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0108.jp2"/>
+			</file>
+			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-11-17T18:37:39" MIMETYPE="image/jp2" SEQ="109" CHECKSUM="313a6fe62c9989891f9e2a9beb622d414c2e0a1e" CHECKSUMTYPE="SHA-1" SIZE="5216529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0109.jp2"/>
+			</file>
+			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-11-17T18:38:11" MIMETYPE="image/jp2" SEQ="110" CHECKSUM="7af6d415b058f25852249a530577628b32ef67a5" CHECKSUMTYPE="SHA-1" SIZE="5409129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0110.jp2"/>
+			</file>
+			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-11-17T18:38:44" MIMETYPE="image/jp2" SEQ="111" CHECKSUM="3b6b354d86fa9a21e158834b0ceea072911e4818" CHECKSUMTYPE="SHA-1" SIZE="5216528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0111.jp2"/>
+			</file>
+			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-11-17T18:39:17" MIMETYPE="image/jp2" SEQ="112" CHECKSUM="fbf2819cf8afbc51e8479da62ae6f1b214bae242" CHECKSUMTYPE="SHA-1" SIZE="5409120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0112.jp2"/>
+			</file>
+			<file ID="IMG00113" ADMID="techmd113" GROUPID="page113" CREATED="2015-11-17T18:39:50" MIMETYPE="image/jp2" SEQ="113" CHECKSUM="90af9ae41825741f8ca4be3ad71ee5eee2a2f0b5" CHECKSUMTYPE="SHA-1" SIZE="5250729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0113.jp2"/>
+			</file>
+			<file ID="IMG00114" ADMID="techmd114" GROUPID="page114" CREATED="2015-11-17T18:40:23" MIMETYPE="image/jp2" SEQ="114" CHECKSUM="2b91cf2b534b2b0c58a0709d0eb2557de00366eb" CHECKSUMTYPE="SHA-1" SIZE="5409089">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0114.jp2"/>
+			</file>
+			<file ID="IMG00115" ADMID="techmd115" GROUPID="page115" CREATED="2015-11-17T18:40:56" MIMETYPE="image/jp2" SEQ="115" CHECKSUM="9c53ecaf8096729608a800823fbd2378a43b5a0e" CHECKSUMTYPE="SHA-1" SIZE="5250726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0115.jp2"/>
+			</file>
+			<file ID="IMG00116" ADMID="techmd116" GROUPID="page116" CREATED="2015-11-17T18:41:29" MIMETYPE="image/jp2" SEQ="116" CHECKSUM="abbd7fb9d0b864025a1951cf2b9c3278dc000d81" CHECKSUMTYPE="SHA-1" SIZE="5409129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0116.jp2"/>
+			</file>
+			<file ID="IMG00117" ADMID="techmd117" GROUPID="page117" CREATED="2015-11-17T18:42:02" MIMETYPE="image/jp2" SEQ="117" CHECKSUM="443feb8b056299376d97f9192e3bea1230a610fc" CHECKSUMTYPE="SHA-1" SIZE="5250725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0117.jp2"/>
+			</file>
+			<file ID="IMG00118" ADMID="techmd118" GROUPID="page118" CREATED="2015-11-17T18:42:34" MIMETYPE="image/jp2" SEQ="118" CHECKSUM="7e2ab809293ddda8e5b493eb692f24a44e3ef64c" CHECKSUMTYPE="SHA-1" SIZE="5409098">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0118.jp2"/>
+			</file>
+			<file ID="IMG00119" ADMID="techmd119" GROUPID="page119" CREATED="2015-11-17T18:43:07" MIMETYPE="image/jp2" SEQ="119" CHECKSUM="540283ae2e8df70cd8fe2de9f4109c8426d3860d" CHECKSUMTYPE="SHA-1" SIZE="5275008">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0119.jp2"/>
+			</file>
+			<file ID="IMG00120" ADMID="techmd120" GROUPID="page120" CREATED="2015-11-17T18:43:41" MIMETYPE="image/jp2" SEQ="120" CHECKSUM="10fa4fc6bfab4c2835bc77c3af17394549f7bda4" CHECKSUMTYPE="SHA-1" SIZE="5409125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0120.jp2"/>
+			</file>
+			<file ID="IMG00121" ADMID="techmd121" GROUPID="page121" CREATED="2015-11-17T18:44:14" MIMETYPE="image/jp2" SEQ="121" CHECKSUM="8dae42e5d4917cf9fc2aa0d0f19b48f753d75662" CHECKSUMTYPE="SHA-1" SIZE="5282199">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0121.jp2"/>
+			</file>
+			<file ID="IMG00122" ADMID="techmd122" GROUPID="page122" CREATED="2015-11-17T18:44:47" MIMETYPE="image/jp2" SEQ="122" CHECKSUM="92ad41b54817413b9468fbe331607ace3ec431cf" CHECKSUMTYPE="SHA-1" SIZE="5409122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0122.jp2"/>
+			</file>
+			<file ID="IMG00123" ADMID="techmd123" GROUPID="page123" CREATED="2015-11-17T18:45:18" MIMETYPE="image/jp2" SEQ="123" CHECKSUM="9bfd2e814385b89bbb0ebe2e874aa4904ae4fdef" CHECKSUMTYPE="SHA-1" SIZE="5232725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0123.jp2"/>
+			</file>
+			<file ID="IMG00124" ADMID="techmd124" GROUPID="page124" CREATED="2015-11-17T18:45:50" MIMETYPE="image/jp2" SEQ="124" CHECKSUM="b4d5b0d5c55e97b997cb20d71aec389e1ab36d51" CHECKSUMTYPE="SHA-1" SIZE="5409121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0124.jp2"/>
+			</file>
+			<file ID="IMG00125" ADMID="techmd125" GROUPID="page125" CREATED="2015-11-17T18:46:24" MIMETYPE="image/jp2" SEQ="125" CHECKSUM="256355ebb3d314c02321bd49b132748d140352da" CHECKSUMTYPE="SHA-1" SIZE="5274124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0125.jp2"/>
+			</file>
+			<file ID="IMG00126" ADMID="techmd126" GROUPID="page126" CREATED="2015-11-17T18:46:57" MIMETYPE="image/jp2" SEQ="126" CHECKSUM="9b6b0ef7d52632e46e0033b8656b65f259c8d1ed" CHECKSUMTYPE="SHA-1" SIZE="5409103">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0126.jp2"/>
+			</file>
+			<file ID="IMG00127" ADMID="techmd127" GROUPID="page127" CREATED="2015-11-17T18:47:31" MIMETYPE="image/jp2" SEQ="127" CHECKSUM="1ebb30ab7b76e7c6c957eb125758628178362424" CHECKSUMTYPE="SHA-1" SIZE="5274129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0127.jp2"/>
+			</file>
+			<file ID="IMG00128" ADMID="techmd128" GROUPID="page128" CREATED="2015-11-17T18:48:05" MIMETYPE="image/jp2" SEQ="128" CHECKSUM="600e238da7e4ad55ffbdc5540df5703ad083b906" CHECKSUMTYPE="SHA-1" SIZE="5390225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0128.jp2"/>
+			</file>
+			<file ID="IMG00129" ADMID="techmd129" GROUPID="page129" CREATED="2015-11-17T18:48:39" MIMETYPE="image/jp2" SEQ="129" CHECKSUM="ba2af117fa48b7b629c5ca4f9b05b46b118e4329" CHECKSUMTYPE="SHA-1" SIZE="5274125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0129.jp2"/>
+			</file>
+			<file ID="IMG00130" ADMID="techmd130" GROUPID="page130" CREATED="2015-11-17T18:49:11" MIMETYPE="image/jp2" SEQ="130" CHECKSUM="a76ae04bcb3b761ad0c2a0e3f1934a67f8198a54" CHECKSUMTYPE="SHA-1" SIZE="5390229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0130.jp2"/>
+			</file>
+			<file ID="IMG00131" ADMID="techmd131" GROUPID="page131" CREATED="2015-11-17T18:49:43" MIMETYPE="image/jp2" SEQ="131" CHECKSUM="39aeafafe6c98af3fefda728d6b713f9a639a82a" CHECKSUMTYPE="SHA-1" SIZE="5274129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0131.jp2"/>
+			</file>
+			<file ID="IMG00132" ADMID="techmd132" GROUPID="page132" CREATED="2015-11-17T18:50:15" MIMETYPE="image/jp2" SEQ="132" CHECKSUM="175e7d93bec54493323995a7acd8f08b7a5add50" CHECKSUMTYPE="SHA-1" SIZE="5390226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0132.jp2"/>
+			</file>
+			<file ID="IMG00133" ADMID="techmd133" GROUPID="page133" CREATED="2015-11-17T18:50:48" MIMETYPE="image/jp2" SEQ="133" CHECKSUM="9d96b0b734b5a313a34dec2db14d0043717e87f0" CHECKSUMTYPE="SHA-1" SIZE="5175128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0133.jp2"/>
+			</file>
+			<file ID="IMG00134" ADMID="techmd134" GROUPID="page134" CREATED="2015-11-17T18:51:19" MIMETYPE="image/jp2" SEQ="134" CHECKSUM="fc1370b16cba19fee8d95a51561bc6c12cd26f57" CHECKSUMTYPE="SHA-1" SIZE="5390222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0134.jp2"/>
+			</file>
+			<file ID="IMG00135" ADMID="techmd135" GROUPID="page135" CREATED="2015-11-17T18:51:50" MIMETYPE="image/jp2" SEQ="135" CHECKSUM="ac96f04302b3306ef2dd8d58b9388896de7d3e2f" CHECKSUMTYPE="SHA-1" SIZE="5175129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0135.jp2"/>
+			</file>
+			<file ID="IMG00136" ADMID="techmd136" GROUPID="page136" CREATED="2015-11-17T18:52:22" MIMETYPE="image/jp2" SEQ="136" CHECKSUM="7891abd35725bd2d36b4bb417ea56e15835d4405" CHECKSUMTYPE="SHA-1" SIZE="5390221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0136.jp2"/>
+			</file>
+			<file ID="IMG00137" ADMID="techmd137" GROUPID="page137" CREATED="2015-11-17T18:52:54" MIMETYPE="image/jp2" SEQ="137" CHECKSUM="dac7ff00434859f8bb347f85fa69775b58c7d413" CHECKSUMTYPE="SHA-1" SIZE="5175126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0137.jp2"/>
+			</file>
+			<file ID="IMG00138" ADMID="techmd138" GROUPID="page138" CREATED="2015-11-17T18:53:26" MIMETYPE="image/jp2" SEQ="138" CHECKSUM="d534dd9308729efd779a687d085d5dd01ba7e9fe" CHECKSUMTYPE="SHA-1" SIZE="5390197">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0138.jp2"/>
+			</file>
+			<file ID="IMG00139" ADMID="techmd139" GROUPID="page139" CREATED="2015-11-17T18:53:59" MIMETYPE="image/jp2" SEQ="139" CHECKSUM="9cc9ee62eb15040c969d6b85f1985e2884b8ab09" CHECKSUMTYPE="SHA-1" SIZE="5175127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0139.jp2"/>
+			</file>
+			<file ID="IMG00140" ADMID="techmd140" GROUPID="page140" CREATED="2015-11-17T18:54:33" MIMETYPE="image/jp2" SEQ="140" CHECKSUM="4001070f2e12b0a9f4d05cf1b099ba8840bd468d" CHECKSUMTYPE="SHA-1" SIZE="5390222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/delivery/bmtnabe_1896-10_01_0140.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-11-17T18:54:54" MIMETYPE="text/xml" CHECKSUM="ad97ad74eccf3a0fbb19d1117f163850b2a21cb8"
-				CHECKSUMTYPE="SHA-1" SIZE="2049">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-11-17T18:54:54" MIMETYPE="text/xml" CHECKSUM="ad97ad74eccf3a0fbb19d1117f163850b2a21cb8" CHECKSUMTYPE="SHA-1" SIZE="2049">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-11-17T18:54:55" MIMETYPE="text/xml" CHECKSUM="05728c72d9b08d41ee5853042bc5658cd52da1c5"
-				CHECKSUMTYPE="SHA-1" SIZE="1645">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-11-17T18:54:55" MIMETYPE="text/xml" CHECKSUM="05728c72d9b08d41ee5853042bc5658cd52da1c5" CHECKSUMTYPE="SHA-1" SIZE="1645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-11-17T18:54:55" MIMETYPE="text/xml" CHECKSUM="c796d81bc8d2e7dcd02dd374746cd5ba0d49e41f"
-				CHECKSUMTYPE="SHA-1" SIZE="1654">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-11-17T18:54:55" MIMETYPE="text/xml" CHECKSUM="c796d81bc8d2e7dcd02dd374746cd5ba0d49e41f" CHECKSUMTYPE="SHA-1" SIZE="1654">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-11-17T18:54:55" MIMETYPE="text/xml" CHECKSUM="5e39723a76b10e5c524ce299081504354dced8f2"
-				CHECKSUMTYPE="SHA-1" SIZE="1645">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-11-17T18:54:55" MIMETYPE="text/xml" CHECKSUM="5e39723a76b10e5c524ce299081504354dced8f2" CHECKSUMTYPE="SHA-1" SIZE="1645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-11-17T18:54:55" MIMETYPE="text/xml" CHECKSUM="5a9e37aec341c9ac99b6940d1f695d3ad9af987f"
-				CHECKSUMTYPE="SHA-1" SIZE="7831">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-11-17T18:54:55" MIMETYPE="text/xml" CHECKSUM="5a9e37aec341c9ac99b6940d1f695d3ad9af987f" CHECKSUMTYPE="SHA-1" SIZE="7831">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-11-17T18:54:56" MIMETYPE="text/xml" CHECKSUM="f0a34f2382ea6e7b6e8f55a98fe3a29790425681"
-				CHECKSUMTYPE="SHA-1" SIZE="1645">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-11-17T18:54:56" MIMETYPE="text/xml" CHECKSUM="f0a34f2382ea6e7b6e8f55a98fe3a29790425681" CHECKSUMTYPE="SHA-1" SIZE="1645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-11-17T18:54:56" MIMETYPE="text/xml" CHECKSUM="1e28fa87242f6b2d5d80df3de83186be06666479"
-				CHECKSUMTYPE="SHA-1" SIZE="1654">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-11-17T18:54:56" MIMETYPE="text/xml" CHECKSUM="1e28fa87242f6b2d5d80df3de83186be06666479" CHECKSUMTYPE="SHA-1" SIZE="1654">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-11-17T18:54:56" MIMETYPE="text/xml" CHECKSUM="29e537344d4f8588a5c843efcbe9883cf5fb13bf"
-				CHECKSUMTYPE="SHA-1" SIZE="1645">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-11-17T18:54:56" MIMETYPE="text/xml" CHECKSUM="29e537344d4f8588a5c843efcbe9883cf5fb13bf" CHECKSUMTYPE="SHA-1" SIZE="1645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-11-17T18:54:56" MIMETYPE="text/xml" CHECKSUM="d8facea86fd49abb61a818409bed2f7ff116008e"
-				CHECKSUMTYPE="SHA-1" SIZE="12256">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-11-17T18:54:56" MIMETYPE="text/xml" CHECKSUM="d8facea86fd49abb61a818409bed2f7ff116008e" CHECKSUMTYPE="SHA-1" SIZE="12256">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-11-17T18:54:57" MIMETYPE="text/xml"
-				CHECKSUM="66faed9122cbf4096454e17bcf54d283cc6f3659" CHECKSUMTYPE="SHA-1" SIZE="3719">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-11-17T18:54:57" MIMETYPE="text/xml" CHECKSUM="66faed9122cbf4096454e17bcf54d283cc6f3659" CHECKSUMTYPE="SHA-1" SIZE="3719">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-11-17T18:54:57" MIMETYPE="text/xml"
-				CHECKSUM="d2f654729ba9f28a5b0f230f99274f055d538d83" CHECKSUMTYPE="SHA-1" SIZE="1662">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-11-17T18:54:57" MIMETYPE="text/xml" CHECKSUM="d2f654729ba9f28a5b0f230f99274f055d538d83" CHECKSUMTYPE="SHA-1" SIZE="1662">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-11-17T18:54:57" MIMETYPE="text/xml"
-				CHECKSUM="cfba79aa888f001500ba4ba64d23f51a0302a4e5" CHECKSUMTYPE="SHA-1" SIZE="3966">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-11-17T18:54:57" MIMETYPE="text/xml" CHECKSUM="cfba79aa888f001500ba4ba64d23f51a0302a4e5" CHECKSUMTYPE="SHA-1" SIZE="3966">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-11-17T18:54:57" MIMETYPE="text/xml"
-				CHECKSUM="11764eeb33831c232f0424062b934783c4a14e55" CHECKSUMTYPE="SHA-1" SIZE="18477">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-11-17T18:54:57" MIMETYPE="text/xml" CHECKSUM="11764eeb33831c232f0424062b934783c4a14e55" CHECKSUMTYPE="SHA-1" SIZE="18477">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-11-17T18:54:58" MIMETYPE="text/xml"
-				CHECKSUM="ee8d59618414a4a431984bf74fa6d8e26d4facac" CHECKSUMTYPE="SHA-1" SIZE="22908">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-11-17T18:54:58" MIMETYPE="text/xml" CHECKSUM="ee8d59618414a4a431984bf74fa6d8e26d4facac" CHECKSUMTYPE="SHA-1" SIZE="22908">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-11-17T18:54:58" MIMETYPE="text/xml"
-				CHECKSUM="3f12450c3918b505d5942005aed2acc44e2262c4" CHECKSUMTYPE="SHA-1" SIZE="25061">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-11-17T18:54:58" MIMETYPE="text/xml" CHECKSUM="3f12450c3918b505d5942005aed2acc44e2262c4" CHECKSUMTYPE="SHA-1" SIZE="25061">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-11-17T18:54:58" MIMETYPE="text/xml"
-				CHECKSUM="53181a51812f0db20fe456e1b03a61f9fdbff23d" CHECKSUMTYPE="SHA-1" SIZE="14893">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-11-17T18:54:58" MIMETYPE="text/xml" CHECKSUM="53181a51812f0db20fe456e1b03a61f9fdbff23d" CHECKSUMTYPE="SHA-1" SIZE="14893">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-11-17T18:54:58" MIMETYPE="text/xml"
-				CHECKSUM="a9921615bf5196f870d4772e148c5572acf5aa99" CHECKSUMTYPE="SHA-1" SIZE="5792">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-11-17T18:54:58" MIMETYPE="text/xml" CHECKSUM="a9921615bf5196f870d4772e148c5572acf5aa99" CHECKSUMTYPE="SHA-1" SIZE="5792">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-11-17T18:54:59" MIMETYPE="text/xml"
-				CHECKSUM="87c588af1cbe91b715e65fd8649e05e370618154" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-11-17T18:54:59" MIMETYPE="text/xml" CHECKSUM="87c588af1cbe91b715e65fd8649e05e370618154" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-11-17T18:54:59" MIMETYPE="text/xml"
-				CHECKSUM="0857d07020bac4ee78fde9345b158547176f9059" CHECKSUMTYPE="SHA-1" SIZE="66015">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-11-17T18:54:59" MIMETYPE="text/xml" CHECKSUM="0857d07020bac4ee78fde9345b158547176f9059" CHECKSUMTYPE="SHA-1" SIZE="66015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-11-17T18:54:59" MIMETYPE="text/xml"
-				CHECKSUM="8181142489e429bd0ebc1cab33399778b72bbd29" CHECKSUMTYPE="SHA-1" SIZE="113568">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-11-17T18:54:59" MIMETYPE="text/xml" CHECKSUM="8181142489e429bd0ebc1cab33399778b72bbd29" CHECKSUMTYPE="SHA-1" SIZE="113568">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-11-17T18:55:00" MIMETYPE="text/xml"
-				CHECKSUM="b52aa6d47797aa2c0252a5493c37e16d1d7187da" CHECKSUMTYPE="SHA-1" SIZE="113271">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-11-17T18:55:00" MIMETYPE="text/xml" CHECKSUM="b52aa6d47797aa2c0252a5493c37e16d1d7187da" CHECKSUMTYPE="SHA-1" SIZE="113271">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-11-17T18:55:00" MIMETYPE="text/xml"
-				CHECKSUM="0de39176eb51134de65d854468bb294be815fbe1" CHECKSUMTYPE="SHA-1" SIZE="115904">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-11-17T18:55:00" MIMETYPE="text/xml" CHECKSUM="0de39176eb51134de65d854468bb294be815fbe1" CHECKSUMTYPE="SHA-1" SIZE="115904">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-11-17T18:55:00" MIMETYPE="text/xml"
-				CHECKSUM="b167e1d118b42dbc7779eb25303aeba79e5ed11b" CHECKSUMTYPE="SHA-1" SIZE="4598">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-11-17T18:55:00" MIMETYPE="text/xml" CHECKSUM="b167e1d118b42dbc7779eb25303aeba79e5ed11b" CHECKSUMTYPE="SHA-1" SIZE="4598">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-11-17T18:55:01" MIMETYPE="text/xml"
-				CHECKSUM="8bbf68a5603a4ceaca968929e9a73ff7d4b91a6d" CHECKSUMTYPE="SHA-1" SIZE="1953">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-11-17T18:55:01" MIMETYPE="text/xml" CHECKSUM="8bbf68a5603a4ceaca968929e9a73ff7d4b91a6d" CHECKSUMTYPE="SHA-1" SIZE="1953">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-11-17T18:55:01" MIMETYPE="text/xml"
-				CHECKSUM="420e55527f4d278061e5f265477a8fb187f2dc9d" CHECKSUMTYPE="SHA-1" SIZE="12952">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-11-17T18:55:01" MIMETYPE="text/xml" CHECKSUM="420e55527f4d278061e5f265477a8fb187f2dc9d" CHECKSUMTYPE="SHA-1" SIZE="12952">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-11-17T18:55:01" MIMETYPE="text/xml"
-				CHECKSUM="a1f7c976529b1c390f77ebe6aeeab8f3ca205dc0" CHECKSUMTYPE="SHA-1" SIZE="27979">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-11-17T18:55:01" MIMETYPE="text/xml" CHECKSUM="a1f7c976529b1c390f77ebe6aeeab8f3ca205dc0" CHECKSUMTYPE="SHA-1" SIZE="27979">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-11-17T18:55:01" MIMETYPE="text/xml"
-				CHECKSUM="f5b65acb1c716728ef74a6bc8c318eb00ef40e02" CHECKSUMTYPE="SHA-1" SIZE="39967">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-11-17T18:55:01" MIMETYPE="text/xml" CHECKSUM="f5b65acb1c716728ef74a6bc8c318eb00ef40e02" CHECKSUMTYPE="SHA-1" SIZE="39967">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-11-17T18:55:02" MIMETYPE="text/xml"
-				CHECKSUM="55ad4559e386cc3703953f227475c075a83d9174" CHECKSUMTYPE="SHA-1" SIZE="17086">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-11-17T18:55:02" MIMETYPE="text/xml" CHECKSUM="55ad4559e386cc3703953f227475c075a83d9174" CHECKSUMTYPE="SHA-1" SIZE="17086">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-11-17T18:55:02" MIMETYPE="text/xml"
-				CHECKSUM="0ce76adb6680d9c4d09fec6cd2db9db74e81ed50" CHECKSUMTYPE="SHA-1" SIZE="4650">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-11-17T18:55:02" MIMETYPE="text/xml" CHECKSUM="0ce76adb6680d9c4d09fec6cd2db9db74e81ed50" CHECKSUMTYPE="SHA-1" SIZE="4650">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-11-17T18:55:02" MIMETYPE="text/xml"
-				CHECKSUM="84f290f2a418bcc55702285a313775833078183f" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-11-17T18:55:02" MIMETYPE="text/xml" CHECKSUM="84f290f2a418bcc55702285a313775833078183f" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-11-17T18:55:02" MIMETYPE="text/xml"
-				CHECKSUM="81bb9913ce34a2b5c029948f671fed24c154d901" CHECKSUMTYPE="SHA-1" SIZE="68997">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-11-17T18:55:02" MIMETYPE="text/xml" CHECKSUM="81bb9913ce34a2b5c029948f671fed24c154d901" CHECKSUMTYPE="SHA-1" SIZE="68997">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-11-17T18:55:03" MIMETYPE="text/xml"
-				CHECKSUM="386ad8febf2d3f7199d36b2c3a252bacd626712d" CHECKSUMTYPE="SHA-1" SIZE="141247">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-11-17T18:55:03" MIMETYPE="text/xml" CHECKSUM="386ad8febf2d3f7199d36b2c3a252bacd626712d" CHECKSUMTYPE="SHA-1" SIZE="141247">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-11-17T18:55:03" MIMETYPE="text/xml"
-				CHECKSUM="bb85736192420c7cc81f42c5e98d1f84b2c607de" CHECKSUMTYPE="SHA-1" SIZE="145937">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-11-17T18:55:03" MIMETYPE="text/xml" CHECKSUM="bb85736192420c7cc81f42c5e98d1f84b2c607de" CHECKSUMTYPE="SHA-1" SIZE="145937">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-11-17T18:55:03" MIMETYPE="text/xml"
-				CHECKSUM="0bdfda8a15d46e1778172eeb517dcbe128ecb226" CHECKSUMTYPE="SHA-1" SIZE="147808">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-11-17T18:55:03" MIMETYPE="text/xml" CHECKSUM="0bdfda8a15d46e1778172eeb517dcbe128ecb226" CHECKSUMTYPE="SHA-1" SIZE="147808">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-11-17T18:55:04" MIMETYPE="text/xml"
-				CHECKSUM="f2cf3e25ea162c9f78c5d69feef9f224932d3a17" CHECKSUMTYPE="SHA-1" SIZE="154312">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-11-17T18:55:04" MIMETYPE="text/xml" CHECKSUM="f2cf3e25ea162c9f78c5d69feef9f224932d3a17" CHECKSUMTYPE="SHA-1" SIZE="154312">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-11-17T18:55:04" MIMETYPE="text/xml"
-				CHECKSUM="c55166b77b90fd052c1d7afec8ae9d4633d950e3" CHECKSUMTYPE="SHA-1" SIZE="152056">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-11-17T18:55:04" MIMETYPE="text/xml" CHECKSUM="c55166b77b90fd052c1d7afec8ae9d4633d950e3" CHECKSUMTYPE="SHA-1" SIZE="152056">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-11-17T18:55:05" MIMETYPE="text/xml"
-				CHECKSUM="6d56fef5302f7edf87000069f085e01fc772473d" CHECKSUMTYPE="SHA-1" SIZE="150850">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-11-17T18:55:05" MIMETYPE="text/xml" CHECKSUM="6d56fef5302f7edf87000069f085e01fc772473d" CHECKSUMTYPE="SHA-1" SIZE="150850">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-11-17T18:55:05" MIMETYPE="text/xml"
-				CHECKSUM="ec3b8b07795a206651c4e1e4de5a42937a63bcb4" CHECKSUMTYPE="SHA-1" SIZE="78868">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-11-17T18:55:05" MIMETYPE="text/xml" CHECKSUM="ec3b8b07795a206651c4e1e4de5a42937a63bcb4" CHECKSUMTYPE="SHA-1" SIZE="78868">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-11-17T18:55:05" MIMETYPE="text/xml"
-				CHECKSUM="04a4368db6d7a3687b27807e08baf17c33c37d97" CHECKSUMTYPE="SHA-1" SIZE="4581">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-11-17T18:55:05" MIMETYPE="text/xml" CHECKSUM="04a4368db6d7a3687b27807e08baf17c33c37d97" CHECKSUMTYPE="SHA-1" SIZE="4581">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-11-17T18:55:06" MIMETYPE="text/xml"
-				CHECKSUM="f9a89cf1b8e27dddbb9b9044cb4deb6e2716bc25" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-11-17T18:55:06" MIMETYPE="text/xml" CHECKSUM="f9a89cf1b8e27dddbb9b9044cb4deb6e2716bc25" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-11-17T18:55:06" MIMETYPE="text/xml"
-				CHECKSUM="664da925d2f0f7a77eb36b9e5650036a06c228c9" CHECKSUMTYPE="SHA-1" SIZE="32414">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-11-17T18:55:06" MIMETYPE="text/xml" CHECKSUM="664da925d2f0f7a77eb36b9e5650036a06c228c9" CHECKSUMTYPE="SHA-1" SIZE="32414">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-11-17T18:55:06" MIMETYPE="text/xml"
-				CHECKSUM="c4761712c72a241941c0d13574387a054d7efc6a" CHECKSUMTYPE="SHA-1" SIZE="16208">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-11-17T18:55:06" MIMETYPE="text/xml" CHECKSUM="c4761712c72a241941c0d13574387a054d7efc6a" CHECKSUMTYPE="SHA-1" SIZE="16208">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-11-17T18:55:06" MIMETYPE="text/xml"
-				CHECKSUM="d9df7ce1f09a943f409e660b52ea6968e4db8b08" CHECKSUMTYPE="SHA-1" SIZE="48533">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-11-17T18:55:06" MIMETYPE="text/xml" CHECKSUM="d9df7ce1f09a943f409e660b52ea6968e4db8b08" CHECKSUMTYPE="SHA-1" SIZE="48533">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-11-17T18:55:07" MIMETYPE="text/xml"
-				CHECKSUM="5dc514f078d6324c7d34455e5f1552fa233540f1" CHECKSUMTYPE="SHA-1" SIZE="84723">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-11-17T18:55:07" MIMETYPE="text/xml" CHECKSUM="5dc514f078d6324c7d34455e5f1552fa233540f1" CHECKSUMTYPE="SHA-1" SIZE="84723">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-11-17T18:55:07" MIMETYPE="text/xml"
-				CHECKSUM="0c27816dd484748041d9bde4e1e4db02f4e0cbef" CHECKSUMTYPE="SHA-1" SIZE="76144">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-11-17T18:55:07" MIMETYPE="text/xml" CHECKSUM="0c27816dd484748041d9bde4e1e4db02f4e0cbef" CHECKSUMTYPE="SHA-1" SIZE="76144">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-11-17T18:55:07" MIMETYPE="text/xml"
-				CHECKSUM="fe1f5bd948e4a1f9a14ee86c04c934f1892cbaf6" CHECKSUMTYPE="SHA-1" SIZE="48297">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-11-17T18:55:07" MIMETYPE="text/xml" CHECKSUM="fe1f5bd948e4a1f9a14ee86c04c934f1892cbaf6" CHECKSUMTYPE="SHA-1" SIZE="48297">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-11-17T18:55:08" MIMETYPE="text/xml"
-				CHECKSUM="8c71e092bdabf673af5cefa78fdd58b34a9f35f5" CHECKSUMTYPE="SHA-1" SIZE="4352">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-11-17T18:55:08" MIMETYPE="text/xml" CHECKSUM="8c71e092bdabf673af5cefa78fdd58b34a9f35f5" CHECKSUMTYPE="SHA-1" SIZE="4352">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-11-17T18:55:08" MIMETYPE="text/xml"
-				CHECKSUM="87126d82403b85276c39054a63b572199bcdd6ca" CHECKSUMTYPE="SHA-1" SIZE="1954">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-11-17T18:55:08" MIMETYPE="text/xml" CHECKSUM="87126d82403b85276c39054a63b572199bcdd6ca" CHECKSUMTYPE="SHA-1" SIZE="1954">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-11-17T18:55:08" MIMETYPE="text/xml"
-				CHECKSUM="8a70d58e113e6ef7e531fc73afb0020294edf135" CHECKSUMTYPE="SHA-1" SIZE="32507">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-11-17T18:55:08" MIMETYPE="text/xml" CHECKSUM="8a70d58e113e6ef7e531fc73afb0020294edf135" CHECKSUMTYPE="SHA-1" SIZE="32507">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-11-17T18:55:09" MIMETYPE="text/xml"
-				CHECKSUM="0d987ec2b7d0a0c461873aafa575576161d0ec5e" CHECKSUMTYPE="SHA-1" SIZE="34137">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-11-17T18:55:09" MIMETYPE="text/xml" CHECKSUM="0d987ec2b7d0a0c461873aafa575576161d0ec5e" CHECKSUMTYPE="SHA-1" SIZE="34137">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-11-17T18:55:09" MIMETYPE="text/xml"
-				CHECKSUM="fa006c77a555799f1d4dcb90f5905b489eaacf87" CHECKSUMTYPE="SHA-1" SIZE="4973">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-11-17T18:55:09" MIMETYPE="text/xml" CHECKSUM="fa006c77a555799f1d4dcb90f5905b489eaacf87" CHECKSUMTYPE="SHA-1" SIZE="4973">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-11-17T18:55:09" MIMETYPE="text/xml"
-				CHECKSUM="dc6f7c7bc5c479387c646cfd69fecb23dfbe2834" CHECKSUMTYPE="SHA-1" SIZE="1954">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-11-17T18:55:09" MIMETYPE="text/xml" CHECKSUM="dc6f7c7bc5c479387c646cfd69fecb23dfbe2834" CHECKSUMTYPE="SHA-1" SIZE="1954">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-11-17T18:55:09" MIMETYPE="text/xml"
-				CHECKSUM="985151124d1090476bbb48c66888047537cce119" CHECKSUMTYPE="SHA-1" SIZE="61509">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-11-17T18:55:09" MIMETYPE="text/xml" CHECKSUM="985151124d1090476bbb48c66888047537cce119" CHECKSUMTYPE="SHA-1" SIZE="61509">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-11-17T18:55:10" MIMETYPE="text/xml"
-				CHECKSUM="833605a3d769d6b7adfdc428d8633df0bf051d3e" CHECKSUMTYPE="SHA-1" SIZE="144146">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-11-17T18:55:10" MIMETYPE="text/xml" CHECKSUM="833605a3d769d6b7adfdc428d8633df0bf051d3e" CHECKSUMTYPE="SHA-1" SIZE="144146">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-11-17T18:55:10" MIMETYPE="text/xml"
-				CHECKSUM="9937ad23fef8f6e2bbfe684cfac9064219e1a5d1" CHECKSUMTYPE="SHA-1" SIZE="142855">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-11-17T18:55:10" MIMETYPE="text/xml" CHECKSUM="9937ad23fef8f6e2bbfe684cfac9064219e1a5d1" CHECKSUMTYPE="SHA-1" SIZE="142855">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-11-17T18:55:11" MIMETYPE="text/xml"
-				CHECKSUM="614a8da390c6deca36f3dfedf6fedb5b980c1ce8" CHECKSUMTYPE="SHA-1" SIZE="135281">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-11-17T18:55:11" MIMETYPE="text/xml" CHECKSUM="614a8da390c6deca36f3dfedf6fedb5b980c1ce8" CHECKSUMTYPE="SHA-1" SIZE="135281">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-11-17T18:55:11" MIMETYPE="text/xml"
-				CHECKSUM="a50c57bba6d22ef98ae23d25b82bb3704dad55f5" CHECKSUMTYPE="SHA-1" SIZE="145804">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-11-17T18:55:11" MIMETYPE="text/xml" CHECKSUM="a50c57bba6d22ef98ae23d25b82bb3704dad55f5" CHECKSUMTYPE="SHA-1" SIZE="145804">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-11-17T18:55:11" MIMETYPE="text/xml"
-				CHECKSUM="933b446abe1774ac436b6b95e4732c59b199afb2" CHECKSUMTYPE="SHA-1" SIZE="132046">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-11-17T18:55:11" MIMETYPE="text/xml" CHECKSUM="933b446abe1774ac436b6b95e4732c59b199afb2" CHECKSUMTYPE="SHA-1" SIZE="132046">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-11-17T18:55:12" MIMETYPE="text/xml"
-				CHECKSUM="8194991cde2a5b77500aeba850f5e4a1095c3814" CHECKSUMTYPE="SHA-1" SIZE="30617">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-11-17T18:55:12" MIMETYPE="text/xml" CHECKSUM="8194991cde2a5b77500aeba850f5e4a1095c3814" CHECKSUMTYPE="SHA-1" SIZE="30617">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-11-17T18:55:12" MIMETYPE="text/xml"
-				CHECKSUM="433a4614721a313bd69267214ca6e911b5eb11c7" CHECKSUMTYPE="SHA-1" SIZE="14891">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-11-17T18:55:12" MIMETYPE="text/xml" CHECKSUM="433a4614721a313bd69267214ca6e911b5eb11c7" CHECKSUMTYPE="SHA-1" SIZE="14891">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-11-17T18:55:12" MIMETYPE="text/xml"
-				CHECKSUM="aba9a188f3b1c5ba1a5ee39bb7a0d3ea04a378c4" CHECKSUMTYPE="SHA-1" SIZE="10412">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-11-17T18:55:12" MIMETYPE="text/xml" CHECKSUM="aba9a188f3b1c5ba1a5ee39bb7a0d3ea04a378c4" CHECKSUMTYPE="SHA-1" SIZE="10412">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-11-17T18:55:12" MIMETYPE="text/xml"
-				CHECKSUM="6bf0343a94b89cb1dab3739bf933bc4e01b34819" CHECKSUMTYPE="SHA-1" SIZE="2344">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-11-17T18:55:12" MIMETYPE="text/xml" CHECKSUM="6bf0343a94b89cb1dab3739bf933bc4e01b34819" CHECKSUMTYPE="SHA-1" SIZE="2344">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-11-17T18:55:13" MIMETYPE="text/xml"
-				CHECKSUM="f56144473ef0ac4ccc6e4f6f00f3057890ba7426" CHECKSUMTYPE="SHA-1" SIZE="2888">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-11-17T18:55:13" MIMETYPE="text/xml" CHECKSUM="f56144473ef0ac4ccc6e4f6f00f3057890ba7426" CHECKSUMTYPE="SHA-1" SIZE="2888">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-11-17T18:55:13" MIMETYPE="text/xml"
-				CHECKSUM="042e6cb1a6800c721082513dfd67cdf54576e3af" CHECKSUMTYPE="SHA-1" SIZE="2857">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-11-17T18:55:13" MIMETYPE="text/xml" CHECKSUM="042e6cb1a6800c721082513dfd67cdf54576e3af" CHECKSUMTYPE="SHA-1" SIZE="2857">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-11-17T18:55:13" MIMETYPE="text/xml"
-				CHECKSUM="4722810e0ff02ecfffdd5db044a45920be5cf7e9" CHECKSUMTYPE="SHA-1" SIZE="75747">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-11-17T18:55:13" MIMETYPE="text/xml" CHECKSUM="4722810e0ff02ecfffdd5db044a45920be5cf7e9" CHECKSUMTYPE="SHA-1" SIZE="75747">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-11-17T18:55:14" MIMETYPE="text/xml"
-				CHECKSUM="73e6b871466145cc030394277ca92d4faade4fc2" CHECKSUMTYPE="SHA-1" SIZE="186608">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-11-17T18:55:14" MIMETYPE="text/xml" CHECKSUM="73e6b871466145cc030394277ca92d4faade4fc2" CHECKSUMTYPE="SHA-1" SIZE="186608">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-11-17T18:55:14" MIMETYPE="text/xml"
-				CHECKSUM="b222209fb6d2557e6b77de8ece7b1aaa1b79d5f2" CHECKSUMTYPE="SHA-1" SIZE="191656">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-11-17T18:55:14" MIMETYPE="text/xml" CHECKSUM="b222209fb6d2557e6b77de8ece7b1aaa1b79d5f2" CHECKSUMTYPE="SHA-1" SIZE="191656">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-11-17T18:55:14" MIMETYPE="text/xml"
-				CHECKSUM="227a6448a67428b334fe0256744426d368314517" CHECKSUMTYPE="SHA-1" SIZE="182711">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-11-17T18:55:14" MIMETYPE="text/xml" CHECKSUM="227a6448a67428b334fe0256744426d368314517" CHECKSUMTYPE="SHA-1" SIZE="182711">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-11-17T18:55:15" MIMETYPE="text/xml"
-				CHECKSUM="497e01d2769fc3590f2a18399f2333798b23bc44" CHECKSUMTYPE="SHA-1" SIZE="191605">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-11-17T18:55:15" MIMETYPE="text/xml" CHECKSUM="497e01d2769fc3590f2a18399f2333798b23bc44" CHECKSUMTYPE="SHA-1" SIZE="191605">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-11-17T18:55:15" MIMETYPE="text/xml"
-				CHECKSUM="ee3b56ae9fd24345f71d5d6b606d2666bc7dcb86" CHECKSUMTYPE="SHA-1" SIZE="182620">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-11-17T18:55:15" MIMETYPE="text/xml" CHECKSUM="ee3b56ae9fd24345f71d5d6b606d2666bc7dcb86" CHECKSUMTYPE="SHA-1" SIZE="182620">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-11-17T18:55:16" MIMETYPE="text/xml"
-				CHECKSUM="6979031e0304e73992e5552b9461210317f9b62b" CHECKSUMTYPE="SHA-1" SIZE="80329">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-11-17T18:55:16" MIMETYPE="text/xml" CHECKSUM="6979031e0304e73992e5552b9461210317f9b62b" CHECKSUMTYPE="SHA-1" SIZE="80329">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-11-17T18:55:16" MIMETYPE="text/xml"
-				CHECKSUM="02c6c537be5723a0e926ee6cb16ad69b8400e7a6" CHECKSUMTYPE="SHA-1" SIZE="73509">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-11-17T18:55:16" MIMETYPE="text/xml" CHECKSUM="02c6c537be5723a0e926ee6cb16ad69b8400e7a6" CHECKSUMTYPE="SHA-1" SIZE="73509">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-11-17T18:55:16" MIMETYPE="text/xml"
-				CHECKSUM="d88f86ebfa33df67c7211c269ce7ad4ac5de91e4" CHECKSUMTYPE="SHA-1" SIZE="186265">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-11-17T18:55:16" MIMETYPE="text/xml" CHECKSUM="d88f86ebfa33df67c7211c269ce7ad4ac5de91e4" CHECKSUMTYPE="SHA-1" SIZE="186265">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-11-17T18:55:17" MIMETYPE="text/xml"
-				CHECKSUM="3cdb4feea513a4cc15f3b1fe861ebbc2cf2e972d" CHECKSUMTYPE="SHA-1" SIZE="101285">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-11-17T18:55:17" MIMETYPE="text/xml" CHECKSUM="3cdb4feea513a4cc15f3b1fe861ebbc2cf2e972d" CHECKSUMTYPE="SHA-1" SIZE="101285">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-11-17T18:55:17" MIMETYPE="text/xml"
-				CHECKSUM="6104617823c7cb98e2a20dd2e2a1f310569e4b51" CHECKSUMTYPE="SHA-1" SIZE="4728">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-11-17T18:55:17" MIMETYPE="text/xml" CHECKSUM="6104617823c7cb98e2a20dd2e2a1f310569e4b51" CHECKSUMTYPE="SHA-1" SIZE="4728">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-11-17T18:55:17" MIMETYPE="text/xml"
-				CHECKSUM="5fdcbe9c7133b088197ba0e36a6f786d5ab9b8e1" CHECKSUMTYPE="SHA-1" SIZE="1954">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-11-17T18:55:17" MIMETYPE="text/xml" CHECKSUM="5fdcbe9c7133b088197ba0e36a6f786d5ab9b8e1" CHECKSUMTYPE="SHA-1" SIZE="1954">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-11-17T18:55:18" MIMETYPE="text/xml"
-				CHECKSUM="a0ec0dbe29e0e18ff42ea9b567ac875b464eed66" CHECKSUMTYPE="SHA-1" SIZE="82796">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-11-17T18:55:18" MIMETYPE="text/xml" CHECKSUM="a0ec0dbe29e0e18ff42ea9b567ac875b464eed66" CHECKSUMTYPE="SHA-1" SIZE="82796">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-11-17T18:55:18" MIMETYPE="text/xml"
-				CHECKSUM="0aba4be582d431d103c7df98012ae8141c99f003" CHECKSUMTYPE="SHA-1" SIZE="144457">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-11-17T18:55:18" MIMETYPE="text/xml" CHECKSUM="0aba4be582d431d103c7df98012ae8141c99f003" CHECKSUMTYPE="SHA-1" SIZE="144457">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-11-17T18:55:18" MIMETYPE="text/xml"
-				CHECKSUM="d948f4ec85703d7adc6f3991cf0cd8f977020192" CHECKSUMTYPE="SHA-1" SIZE="131063">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-11-17T18:55:18" MIMETYPE="text/xml" CHECKSUM="d948f4ec85703d7adc6f3991cf0cd8f977020192" CHECKSUMTYPE="SHA-1" SIZE="131063">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-11-17T18:55:19" MIMETYPE="text/xml"
-				CHECKSUM="93ec7ac3473af66dc9b1a2e1af803217f616413d" CHECKSUMTYPE="SHA-1" SIZE="86831">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-11-17T18:55:19" MIMETYPE="text/xml" CHECKSUM="93ec7ac3473af66dc9b1a2e1af803217f616413d" CHECKSUMTYPE="SHA-1" SIZE="86831">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-11-17T18:55:19" MIMETYPE="text/xml"
-				CHECKSUM="7baa0cb0392b4233c70de1a8130658f592c59ef7" CHECKSUMTYPE="SHA-1" SIZE="178817">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-11-17T18:55:19" MIMETYPE="text/xml" CHECKSUM="7baa0cb0392b4233c70de1a8130658f592c59ef7" CHECKSUMTYPE="SHA-1" SIZE="178817">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-11-17T18:55:20" MIMETYPE="text/xml"
-				CHECKSUM="b1617206e3678c9adecbaf7d52bd92ec2993a050" CHECKSUMTYPE="SHA-1" SIZE="183254">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-11-17T18:55:20" MIMETYPE="text/xml" CHECKSUM="b1617206e3678c9adecbaf7d52bd92ec2993a050" CHECKSUMTYPE="SHA-1" SIZE="183254">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-11-17T18:55:20" MIMETYPE="text/xml"
-				CHECKSUM="773d13124c43b9ab6ea78fc01d7a5bce506e6c08" CHECKSUMTYPE="SHA-1" SIZE="68765">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-11-17T18:55:20" MIMETYPE="text/xml" CHECKSUM="773d13124c43b9ab6ea78fc01d7a5bce506e6c08" CHECKSUMTYPE="SHA-1" SIZE="68765">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-11-17T18:55:20" MIMETYPE="text/xml"
-				CHECKSUM="29cd22d7be8006c4767ac55467e780ef3fa9600d" CHECKSUMTYPE="SHA-1" SIZE="150106">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-11-17T18:55:20" MIMETYPE="text/xml" CHECKSUM="29cd22d7be8006c4767ac55467e780ef3fa9600d" CHECKSUMTYPE="SHA-1" SIZE="150106">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-11-17T18:55:21" MIMETYPE="text/xml"
-				CHECKSUM="2452b99fb5ed016c2a5727b57d6d722dd96c3db1" CHECKSUMTYPE="SHA-1" SIZE="87655">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-11-17T18:55:21" MIMETYPE="text/xml" CHECKSUM="2452b99fb5ed016c2a5727b57d6d722dd96c3db1" CHECKSUMTYPE="SHA-1" SIZE="87655">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-11-17T18:55:21" MIMETYPE="text/xml"
-				CHECKSUM="c692aa39bd8bd4f7fc15543c7a973fbe8a97996e" CHECKSUMTYPE="SHA-1" SIZE="197662">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-11-17T18:55:21" MIMETYPE="text/xml" CHECKSUM="c692aa39bd8bd4f7fc15543c7a973fbe8a97996e" CHECKSUMTYPE="SHA-1" SIZE="197662">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-11-17T18:55:21" MIMETYPE="text/xml"
-				CHECKSUM="362f1e0f71bb0dbed78bfd7620653f257845c664" CHECKSUMTYPE="SHA-1" SIZE="4960">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-11-17T18:55:21" MIMETYPE="text/xml" CHECKSUM="362f1e0f71bb0dbed78bfd7620653f257845c664" CHECKSUMTYPE="SHA-1" SIZE="4960">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-11-17T18:55:22" MIMETYPE="text/xml"
-				CHECKSUM="c5faaf0df1734f22bc463fbac3b6941ab6f91cb4" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-11-17T18:55:22" MIMETYPE="text/xml" CHECKSUM="c5faaf0df1734f22bc463fbac3b6941ab6f91cb4" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-11-17T18:55:22" MIMETYPE="text/xml"
-				CHECKSUM="8d6e4924efb0eaf4bcca22f0b1ec4000bee0fc65" CHECKSUMTYPE="SHA-1" SIZE="130799">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-11-17T18:55:22" MIMETYPE="text/xml" CHECKSUM="8d6e4924efb0eaf4bcca22f0b1ec4000bee0fc65" CHECKSUMTYPE="SHA-1" SIZE="130799">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-11-17T18:55:22" MIMETYPE="text/xml"
-				CHECKSUM="bdc06b09a9d7d95dd488d4f75d2987f876b36900" CHECKSUMTYPE="SHA-1" SIZE="193326">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-11-17T18:55:22" MIMETYPE="text/xml" CHECKSUM="bdc06b09a9d7d95dd488d4f75d2987f876b36900" CHECKSUMTYPE="SHA-1" SIZE="193326">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-11-17T18:55:23" MIMETYPE="text/xml"
-				CHECKSUM="4f4fdffb458618a2514ebb386de5e88ecb9fadb0" CHECKSUMTYPE="SHA-1" SIZE="87154">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-11-17T18:55:23" MIMETYPE="text/xml" CHECKSUM="4f4fdffb458618a2514ebb386de5e88ecb9fadb0" CHECKSUMTYPE="SHA-1" SIZE="87154">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-11-17T18:55:23" MIMETYPE="text/xml"
-				CHECKSUM="8781d579cc442ea0c06c077a88b25e61300a0429" CHECKSUMTYPE="SHA-1" SIZE="65588">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-11-17T18:55:23" MIMETYPE="text/xml" CHECKSUM="8781d579cc442ea0c06c077a88b25e61300a0429" CHECKSUMTYPE="SHA-1" SIZE="65588">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-11-17T18:55:23" MIMETYPE="text/xml"
-				CHECKSUM="fdae69f6075a45b57ac8a10ad546d549f01998ec" CHECKSUMTYPE="SHA-1" SIZE="4903">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-11-17T18:55:23" MIMETYPE="text/xml" CHECKSUM="fdae69f6075a45b57ac8a10ad546d549f01998ec" CHECKSUMTYPE="SHA-1" SIZE="4903">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-11-17T18:55:24" MIMETYPE="text/xml"
-				CHECKSUM="3ac553fdaec0b16ad28920d445ed0c9a466bc35f" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-11-17T18:55:24" MIMETYPE="text/xml" CHECKSUM="3ac553fdaec0b16ad28920d445ed0c9a466bc35f" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0094.alto.xml"/>
 			</file>
-			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-11-17T18:55:24" MIMETYPE="text/xml"
-				CHECKSUM="71fe672e6104525eca9ef783ba8690345331a7fc" CHECKSUMTYPE="SHA-1" SIZE="126306">
+			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-11-17T18:55:24" MIMETYPE="text/xml" CHECKSUM="71fe672e6104525eca9ef783ba8690345331a7fc" CHECKSUMTYPE="SHA-1" SIZE="126306">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0095.alto.xml"/>
 			</file>
-			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-11-17T18:55:24" MIMETYPE="text/xml"
-				CHECKSUM="67fd04b45db05ee7cfb7322bd2520189fd3c07a5" CHECKSUMTYPE="SHA-1" SIZE="193385">
+			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-11-17T18:55:24" MIMETYPE="text/xml" CHECKSUM="67fd04b45db05ee7cfb7322bd2520189fd3c07a5" CHECKSUMTYPE="SHA-1" SIZE="193385">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0096.alto.xml"/>
 			</file>
-			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-11-17T18:55:25" MIMETYPE="text/xml"
-				CHECKSUM="221b4ece85f9a82d90da6266b4a906985cfac843" CHECKSUMTYPE="SHA-1" SIZE="198312">
+			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-11-17T18:55:25" MIMETYPE="text/xml" CHECKSUM="221b4ece85f9a82d90da6266b4a906985cfac843" CHECKSUMTYPE="SHA-1" SIZE="198312">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0097.alto.xml"/>
 			</file>
-			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-11-17T18:55:25" MIMETYPE="text/xml"
-				CHECKSUM="9aef40030d517b9e391eac604ed66a5dffb24395" CHECKSUMTYPE="SHA-1" SIZE="190565">
+			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-11-17T18:55:25" MIMETYPE="text/xml" CHECKSUM="9aef40030d517b9e391eac604ed66a5dffb24395" CHECKSUMTYPE="SHA-1" SIZE="190565">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0098.alto.xml"/>
 			</file>
-			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-11-17T18:55:26" MIMETYPE="text/xml"
-				CHECKSUM="7a9956252545d6937e6f3094acb851e34a2e15a2" CHECKSUMTYPE="SHA-1" SIZE="192429">
+			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-11-17T18:55:26" MIMETYPE="text/xml" CHECKSUM="7a9956252545d6937e6f3094acb851e34a2e15a2" CHECKSUMTYPE="SHA-1" SIZE="192429">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0099.alto.xml"/>
 			</file>
-			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-11-17T18:55:26" MIMETYPE="text/xml"
-				CHECKSUM="c19f259a45edbd1c382722f4571654325d483c04" CHECKSUMTYPE="SHA-1" SIZE="70378">
+			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-11-17T18:55:26" MIMETYPE="text/xml" CHECKSUM="c19f259a45edbd1c382722f4571654325d483c04" CHECKSUMTYPE="SHA-1" SIZE="70378">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0100.alto.xml"/>
 			</file>
-			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-11-17T18:55:27" MIMETYPE="text/xml"
-				CHECKSUM="c994033675885adce1d3577321f588d88551918a" CHECKSUMTYPE="SHA-1" SIZE="184200">
+			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-11-17T18:55:27" MIMETYPE="text/xml" CHECKSUM="c994033675885adce1d3577321f588d88551918a" CHECKSUMTYPE="SHA-1" SIZE="184200">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0101.alto.xml"/>
 			</file>
-			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-11-17T18:55:27" MIMETYPE="text/xml"
-				CHECKSUM="98f2a13aafc63003e24bebdc04f65da79981cc2b" CHECKSUMTYPE="SHA-1" SIZE="207356">
+			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-11-17T18:55:27" MIMETYPE="text/xml" CHECKSUM="98f2a13aafc63003e24bebdc04f65da79981cc2b" CHECKSUMTYPE="SHA-1" SIZE="207356">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0102.alto.xml"/>
 			</file>
-			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-11-17T18:55:27" MIMETYPE="text/xml"
-				CHECKSUM="ec75ded1ae33b045c3adda4226b0aaf0d34eb036" CHECKSUMTYPE="SHA-1" SIZE="5897">
+			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-11-17T18:55:27" MIMETYPE="text/xml" CHECKSUM="ec75ded1ae33b045c3adda4226b0aaf0d34eb036" CHECKSUMTYPE="SHA-1" SIZE="5897">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0103.alto.xml"/>
 			</file>
-			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-11-17T18:55:28" MIMETYPE="text/xml"
-				CHECKSUM="4ec8a227daa2ab2572c6cf4b04662a4df5672bc7" CHECKSUMTYPE="SHA-1" SIZE="1961">
+			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-11-17T18:55:28" MIMETYPE="text/xml" CHECKSUM="4ec8a227daa2ab2572c6cf4b04662a4df5672bc7" CHECKSUMTYPE="SHA-1" SIZE="1961">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0104.alto.xml"/>
 			</file>
-			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-11-17T18:55:28" MIMETYPE="text/xml"
-				CHECKSUM="3566f11ac2cf7ee21cda6164aa36c36fde46825e" CHECKSUMTYPE="SHA-1" SIZE="190961">
+			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-11-17T18:55:28" MIMETYPE="text/xml" CHECKSUM="3566f11ac2cf7ee21cda6164aa36c36fde46825e" CHECKSUMTYPE="SHA-1" SIZE="190961">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0105.alto.xml"/>
 			</file>
-			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-11-17T18:55:28" MIMETYPE="text/xml"
-				CHECKSUM="9c21e84e6c00a01545c2230c4de8e667d24a391c" CHECKSUMTYPE="SHA-1" SIZE="173801">
+			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-11-17T18:55:28" MIMETYPE="text/xml" CHECKSUM="9c21e84e6c00a01545c2230c4de8e667d24a391c" CHECKSUMTYPE="SHA-1" SIZE="173801">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0106.alto.xml"/>
 			</file>
-			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-11-17T18:55:29" MIMETYPE="text/xml"
-				CHECKSUM="13be30a54b2d4e973a518eefb79a6cebdb67cd4b" CHECKSUMTYPE="SHA-1" SIZE="170115">
+			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-11-17T18:55:29" MIMETYPE="text/xml" CHECKSUM="13be30a54b2d4e973a518eefb79a6cebdb67cd4b" CHECKSUMTYPE="SHA-1" SIZE="170115">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0107.alto.xml"/>
 			</file>
-			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-11-17T18:55:29" MIMETYPE="text/xml"
-				CHECKSUM="59078e3d23bc27f26735492f87b687e5e94967c8" CHECKSUMTYPE="SHA-1" SIZE="187789">
+			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-11-17T18:55:29" MIMETYPE="text/xml" CHECKSUM="59078e3d23bc27f26735492f87b687e5e94967c8" CHECKSUMTYPE="SHA-1" SIZE="187789">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0108.alto.xml"/>
 			</file>
-			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-11-17T18:55:30" MIMETYPE="text/xml"
-				CHECKSUM="98ca2973e57e2c6755c971ff909e7511948bdc15" CHECKSUMTYPE="SHA-1" SIZE="197592">
+			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-11-17T18:55:30" MIMETYPE="text/xml" CHECKSUM="98ca2973e57e2c6755c971ff909e7511948bdc15" CHECKSUMTYPE="SHA-1" SIZE="197592">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0109.alto.xml"/>
 			</file>
-			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-11-17T18:55:30" MIMETYPE="text/xml"
-				CHECKSUM="df0352099954713756e65b4e5292fda113fce7ad" CHECKSUMTYPE="SHA-1" SIZE="200460">
+			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-11-17T18:55:30" MIMETYPE="text/xml" CHECKSUM="df0352099954713756e65b4e5292fda113fce7ad" CHECKSUMTYPE="SHA-1" SIZE="200460">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0110.alto.xml"/>
 			</file>
-			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-11-17T18:55:31" MIMETYPE="text/xml"
-				CHECKSUM="e2b1017f4bf371822e249e97295b16a2743a5c66" CHECKSUMTYPE="SHA-1" SIZE="68387">
+			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-11-17T18:55:31" MIMETYPE="text/xml" CHECKSUM="e2b1017f4bf371822e249e97295b16a2743a5c66" CHECKSUMTYPE="SHA-1" SIZE="68387">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0111.alto.xml"/>
 			</file>
-			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-11-17T18:55:31" MIMETYPE="text/xml"
-				CHECKSUM="626f3f9ce2fe2c50c725f7175b588228ed9b3265" CHECKSUMTYPE="SHA-1" SIZE="69402">
+			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-11-17T18:55:31" MIMETYPE="text/xml" CHECKSUM="626f3f9ce2fe2c50c725f7175b588228ed9b3265" CHECKSUMTYPE="SHA-1" SIZE="69402">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0112.alto.xml"/>
 			</file>
-			<file ID="ALTO00113" GROUPID="page113" CREATED="2015-11-17T18:55:31" MIMETYPE="text/xml"
-				CHECKSUM="6f7895d8cc39b6fb917e683f02a97321f7e2521a" CHECKSUMTYPE="SHA-1" SIZE="5105">
+			<file ID="ALTO00113" GROUPID="page113" CREATED="2015-11-17T18:55:31" MIMETYPE="text/xml" CHECKSUM="6f7895d8cc39b6fb917e683f02a97321f7e2521a" CHECKSUMTYPE="SHA-1" SIZE="5105">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0113.alto.xml"/>
 			</file>
-			<file ID="ALTO00114" GROUPID="page114" CREATED="2015-11-17T18:55:31" MIMETYPE="text/xml"
-				CHECKSUM="d085ddf0370bcef48ba2e5e1ba29af34cc7409f1" CHECKSUMTYPE="SHA-1" SIZE="1961">
+			<file ID="ALTO00114" GROUPID="page114" CREATED="2015-11-17T18:55:31" MIMETYPE="text/xml" CHECKSUM="d085ddf0370bcef48ba2e5e1ba29af34cc7409f1" CHECKSUMTYPE="SHA-1" SIZE="1961">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0114.alto.xml"/>
 			</file>
-			<file ID="ALTO00115" GROUPID="page115" CREATED="2015-11-17T18:55:32" MIMETYPE="text/xml"
-				CHECKSUM="f45bdf42709f3cc285e6fc83272af2245b809cc8" CHECKSUMTYPE="SHA-1" SIZE="191354">
+			<file ID="ALTO00115" GROUPID="page115" CREATED="2015-11-17T18:55:32" MIMETYPE="text/xml" CHECKSUM="f45bdf42709f3cc285e6fc83272af2245b809cc8" CHECKSUMTYPE="SHA-1" SIZE="191354">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0115.alto.xml"/>
 			</file>
-			<file ID="ALTO00116" GROUPID="page116" CREATED="2015-11-17T18:55:32" MIMETYPE="text/xml"
-				CHECKSUM="c483d8f20ec01897a8d2e2c3c6ddafe2f51fe7d4" CHECKSUMTYPE="SHA-1" SIZE="85178">
+			<file ID="ALTO00116" GROUPID="page116" CREATED="2015-11-17T18:55:32" MIMETYPE="text/xml" CHECKSUM="c483d8f20ec01897a8d2e2c3c6ddafe2f51fe7d4" CHECKSUMTYPE="SHA-1" SIZE="85178">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0116.alto.xml"/>
 			</file>
-			<file ID="ALTO00117" GROUPID="page117" CREATED="2015-11-17T18:55:33" MIMETYPE="text/xml"
-				CHECKSUM="5010167d36a939fef453350bdd85e884d094482f" CHECKSUMTYPE="SHA-1" SIZE="88319">
+			<file ID="ALTO00117" GROUPID="page117" CREATED="2015-11-17T18:55:33" MIMETYPE="text/xml" CHECKSUM="5010167d36a939fef453350bdd85e884d094482f" CHECKSUMTYPE="SHA-1" SIZE="88319">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0117.alto.xml"/>
 			</file>
-			<file ID="ALTO00118" GROUPID="page118" CREATED="2015-11-17T18:55:33" MIMETYPE="text/xml"
-				CHECKSUM="a495c428cd3be5606bef5011d5028f585a03d146" CHECKSUMTYPE="SHA-1" SIZE="61323">
+			<file ID="ALTO00118" GROUPID="page118" CREATED="2015-11-17T18:55:33" MIMETYPE="text/xml" CHECKSUM="a495c428cd3be5606bef5011d5028f585a03d146" CHECKSUMTYPE="SHA-1" SIZE="61323">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0118.alto.xml"/>
 			</file>
-			<file ID="ALTO00119" GROUPID="page119" CREATED="2015-11-17T18:55:33" MIMETYPE="text/xml"
-				CHECKSUM="a7c7b06e3577a4bc4504efaea318c493509fa944" CHECKSUMTYPE="SHA-1" SIZE="73162">
+			<file ID="ALTO00119" GROUPID="page119" CREATED="2015-11-17T18:55:33" MIMETYPE="text/xml" CHECKSUM="a7c7b06e3577a4bc4504efaea318c493509fa944" CHECKSUMTYPE="SHA-1" SIZE="73162">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0119.alto.xml"/>
 			</file>
-			<file ID="ALTO00120" GROUPID="page120" CREATED="2015-11-17T18:55:34" MIMETYPE="text/xml"
-				CHECKSUM="36e9a292f518ff56b0b52828d4335547d0a01f5f" CHECKSUMTYPE="SHA-1" SIZE="141834">
+			<file ID="ALTO00120" GROUPID="page120" CREATED="2015-11-17T18:55:34" MIMETYPE="text/xml" CHECKSUM="36e9a292f518ff56b0b52828d4335547d0a01f5f" CHECKSUMTYPE="SHA-1" SIZE="141834">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0120.alto.xml"/>
 			</file>
-			<file ID="ALTO00121" GROUPID="page121" CREATED="2015-11-17T18:55:34" MIMETYPE="text/xml"
-				CHECKSUM="441f534dcd7593d3f6aee767c43bb79fb215b27f" CHECKSUMTYPE="SHA-1" SIZE="4685">
+			<file ID="ALTO00121" GROUPID="page121" CREATED="2015-11-17T18:55:34" MIMETYPE="text/xml" CHECKSUM="441f534dcd7593d3f6aee767c43bb79fb215b27f" CHECKSUMTYPE="SHA-1" SIZE="4685">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0121.alto.xml"/>
 			</file>
-			<file ID="ALTO00122" GROUPID="page122" CREATED="2015-11-17T18:55:34" MIMETYPE="text/xml"
-				CHECKSUM="9df241b675f68eb244d6fc6f16d49d7bc85f04a5" CHECKSUMTYPE="SHA-1" SIZE="1961">
+			<file ID="ALTO00122" GROUPID="page122" CREATED="2015-11-17T18:55:34" MIMETYPE="text/xml" CHECKSUM="9df241b675f68eb244d6fc6f16d49d7bc85f04a5" CHECKSUMTYPE="SHA-1" SIZE="1961">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0122.alto.xml"/>
 			</file>
-			<file ID="ALTO00123" GROUPID="page123" CREATED="2015-11-17T18:55:34" MIMETYPE="text/xml"
-				CHECKSUM="166d186953b8b2af9dd0abc2350834285065fbf2" CHECKSUMTYPE="SHA-1" SIZE="27348">
+			<file ID="ALTO00123" GROUPID="page123" CREATED="2015-11-17T18:55:34" MIMETYPE="text/xml" CHECKSUM="166d186953b8b2af9dd0abc2350834285065fbf2" CHECKSUMTYPE="SHA-1" SIZE="27348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0123.alto.xml"/>
 			</file>
-			<file ID="ALTO00124" GROUPID="page124" CREATED="2015-11-17T18:55:35" MIMETYPE="text/xml"
-				CHECKSUM="0be36d3b3d8ffd6446ea2543f741eca96a99a7ae" CHECKSUMTYPE="SHA-1" SIZE="86308">
+			<file ID="ALTO00124" GROUPID="page124" CREATED="2015-11-17T18:55:35" MIMETYPE="text/xml" CHECKSUM="0be36d3b3d8ffd6446ea2543f741eca96a99a7ae" CHECKSUMTYPE="SHA-1" SIZE="86308">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0124.alto.xml"/>
 			</file>
-			<file ID="ALTO00125" GROUPID="page125" CREATED="2015-11-17T18:55:35" MIMETYPE="text/xml"
-				CHECKSUM="1720b4e84bc8fa6485d860ea6677aa4f995bf9cb" CHECKSUMTYPE="SHA-1" SIZE="163506">
+			<file ID="ALTO00125" GROUPID="page125" CREATED="2015-11-17T18:55:35" MIMETYPE="text/xml" CHECKSUM="1720b4e84bc8fa6485d860ea6677aa4f995bf9cb" CHECKSUMTYPE="SHA-1" SIZE="163506">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0125.alto.xml"/>
 			</file>
-			<file ID="ALTO00126" GROUPID="page126" CREATED="2015-11-17T18:55:36" MIMETYPE="text/xml"
-				CHECKSUM="379923f35f84d53b7a7ed83a5fc66a61c0054540" CHECKSUMTYPE="SHA-1" SIZE="156601">
+			<file ID="ALTO00126" GROUPID="page126" CREATED="2015-11-17T18:55:36" MIMETYPE="text/xml" CHECKSUM="379923f35f84d53b7a7ed83a5fc66a61c0054540" CHECKSUMTYPE="SHA-1" SIZE="156601">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0126.alto.xml"/>
 			</file>
-			<file ID="ALTO00127" GROUPID="page127" CREATED="2015-11-17T18:55:36" MIMETYPE="text/xml"
-				CHECKSUM="87f4c88514eeb2262c98c6bea970158edbff0b12" CHECKSUMTYPE="SHA-1" SIZE="157095">
+			<file ID="ALTO00127" GROUPID="page127" CREATED="2015-11-17T18:55:36" MIMETYPE="text/xml" CHECKSUM="87f4c88514eeb2262c98c6bea970158edbff0b12" CHECKSUMTYPE="SHA-1" SIZE="157095">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0127.alto.xml"/>
 			</file>
-			<file ID="ALTO00128" GROUPID="page128" CREATED="2015-11-17T18:55:36" MIMETYPE="text/xml"
-				CHECKSUM="d122f870941b7f714578d718eefccb07427a031e" CHECKSUMTYPE="SHA-1" SIZE="143096">
+			<file ID="ALTO00128" GROUPID="page128" CREATED="2015-11-17T18:55:36" MIMETYPE="text/xml" CHECKSUM="d122f870941b7f714578d718eefccb07427a031e" CHECKSUMTYPE="SHA-1" SIZE="143096">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0128.alto.xml"/>
 			</file>
-			<file ID="ALTO00129" GROUPID="page129" CREATED="2015-11-17T18:55:37" MIMETYPE="text/xml"
-				CHECKSUM="e53d7cafc6c3b9c6ba1178d6edbb1c8de0b1bb18" CHECKSUMTYPE="SHA-1" SIZE="5285">
+			<file ID="ALTO00129" GROUPID="page129" CREATED="2015-11-17T18:55:37" MIMETYPE="text/xml" CHECKSUM="e53d7cafc6c3b9c6ba1178d6edbb1c8de0b1bb18" CHECKSUMTYPE="SHA-1" SIZE="5285">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0129.alto.xml"/>
 			</file>
-			<file ID="ALTO00130" GROUPID="page130" CREATED="2015-11-17T18:55:37" MIMETYPE="text/xml"
-				CHECKSUM="fdcd749db78f5b323cb76849ee303f8daeafef8e" CHECKSUMTYPE="SHA-1" SIZE="1951">
+			<file ID="ALTO00130" GROUPID="page130" CREATED="2015-11-17T18:55:37" MIMETYPE="text/xml" CHECKSUM="fdcd749db78f5b323cb76849ee303f8daeafef8e" CHECKSUMTYPE="SHA-1" SIZE="1951">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0130.alto.xml"/>
 			</file>
-			<file ID="ALTO00131" GROUPID="page131" CREATED="2015-11-17T18:55:37" MIMETYPE="text/xml"
-				CHECKSUM="ec354008ef92c9b44ad9552f5ecd855a26c2ebc7" CHECKSUMTYPE="SHA-1" SIZE="60581">
+			<file ID="ALTO00131" GROUPID="page131" CREATED="2015-11-17T18:55:37" MIMETYPE="text/xml" CHECKSUM="ec354008ef92c9b44ad9552f5ecd855a26c2ebc7" CHECKSUMTYPE="SHA-1" SIZE="60581">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0131.alto.xml"/>
 			</file>
-			<file ID="ALTO00132" GROUPID="page132" CREATED="2015-11-17T18:55:38" MIMETYPE="text/xml"
-				CHECKSUM="5fe84dd03f8cbf55d89dc85fdb23cdd3c0a61651" CHECKSUMTYPE="SHA-1" SIZE="192845">
+			<file ID="ALTO00132" GROUPID="page132" CREATED="2015-11-17T18:55:38" MIMETYPE="text/xml" CHECKSUM="5fe84dd03f8cbf55d89dc85fdb23cdd3c0a61651" CHECKSUMTYPE="SHA-1" SIZE="192845">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0132.alto.xml"/>
 			</file>
-			<file ID="ALTO00133" GROUPID="page133" CREATED="2015-11-17T18:55:38" MIMETYPE="text/xml"
-				CHECKSUM="73b59f8314829cf6c8597a3340da9a3e66421267" CHECKSUMTYPE="SHA-1" SIZE="197620">
+			<file ID="ALTO00133" GROUPID="page133" CREATED="2015-11-17T18:55:38" MIMETYPE="text/xml" CHECKSUM="73b59f8314829cf6c8597a3340da9a3e66421267" CHECKSUMTYPE="SHA-1" SIZE="197620">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0133.alto.xml"/>
 			</file>
-			<file ID="ALTO00134" GROUPID="page134" CREATED="2015-11-17T18:55:39" MIMETYPE="text/xml"
-				CHECKSUM="9eac9707a641c0f355c27885f452505201d1bdd7" CHECKSUMTYPE="SHA-1" SIZE="138981">
+			<file ID="ALTO00134" GROUPID="page134" CREATED="2015-11-17T18:55:39" MIMETYPE="text/xml" CHECKSUM="9eac9707a641c0f355c27885f452505201d1bdd7" CHECKSUMTYPE="SHA-1" SIZE="138981">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0134.alto.xml"/>
 			</file>
-			<file ID="ALTO00135" GROUPID="page135" CREATED="2015-11-17T18:55:39" MIMETYPE="text/xml"
-				CHECKSUM="6c37487cd6cd1679b1295d9e4138929090982136" CHECKSUMTYPE="SHA-1" SIZE="71870">
+			<file ID="ALTO00135" GROUPID="page135" CREATED="2015-11-17T18:55:39" MIMETYPE="text/xml" CHECKSUM="6c37487cd6cd1679b1295d9e4138929090982136" CHECKSUMTYPE="SHA-1" SIZE="71870">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0135.alto.xml"/>
 			</file>
-			<file ID="ALTO00136" GROUPID="page136" CREATED="2015-11-17T18:55:39" MIMETYPE="text/xml"
-				CHECKSUM="e37d051b7d0963659a0a792b4301999a652b5dc6" CHECKSUMTYPE="SHA-1" SIZE="49678">
+			<file ID="ALTO00136" GROUPID="page136" CREATED="2015-11-17T18:55:39" MIMETYPE="text/xml" CHECKSUM="e37d051b7d0963659a0a792b4301999a652b5dc6" CHECKSUMTYPE="SHA-1" SIZE="49678">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0136.alto.xml"/>
 			</file>
-			<file ID="ALTO00137" GROUPID="page137" CREATED="2015-11-17T18:55:39" MIMETYPE="text/xml"
-				CHECKSUM="02adc1a38acc2802dc3631e19e446bd7534c2d39" CHECKSUMTYPE="SHA-1" SIZE="24161">
+			<file ID="ALTO00137" GROUPID="page137" CREATED="2015-11-17T18:55:39" MIMETYPE="text/xml" CHECKSUM="02adc1a38acc2802dc3631e19e446bd7534c2d39" CHECKSUMTYPE="SHA-1" SIZE="24161">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0137.alto.xml"/>
 			</file>
-			<file ID="ALTO00138" GROUPID="page138" CREATED="2015-11-17T18:55:40" MIMETYPE="text/xml"
-				CHECKSUM="5c62d31b59cbf07a55a102c003cedaaf597dafab" CHECKSUMTYPE="SHA-1" SIZE="53275">
+			<file ID="ALTO00138" GROUPID="page138" CREATED="2015-11-17T18:55:40" MIMETYPE="text/xml" CHECKSUM="5c62d31b59cbf07a55a102c003cedaaf597dafab" CHECKSUMTYPE="SHA-1" SIZE="53275">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0138.alto.xml"/>
 			</file>
-			<file ID="ALTO00139" GROUPID="page139" CREATED="2015-11-17T18:55:40" MIMETYPE="text/xml"
-				CHECKSUM="90c30125ceb76d2a29f7a777d015c4f748f2b97b" CHECKSUMTYPE="SHA-1" SIZE="1951">
+			<file ID="ALTO00139" GROUPID="page139" CREATED="2015-11-17T18:55:40" MIMETYPE="text/xml" CHECKSUM="90c30125ceb76d2a29f7a777d015c4f748f2b97b" CHECKSUMTYPE="SHA-1" SIZE="1951">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0139.alto.xml"/>
 			</file>
-			<file ID="ALTO00140" GROUPID="page140" CREATED="2015-11-17T18:55:40" MIMETYPE="text/xml"
-				CHECKSUM="2832112ee209c4b320a37740af71930ff2f60683" CHECKSUMTYPE="SHA-1" SIZE="4745">
+			<file ID="ALTO00140" GROUPID="page140" CREATED="2015-11-17T18:55:40" MIMETYPE="text/xml" CHECKSUM="2832112ee209c4b320a37740af71930ff2f60683" CHECKSUMTYPE="SHA-1" SIZE="4745">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-10_01_0140.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-11-17T19:02:04" MIMETYPE="application/pdf" CHECKSUM="01eabd713765639d2000b0f9d1e6ae665ae3531e"
-				CHECKSUMTYPE="SHA-1" SIZE="94641425">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/bmtnabe_1896-10_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-11-17T19:02:04" MIMETYPE="application/pdf" CHECKSUM="01eabd713765639d2000b0f9d1e6ae665ae3531e" CHECKSUMTYPE="SHA-1" SIZE="94641425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/10_01/bmtnabe_1896-10_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -16108,8 +15682,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.22" TYPE="TextContent" ORDER="22" DMDID="c077"
-						LABEL="DEUTSCHE WANDERBUEHNE UND IHR BRUCH MIT DEM DILETTANTISMUS IM 17. JAHRHUNDERT">
+					<div ID="L.1.1.3.22" TYPE="TextContent" ORDER="22" DMDID="c077" LABEL="DEUTSCHE WANDERBUEHNE UND IHR BRUCH MIT DEM DILETTANTISMUS IM 17. JAHRHUNDERT">
 						<div ID="L.1.1.3.22.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00095" BEGIN="P95_TB00002"/>

--- a/metadata/periodicals/bmtnabe/issues/1896/11_01/bmtnabe_1896-11_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1896/11_01/bmtnabe_1896-11_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1896-11_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1896-11_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-11_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-11_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1896-11_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1896-11_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1896-11_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -10929,1130 +10925,756 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:14:19" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="c587a41f2545c7eee2087586eb32db68d9067c75" CHECKSUMTYPE="SHA-1" SIZE="5175128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:14:52" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="84bbeabfe8c56aa81ffeffc1c808046df17f8490" CHECKSUMTYPE="SHA-1" SIZE="5386629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:15:24" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="c47f58de666c03faba285a3a2a536a99a80326a6" CHECKSUMTYPE="SHA-1" SIZE="5200328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:15:52" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="2364368c468af4391c08122e29264af0612331d8" CHECKSUMTYPE="SHA-1" SIZE="5386628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:16:23" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="5695270755b7f56a1140d1052962f6c9f51466b6" CHECKSUMTYPE="SHA-1" SIZE="5200328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:16:53" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="94570626a7c3d5acc482d104878c486296fc1ddd" CHECKSUMTYPE="SHA-1" SIZE="5368622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:17:21" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="68bcf9849144ae59415d4ee805db939d54cc39b7" CHECKSUMTYPE="SHA-1" SIZE="5214702">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:17:49" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="7a798236ce700f8ff54c9db8c8617000ceddc289" CHECKSUMTYPE="SHA-1" SIZE="5368627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:18:25" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="8e0cc4abb73b02f6b321456ff65769c8c68feabc" CHECKSUMTYPE="SHA-1" SIZE="5214708">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:18:55" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="a1756ed9f42b2219da3c0f29d8575a451344a069" CHECKSUMTYPE="SHA-1" SIZE="5330828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:19:24" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="3433ae52cbbda531e21b61b1184316d611cb4235" CHECKSUMTYPE="SHA-1" SIZE="5214727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:19:52" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="9e517c9c3482a0970765bc5cf85126617b82e480" CHECKSUMTYPE="SHA-1" SIZE="5330826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:20:20" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="e361a060981b0227f1b4f5c80651ef4da4706a0a" CHECKSUMTYPE="SHA-1" SIZE="5214726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:20:49" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="275b37d1fd00f51cf781e1bee4d2107cb29da7eb" CHECKSUMTYPE="SHA-1" SIZE="5330804">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:21:19" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="57e341347e2a02b9b00496b86caa4ae36a621569" CHECKSUMTYPE="SHA-1" SIZE="5214729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:21:49" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="8bd7b26b64385f067b8afe40ecab79852f30e00f" CHECKSUMTYPE="SHA-1" SIZE="5330825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:22:21" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="54264e5cbaad407c90c56d80b43d46f7d41e4c27" CHECKSUMTYPE="SHA-1" SIZE="5214696">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:22:54" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="fb8022b90d5ef167c892ebdb891a71abf314fa31" CHECKSUMTYPE="SHA-1" SIZE="5330825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:23:24" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="ccaadbb067ddf96d192106c109ad4ff4b1b3d944" CHECKSUMTYPE="SHA-1" SIZE="5337094">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:23:51" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="b9093913263ea9ca8d45addfe90808da9d3616f3" CHECKSUMTYPE="SHA-1" SIZE="5330814">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:24:18" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="cd807977cd16abcb47fec1c6879746cf9ca26deb" CHECKSUMTYPE="SHA-1" SIZE="5241727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:24:46" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="4fadd1675383a9c77559aa4add46653d55bb2d45" CHECKSUMTYPE="SHA-1" SIZE="5309223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:25:14" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="59d12460c38fd6d0946d5e5f6b3c9a76c8053334" CHECKSUMTYPE="SHA-1" SIZE="5249815">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:25:50" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="8ee980e4c176a8cda73586f89341bf2e7e7fff71" CHECKSUMTYPE="SHA-1" SIZE="5309224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:26:20" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="0becc4a3ea3de6f895e48d806c6f920ed58a54d2" CHECKSUMTYPE="SHA-1" SIZE="5249824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:26:52" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="d72117b54b55d0b71fd6d292440df85894e2380a" CHECKSUMTYPE="SHA-1" SIZE="5260627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:27:23" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="3f5e0ba1c46f49623f583d077482061a2ebad3b7" CHECKSUMTYPE="SHA-1" SIZE="5249803">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:27:54" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="fed844d29f738003fb01a27bb81262b5f519d8f4" CHECKSUMTYPE="SHA-1" SIZE="5260624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:28:25" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="fa50ced433a69c66eda7acda6ac345542ca4708e" CHECKSUMTYPE="SHA-1" SIZE="5249826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:28:54" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="4b39481d9c9c03ec1b26f5f0aed28bf1ac8cbfc4" CHECKSUMTYPE="SHA-1" SIZE="5260577">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:29:26" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="d72e208578c4600452e119e7b9f187889ad83a44" CHECKSUMTYPE="SHA-1" SIZE="5249821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:29:59" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="f87f3a2397b1631e1ae54e5f2693be6b3fe94be3" CHECKSUMTYPE="SHA-1" SIZE="5260622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:30:28" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="5832e203bb4c59131e39409c8b3737a918e9d9f0" CHECKSUMTYPE="SHA-1" SIZE="5249820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:30:56" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="cb1b9ca7506f8b9561fb08d2b4047d1689353241" CHECKSUMTYPE="SHA-1" SIZE="5260627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:31:26" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="d7741bad8827e897580138ea714ac60dba9065ab" CHECKSUMTYPE="SHA-1" SIZE="5249660">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:31:53" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="1a2bfb46d0c16a9a950c74b233a47420172d36d9" CHECKSUMTYPE="SHA-1" SIZE="5260596">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:32:21" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="2ced93009f503c8cc1d9cb3851328d551f7040bf" CHECKSUMTYPE="SHA-1" SIZE="5249806">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:32:53" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="983502721c927d08ead478cd4903d927973549cf" CHECKSUMTYPE="SHA-1" SIZE="5260577">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:33:22" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="8048db8d1c3630f3e1159353ac4e4d83b369f056" CHECKSUMTYPE="SHA-1" SIZE="5249824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:33:50" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="a10513a1e9c2b2c41c2b7ab9bdc296ddb7e80669" CHECKSUMTYPE="SHA-1" SIZE="5260629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:34:18" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="281fe60a48adf64e5bbc08cf5edd1a8000248a0a" CHECKSUMTYPE="SHA-1" SIZE="5249766">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:34:46" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="8a83cc0462bab22a88dafed69c49addaa94a959d" CHECKSUMTYPE="SHA-1" SIZE="5225401">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:35:13" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="016983ce1a2742ba7f17cbbaf151f30595ba29b9" CHECKSUMTYPE="SHA-1" SIZE="5249825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:35:43" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="cbcfcf302758de0a2ebec96bcaa53706082cef0b" CHECKSUMTYPE="SHA-1" SIZE="5225502">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:36:11" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="d38adcfb5e47354cdb389368446a2fcaa5b1a0a2" CHECKSUMTYPE="SHA-1" SIZE="5266029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:36:38" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="d1d405416536f0baa3c21d382bb3bd2c858ba3db" CHECKSUMTYPE="SHA-1" SIZE="5225526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:37:07" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="bd5d169f2d75c9a4229ed30615dc21afad7913b2" CHECKSUMTYPE="SHA-1" SIZE="5265925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:37:38" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="3097e82add1bca5b2adab52598a8e830f98e9578" CHECKSUMTYPE="SHA-1" SIZE="5225390">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:38:06" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="2a291cdf7fc48295548978bb99fb3a627bc6a297" CHECKSUMTYPE="SHA-1" SIZE="5281326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:38:34" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="2f2fbfd807a57884f7a9e7db691e652b889f2012" CHECKSUMTYPE="SHA-1" SIZE="5225523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:39:03" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="d6dbb2e21d0357ac17f3fa75fe427bb69082f5c6" CHECKSUMTYPE="SHA-1" SIZE="5281321">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:39:35" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="13eb500968733ac319396c6ec885e1296f662537" CHECKSUMTYPE="SHA-1" SIZE="5225529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:40:02" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="e5e6e503f237494d3d5b87f9a3958a233db6b3aa" CHECKSUMTYPE="SHA-1" SIZE="5281323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:40:32" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="48ba273a4d978de5735cd32757bcab497a9cdf61" CHECKSUMTYPE="SHA-1" SIZE="5225466">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:41:00" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="6b3588f9706c94d479b06e780bb57ca0e53e9b7a" CHECKSUMTYPE="SHA-1" SIZE="5328126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:41:28" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="9d00aebad17177c63f8205cbe4822be660dc18fb" CHECKSUMTYPE="SHA-1" SIZE="5225370">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:41:58" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="24926531542c40c16a6a0d506b95e3cac9b29966" CHECKSUMTYPE="SHA-1" SIZE="5328071">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:42:26" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="5d6287a203baf3b4bb87ad885a7d80bc5581bbee" CHECKSUMTYPE="SHA-1" SIZE="5225495">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T17:42:55" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="39d3ac5dd5ac15b0e0f04d56929ae2f4afcf2656" CHECKSUMTYPE="SHA-1" SIZE="5328128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T17:43:24" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="ac7185f6b4b5b420e4468e57deeb43acdd5e931b" CHECKSUMTYPE="SHA-1" SIZE="5225529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T17:43:51" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="375f880dbd4190e3bf29ffd504af221450e49759" CHECKSUMTYPE="SHA-1" SIZE="5352359">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T17:44:21" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="f689e9efaf1041ab46684551fcfaced664041862" CHECKSUMTYPE="SHA-1" SIZE="5225508">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T17:44:47" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="6deb37085588e1c1b7435ee5d0ab16c1a4338436" CHECKSUMTYPE="SHA-1" SIZE="5352429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T17:45:14" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="362b162545ef7afa2d1deddfab0925c463bc5b34" CHECKSUMTYPE="SHA-1" SIZE="5225527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T17:45:40" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="756af0db5209b77c5c3670d774d378d64ca98933" CHECKSUMTYPE="SHA-1" SIZE="5352310">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T17:46:09" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="e7a35dc199305d4a8e7add6d96e09067b0d7cd1c" CHECKSUMTYPE="SHA-1" SIZE="5225529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T17:46:37" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="3da322ef9f040a1b8b5d1aaa26f76164709f6c22" CHECKSUMTYPE="SHA-1" SIZE="5352427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T17:47:13" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="800870a8c764065be9a5c7d79bd78f97e6367850" CHECKSUMTYPE="SHA-1" SIZE="5175127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T17:47:45" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="ba66669465a75971be4f1388af9eea42a50788c3" CHECKSUMTYPE="SHA-1" SIZE="5352429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T17:48:15" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="ce8a75e468b50fab94891768f40feab228f42635" CHECKSUMTYPE="SHA-1" SIZE="5175129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T17:48:44" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="e20144214578092fb9c6cdcaa42682705c1ed1b0" CHECKSUMTYPE="SHA-1" SIZE="5352353">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T17:49:15" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="2a061865aced8754c872af6d7d0011ac60b2daad" CHECKSUMTYPE="SHA-1" SIZE="5175096">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T17:49:43" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="ba147910f3358e926f6fa70de5953835b1bafa3a" CHECKSUMTYPE="SHA-1" SIZE="5352425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T17:50:10" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="0311ba9bfcd93042dd2ae962b0e5fc489c1038bf" CHECKSUMTYPE="SHA-1" SIZE="5175128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T17:50:39" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="e550b5816204d95e5774eeeb40a82dc692ac2ff0" CHECKSUMTYPE="SHA-1" SIZE="5352422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T17:51:09" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="5c628c1af48407ad0b517d974a80b886b399a0d1" CHECKSUMTYPE="SHA-1" SIZE="5175129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T17:51:37" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="a1a6d8f1a02a0ef64fed0037c2eaf675a926826a" CHECKSUMTYPE="SHA-1" SIZE="5386629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T17:52:08" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="11630577b387c07a6aa8f222441199d51026192f" CHECKSUMTYPE="SHA-1" SIZE="5175129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:52:37" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="cd2ac3af92f82cf82b2e537d6092bff882408143" CHECKSUMTYPE="SHA-1" SIZE="5352415">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:53:06" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="6f991584ab0d2f8c2ed401a90161833e4062f849" CHECKSUMTYPE="SHA-1" SIZE="5175126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:53:35" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="e597f0d96268d664d0a44139030d5826c1bde509" CHECKSUMTYPE="SHA-1" SIZE="5346072">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:54:05" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="fabba4b27dd8d9dddca23175a3c43f75ffd8d87b" CHECKSUMTYPE="SHA-1" SIZE="5175122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:54:34" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="cb2e4edfe1f8d670890da279568b69ffb72aa0ae" CHECKSUMTYPE="SHA-1" SIZE="5336217">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:55:03" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="005e3f72a54f645fe698c29ce4addfafbf00a967" CHECKSUMTYPE="SHA-1" SIZE="5175126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:55:32" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="9eed4405e0cca74d6eedc24e3561434576013cb1" CHECKSUMTYPE="SHA-1" SIZE="5336097">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:56:04" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="6c00b7fdf1705b5e08658fe5cf259a9aa862b71d" CHECKSUMTYPE="SHA-1" SIZE="5175128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:56:32" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="6897534532b1b962895c93bfca9594181834ec28" CHECKSUMTYPE="SHA-1" SIZE="5336226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:57:01" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="b8b7531b163775604556a9291f6182b5a517db3a" CHECKSUMTYPE="SHA-1" SIZE="5175033">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:57:29" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="21c46fef89cfb3710107b3d2194e45c258519e3f" CHECKSUMTYPE="SHA-1" SIZE="5336225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:57:58" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="67945eb3b985b0bc671abda7f47c91558bbc0622" CHECKSUMTYPE="SHA-1" SIZE="5175128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:58:26" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="11da8bbca7c27dd4dd9c12fdc170507cf5ba81c1" CHECKSUMTYPE="SHA-1" SIZE="5336229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:58:58" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="3dc3f371a69f28825a8d3d79ab0325ce0fbe1317" CHECKSUMTYPE="SHA-1" SIZE="5175048">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:59:31" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="a2af13f552434f5ff7ff542c2c1c63068219a4e6" CHECKSUMTYPE="SHA-1" SIZE="5336220">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T18:00:02" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="e4583ebba61f69ab7db2e34eb38342fe4b582233" CHECKSUMTYPE="SHA-1" SIZE="5175127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0094.jp2"/>
-			</file>
-			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T18:00:32" MIMETYPE="image/jp2" SEQ="95"
-				CHECKSUM="8090b987193dbb9946da967dd76ff74c6cb58c5e" CHECKSUMTYPE="SHA-1" SIZE="5336222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0095.jp2"/>
-			</file>
-			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T18:01:02" MIMETYPE="image/jp2" SEQ="96"
-				CHECKSUM="13d654b8272f2271ccd91590af141339f724f902" CHECKSUMTYPE="SHA-1" SIZE="5175115">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0096.jp2"/>
-			</file>
-			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T18:01:33" MIMETYPE="image/jp2" SEQ="97"
-				CHECKSUM="1e645bce8e73403839b0d3876999070328b5a0b4" CHECKSUMTYPE="SHA-1" SIZE="5336228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0097.jp2"/>
-			</file>
-			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T18:02:08" MIMETYPE="image/jp2" SEQ="98"
-				CHECKSUM="bc8236b2702759fb4026b338327c9ee3524efda1" CHECKSUMTYPE="SHA-1" SIZE="5277723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0098.jp2"/>
-			</file>
-			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T18:02:38" MIMETYPE="image/jp2" SEQ="99"
-				CHECKSUM="e16b813f7416e3910093672018ea92e0d8909e23" CHECKSUMTYPE="SHA-1" SIZE="5336124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0099.jp2"/>
-			</file>
-			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T18:03:09" MIMETYPE="image/jp2" SEQ="100"
-				CHECKSUM="9a23c0227822038f44659ff37b9c7ae09fbf8e80" CHECKSUMTYPE="SHA-1" SIZE="5175106">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0100.jp2"/>
-			</file>
-			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T18:03:40" MIMETYPE="image/jp2" SEQ="101"
-				CHECKSUM="d9bd7d35d19d112d2559616535ddecf8af5cb8f3" CHECKSUMTYPE="SHA-1" SIZE="5347025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0101.jp2"/>
-			</file>
-			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T18:04:11" MIMETYPE="image/jp2" SEQ="102"
-				CHECKSUM="779f83cfdfc49bd99ee0515b7a0b360547366673" CHECKSUMTYPE="SHA-1" SIZE="5175090">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0102.jp2"/>
-			</file>
-			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T18:04:40" MIMETYPE="image/jp2" SEQ="103"
-				CHECKSUM="dc484c8e46bf444af1a2aa4c2310db1acb8ce816" CHECKSUMTYPE="SHA-1" SIZE="5375827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0103.jp2"/>
-			</file>
-			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T18:05:12" MIMETYPE="image/jp2" SEQ="104"
-				CHECKSUM="b1f1ee2f7149bf097b1c5602e5dc1ae80ea28e65" CHECKSUMTYPE="SHA-1" SIZE="5175103">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0104.jp2"/>
-			</file>
-			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T18:05:43" MIMETYPE="image/jp2" SEQ="105"
-				CHECKSUM="f203fc0ee8f0a56d7cc3152574bc24e441acc4c5" CHECKSUMTYPE="SHA-1" SIZE="5351498">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0105.jp2"/>
-			</file>
-			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T18:06:14" MIMETYPE="image/jp2" SEQ="106"
-				CHECKSUM="906ebe99df7ac17a61b53671550f6528cde0aec9" CHECKSUMTYPE="SHA-1" SIZE="5175127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0106.jp2"/>
-			</file>
-			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T18:06:43" MIMETYPE="image/jp2" SEQ="107"
-				CHECKSUM="7997fba4b232f3c64dae9104078807353998d3ef" CHECKSUMTYPE="SHA-1" SIZE="5351525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0107.jp2"/>
-			</file>
-			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T18:07:15" MIMETYPE="image/jp2" SEQ="108"
-				CHECKSUM="f7f04ad168b8f862a8708f111e566ee9331bd606" CHECKSUMTYPE="SHA-1" SIZE="5175105">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0108.jp2"/>
-			</file>
-			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T18:07:44" MIMETYPE="image/jp2" SEQ="109"
-				CHECKSUM="f70c2b4fea69475d6077c761329d82e4db65f1e4" CHECKSUMTYPE="SHA-1" SIZE="5351482">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0109.jp2"/>
-			</file>
-			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T18:08:12" MIMETYPE="image/jp2" SEQ="110"
-				CHECKSUM="f014b83c97ecb586d75032f6419bcb712287c065" CHECKSUMTYPE="SHA-1" SIZE="5174937">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0110.jp2"/>
-			</file>
-			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-07-30T18:08:39" MIMETYPE="image/jp2" SEQ="111"
-				CHECKSUM="e82bf2705ec907175412b7ec399c724a644840d3" CHECKSUMTYPE="SHA-1" SIZE="5351526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0111.jp2"/>
-			</file>
-			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-07-30T18:09:10" MIMETYPE="image/jp2" SEQ="112"
-				CHECKSUM="77ee6474938e66baba62005bcfffe85460488047" CHECKSUMTYPE="SHA-1" SIZE="5175129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0112.jp2"/>
-			</file>
-			<file ID="IMG00113" ADMID="techmd113" GROUPID="page113" CREATED="2015-07-30T18:09:39" MIMETYPE="image/jp2" SEQ="113"
-				CHECKSUM="5db672808442da0c2883468fbd995ad52b3df64f" CHECKSUMTYPE="SHA-1" SIZE="5340720">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0113.jp2"/>
-			</file>
-			<file ID="IMG00114" ADMID="techmd114" GROUPID="page114" CREATED="2015-07-30T18:10:10" MIMETYPE="image/jp2" SEQ="114"
-				CHECKSUM="315debdb48eb2a517c7065ed09a529b7aa9386e9" CHECKSUMTYPE="SHA-1" SIZE="5175119">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0114.jp2"/>
-			</file>
-			<file ID="IMG00115" ADMID="techmd115" GROUPID="page115" CREATED="2015-07-30T18:10:39" MIMETYPE="image/jp2" SEQ="115"
-				CHECKSUM="cb3b509479ff4c954ddc7563b7f632b40490567c" CHECKSUMTYPE="SHA-1" SIZE="5340718">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0115.jp2"/>
-			</file>
-			<file ID="IMG00116" ADMID="techmd116" GROUPID="page116" CREATED="2015-07-30T18:11:09" MIMETYPE="image/jp2" SEQ="116"
-				CHECKSUM="953b9862c2bf1f4cd5cff047074eb62fb13f283f" CHECKSUMTYPE="SHA-1" SIZE="5175124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0116.jp2"/>
-			</file>
-			<file ID="IMG00117" ADMID="techmd117" GROUPID="page117" CREATED="2015-07-30T18:11:38" MIMETYPE="image/jp2" SEQ="117"
-				CHECKSUM="5914aaa2a3e54c187e4240b6b72d7015e8ed799a" CHECKSUMTYPE="SHA-1" SIZE="5340714">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0117.jp2"/>
-			</file>
-			<file ID="IMG00118" ADMID="techmd118" GROUPID="page118" CREATED="2015-07-30T18:12:08" MIMETYPE="image/jp2" SEQ="118"
-				CHECKSUM="1070b280cbe5826e58bdd005dbe7346fddaab8e2" CHECKSUMTYPE="SHA-1" SIZE="5175118">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0118.jp2"/>
-			</file>
-			<file ID="IMG00119" ADMID="techmd119" GROUPID="page119" CREATED="2015-07-30T18:12:36" MIMETYPE="image/jp2" SEQ="119"
-				CHECKSUM="73ea856aa1b1a0b36cc4ceac2e55c41d5a18cb54" CHECKSUMTYPE="SHA-1" SIZE="5310047">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0119.jp2"/>
-			</file>
-			<file ID="IMG00120" ADMID="techmd120" GROUPID="page120" CREATED="2015-07-30T18:13:04" MIMETYPE="image/jp2" SEQ="120"
-				CHECKSUM="92b296986ae68f2b8b3ae2a2d88f5d2f80d78a11" CHECKSUMTYPE="SHA-1" SIZE="5175126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0120.jp2"/>
-			</file>
-			<file ID="IMG00121" ADMID="techmd121" GROUPID="page121" CREATED="2015-07-30T18:13:33" MIMETYPE="image/jp2" SEQ="121"
-				CHECKSUM="3e5da93f59526e4922a9ef6bba5dfaa408ee5008" CHECKSUMTYPE="SHA-1" SIZE="5299290">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0121.jp2"/>
-			</file>
-			<file ID="IMG00122" ADMID="techmd122" GROUPID="page122" CREATED="2015-07-30T18:14:03" MIMETYPE="image/jp2" SEQ="122"
-				CHECKSUM="5dfa50fca036a522932343c0627d60f44cfe5b72" CHECKSUMTYPE="SHA-1" SIZE="5202116">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0122.jp2"/>
-			</file>
-			<file ID="IMG00123" ADMID="techmd123" GROUPID="page123" CREATED="2015-07-30T18:14:33" MIMETYPE="image/jp2" SEQ="123"
-				CHECKSUM="c13a7a55b5f9e52f5c2dfbe3337999ae669a9fd4" CHECKSUMTYPE="SHA-1" SIZE="5329897">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0123.jp2"/>
-			</file>
-			<file ID="IMG00124" ADMID="techmd124" GROUPID="page124" CREATED="2015-07-30T18:15:04" MIMETYPE="image/jp2" SEQ="124"
-				CHECKSUM="055cb287b13c83f3faa86c3f990fdae768230b52" CHECKSUMTYPE="SHA-1" SIZE="5175127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0124.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:14:19" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="c587a41f2545c7eee2087586eb32db68d9067c75" CHECKSUMTYPE="SHA-1" SIZE="5175128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:14:52" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="84bbeabfe8c56aa81ffeffc1c808046df17f8490" CHECKSUMTYPE="SHA-1" SIZE="5386629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:15:24" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c47f58de666c03faba285a3a2a536a99a80326a6" CHECKSUMTYPE="SHA-1" SIZE="5200328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:15:52" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="2364368c468af4391c08122e29264af0612331d8" CHECKSUMTYPE="SHA-1" SIZE="5386628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:16:23" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="5695270755b7f56a1140d1052962f6c9f51466b6" CHECKSUMTYPE="SHA-1" SIZE="5200328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:16:53" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="94570626a7c3d5acc482d104878c486296fc1ddd" CHECKSUMTYPE="SHA-1" SIZE="5368622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:17:21" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="68bcf9849144ae59415d4ee805db939d54cc39b7" CHECKSUMTYPE="SHA-1" SIZE="5214702">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:17:49" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="7a798236ce700f8ff54c9db8c8617000ceddc289" CHECKSUMTYPE="SHA-1" SIZE="5368627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:18:25" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="8e0cc4abb73b02f6b321456ff65769c8c68feabc" CHECKSUMTYPE="SHA-1" SIZE="5214708">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:18:55" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="a1756ed9f42b2219da3c0f29d8575a451344a069" CHECKSUMTYPE="SHA-1" SIZE="5330828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:19:24" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="3433ae52cbbda531e21b61b1184316d611cb4235" CHECKSUMTYPE="SHA-1" SIZE="5214727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:19:52" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="9e517c9c3482a0970765bc5cf85126617b82e480" CHECKSUMTYPE="SHA-1" SIZE="5330826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:20:20" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="e361a060981b0227f1b4f5c80651ef4da4706a0a" CHECKSUMTYPE="SHA-1" SIZE="5214726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:20:49" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="275b37d1fd00f51cf781e1bee4d2107cb29da7eb" CHECKSUMTYPE="SHA-1" SIZE="5330804">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:21:19" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="57e341347e2a02b9b00496b86caa4ae36a621569" CHECKSUMTYPE="SHA-1" SIZE="5214729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:21:49" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="8bd7b26b64385f067b8afe40ecab79852f30e00f" CHECKSUMTYPE="SHA-1" SIZE="5330825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:22:21" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="54264e5cbaad407c90c56d80b43d46f7d41e4c27" CHECKSUMTYPE="SHA-1" SIZE="5214696">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:22:54" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="fb8022b90d5ef167c892ebdb891a71abf314fa31" CHECKSUMTYPE="SHA-1" SIZE="5330825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:23:24" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="ccaadbb067ddf96d192106c109ad4ff4b1b3d944" CHECKSUMTYPE="SHA-1" SIZE="5337094">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:23:51" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="b9093913263ea9ca8d45addfe90808da9d3616f3" CHECKSUMTYPE="SHA-1" SIZE="5330814">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:24:18" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="cd807977cd16abcb47fec1c6879746cf9ca26deb" CHECKSUMTYPE="SHA-1" SIZE="5241727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:24:46" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="4fadd1675383a9c77559aa4add46653d55bb2d45" CHECKSUMTYPE="SHA-1" SIZE="5309223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:25:14" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="59d12460c38fd6d0946d5e5f6b3c9a76c8053334" CHECKSUMTYPE="SHA-1" SIZE="5249815">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:25:50" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="8ee980e4c176a8cda73586f89341bf2e7e7fff71" CHECKSUMTYPE="SHA-1" SIZE="5309224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:26:20" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="0becc4a3ea3de6f895e48d806c6f920ed58a54d2" CHECKSUMTYPE="SHA-1" SIZE="5249824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:26:52" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="d72117b54b55d0b71fd6d292440df85894e2380a" CHECKSUMTYPE="SHA-1" SIZE="5260627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:27:23" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="3f5e0ba1c46f49623f583d077482061a2ebad3b7" CHECKSUMTYPE="SHA-1" SIZE="5249803">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:27:54" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="fed844d29f738003fb01a27bb81262b5f519d8f4" CHECKSUMTYPE="SHA-1" SIZE="5260624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:28:25" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="fa50ced433a69c66eda7acda6ac345542ca4708e" CHECKSUMTYPE="SHA-1" SIZE="5249826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:28:54" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="4b39481d9c9c03ec1b26f5f0aed28bf1ac8cbfc4" CHECKSUMTYPE="SHA-1" SIZE="5260577">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:29:26" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="d72e208578c4600452e119e7b9f187889ad83a44" CHECKSUMTYPE="SHA-1" SIZE="5249821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:29:59" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="f87f3a2397b1631e1ae54e5f2693be6b3fe94be3" CHECKSUMTYPE="SHA-1" SIZE="5260622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:30:28" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="5832e203bb4c59131e39409c8b3737a918e9d9f0" CHECKSUMTYPE="SHA-1" SIZE="5249820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:30:56" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="cb1b9ca7506f8b9561fb08d2b4047d1689353241" CHECKSUMTYPE="SHA-1" SIZE="5260627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:31:26" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="d7741bad8827e897580138ea714ac60dba9065ab" CHECKSUMTYPE="SHA-1" SIZE="5249660">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:31:53" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="1a2bfb46d0c16a9a950c74b233a47420172d36d9" CHECKSUMTYPE="SHA-1" SIZE="5260596">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:32:21" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="2ced93009f503c8cc1d9cb3851328d551f7040bf" CHECKSUMTYPE="SHA-1" SIZE="5249806">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:32:53" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="983502721c927d08ead478cd4903d927973549cf" CHECKSUMTYPE="SHA-1" SIZE="5260577">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:33:22" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="8048db8d1c3630f3e1159353ac4e4d83b369f056" CHECKSUMTYPE="SHA-1" SIZE="5249824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:33:50" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="a10513a1e9c2b2c41c2b7ab9bdc296ddb7e80669" CHECKSUMTYPE="SHA-1" SIZE="5260629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:34:18" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="281fe60a48adf64e5bbc08cf5edd1a8000248a0a" CHECKSUMTYPE="SHA-1" SIZE="5249766">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:34:46" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="8a83cc0462bab22a88dafed69c49addaa94a959d" CHECKSUMTYPE="SHA-1" SIZE="5225401">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:35:13" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="016983ce1a2742ba7f17cbbaf151f30595ba29b9" CHECKSUMTYPE="SHA-1" SIZE="5249825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:35:43" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="cbcfcf302758de0a2ebec96bcaa53706082cef0b" CHECKSUMTYPE="SHA-1" SIZE="5225502">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:36:11" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="d38adcfb5e47354cdb389368446a2fcaa5b1a0a2" CHECKSUMTYPE="SHA-1" SIZE="5266029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:36:38" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="d1d405416536f0baa3c21d382bb3bd2c858ba3db" CHECKSUMTYPE="SHA-1" SIZE="5225526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:37:07" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="bd5d169f2d75c9a4229ed30615dc21afad7913b2" CHECKSUMTYPE="SHA-1" SIZE="5265925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:37:38" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="3097e82add1bca5b2adab52598a8e830f98e9578" CHECKSUMTYPE="SHA-1" SIZE="5225390">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:38:06" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="2a291cdf7fc48295548978bb99fb3a627bc6a297" CHECKSUMTYPE="SHA-1" SIZE="5281326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:38:34" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="2f2fbfd807a57884f7a9e7db691e652b889f2012" CHECKSUMTYPE="SHA-1" SIZE="5225523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:39:03" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="d6dbb2e21d0357ac17f3fa75fe427bb69082f5c6" CHECKSUMTYPE="SHA-1" SIZE="5281321">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:39:35" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="13eb500968733ac319396c6ec885e1296f662537" CHECKSUMTYPE="SHA-1" SIZE="5225529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:40:02" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="e5e6e503f237494d3d5b87f9a3958a233db6b3aa" CHECKSUMTYPE="SHA-1" SIZE="5281323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:40:32" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="48ba273a4d978de5735cd32757bcab497a9cdf61" CHECKSUMTYPE="SHA-1" SIZE="5225466">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:41:00" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="6b3588f9706c94d479b06e780bb57ca0e53e9b7a" CHECKSUMTYPE="SHA-1" SIZE="5328126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:41:28" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="9d00aebad17177c63f8205cbe4822be660dc18fb" CHECKSUMTYPE="SHA-1" SIZE="5225370">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:41:58" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="24926531542c40c16a6a0d506b95e3cac9b29966" CHECKSUMTYPE="SHA-1" SIZE="5328071">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:42:26" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="5d6287a203baf3b4bb87ad885a7d80bc5581bbee" CHECKSUMTYPE="SHA-1" SIZE="5225495">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T17:42:55" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="39d3ac5dd5ac15b0e0f04d56929ae2f4afcf2656" CHECKSUMTYPE="SHA-1" SIZE="5328128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T17:43:24" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="ac7185f6b4b5b420e4468e57deeb43acdd5e931b" CHECKSUMTYPE="SHA-1" SIZE="5225529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T17:43:51" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="375f880dbd4190e3bf29ffd504af221450e49759" CHECKSUMTYPE="SHA-1" SIZE="5352359">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T17:44:21" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="f689e9efaf1041ab46684551fcfaced664041862" CHECKSUMTYPE="SHA-1" SIZE="5225508">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T17:44:47" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="6deb37085588e1c1b7435ee5d0ab16c1a4338436" CHECKSUMTYPE="SHA-1" SIZE="5352429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T17:45:14" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="362b162545ef7afa2d1deddfab0925c463bc5b34" CHECKSUMTYPE="SHA-1" SIZE="5225527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T17:45:40" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="756af0db5209b77c5c3670d774d378d64ca98933" CHECKSUMTYPE="SHA-1" SIZE="5352310">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T17:46:09" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="e7a35dc199305d4a8e7add6d96e09067b0d7cd1c" CHECKSUMTYPE="SHA-1" SIZE="5225529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T17:46:37" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="3da322ef9f040a1b8b5d1aaa26f76164709f6c22" CHECKSUMTYPE="SHA-1" SIZE="5352427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T17:47:13" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="800870a8c764065be9a5c7d79bd78f97e6367850" CHECKSUMTYPE="SHA-1" SIZE="5175127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T17:47:45" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="ba66669465a75971be4f1388af9eea42a50788c3" CHECKSUMTYPE="SHA-1" SIZE="5352429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T17:48:15" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="ce8a75e468b50fab94891768f40feab228f42635" CHECKSUMTYPE="SHA-1" SIZE="5175129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T17:48:44" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="e20144214578092fb9c6cdcaa42682705c1ed1b0" CHECKSUMTYPE="SHA-1" SIZE="5352353">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T17:49:15" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="2a061865aced8754c872af6d7d0011ac60b2daad" CHECKSUMTYPE="SHA-1" SIZE="5175096">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T17:49:43" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="ba147910f3358e926f6fa70de5953835b1bafa3a" CHECKSUMTYPE="SHA-1" SIZE="5352425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T17:50:10" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="0311ba9bfcd93042dd2ae962b0e5fc489c1038bf" CHECKSUMTYPE="SHA-1" SIZE="5175128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T17:50:39" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="e550b5816204d95e5774eeeb40a82dc692ac2ff0" CHECKSUMTYPE="SHA-1" SIZE="5352422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T17:51:09" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="5c628c1af48407ad0b517d974a80b886b399a0d1" CHECKSUMTYPE="SHA-1" SIZE="5175129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T17:51:37" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="a1a6d8f1a02a0ef64fed0037c2eaf675a926826a" CHECKSUMTYPE="SHA-1" SIZE="5386629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T17:52:08" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="11630577b387c07a6aa8f222441199d51026192f" CHECKSUMTYPE="SHA-1" SIZE="5175129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:52:37" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="cd2ac3af92f82cf82b2e537d6092bff882408143" CHECKSUMTYPE="SHA-1" SIZE="5352415">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:53:06" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="6f991584ab0d2f8c2ed401a90161833e4062f849" CHECKSUMTYPE="SHA-1" SIZE="5175126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:53:35" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="e597f0d96268d664d0a44139030d5826c1bde509" CHECKSUMTYPE="SHA-1" SIZE="5346072">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:54:05" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="fabba4b27dd8d9dddca23175a3c43f75ffd8d87b" CHECKSUMTYPE="SHA-1" SIZE="5175122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:54:34" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="cb2e4edfe1f8d670890da279568b69ffb72aa0ae" CHECKSUMTYPE="SHA-1" SIZE="5336217">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:55:03" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="005e3f72a54f645fe698c29ce4addfafbf00a967" CHECKSUMTYPE="SHA-1" SIZE="5175126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:55:32" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="9eed4405e0cca74d6eedc24e3561434576013cb1" CHECKSUMTYPE="SHA-1" SIZE="5336097">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:56:04" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="6c00b7fdf1705b5e08658fe5cf259a9aa862b71d" CHECKSUMTYPE="SHA-1" SIZE="5175128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:56:32" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="6897534532b1b962895c93bfca9594181834ec28" CHECKSUMTYPE="SHA-1" SIZE="5336226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:57:01" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="b8b7531b163775604556a9291f6182b5a517db3a" CHECKSUMTYPE="SHA-1" SIZE="5175033">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:57:29" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="21c46fef89cfb3710107b3d2194e45c258519e3f" CHECKSUMTYPE="SHA-1" SIZE="5336225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:57:58" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="67945eb3b985b0bc671abda7f47c91558bbc0622" CHECKSUMTYPE="SHA-1" SIZE="5175128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:58:26" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="11da8bbca7c27dd4dd9c12fdc170507cf5ba81c1" CHECKSUMTYPE="SHA-1" SIZE="5336229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:58:58" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="3dc3f371a69f28825a8d3d79ab0325ce0fbe1317" CHECKSUMTYPE="SHA-1" SIZE="5175048">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:59:31" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="a2af13f552434f5ff7ff542c2c1c63068219a4e6" CHECKSUMTYPE="SHA-1" SIZE="5336220">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T18:00:02" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="e4583ebba61f69ab7db2e34eb38342fe4b582233" CHECKSUMTYPE="SHA-1" SIZE="5175127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0094.jp2"/>
+			</file>
+			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T18:00:32" MIMETYPE="image/jp2" SEQ="95" CHECKSUM="8090b987193dbb9946da967dd76ff74c6cb58c5e" CHECKSUMTYPE="SHA-1" SIZE="5336222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0095.jp2"/>
+			</file>
+			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T18:01:02" MIMETYPE="image/jp2" SEQ="96" CHECKSUM="13d654b8272f2271ccd91590af141339f724f902" CHECKSUMTYPE="SHA-1" SIZE="5175115">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0096.jp2"/>
+			</file>
+			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T18:01:33" MIMETYPE="image/jp2" SEQ="97" CHECKSUM="1e645bce8e73403839b0d3876999070328b5a0b4" CHECKSUMTYPE="SHA-1" SIZE="5336228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0097.jp2"/>
+			</file>
+			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T18:02:08" MIMETYPE="image/jp2" SEQ="98" CHECKSUM="bc8236b2702759fb4026b338327c9ee3524efda1" CHECKSUMTYPE="SHA-1" SIZE="5277723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0098.jp2"/>
+			</file>
+			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T18:02:38" MIMETYPE="image/jp2" SEQ="99" CHECKSUM="e16b813f7416e3910093672018ea92e0d8909e23" CHECKSUMTYPE="SHA-1" SIZE="5336124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0099.jp2"/>
+			</file>
+			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T18:03:09" MIMETYPE="image/jp2" SEQ="100" CHECKSUM="9a23c0227822038f44659ff37b9c7ae09fbf8e80" CHECKSUMTYPE="SHA-1" SIZE="5175106">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0100.jp2"/>
+			</file>
+			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T18:03:40" MIMETYPE="image/jp2" SEQ="101" CHECKSUM="d9bd7d35d19d112d2559616535ddecf8af5cb8f3" CHECKSUMTYPE="SHA-1" SIZE="5347025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0101.jp2"/>
+			</file>
+			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T18:04:11" MIMETYPE="image/jp2" SEQ="102" CHECKSUM="779f83cfdfc49bd99ee0515b7a0b360547366673" CHECKSUMTYPE="SHA-1" SIZE="5175090">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0102.jp2"/>
+			</file>
+			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T18:04:40" MIMETYPE="image/jp2" SEQ="103" CHECKSUM="dc484c8e46bf444af1a2aa4c2310db1acb8ce816" CHECKSUMTYPE="SHA-1" SIZE="5375827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0103.jp2"/>
+			</file>
+			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T18:05:12" MIMETYPE="image/jp2" SEQ="104" CHECKSUM="b1f1ee2f7149bf097b1c5602e5dc1ae80ea28e65" CHECKSUMTYPE="SHA-1" SIZE="5175103">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0104.jp2"/>
+			</file>
+			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T18:05:43" MIMETYPE="image/jp2" SEQ="105" CHECKSUM="f203fc0ee8f0a56d7cc3152574bc24e441acc4c5" CHECKSUMTYPE="SHA-1" SIZE="5351498">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0105.jp2"/>
+			</file>
+			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T18:06:14" MIMETYPE="image/jp2" SEQ="106" CHECKSUM="906ebe99df7ac17a61b53671550f6528cde0aec9" CHECKSUMTYPE="SHA-1" SIZE="5175127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0106.jp2"/>
+			</file>
+			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T18:06:43" MIMETYPE="image/jp2" SEQ="107" CHECKSUM="7997fba4b232f3c64dae9104078807353998d3ef" CHECKSUMTYPE="SHA-1" SIZE="5351525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0107.jp2"/>
+			</file>
+			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T18:07:15" MIMETYPE="image/jp2" SEQ="108" CHECKSUM="f7f04ad168b8f862a8708f111e566ee9331bd606" CHECKSUMTYPE="SHA-1" SIZE="5175105">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0108.jp2"/>
+			</file>
+			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T18:07:44" MIMETYPE="image/jp2" SEQ="109" CHECKSUM="f70c2b4fea69475d6077c761329d82e4db65f1e4" CHECKSUMTYPE="SHA-1" SIZE="5351482">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0109.jp2"/>
+			</file>
+			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T18:08:12" MIMETYPE="image/jp2" SEQ="110" CHECKSUM="f014b83c97ecb586d75032f6419bcb712287c065" CHECKSUMTYPE="SHA-1" SIZE="5174937">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0110.jp2"/>
+			</file>
+			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-07-30T18:08:39" MIMETYPE="image/jp2" SEQ="111" CHECKSUM="e82bf2705ec907175412b7ec399c724a644840d3" CHECKSUMTYPE="SHA-1" SIZE="5351526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0111.jp2"/>
+			</file>
+			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-07-30T18:09:10" MIMETYPE="image/jp2" SEQ="112" CHECKSUM="77ee6474938e66baba62005bcfffe85460488047" CHECKSUMTYPE="SHA-1" SIZE="5175129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0112.jp2"/>
+			</file>
+			<file ID="IMG00113" ADMID="techmd113" GROUPID="page113" CREATED="2015-07-30T18:09:39" MIMETYPE="image/jp2" SEQ="113" CHECKSUM="5db672808442da0c2883468fbd995ad52b3df64f" CHECKSUMTYPE="SHA-1" SIZE="5340720">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0113.jp2"/>
+			</file>
+			<file ID="IMG00114" ADMID="techmd114" GROUPID="page114" CREATED="2015-07-30T18:10:10" MIMETYPE="image/jp2" SEQ="114" CHECKSUM="315debdb48eb2a517c7065ed09a529b7aa9386e9" CHECKSUMTYPE="SHA-1" SIZE="5175119">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0114.jp2"/>
+			</file>
+			<file ID="IMG00115" ADMID="techmd115" GROUPID="page115" CREATED="2015-07-30T18:10:39" MIMETYPE="image/jp2" SEQ="115" CHECKSUM="cb3b509479ff4c954ddc7563b7f632b40490567c" CHECKSUMTYPE="SHA-1" SIZE="5340718">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0115.jp2"/>
+			</file>
+			<file ID="IMG00116" ADMID="techmd116" GROUPID="page116" CREATED="2015-07-30T18:11:09" MIMETYPE="image/jp2" SEQ="116" CHECKSUM="953b9862c2bf1f4cd5cff047074eb62fb13f283f" CHECKSUMTYPE="SHA-1" SIZE="5175124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0116.jp2"/>
+			</file>
+			<file ID="IMG00117" ADMID="techmd117" GROUPID="page117" CREATED="2015-07-30T18:11:38" MIMETYPE="image/jp2" SEQ="117" CHECKSUM="5914aaa2a3e54c187e4240b6b72d7015e8ed799a" CHECKSUMTYPE="SHA-1" SIZE="5340714">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0117.jp2"/>
+			</file>
+			<file ID="IMG00118" ADMID="techmd118" GROUPID="page118" CREATED="2015-07-30T18:12:08" MIMETYPE="image/jp2" SEQ="118" CHECKSUM="1070b280cbe5826e58bdd005dbe7346fddaab8e2" CHECKSUMTYPE="SHA-1" SIZE="5175118">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0118.jp2"/>
+			</file>
+			<file ID="IMG00119" ADMID="techmd119" GROUPID="page119" CREATED="2015-07-30T18:12:36" MIMETYPE="image/jp2" SEQ="119" CHECKSUM="73ea856aa1b1a0b36cc4ceac2e55c41d5a18cb54" CHECKSUMTYPE="SHA-1" SIZE="5310047">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0119.jp2"/>
+			</file>
+			<file ID="IMG00120" ADMID="techmd120" GROUPID="page120" CREATED="2015-07-30T18:13:04" MIMETYPE="image/jp2" SEQ="120" CHECKSUM="92b296986ae68f2b8b3ae2a2d88f5d2f80d78a11" CHECKSUMTYPE="SHA-1" SIZE="5175126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0120.jp2"/>
+			</file>
+			<file ID="IMG00121" ADMID="techmd121" GROUPID="page121" CREATED="2015-07-30T18:13:33" MIMETYPE="image/jp2" SEQ="121" CHECKSUM="3e5da93f59526e4922a9ef6bba5dfaa408ee5008" CHECKSUMTYPE="SHA-1" SIZE="5299290">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0121.jp2"/>
+			</file>
+			<file ID="IMG00122" ADMID="techmd122" GROUPID="page122" CREATED="2015-07-30T18:14:03" MIMETYPE="image/jp2" SEQ="122" CHECKSUM="5dfa50fca036a522932343c0627d60f44cfe5b72" CHECKSUMTYPE="SHA-1" SIZE="5202116">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0122.jp2"/>
+			</file>
+			<file ID="IMG00123" ADMID="techmd123" GROUPID="page123" CREATED="2015-07-30T18:14:33" MIMETYPE="image/jp2" SEQ="123" CHECKSUM="c13a7a55b5f9e52f5c2dfbe3337999ae669a9fd4" CHECKSUMTYPE="SHA-1" SIZE="5329897">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0123.jp2"/>
+			</file>
+			<file ID="IMG00124" ADMID="techmd124" GROUPID="page124" CREATED="2015-07-30T18:15:04" MIMETYPE="image/jp2" SEQ="124" CHECKSUM="055cb287b13c83f3faa86c3f990fdae768230b52" CHECKSUMTYPE="SHA-1" SIZE="5175127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/delivery/bmtnabe_1896-11_01_0124.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:15:20" MIMETYPE="text/xml" CHECKSUM="f2b530ae173ab40cf4020ef662ed84ae80d02b91"
-				CHECKSUMTYPE="SHA-1" SIZE="2110">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:15:20" MIMETYPE="text/xml" CHECKSUM="f2b530ae173ab40cf4020ef662ed84ae80d02b91" CHECKSUMTYPE="SHA-1" SIZE="2110">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:15:20" MIMETYPE="text/xml" CHECKSUM="d52e50c4e1f4cc2d4d61edefb81aa2e3ad8438b3"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:15:20" MIMETYPE="text/xml" CHECKSUM="d52e50c4e1f4cc2d4d61edefb81aa2e3ad8438b3" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:15:21" MIMETYPE="text/xml" CHECKSUM="1c37bab9ca72719da93060dad0a2729d17a4b51e"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:15:21" MIMETYPE="text/xml" CHECKSUM="1c37bab9ca72719da93060dad0a2729d17a4b51e" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:15:21" MIMETYPE="text/xml" CHECKSUM="b3c57292e7c13f07d296fbff9665dabf814149e5"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:15:21" MIMETYPE="text/xml" CHECKSUM="b3c57292e7c13f07d296fbff9665dabf814149e5" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:15:21" MIMETYPE="text/xml" CHECKSUM="954e997e2ad6eeca04111c3b5b4af2eb808ca879"
-				CHECKSUMTYPE="SHA-1" SIZE="12516">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:15:21" MIMETYPE="text/xml" CHECKSUM="954e997e2ad6eeca04111c3b5b4af2eb808ca879" CHECKSUMTYPE="SHA-1" SIZE="12516">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:15:21" MIMETYPE="text/xml" CHECKSUM="ef343340d07a826f30b0dd248765991d1e8177ec"
-				CHECKSUMTYPE="SHA-1" SIZE="3671">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:15:21" MIMETYPE="text/xml" CHECKSUM="ef343340d07a826f30b0dd248765991d1e8177ec" CHECKSUMTYPE="SHA-1" SIZE="3671">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:15:22" MIMETYPE="text/xml" CHECKSUM="4ae4beffcef436ba8a9801836a7dfa4fc7793cc0"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:15:22" MIMETYPE="text/xml" CHECKSUM="4ae4beffcef436ba8a9801836a7dfa4fc7793cc0" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:15:22" MIMETYPE="text/xml" CHECKSUM="679ead2162f4b1816c3c086aec29a08b729814fc"
-				CHECKSUMTYPE="SHA-1" SIZE="5973">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:15:22" MIMETYPE="text/xml" CHECKSUM="679ead2162f4b1816c3c086aec29a08b729814fc" CHECKSUMTYPE="SHA-1" SIZE="5973">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:15:22" MIMETYPE="text/xml" CHECKSUM="8ab2068ac12ac791c4d0f7abec9fae22b04f3e49"
-				CHECKSUMTYPE="SHA-1" SIZE="25754">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:15:22" MIMETYPE="text/xml" CHECKSUM="8ab2068ac12ac791c4d0f7abec9fae22b04f3e49" CHECKSUMTYPE="SHA-1" SIZE="25754">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:15:23" MIMETYPE="text/xml"
-				CHECKSUM="0b5e94a25b411b3f6ae83913acf179a660dd89bb" CHECKSUMTYPE="SHA-1" SIZE="26142">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:15:23" MIMETYPE="text/xml" CHECKSUM="0b5e94a25b411b3f6ae83913acf179a660dd89bb" CHECKSUMTYPE="SHA-1" SIZE="26142">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:15:23" MIMETYPE="text/xml"
-				CHECKSUM="0ef947e8ea7b379eb37c2d4c8349e6c14b7158fd" CHECKSUMTYPE="SHA-1" SIZE="35118">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:15:23" MIMETYPE="text/xml" CHECKSUM="0ef947e8ea7b379eb37c2d4c8349e6c14b7158fd" CHECKSUMTYPE="SHA-1" SIZE="35118">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:15:23" MIMETYPE="text/xml"
-				CHECKSUM="21f8dbf2311a298b0d4b46502912f483e754d6a1" CHECKSUMTYPE="SHA-1" SIZE="24133">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:15:23" MIMETYPE="text/xml" CHECKSUM="21f8dbf2311a298b0d4b46502912f483e754d6a1" CHECKSUMTYPE="SHA-1" SIZE="24133">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:15:23" MIMETYPE="text/xml"
-				CHECKSUM="0cbcf3470c42eda4163bf2a3dd16d7afed1bceb9" CHECKSUMTYPE="SHA-1" SIZE="4417">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:15:23" MIMETYPE="text/xml" CHECKSUM="0cbcf3470c42eda4163bf2a3dd16d7afed1bceb9" CHECKSUMTYPE="SHA-1" SIZE="4417">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:15:24" MIMETYPE="text/xml"
-				CHECKSUM="b8614c4032dacc902772a6f56c493d6a3423daaf" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:15:24" MIMETYPE="text/xml" CHECKSUM="b8614c4032dacc902772a6f56c493d6a3423daaf" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:15:24" MIMETYPE="text/xml"
-				CHECKSUM="2484fccd4b46abcb4d105bcab6967996dc9f7a24" CHECKSUMTYPE="SHA-1" SIZE="58719">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:15:24" MIMETYPE="text/xml" CHECKSUM="2484fccd4b46abcb4d105bcab6967996dc9f7a24" CHECKSUMTYPE="SHA-1" SIZE="58719">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:15:24" MIMETYPE="text/xml"
-				CHECKSUM="7c21d2f7f29a100c768055eeba182605909ab8d6" CHECKSUMTYPE="SHA-1" SIZE="112240">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:15:24" MIMETYPE="text/xml" CHECKSUM="7c21d2f7f29a100c768055eeba182605909ab8d6" CHECKSUMTYPE="SHA-1" SIZE="112240">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:15:24" MIMETYPE="text/xml"
-				CHECKSUM="c9addfe69d0c8ecc0efb65e126af809a988c573a" CHECKSUMTYPE="SHA-1" SIZE="118848">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:15:24" MIMETYPE="text/xml" CHECKSUM="c9addfe69d0c8ecc0efb65e126af809a988c573a" CHECKSUMTYPE="SHA-1" SIZE="118848">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:15:25" MIMETYPE="text/xml"
-				CHECKSUM="0c00e261d3045cdf1c234d25f1cab2b0675e134b" CHECKSUMTYPE="SHA-1" SIZE="117805">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:15:25" MIMETYPE="text/xml" CHECKSUM="0c00e261d3045cdf1c234d25f1cab2b0675e134b" CHECKSUMTYPE="SHA-1" SIZE="117805">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:15:25" MIMETYPE="text/xml"
-				CHECKSUM="5d156da394a8bfc6a3d074ca2990facdda0c423c" CHECKSUMTYPE="SHA-1" SIZE="120560">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:15:25" MIMETYPE="text/xml" CHECKSUM="5d156da394a8bfc6a3d074ca2990facdda0c423c" CHECKSUMTYPE="SHA-1" SIZE="120560">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:15:25" MIMETYPE="text/xml"
-				CHECKSUM="5c35624f4e645465851c8dbb4db1c3d69e224031" CHECKSUMTYPE="SHA-1" SIZE="125537">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:15:25" MIMETYPE="text/xml" CHECKSUM="5c35624f4e645465851c8dbb4db1c3d69e224031" CHECKSUMTYPE="SHA-1" SIZE="125537">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:15:26" MIMETYPE="text/xml"
-				CHECKSUM="c996f75be6fc3b6b8f47e51e538f18061a1d09cc" CHECKSUMTYPE="SHA-1" SIZE="30266">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:15:26" MIMETYPE="text/xml" CHECKSUM="c996f75be6fc3b6b8f47e51e538f18061a1d09cc" CHECKSUMTYPE="SHA-1" SIZE="30266">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:15:26" MIMETYPE="text/xml"
-				CHECKSUM="b1b18706d7d8971125d7ea8458041aa0389dad65" CHECKSUMTYPE="SHA-1" SIZE="35105">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:15:26" MIMETYPE="text/xml" CHECKSUM="b1b18706d7d8971125d7ea8458041aa0389dad65" CHECKSUMTYPE="SHA-1" SIZE="35105">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:15:26" MIMETYPE="text/xml"
-				CHECKSUM="f2b16c3a047a0868c366b7813e558be3b4ff1adf" CHECKSUMTYPE="SHA-1" SIZE="4755">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:15:26" MIMETYPE="text/xml" CHECKSUM="f2b16c3a047a0868c366b7813e558be3b4ff1adf" CHECKSUMTYPE="SHA-1" SIZE="4755">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:15:26" MIMETYPE="text/xml"
-				CHECKSUM="e54c697ff64f8d8c2372341b974fae41a9b23327" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:15:26" MIMETYPE="text/xml" CHECKSUM="e54c697ff64f8d8c2372341b974fae41a9b23327" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:15:27" MIMETYPE="text/xml"
-				CHECKSUM="a572d4caf9a9727bb5a0cb500e7639d24f9f46e0" CHECKSUMTYPE="SHA-1" SIZE="80980">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:15:27" MIMETYPE="text/xml" CHECKSUM="a572d4caf9a9727bb5a0cb500e7639d24f9f46e0" CHECKSUMTYPE="SHA-1" SIZE="80980">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:15:27" MIMETYPE="text/xml"
-				CHECKSUM="079ddd842f988559be19c8767813b2a839b4f6c5" CHECKSUMTYPE="SHA-1" SIZE="196697">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:15:27" MIMETYPE="text/xml" CHECKSUM="079ddd842f988559be19c8767813b2a839b4f6c5" CHECKSUMTYPE="SHA-1" SIZE="196697">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:15:28" MIMETYPE="text/xml"
-				CHECKSUM="26fb08c882b95ffaddde360aa728185d26362812" CHECKSUMTYPE="SHA-1" SIZE="184127">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:15:28" MIMETYPE="text/xml" CHECKSUM="26fb08c882b95ffaddde360aa728185d26362812" CHECKSUMTYPE="SHA-1" SIZE="184127">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:15:28" MIMETYPE="text/xml"
-				CHECKSUM="2b921fd67535ad24c54bf8bf14505cbed936b7a3" CHECKSUMTYPE="SHA-1" SIZE="198583">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:15:28" MIMETYPE="text/xml" CHECKSUM="2b921fd67535ad24c54bf8bf14505cbed936b7a3" CHECKSUMTYPE="SHA-1" SIZE="198583">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:15:28" MIMETYPE="text/xml"
-				CHECKSUM="0bf33aabf3ef3a885f7acac788a032c9db093907" CHECKSUMTYPE="SHA-1" SIZE="194096">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:15:28" MIMETYPE="text/xml" CHECKSUM="0bf33aabf3ef3a885f7acac788a032c9db093907" CHECKSUMTYPE="SHA-1" SIZE="194096">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:15:29" MIMETYPE="text/xml"
-				CHECKSUM="36957c2cbb26663a63156688499dfe234ccf8af8" CHECKSUMTYPE="SHA-1" SIZE="192253">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:15:29" MIMETYPE="text/xml" CHECKSUM="36957c2cbb26663a63156688499dfe234ccf8af8" CHECKSUMTYPE="SHA-1" SIZE="192253">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:15:29" MIMETYPE="text/xml"
-				CHECKSUM="bdb86bc1b656bfeb17224035d6172ea97492de4a" CHECKSUMTYPE="SHA-1" SIZE="185447">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:15:29" MIMETYPE="text/xml" CHECKSUM="bdb86bc1b656bfeb17224035d6172ea97492de4a" CHECKSUMTYPE="SHA-1" SIZE="185447">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:15:29" MIMETYPE="text/xml"
-				CHECKSUM="888c90015ad499f776cda2a27e854b9b071500fa" CHECKSUMTYPE="SHA-1" SIZE="195389">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:15:29" MIMETYPE="text/xml" CHECKSUM="888c90015ad499f776cda2a27e854b9b071500fa" CHECKSUMTYPE="SHA-1" SIZE="195389">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:15:30" MIMETYPE="text/xml"
-				CHECKSUM="ba407e4b46ce57ec76d098869b44e94c812011c6" CHECKSUMTYPE="SHA-1" SIZE="197796">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:15:30" MIMETYPE="text/xml" CHECKSUM="ba407e4b46ce57ec76d098869b44e94c812011c6" CHECKSUMTYPE="SHA-1" SIZE="197796">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:15:30" MIMETYPE="text/xml"
-				CHECKSUM="c1e48a55786d78e002325084d8ecb37f4f2cf604" CHECKSUMTYPE="SHA-1" SIZE="196966">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:15:30" MIMETYPE="text/xml" CHECKSUM="c1e48a55786d78e002325084d8ecb37f4f2cf604" CHECKSUMTYPE="SHA-1" SIZE="196966">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:15:31" MIMETYPE="text/xml"
-				CHECKSUM="97916967c848d7ee1f38590bf57f76c9149dae9c" CHECKSUMTYPE="SHA-1" SIZE="169023">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:15:31" MIMETYPE="text/xml" CHECKSUM="97916967c848d7ee1f38590bf57f76c9149dae9c" CHECKSUMTYPE="SHA-1" SIZE="169023">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:15:31" MIMETYPE="text/xml"
-				CHECKSUM="7d908b6bfb0dc42b4cb441992c3a5ff02c305c77" CHECKSUMTYPE="SHA-1" SIZE="47268">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:15:31" MIMETYPE="text/xml" CHECKSUM="7d908b6bfb0dc42b4cb441992c3a5ff02c305c77" CHECKSUMTYPE="SHA-1" SIZE="47268">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:15:31" MIMETYPE="text/xml"
-				CHECKSUM="9c5c27c586240ccf6eedb703dab57e55abd080da" CHECKSUMTYPE="SHA-1" SIZE="4458">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:15:31" MIMETYPE="text/xml" CHECKSUM="9c5c27c586240ccf6eedb703dab57e55abd080da" CHECKSUMTYPE="SHA-1" SIZE="4458">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:15:31" MIMETYPE="text/xml"
-				CHECKSUM="95eb875f7528425d7088398b2daff36e77308ac3" CHECKSUMTYPE="SHA-1" SIZE="2012">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:15:31" MIMETYPE="text/xml" CHECKSUM="95eb875f7528425d7088398b2daff36e77308ac3" CHECKSUMTYPE="SHA-1" SIZE="2012">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:15:32" MIMETYPE="text/xml"
-				CHECKSUM="62946c0c7f4d812c614ef0295fc4113936175855" CHECKSUMTYPE="SHA-1" SIZE="12164">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:15:32" MIMETYPE="text/xml" CHECKSUM="62946c0c7f4d812c614ef0295fc4113936175855" CHECKSUMTYPE="SHA-1" SIZE="12164">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:15:32" MIMETYPE="text/xml"
-				CHECKSUM="b854c4198bd47674b3c752a50bb4603585be6125" CHECKSUMTYPE="SHA-1" SIZE="15080">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:15:32" MIMETYPE="text/xml" CHECKSUM="b854c4198bd47674b3c752a50bb4603585be6125" CHECKSUMTYPE="SHA-1" SIZE="15080">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:15:32" MIMETYPE="text/xml"
-				CHECKSUM="876f8de1484e0721a71f8955e254c92053d45549" CHECKSUMTYPE="SHA-1" SIZE="4466">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:15:32" MIMETYPE="text/xml" CHECKSUM="876f8de1484e0721a71f8955e254c92053d45549" CHECKSUMTYPE="SHA-1" SIZE="4466">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:15:32" MIMETYPE="text/xml"
-				CHECKSUM="f360e91ecd2cfca7d5a8c61eedeb9d8b7ab82d08" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:15:32" MIMETYPE="text/xml" CHECKSUM="f360e91ecd2cfca7d5a8c61eedeb9d8b7ab82d08" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:15:33" MIMETYPE="text/xml"
-				CHECKSUM="4adbd0046fe98a6795c89728c22ebd3f06b72739" CHECKSUMTYPE="SHA-1" SIZE="48004">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:15:33" MIMETYPE="text/xml" CHECKSUM="4adbd0046fe98a6795c89728c22ebd3f06b72739" CHECKSUMTYPE="SHA-1" SIZE="48004">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:15:33" MIMETYPE="text/xml"
-				CHECKSUM="7f5726b2f1b86c6992805ffcf20a0d48401879f7" CHECKSUMTYPE="SHA-1" SIZE="79952">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:15:33" MIMETYPE="text/xml" CHECKSUM="7f5726b2f1b86c6992805ffcf20a0d48401879f7" CHECKSUMTYPE="SHA-1" SIZE="79952">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:15:33" MIMETYPE="text/xml"
-				CHECKSUM="4e51f99ff039b7977badfccf8a656a2e932bfc49" CHECKSUMTYPE="SHA-1" SIZE="59062">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:15:33" MIMETYPE="text/xml" CHECKSUM="4e51f99ff039b7977badfccf8a656a2e932bfc49" CHECKSUMTYPE="SHA-1" SIZE="59062">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:15:33" MIMETYPE="text/xml"
-				CHECKSUM="a7f61dd0b4be33b606ce190098400d0f9db9c94b" CHECKSUMTYPE="SHA-1" SIZE="13655">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:15:33" MIMETYPE="text/xml" CHECKSUM="a7f61dd0b4be33b606ce190098400d0f9db9c94b" CHECKSUMTYPE="SHA-1" SIZE="13655">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:15:34" MIMETYPE="text/xml"
-				CHECKSUM="a492b7517edc382191a7ba4ebff574951b2be364" CHECKSUMTYPE="SHA-1" SIZE="5148">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:15:34" MIMETYPE="text/xml" CHECKSUM="a492b7517edc382191a7ba4ebff574951b2be364" CHECKSUMTYPE="SHA-1" SIZE="5148">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:15:34" MIMETYPE="text/xml"
-				CHECKSUM="5460d65bd1dfb7cdfa3e20709c854c8853f17369" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:15:34" MIMETYPE="text/xml" CHECKSUM="5460d65bd1dfb7cdfa3e20709c854c8853f17369" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:15:34" MIMETYPE="text/xml"
-				CHECKSUM="da49c7b2e772542ad38d04ac7d0037fbada1423b" CHECKSUMTYPE="SHA-1" SIZE="74242">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:15:34" MIMETYPE="text/xml" CHECKSUM="da49c7b2e772542ad38d04ac7d0037fbada1423b" CHECKSUMTYPE="SHA-1" SIZE="74242">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:15:34" MIMETYPE="text/xml"
-				CHECKSUM="6e7b49604e9c5eae3e041ffc481fe313d87f1fbf" CHECKSUMTYPE="SHA-1" SIZE="194203">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:15:34" MIMETYPE="text/xml" CHECKSUM="6e7b49604e9c5eae3e041ffc481fe313d87f1fbf" CHECKSUMTYPE="SHA-1" SIZE="194203">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:15:35" MIMETYPE="text/xml"
-				CHECKSUM="7ec2468e2190ccd5652541a645a22317369e4885" CHECKSUMTYPE="SHA-1" SIZE="190434">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:15:35" MIMETYPE="text/xml" CHECKSUM="7ec2468e2190ccd5652541a645a22317369e4885" CHECKSUMTYPE="SHA-1" SIZE="190434">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:15:35" MIMETYPE="text/xml"
-				CHECKSUM="0c34509497e9b9968e003d4f842e767709e85a92" CHECKSUMTYPE="SHA-1" SIZE="187316">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:15:35" MIMETYPE="text/xml" CHECKSUM="0c34509497e9b9968e003d4f842e767709e85a92" CHECKSUMTYPE="SHA-1" SIZE="187316">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml"
-				CHECKSUM="e85118867be3c6eaa8dc76a21f6e46f09fcbe1be" CHECKSUMTYPE="SHA-1" SIZE="186770">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml" CHECKSUM="e85118867be3c6eaa8dc76a21f6e46f09fcbe1be" CHECKSUMTYPE="SHA-1" SIZE="186770">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml"
-				CHECKSUM="d52ba42309e2df27e3d917f4599719100c14fe57" CHECKSUMTYPE="SHA-1" SIZE="126900">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml" CHECKSUM="d52ba42309e2df27e3d917f4599719100c14fe57" CHECKSUMTYPE="SHA-1" SIZE="126900">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml"
-				CHECKSUM="0b680e401be13f0095b1d6b91d1f0a026ae12c99" CHECKSUMTYPE="SHA-1" SIZE="4586">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml" CHECKSUM="0b680e401be13f0095b1d6b91d1f0a026ae12c99" CHECKSUMTYPE="SHA-1" SIZE="4586">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml"
-				CHECKSUM="e049d0b356e86c5a50c9393496ebd594e5dcfd08" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="e049d0b356e86c5a50c9393496ebd594e5dcfd08" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml"
-				CHECKSUM="292728728ba0f02eba266f9a40e2a743a06ececd" CHECKSUMTYPE="SHA-1" SIZE="47433">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="292728728ba0f02eba266f9a40e2a743a06ececd" CHECKSUMTYPE="SHA-1" SIZE="47433">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml"
-				CHECKSUM="032563afc2781588ccee8baba61df16541fad801" CHECKSUMTYPE="SHA-1" SIZE="22408">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="032563afc2781588ccee8baba61df16541fad801" CHECKSUMTYPE="SHA-1" SIZE="22408">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml"
-				CHECKSUM="c9be350b1de6559f8b6a25e0e6d032111590177f" CHECKSUMTYPE="SHA-1" SIZE="51580">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="c9be350b1de6559f8b6a25e0e6d032111590177f" CHECKSUMTYPE="SHA-1" SIZE="51580">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml"
-				CHECKSUM="fc11ae2becac5a5abd3a9cb929c88395451cc7c3" CHECKSUMTYPE="SHA-1" SIZE="74672">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml" CHECKSUM="fc11ae2becac5a5abd3a9cb929c88395451cc7c3" CHECKSUMTYPE="SHA-1" SIZE="74672">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml"
-				CHECKSUM="bb766814d873948a4c14320f163be6e13b1c2250" CHECKSUMTYPE="SHA-1" SIZE="4518">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml" CHECKSUM="bb766814d873948a4c14320f163be6e13b1c2250" CHECKSUMTYPE="SHA-1" SIZE="4518">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml"
-				CHECKSUM="8f72e3add63d1e59ce9334f6d5dec6b06d66675f" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml" CHECKSUM="8f72e3add63d1e59ce9334f6d5dec6b06d66675f" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml"
-				CHECKSUM="a3efd43d188912b5e9a5ccf845cb99bd14d56405" CHECKSUMTYPE="SHA-1" SIZE="21328">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml" CHECKSUM="a3efd43d188912b5e9a5ccf845cb99bd14d56405" CHECKSUMTYPE="SHA-1" SIZE="21328">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml"
-				CHECKSUM="2f51ea91a93dcc1b58fdf481192386fb2843a247" CHECKSUMTYPE="SHA-1" SIZE="11831">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml" CHECKSUM="2f51ea91a93dcc1b58fdf481192386fb2843a247" CHECKSUMTYPE="SHA-1" SIZE="11831">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml"
-				CHECKSUM="d09d96fafecb2c76fe31991d4a2d2471bdd44d45" CHECKSUMTYPE="SHA-1" SIZE="4749">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml" CHECKSUM="d09d96fafecb2c76fe31991d4a2d2471bdd44d45" CHECKSUMTYPE="SHA-1" SIZE="4749">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml"
-				CHECKSUM="a548c3a6f755f852471be331b22a551ca595363c" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml" CHECKSUM="a548c3a6f755f852471be331b22a551ca595363c" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml"
-				CHECKSUM="5696dddc4020b3ec6e08e505846bffae6fd94831" CHECKSUMTYPE="SHA-1" SIZE="66398">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml" CHECKSUM="5696dddc4020b3ec6e08e505846bffae6fd94831" CHECKSUMTYPE="SHA-1" SIZE="66398">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml"
-				CHECKSUM="34c39e694d18a47e44b9504f06aa39ba7507e40b" CHECKSUMTYPE="SHA-1" SIZE="110980">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml" CHECKSUM="34c39e694d18a47e44b9504f06aa39ba7507e40b" CHECKSUMTYPE="SHA-1" SIZE="110980">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml"
-				CHECKSUM="f0cf5fc7e7c2499803eb82a76de8461a3fb0aaef" CHECKSUMTYPE="SHA-1" SIZE="86959">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml" CHECKSUM="f0cf5fc7e7c2499803eb82a76de8461a3fb0aaef" CHECKSUMTYPE="SHA-1" SIZE="86959">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml"
-				CHECKSUM="b6861ce1c857a3df12ecf921db7be806f0679b9a" CHECKSUMTYPE="SHA-1" SIZE="90063">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml" CHECKSUM="b6861ce1c857a3df12ecf921db7be806f0679b9a" CHECKSUMTYPE="SHA-1" SIZE="90063">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml"
-				CHECKSUM="361dba0df0eb35cdb1546d7c6d7088114fbc54f7" CHECKSUMTYPE="SHA-1" SIZE="81643">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml" CHECKSUM="361dba0df0eb35cdb1546d7c6d7088114fbc54f7" CHECKSUMTYPE="SHA-1" SIZE="81643">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml"
-				CHECKSUM="0f86e4a98da906c72dd9902a148901665d822f4b" CHECKSUMTYPE="SHA-1" SIZE="105190">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml" CHECKSUM="0f86e4a98da906c72dd9902a148901665d822f4b" CHECKSUMTYPE="SHA-1" SIZE="105190">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:15:42" MIMETYPE="text/xml"
-				CHECKSUM="17accea5b47903864dedad7977f03acc2f0668f2" CHECKSUMTYPE="SHA-1" SIZE="100198">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:15:42" MIMETYPE="text/xml" CHECKSUM="17accea5b47903864dedad7977f03acc2f0668f2" CHECKSUMTYPE="SHA-1" SIZE="100198">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:15:42" MIMETYPE="text/xml"
-				CHECKSUM="64f55d4c05b4fa8b3f7c1c6fd700fc82e3b80f1b" CHECKSUMTYPE="SHA-1" SIZE="95691">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:15:42" MIMETYPE="text/xml" CHECKSUM="64f55d4c05b4fa8b3f7c1c6fd700fc82e3b80f1b" CHECKSUMTYPE="SHA-1" SIZE="95691">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:15:42" MIMETYPE="text/xml"
-				CHECKSUM="efaf7c5e78050b6bdad3754b5413145de7c3fd9e" CHECKSUMTYPE="SHA-1" SIZE="93078">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:15:42" MIMETYPE="text/xml" CHECKSUM="efaf7c5e78050b6bdad3754b5413145de7c3fd9e" CHECKSUMTYPE="SHA-1" SIZE="93078">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml"
-				CHECKSUM="d40257651de9e025344fc8d5bdc7b0826c4d7b9b" CHECKSUMTYPE="SHA-1" SIZE="70000">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml" CHECKSUM="d40257651de9e025344fc8d5bdc7b0826c4d7b9b" CHECKSUMTYPE="SHA-1" SIZE="70000">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml"
-				CHECKSUM="4c9918755a01f8b573d6804a0bd148c8607cafa7" CHECKSUMTYPE="SHA-1" SIZE="4647">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml" CHECKSUM="4c9918755a01f8b573d6804a0bd148c8607cafa7" CHECKSUMTYPE="SHA-1" SIZE="4647">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml"
-				CHECKSUM="50d11c6ce06bd2c0b1ebcb5305e44d2be762c1a0" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml" CHECKSUM="50d11c6ce06bd2c0b1ebcb5305e44d2be762c1a0" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:15:44" MIMETYPE="text/xml"
-				CHECKSUM="6ad003f1871cee4a754384e4c7487ac29cc4c67a" CHECKSUMTYPE="SHA-1" SIZE="91889">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:15:44" MIMETYPE="text/xml" CHECKSUM="6ad003f1871cee4a754384e4c7487ac29cc4c67a" CHECKSUMTYPE="SHA-1" SIZE="91889">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:15:44" MIMETYPE="text/xml"
-				CHECKSUM="c8a628ef10e733b48f4dacd726a4c267abe5bc16" CHECKSUMTYPE="SHA-1" SIZE="196561">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:15:44" MIMETYPE="text/xml" CHECKSUM="c8a628ef10e733b48f4dacd726a4c267abe5bc16" CHECKSUMTYPE="SHA-1" SIZE="196561">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml"
-				CHECKSUM="606e25febbb4f371dd93c561390c852d043c32e4" CHECKSUMTYPE="SHA-1" SIZE="159086">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml" CHECKSUM="606e25febbb4f371dd93c561390c852d043c32e4" CHECKSUMTYPE="SHA-1" SIZE="159086">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml"
-				CHECKSUM="e57115a0735408177a42b14dd8e29e4a3889cb45" CHECKSUMTYPE="SHA-1" SIZE="61180">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml" CHECKSUM="e57115a0735408177a42b14dd8e29e4a3889cb45" CHECKSUMTYPE="SHA-1" SIZE="61180">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml"
-				CHECKSUM="8bc6c002ee50091d7fcc871fe3f7d96d1af4d1f2" CHECKSUMTYPE="SHA-1" SIZE="133340">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml" CHECKSUM="8bc6c002ee50091d7fcc871fe3f7d96d1af4d1f2" CHECKSUMTYPE="SHA-1" SIZE="133340">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:15:46" MIMETYPE="text/xml"
-				CHECKSUM="5587fbbac2c99dcb59dbcadfa59fdb5dc1b977de" CHECKSUMTYPE="SHA-1" SIZE="136228">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:15:46" MIMETYPE="text/xml" CHECKSUM="5587fbbac2c99dcb59dbcadfa59fdb5dc1b977de" CHECKSUMTYPE="SHA-1" SIZE="136228">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:15:46" MIMETYPE="text/xml"
-				CHECKSUM="750d7b89ab0aaec51456c76d5f5e82a9695e09a2" CHECKSUMTYPE="SHA-1" SIZE="137090">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:15:46" MIMETYPE="text/xml" CHECKSUM="750d7b89ab0aaec51456c76d5f5e82a9695e09a2" CHECKSUMTYPE="SHA-1" SIZE="137090">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:15:46" MIMETYPE="text/xml"
-				CHECKSUM="869720d850e9e1b583a7e812eb3a883435296eff" CHECKSUMTYPE="SHA-1" SIZE="31286">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:15:46" MIMETYPE="text/xml" CHECKSUM="869720d850e9e1b583a7e812eb3a883435296eff" CHECKSUMTYPE="SHA-1" SIZE="31286">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:15:47" MIMETYPE="text/xml"
-				CHECKSUM="e2230b87e9ed2b6107abd2d0cc3263faeaaaba25" CHECKSUMTYPE="SHA-1" SIZE="4573">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:15:47" MIMETYPE="text/xml" CHECKSUM="e2230b87e9ed2b6107abd2d0cc3263faeaaaba25" CHECKSUMTYPE="SHA-1" SIZE="4573">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:15:47" MIMETYPE="text/xml"
-				CHECKSUM="60cbaf870c3a5b4607ea23a3b8e67eedcbea7ffa" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:15:47" MIMETYPE="text/xml" CHECKSUM="60cbaf870c3a5b4607ea23a3b8e67eedcbea7ffa" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:15:47" MIMETYPE="text/xml"
-				CHECKSUM="76081abbd8eb94f7cf8067518486b94ed5cf0704" CHECKSUMTYPE="SHA-1" SIZE="98250">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:15:47" MIMETYPE="text/xml" CHECKSUM="76081abbd8eb94f7cf8067518486b94ed5cf0704" CHECKSUMTYPE="SHA-1" SIZE="98250">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml"
-				CHECKSUM="ee5b544bdcb52468f448f14dd3a07b79ce7bec80" CHECKSUMTYPE="SHA-1" SIZE="180844">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml" CHECKSUM="ee5b544bdcb52468f448f14dd3a07b79ce7bec80" CHECKSUMTYPE="SHA-1" SIZE="180844">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml"
-				CHECKSUM="64ed653e3c9deed44f879a0e72d397c86e8b2862" CHECKSUMTYPE="SHA-1" SIZE="5442">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml" CHECKSUM="64ed653e3c9deed44f879a0e72d397c86e8b2862" CHECKSUMTYPE="SHA-1" SIZE="5442">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml"
-				CHECKSUM="8a4431ec7390d04bb474aba2e9c70bd80744c956" CHECKSUMTYPE="SHA-1" SIZE="2018">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml" CHECKSUM="8a4431ec7390d04bb474aba2e9c70bd80744c956" CHECKSUMTYPE="SHA-1" SIZE="2018">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml"
-				CHECKSUM="5f2bad7d542c7308ab74eaeff041c2850b2b5215" CHECKSUMTYPE="SHA-1" SIZE="78137">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml" CHECKSUM="5f2bad7d542c7308ab74eaeff041c2850b2b5215" CHECKSUMTYPE="SHA-1" SIZE="78137">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T18:15:49" MIMETYPE="text/xml"
-				CHECKSUM="be9ce50d3653cd7e8f74df6e5e19ca2e7be45f79" CHECKSUMTYPE="SHA-1" SIZE="194266">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T18:15:49" MIMETYPE="text/xml" CHECKSUM="be9ce50d3653cd7e8f74df6e5e19ca2e7be45f79" CHECKSUMTYPE="SHA-1" SIZE="194266">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0094.alto.xml"/>
 			</file>
-			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T18:15:49" MIMETYPE="text/xml"
-				CHECKSUM="8f5c7d6b18317f46d98d1ccad7b1d57e8fca4486" CHECKSUMTYPE="SHA-1" SIZE="91851">
+			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T18:15:49" MIMETYPE="text/xml" CHECKSUM="8f5c7d6b18317f46d98d1ccad7b1d57e8fca4486" CHECKSUMTYPE="SHA-1" SIZE="91851">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0095.alto.xml"/>
 			</file>
-			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml"
-				CHECKSUM="9f7b9767347f4b1f1b945f4b10a5ebeaf028e08d" CHECKSUMTYPE="SHA-1" SIZE="198348">
+			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml" CHECKSUM="9f7b9767347f4b1f1b945f4b10a5ebeaf028e08d" CHECKSUMTYPE="SHA-1" SIZE="198348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0096.alto.xml"/>
 			</file>
-			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml"
-				CHECKSUM="d77249a12dc3697e9878d1306e884c18214a9228" CHECKSUMTYPE="SHA-1" SIZE="40153">
+			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml" CHECKSUM="d77249a12dc3697e9878d1306e884c18214a9228" CHECKSUMTYPE="SHA-1" SIZE="40153">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0097.alto.xml"/>
 			</file>
-			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml"
-				CHECKSUM="7af9552f73efa9faafb2c4b06a60035c9f7beb25" CHECKSUMTYPE="SHA-1" SIZE="68966">
+			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml" CHECKSUM="7af9552f73efa9faafb2c4b06a60035c9f7beb25" CHECKSUMTYPE="SHA-1" SIZE="68966">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0098.alto.xml"/>
 			</file>
-			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml"
-				CHECKSUM="511ffaddd7b51b343e10e25ef0b1a33cc05ba855" CHECKSUMTYPE="SHA-1" SIZE="166526">
+			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml" CHECKSUM="511ffaddd7b51b343e10e25ef0b1a33cc05ba855" CHECKSUMTYPE="SHA-1" SIZE="166526">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0099.alto.xml"/>
 			</file>
-			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml"
-				CHECKSUM="9d6c2f701e64b7df5d2b0d9e50ed3c923751a031" CHECKSUMTYPE="SHA-1" SIZE="171987">
+			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml" CHECKSUM="9d6c2f701e64b7df5d2b0d9e50ed3c923751a031" CHECKSUMTYPE="SHA-1" SIZE="171987">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0100.alto.xml"/>
 			</file>
-			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T18:15:52" MIMETYPE="text/xml"
-				CHECKSUM="f5cf8f612a11c796dc86c3a77106c42f1f0e9479" CHECKSUMTYPE="SHA-1" SIZE="185219">
+			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T18:15:52" MIMETYPE="text/xml" CHECKSUM="f5cf8f612a11c796dc86c3a77106c42f1f0e9479" CHECKSUMTYPE="SHA-1" SIZE="185219">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0101.alto.xml"/>
 			</file>
-			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T18:15:52" MIMETYPE="text/xml"
-				CHECKSUM="a23a8f2f7b3472ced76ddf1e121755480dab4db2" CHECKSUMTYPE="SHA-1" SIZE="129652">
+			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T18:15:52" MIMETYPE="text/xml" CHECKSUM="a23a8f2f7b3472ced76ddf1e121755480dab4db2" CHECKSUMTYPE="SHA-1" SIZE="129652">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0102.alto.xml"/>
 			</file>
-			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml"
-				CHECKSUM="55939bec352899bea56361a0277d65cd4597ed58" CHECKSUMTYPE="SHA-1" SIZE="4580">
+			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml" CHECKSUM="55939bec352899bea56361a0277d65cd4597ed58" CHECKSUMTYPE="SHA-1" SIZE="4580">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0103.alto.xml"/>
 			</file>
-			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml"
-				CHECKSUM="bd68e859a79f23ebfbc18d9da7b2b46e4e7a4f97" CHECKSUMTYPE="SHA-1" SIZE="2023">
+			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml" CHECKSUM="bd68e859a79f23ebfbc18d9da7b2b46e4e7a4f97" CHECKSUMTYPE="SHA-1" SIZE="2023">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0104.alto.xml"/>
 			</file>
-			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml"
-				CHECKSUM="cabf657688199b1b1e6b6e30ac1ee9f7da48114d" CHECKSUMTYPE="SHA-1" SIZE="117585">
+			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml" CHECKSUM="cabf657688199b1b1e6b6e30ac1ee9f7da48114d" CHECKSUMTYPE="SHA-1" SIZE="117585">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0105.alto.xml"/>
 			</file>
-			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml"
-				CHECKSUM="63b0b158e7fee68390e2fcaa3215d4b33538c0fb" CHECKSUMTYPE="SHA-1" SIZE="181708">
+			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml" CHECKSUM="63b0b158e7fee68390e2fcaa3215d4b33538c0fb" CHECKSUMTYPE="SHA-1" SIZE="181708">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0106.alto.xml"/>
 			</file>
-			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T18:15:54" MIMETYPE="text/xml"
-				CHECKSUM="5ae89786feff0d15fa9faa8557329b3556982065" CHECKSUMTYPE="SHA-1" SIZE="185748">
+			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T18:15:54" MIMETYPE="text/xml" CHECKSUM="5ae89786feff0d15fa9faa8557329b3556982065" CHECKSUMTYPE="SHA-1" SIZE="185748">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0107.alto.xml"/>
 			</file>
-			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T18:15:54" MIMETYPE="text/xml"
-				CHECKSUM="1dbe1c29f470103239d4338be74421ae02158c72" CHECKSUMTYPE="SHA-1" SIZE="161669">
+			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T18:15:54" MIMETYPE="text/xml" CHECKSUM="1dbe1c29f470103239d4338be74421ae02158c72" CHECKSUMTYPE="SHA-1" SIZE="161669">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0108.alto.xml"/>
 			</file>
-			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml"
-				CHECKSUM="bbe1f02909f1f034164e2f4e1f6827e5141928ad" CHECKSUMTYPE="SHA-1" SIZE="4702">
+			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml" CHECKSUM="bbe1f02909f1f034164e2f4e1f6827e5141928ad" CHECKSUMTYPE="SHA-1" SIZE="4702">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0109.alto.xml"/>
 			</file>
-			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml"
-				CHECKSUM="1711a3a9ae9c5999f78504bcbd1ee75280ece768" CHECKSUMTYPE="SHA-1" SIZE="2020">
+			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml" CHECKSUM="1711a3a9ae9c5999f78504bcbd1ee75280ece768" CHECKSUMTYPE="SHA-1" SIZE="2020">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0110.alto.xml"/>
 			</file>
-			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml"
-				CHECKSUM="c2554b8a4d775731da41d4809befd08282984cf4" CHECKSUMTYPE="SHA-1" SIZE="36377">
+			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml" CHECKSUM="c2554b8a4d775731da41d4809befd08282984cf4" CHECKSUMTYPE="SHA-1" SIZE="36377">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0111.alto.xml"/>
 			</file>
-			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml"
-				CHECKSUM="38bc2559ad3052ae17ef5362c7d27fdbcd697061" CHECKSUMTYPE="SHA-1" SIZE="78224">
+			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml" CHECKSUM="38bc2559ad3052ae17ef5362c7d27fdbcd697061" CHECKSUMTYPE="SHA-1" SIZE="78224">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0112.alto.xml"/>
 			</file>
-			<file ID="ALTO00113" GROUPID="page113" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml"
-				CHECKSUM="2e26cf518ba1a5fe7020c7ad884570f13424d89b" CHECKSUMTYPE="SHA-1" SIZE="72472">
+			<file ID="ALTO00113" GROUPID="page113" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml" CHECKSUM="2e26cf518ba1a5fe7020c7ad884570f13424d89b" CHECKSUMTYPE="SHA-1" SIZE="72472">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0113.alto.xml"/>
 			</file>
-			<file ID="ALTO00114" GROUPID="page114" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml"
-				CHECKSUM="817077ab0e098d1027f3ecef88a78be7de091fde" CHECKSUMTYPE="SHA-1" SIZE="66100">
+			<file ID="ALTO00114" GROUPID="page114" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml" CHECKSUM="817077ab0e098d1027f3ecef88a78be7de091fde" CHECKSUMTYPE="SHA-1" SIZE="66100">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0114.alto.xml"/>
 			</file>
-			<file ID="ALTO00115" GROUPID="page115" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml"
-				CHECKSUM="878adfe5cb88ee5d287bd88c84626b06a11e5baf" CHECKSUMTYPE="SHA-1" SIZE="77085">
+			<file ID="ALTO00115" GROUPID="page115" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml" CHECKSUM="878adfe5cb88ee5d287bd88c84626b06a11e5baf" CHECKSUMTYPE="SHA-1" SIZE="77085">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0115.alto.xml"/>
 			</file>
-			<file ID="ALTO00116" GROUPID="page116" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml"
-				CHECKSUM="c0018abd224e5a8478e19ac8084d722c2608ee6a" CHECKSUMTYPE="SHA-1" SIZE="80959">
+			<file ID="ALTO00116" GROUPID="page116" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml" CHECKSUM="c0018abd224e5a8478e19ac8084d722c2608ee6a" CHECKSUMTYPE="SHA-1" SIZE="80959">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0116.alto.xml"/>
 			</file>
-			<file ID="ALTO00117" GROUPID="page117" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml"
-				CHECKSUM="de222b8a5c435c8c30904c220f8141c681c55842" CHECKSUMTYPE="SHA-1" SIZE="65645">
+			<file ID="ALTO00117" GROUPID="page117" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml" CHECKSUM="de222b8a5c435c8c30904c220f8141c681c55842" CHECKSUMTYPE="SHA-1" SIZE="65645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0117.alto.xml"/>
 			</file>
-			<file ID="ALTO00118" GROUPID="page118" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml"
-				CHECKSUM="aa30005c5686d3484ca34507c9e899fbfbd070f9" CHECKSUMTYPE="SHA-1" SIZE="20680">
+			<file ID="ALTO00118" GROUPID="page118" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml" CHECKSUM="aa30005c5686d3484ca34507c9e899fbfbd070f9" CHECKSUMTYPE="SHA-1" SIZE="20680">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0118.alto.xml"/>
 			</file>
-			<file ID="ALTO00119" GROUPID="page119" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml"
-				CHECKSUM="bdfda465afb6a59944560eec3b0560f3470958ae" CHECKSUMTYPE="SHA-1" SIZE="54457">
+			<file ID="ALTO00119" GROUPID="page119" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml" CHECKSUM="bdfda465afb6a59944560eec3b0560f3470958ae" CHECKSUMTYPE="SHA-1" SIZE="54457">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0119.alto.xml"/>
 			</file>
-			<file ID="ALTO00120" GROUPID="page120" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml"
-				CHECKSUM="56264e7e1c1d219311c92b420f8efd8ba7f221b6" CHECKSUMTYPE="SHA-1" SIZE="35587">
+			<file ID="ALTO00120" GROUPID="page120" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml" CHECKSUM="56264e7e1c1d219311c92b420f8efd8ba7f221b6" CHECKSUMTYPE="SHA-1" SIZE="35587">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0120.alto.xml"/>
 			</file>
-			<file ID="ALTO00121" GROUPID="page121" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml"
-				CHECKSUM="e895891da423a3598a9cf794601107a27340786c" CHECKSUMTYPE="SHA-1" SIZE="27186">
+			<file ID="ALTO00121" GROUPID="page121" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml" CHECKSUM="e895891da423a3598a9cf794601107a27340786c" CHECKSUMTYPE="SHA-1" SIZE="27186">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0121.alto.xml"/>
 			</file>
-			<file ID="ALTO00122" GROUPID="page122" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml"
-				CHECKSUM="53d8b8f4751d69d3ac66ce0156b40bfca148c138" CHECKSUMTYPE="SHA-1" SIZE="52722">
+			<file ID="ALTO00122" GROUPID="page122" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml" CHECKSUM="53d8b8f4751d69d3ac66ce0156b40bfca148c138" CHECKSUMTYPE="SHA-1" SIZE="52722">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0122.alto.xml"/>
 			</file>
-			<file ID="ALTO00123" GROUPID="page123" CREATED="2015-07-30T18:15:59" MIMETYPE="text/xml"
-				CHECKSUM="12ca71008af83acd3b6f30d49be583d5e77afefc" CHECKSUMTYPE="SHA-1" SIZE="2012">
+			<file ID="ALTO00123" GROUPID="page123" CREATED="2015-07-30T18:15:59" MIMETYPE="text/xml" CHECKSUM="12ca71008af83acd3b6f30d49be583d5e77afefc" CHECKSUMTYPE="SHA-1" SIZE="2012">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0123.alto.xml"/>
 			</file>
-			<file ID="ALTO00124" GROUPID="page124" CREATED="2015-07-30T18:15:59" MIMETYPE="text/xml"
-				CHECKSUM="fdce8a1149265961120fcf23cb3d7b89036e6c68" CHECKSUMTYPE="SHA-1" SIZE="2613">
+			<file ID="ALTO00124" GROUPID="page124" CREATED="2015-07-30T18:15:59" MIMETYPE="text/xml" CHECKSUM="fdce8a1149265961120fcf23cb3d7b89036e6c68" CHECKSUMTYPE="SHA-1" SIZE="2613">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1896-11_01_0124.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:21:08" MIMETYPE="application/pdf" CHECKSUM="d8141edb76ec67ef5016034d307bf10c7b0ff94f"
-				CHECKSUMTYPE="SHA-1" SIZE="82830277">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/bmtnabe_1896-11_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:21:08" MIMETYPE="application/pdf" CHECKSUM="d8141edb76ec67ef5016034d307bf10c7b0ff94f" CHECKSUMTYPE="SHA-1" SIZE="82830277">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1896/11_01/bmtnabe_1896-11_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>

--- a/metadata/periodicals/bmtnabe/issues/1897/04_01/bmtnabe_1897-04_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1897/04_01/bmtnabe_1897-04_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1897-04_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1897-04_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-04_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-04_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1897-04_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1897-04_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-04_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -11002,1094 +10998,732 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:15:03" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="b488e1cdf26ec93556304ab819ceadca744ca070" CHECKSUMTYPE="SHA-1" SIZE="5346128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:15:34" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="b50e3bf67eb13940333658d49101fb34c0a107c7" CHECKSUMTYPE="SHA-1" SIZE="5177648">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:16:05" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="0a5e815b2f207611801360ad3e32d7b00f7cc6a6" CHECKSUMTYPE="SHA-1" SIZE="5257025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:16:32" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="a2fd5c63d482368ccf41b6259a8c8cba2e3b49fe" CHECKSUMTYPE="SHA-1" SIZE="5177700">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:17:01" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="9a18a19e20f4388ff54b3f1a17aa78f7e9f442fa" CHECKSUMTYPE="SHA-1" SIZE="5257021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:17:27" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="3e89d7cdb404e07ac7cf817eb30005e7c086ec0f" CHECKSUMTYPE="SHA-1" SIZE="5177828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:17:54" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="49dc9dbfe86bb057b74d464a41fa4abe5d18e052" CHECKSUMTYPE="SHA-1" SIZE="5257029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:18:21" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="6c5cf6fe954a22d46f16ed324a1f4c85bed0b317" CHECKSUMTYPE="SHA-1" SIZE="5177824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:18:47" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="d06348a651ffa34de179b07ff8eaf1b901404edd" CHECKSUMTYPE="SHA-1" SIZE="5256975">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:19:14" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="781caae1f169158008c0a4c498b6f28c98b0de85" CHECKSUMTYPE="SHA-1" SIZE="5177819">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:19:42" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="4572a24284aff2be1ac8614ea6cba89ab62504db" CHECKSUMTYPE="SHA-1" SIZE="5257027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:20:12" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="2354b02f03163991e21f48039f668f65469459c7" CHECKSUMTYPE="SHA-1" SIZE="5177825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:20:38" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="e6865e54e37368ff6bb99790a6741765a6bb114b" CHECKSUMTYPE="SHA-1" SIZE="5257025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:21:07" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="498bbf1b3dd33cff7c491f9f423df52f31280936" CHECKSUMTYPE="SHA-1" SIZE="5177829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:21:35" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="e95c06392c5f9be2c2babb37d08dfa1af4123ede" CHECKSUMTYPE="SHA-1" SIZE="5257014">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:22:03" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="e58d75b44bed9aa7526cb69ef7eadcf7711460b8" CHECKSUMTYPE="SHA-1" SIZE="5177826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:22:34" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="dc971751c93ea7825ab90c7ff94f8872a59dc9c0" CHECKSUMTYPE="SHA-1" SIZE="5257026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:23:03" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="abc6f594492e036e8f4ed531292b9083423bfa55" CHECKSUMTYPE="SHA-1" SIZE="5177827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:23:30" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="27d4f048ff7aadcd8b7fa6cfda0c860493fc0301" CHECKSUMTYPE="SHA-1" SIZE="5257029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:23:58" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="361f55ca14be4b601e2c5670c8ffaf3bc5ad9d5b" CHECKSUMTYPE="SHA-1" SIZE="5166976">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:24:24" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="f63b007690df1d7c887e654bee8fb9a8f99ad8b8" CHECKSUMTYPE="SHA-1" SIZE="5257026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:24:50" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="3bb45297363a31782f2493e40a83303fb5efe759" CHECKSUMTYPE="SHA-1" SIZE="5177825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:25:19" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="27b72e5944335be0eb317aab7a34307af0dbdc35" CHECKSUMTYPE="SHA-1" SIZE="5230907">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:25:50" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="e326f07ca3061bf27291887a4b36e30c70f5a42d" CHECKSUMTYPE="SHA-1" SIZE="5145427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:26:18" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="942c4c203e757952eb4207fdbc8606bb74de76a9" CHECKSUMTYPE="SHA-1" SIZE="5253428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:26:48" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="06f237e545e0eaab32176ff232ea6378e265cbff" CHECKSUMTYPE="SHA-1" SIZE="5239858">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:27:22" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="bbc4cd38158f73521518ce4ae71ffdd763bc088f" CHECKSUMTYPE="SHA-1" SIZE="5253429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:27:50" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="b4fe131db7b8a236ef7d4406afc0047bed5b7c9c" CHECKSUMTYPE="SHA-1" SIZE="5145419">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:28:18" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="15e074d9d56357d8c935f6a82ace6368dd970096" CHECKSUMTYPE="SHA-1" SIZE="5253412">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:28:45" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="3d853c90be6606627b523101745f2388ec104722" CHECKSUMTYPE="SHA-1" SIZE="5145418">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:29:16" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="c4cef3ef76bd7c6e48c9deae2fde75283fd339c1" CHECKSUMTYPE="SHA-1" SIZE="5253427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:29:47" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="7a74337578d7657dbb835557ccd338023b7118c8" CHECKSUMTYPE="SHA-1" SIZE="5145383">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:30:18" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="262c33bad46f1e5db68c20b7a3df5d1ecfd93eb2" CHECKSUMTYPE="SHA-1" SIZE="5253401">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:30:49" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="7d330ddb5c2d5fd6646dff7743ac1741ae488259" CHECKSUMTYPE="SHA-1" SIZE="5145425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:31:17" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="75d138fa80bd857db22deb872d0df67a87dc5a75" CHECKSUMTYPE="SHA-1" SIZE="5253394">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:31:45" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="2608ea274ffd7cf37c4be5d238d31ce6c1ed2e0f" CHECKSUMTYPE="SHA-1" SIZE="5145390">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:32:13" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="a783b671e708581e05b060cb9ce7844b87ddd4e7" CHECKSUMTYPE="SHA-1" SIZE="5253404">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:32:44" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="aba39aab94622dbe9d17854dc55d44112d296f2e" CHECKSUMTYPE="SHA-1" SIZE="5145423">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:33:10" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="d6a4725c4f1d1b1ba83369b8a61863e094ccf8c2" CHECKSUMTYPE="SHA-1" SIZE="5253419">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:33:39" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="a3be68f103d6c991c8b5fe3674864012471ff777" CHECKSUMTYPE="SHA-1" SIZE="5145421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:34:05" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="dd7d006ab2b8d89791d167b5803f9210bb627411" CHECKSUMTYPE="SHA-1" SIZE="5253416">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:34:33" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="2f976462c60b272e224646a7208ed9921ae2deef" CHECKSUMTYPE="SHA-1" SIZE="5145406">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:35:00" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="0127012df7b07ccf9159faf5c449db9dcb16fb7a" CHECKSUMTYPE="SHA-1" SIZE="5253429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:35:31" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="8565df91637e4bbc1b15f9ab01236565c87998e6" CHECKSUMTYPE="SHA-1" SIZE="5145427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:36:01" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="e5cb25d544a844f154f7902ffbed2217aab42cfa" CHECKSUMTYPE="SHA-1" SIZE="5253428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:36:30" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="936f1bd804cbd127a49623f539a977c5e49156e6" CHECKSUMTYPE="SHA-1" SIZE="5145427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:36:58" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="4bab5d386629e25bb606018c6724418ffc07f606" CHECKSUMTYPE="SHA-1" SIZE="5222808">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:37:30" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="88e55204372ec216369c4b479241f36c5f8bfbf0" CHECKSUMTYPE="SHA-1" SIZE="5145404">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:38:00" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="166b20960d78f25bf8c6d2501da7f2f252cb4b40" CHECKSUMTYPE="SHA-1" SIZE="5222823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:38:29" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="365ea109d8343cd2a7e46c5581398d1286a7efd0" CHECKSUMTYPE="SHA-1" SIZE="5145429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:38:57" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="a917e5de3bdba67ac65cf2fe8fd374ddf28283e5" CHECKSUMTYPE="SHA-1" SIZE="5222814">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:39:25" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="0a819fd53298948bcb5968ed822f785d1e6da378" CHECKSUMTYPE="SHA-1" SIZE="5124697">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:39:53" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="b780e4ef3de0c92d2a6cffbad11e00ac061aa401" CHECKSUMTYPE="SHA-1" SIZE="5222722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:40:21" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="88cd9b839cb0b75bc6c4e03cd0ef55b3491964c8" CHECKSUMTYPE="SHA-1" SIZE="5124726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:40:51" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="57dea87677b08239108b7b9a9d1d29e44491b7ef" CHECKSUMTYPE="SHA-1" SIZE="5200321">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:41:19" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="19dda2c2733869805b09c9f09b2c3c844d638695" CHECKSUMTYPE="SHA-1" SIZE="5124693">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:41:50" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="f9d76814e76aba78cfe4bd97e86c2fdbc681659e" CHECKSUMTYPE="SHA-1" SIZE="5200314">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:42:20" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="b0c4adaf2fe4351b437c6c39447af62d413512c8" CHECKSUMTYPE="SHA-1" SIZE="5124725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T17:42:48" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="3eeabcefeaea012157be62c47cafe05fbf485432" CHECKSUMTYPE="SHA-1" SIZE="5179595">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T17:43:15" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="9674e026b65d5868b4bc68614d2cd7cc4e741ff0" CHECKSUMTYPE="SHA-1" SIZE="5124725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T17:43:43" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="be7594c9216db3c4d543b59d2702afe915a0ce00" CHECKSUMTYPE="SHA-1" SIZE="5179602">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T17:44:14" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="113f4c07e7bb6bc5178a9dc26ee4fca20e980696" CHECKSUMTYPE="SHA-1" SIZE="5094124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T17:44:42" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="12d11da67542563e2552d4c1fa79912993fccf92" CHECKSUMTYPE="SHA-1" SIZE="5179625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T17:45:09" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="e94ca9e2ccc4332d8e6c970d0bf26a4fe4764976" CHECKSUMTYPE="SHA-1" SIZE="5116620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T17:45:37" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="4f42dee0e8025e709e72ac7b001a5cba8d27269a" CHECKSUMTYPE="SHA-1" SIZE="5179625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T17:46:05" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="30109ccac95d1fbd1a0cc2e0b6cbf55c72337b4e" CHECKSUMTYPE="SHA-1" SIZE="5113923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T17:46:33" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="1680a1ccc21302c4a1ee34ca15b3f950743b14c8" CHECKSUMTYPE="SHA-1" SIZE="5179628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T17:47:08" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="ec766ab2dcd9ea2135f8b4b44c57340a94cbc1f1" CHECKSUMTYPE="SHA-1" SIZE="5135529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T17:47:44" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="5b89b6eca88b8b416604944ffcade21b77863910" CHECKSUMTYPE="SHA-1" SIZE="5169726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T17:48:11" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="916e6942f6f3367a99f849fd7fa9d159aa4cce0e" CHECKSUMTYPE="SHA-1" SIZE="5135503">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T17:48:40" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="cc6853a427d7c8036f0ed9cfbf910b31d2b48ecd" CHECKSUMTYPE="SHA-1" SIZE="5169616">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T17:49:11" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="374a25aa8498efbb678de2b1b91c82ba495c1a4a" CHECKSUMTYPE="SHA-1" SIZE="5145426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T17:49:39" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="41dd1b5e7d5e7fda5f382eac939ea232f8ccfd6b" CHECKSUMTYPE="SHA-1" SIZE="5169718">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T17:50:07" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="7a6411d6974c04116482c7e51560acdc0436144c" CHECKSUMTYPE="SHA-1" SIZE="5145427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T17:50:36" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="6d3f5a097a9ddb3718172667ef89e59f1475be8f" CHECKSUMTYPE="SHA-1" SIZE="5169727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T17:51:05" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="a902cd1bbbee1867ede4fe8c6b7d0dca76775136" CHECKSUMTYPE="SHA-1" SIZE="5145428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T17:51:32" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="7c975ecd2fa1fbbd6bafaa55632ba836ca541a9e" CHECKSUMTYPE="SHA-1" SIZE="5169693">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T17:52:00" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="b447560020ce0a00149994d3955e8d3272aeeded" CHECKSUMTYPE="SHA-1" SIZE="5135422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:52:29" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="5f0840428214d857df076c5b2cae9e3d8ef7ba1e" CHECKSUMTYPE="SHA-1" SIZE="5169727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:52:57" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="d14e18e4576d7c81e93300ed50f6cf2084f6d0f9" CHECKSUMTYPE="SHA-1" SIZE="5135528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:53:25" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="71b2f35f83d486de68bc17bf7dde641b4a561eb6" CHECKSUMTYPE="SHA-1" SIZE="5169728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:53:56" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="01a5bde1027b82eb1782e02801eddec16c570660" CHECKSUMTYPE="SHA-1" SIZE="5135526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:54:24" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="f805c69a671764808074f7734e6414dfeabedf43" CHECKSUMTYPE="SHA-1" SIZE="5159651">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:54:54" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="94ff063ebd9a353fe6f8bbab5c06296d8faeaa7e" CHECKSUMTYPE="SHA-1" SIZE="5135528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:55:22" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="9c49df0a05192c162a66b4dde00dfd8cd152087a" CHECKSUMTYPE="SHA-1" SIZE="5153529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:55:52" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="5561bf143d44912606921b95279caa4519861a64" CHECKSUMTYPE="SHA-1" SIZE="5145413">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:56:22" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="1ebe05fdbf5afb4c94ba153d75632ab34fb07f64" CHECKSUMTYPE="SHA-1" SIZE="5153524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:56:53" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="ae115008f7845123210d94ca4cdc8e25bf701673" CHECKSUMTYPE="SHA-1" SIZE="5135527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:57:21" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="784a13125317b267161b6fcb9c4c1ecd121de3d0" CHECKSUMTYPE="SHA-1" SIZE="5122854">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:57:51" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="100c3f3dc923997c94ccbbc2abc5cd44f50be75e" CHECKSUMTYPE="SHA-1" SIZE="5001337">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:58:17" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="bbe1d79c67a3faaf4cddab7c09920d2f0d32d407" CHECKSUMTYPE="SHA-1" SIZE="5133728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:58:47" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="46210e4ce316795f641af7ccc608dd4be5a25112" CHECKSUMTYPE="SHA-1" SIZE="5001429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:59:15" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="af607b1929989c76f6811fc4f2f58e4b9e186ec6" CHECKSUMTYPE="SHA-1" SIZE="5133695">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T17:59:43" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="f642482a191192033cc5533b17818105c572c4dc" CHECKSUMTYPE="SHA-1" SIZE="5001370">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0094.jp2"/>
-			</file>
-			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T18:00:10" MIMETYPE="image/jp2" SEQ="95"
-				CHECKSUM="b58b4a5ece475df527777c48a3f34bd745f2714c" CHECKSUMTYPE="SHA-1" SIZE="5133725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0095.jp2"/>
-			</file>
-			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T18:00:40" MIMETYPE="image/jp2" SEQ="96"
-				CHECKSUM="40bdcbebb9d7ccc203808321d5550f6912642c7a" CHECKSUMTYPE="SHA-1" SIZE="5001427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0096.jp2"/>
-			</file>
-			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T18:01:12" MIMETYPE="image/jp2" SEQ="97"
-				CHECKSUM="8710031a956a1349b7e8cc560d9b8c1465c5fe85" CHECKSUMTYPE="SHA-1" SIZE="5121732">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0097.jp2"/>
-			</file>
-			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T18:01:43" MIMETYPE="image/jp2" SEQ="98"
-				CHECKSUM="c2f31c0ada46a6611e49a1cbdf1361e6b085ebb2" CHECKSUMTYPE="SHA-1" SIZE="5001429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0098.jp2"/>
-			</file>
-			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T18:02:11" MIMETYPE="image/jp2" SEQ="99"
-				CHECKSUM="645ed46ac66bd072026007d94ecf4294597a06e8" CHECKSUMTYPE="SHA-1" SIZE="5122017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0099.jp2"/>
-			</file>
-			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T18:02:38" MIMETYPE="image/jp2" SEQ="100"
-				CHECKSUM="1329f81c0ed7850c96fc674292a203548a0d87c6" CHECKSUMTYPE="SHA-1" SIZE="4941127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0100.jp2"/>
-			</file>
-			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T18:03:04" MIMETYPE="image/jp2" SEQ="101"
-				CHECKSUM="796c97381b6bc91879e63b99045a8ba0e4c2f5e8" CHECKSUMTYPE="SHA-1" SIZE="5107619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0101.jp2"/>
-			</file>
-			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T18:03:30" MIMETYPE="image/jp2" SEQ="102"
-				CHECKSUM="89d35498ab353b4deb96dce75247ab9dfc71d2b9" CHECKSUMTYPE="SHA-1" SIZE="4941103">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0102.jp2"/>
-			</file>
-			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T18:03:54" MIMETYPE="image/jp2" SEQ="103"
-				CHECKSUM="d327110fe7f81f00cb8dcd4c6b6b1c6cdc28af99" CHECKSUMTYPE="SHA-1" SIZE="5098623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0103.jp2"/>
-			</file>
-			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T18:04:23" MIMETYPE="image/jp2" SEQ="104"
-				CHECKSUM="970f39d281a22573a022b72575ac546fbc0b2fe6" CHECKSUMTYPE="SHA-1" SIZE="4941129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0104.jp2"/>
-			</file>
-			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T18:04:52" MIMETYPE="image/jp2" SEQ="105"
-				CHECKSUM="7bb2c061acc7a89e859b91afc55e7ad945b0b856" CHECKSUMTYPE="SHA-1" SIZE="5072529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0105.jp2"/>
-			</file>
-			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T18:05:21" MIMETYPE="image/jp2" SEQ="106"
-				CHECKSUM="b0915a554bec3efbbd89ef4a357d9fe43bbf19ea" CHECKSUMTYPE="SHA-1" SIZE="4941128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0106.jp2"/>
-			</file>
-			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T18:05:49" MIMETYPE="image/jp2" SEQ="107"
-				CHECKSUM="e988f170a5989b2389c6534e4a42058274b0d9c3" CHECKSUMTYPE="SHA-1" SIZE="5059925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0107.jp2"/>
-			</file>
-			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T18:06:21" MIMETYPE="image/jp2" SEQ="108"
-				CHECKSUM="29799e2c431056b001f02b6f1bc79304faaf3024" CHECKSUMTYPE="SHA-1" SIZE="4941128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0108.jp2"/>
-			</file>
-			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T18:06:47" MIMETYPE="image/jp2" SEQ="109"
-				CHECKSUM="c745bb8b3b32d10afb066bc0e662dce5274d1873" CHECKSUMTYPE="SHA-1" SIZE="5059920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0109.jp2"/>
-			</file>
-			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T18:07:14" MIMETYPE="image/jp2" SEQ="110"
-				CHECKSUM="56cd50f0cac9e63f6d2a32d055f07129e26b1abc" CHECKSUMTYPE="SHA-1" SIZE="4941125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0110.jp2"/>
-			</file>
-			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-07-30T18:07:41" MIMETYPE="image/jp2" SEQ="111"
-				CHECKSUM="f1ebfff06739d29f9da127ac006aa6dd36505f59" CHECKSUMTYPE="SHA-1" SIZE="5059925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0111.jp2"/>
-			</file>
-			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-07-30T18:08:12" MIMETYPE="image/jp2" SEQ="112"
-				CHECKSUM="cdf1078f4bfaff4200cde74867c7ff0674d6d752" CHECKSUMTYPE="SHA-1" SIZE="4941128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0112.jp2"/>
-			</file>
-			<file ID="IMG00113" ADMID="techmd113" GROUPID="page113" CREATED="2015-07-30T18:08:40" MIMETYPE="image/jp2" SEQ="113"
-				CHECKSUM="acff170e48a8d5a439d55e74433f89b8b019598f" CHECKSUMTYPE="SHA-1" SIZE="4987918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0113.jp2"/>
-			</file>
-			<file ID="IMG00114" ADMID="techmd114" GROUPID="page114" CREATED="2015-07-30T18:09:11" MIMETYPE="image/jp2" SEQ="114"
-				CHECKSUM="4985ddba9eaae426d0097b7dd7d65fed1c35e310" CHECKSUMTYPE="SHA-1" SIZE="4987024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0114.jp2"/>
-			</file>
-			<file ID="IMG00115" ADMID="techmd115" GROUPID="page115" CREATED="2015-07-30T18:09:38" MIMETYPE="image/jp2" SEQ="115"
-				CHECKSUM="1ef7e0db3e1532626101b85fe4355ca6fd020bfb" CHECKSUMTYPE="SHA-1" SIZE="4987024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0115.jp2"/>
-			</file>
-			<file ID="IMG00116" ADMID="techmd116" GROUPID="page116" CREATED="2015-07-30T18:10:05" MIMETYPE="image/jp2" SEQ="116"
-				CHECKSUM="763186146bb6f8448437280e19e31039e287130f" CHECKSUMTYPE="SHA-1" SIZE="4987022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0116.jp2"/>
-			</file>
-			<file ID="IMG00117" ADMID="techmd117" GROUPID="page117" CREATED="2015-07-30T18:10:32" MIMETYPE="image/jp2" SEQ="117"
-				CHECKSUM="ea1602c87bd6dc83c26081da8e7f81be055a2665" CHECKSUMTYPE="SHA-1" SIZE="5034606">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0117.jp2"/>
-			</file>
-			<file ID="IMG00118" ADMID="techmd118" GROUPID="page118" CREATED="2015-07-30T18:11:00" MIMETYPE="image/jp2" SEQ="118"
-				CHECKSUM="aded7b0c381abaf4915627a22b45fa09059ea4cf" CHECKSUMTYPE="SHA-1" SIZE="4987029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0118.jp2"/>
-			</file>
-			<file ID="IMG00119" ADMID="techmd119" GROUPID="page119" CREATED="2015-07-30T18:11:27" MIMETYPE="image/jp2" SEQ="119"
-				CHECKSUM="1d8698779cd0dce0ec560c7ebdbcb9d94554c13b" CHECKSUMTYPE="SHA-1" SIZE="5019428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0119.jp2"/>
-			</file>
-			<file ID="IMG00120" ADMID="techmd120" GROUPID="page120" CREATED="2015-07-30T18:11:57" MIMETYPE="image/jp2" SEQ="120"
-				CHECKSUM="4987e50f8610286064a3fa2e70c0d6134fc41161" CHECKSUMTYPE="SHA-1" SIZE="4986952">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0120.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:15:03" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="b488e1cdf26ec93556304ab819ceadca744ca070" CHECKSUMTYPE="SHA-1" SIZE="5346128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:15:34" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="b50e3bf67eb13940333658d49101fb34c0a107c7" CHECKSUMTYPE="SHA-1" SIZE="5177648">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:16:05" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="0a5e815b2f207611801360ad3e32d7b00f7cc6a6" CHECKSUMTYPE="SHA-1" SIZE="5257025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:16:32" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a2fd5c63d482368ccf41b6259a8c8cba2e3b49fe" CHECKSUMTYPE="SHA-1" SIZE="5177700">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:17:01" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="9a18a19e20f4388ff54b3f1a17aa78f7e9f442fa" CHECKSUMTYPE="SHA-1" SIZE="5257021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:17:27" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="3e89d7cdb404e07ac7cf817eb30005e7c086ec0f" CHECKSUMTYPE="SHA-1" SIZE="5177828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:17:54" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="49dc9dbfe86bb057b74d464a41fa4abe5d18e052" CHECKSUMTYPE="SHA-1" SIZE="5257029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:18:21" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="6c5cf6fe954a22d46f16ed324a1f4c85bed0b317" CHECKSUMTYPE="SHA-1" SIZE="5177824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:18:47" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="d06348a651ffa34de179b07ff8eaf1b901404edd" CHECKSUMTYPE="SHA-1" SIZE="5256975">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:19:14" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="781caae1f169158008c0a4c498b6f28c98b0de85" CHECKSUMTYPE="SHA-1" SIZE="5177819">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:19:42" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="4572a24284aff2be1ac8614ea6cba89ab62504db" CHECKSUMTYPE="SHA-1" SIZE="5257027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:20:12" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="2354b02f03163991e21f48039f668f65469459c7" CHECKSUMTYPE="SHA-1" SIZE="5177825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:20:38" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="e6865e54e37368ff6bb99790a6741765a6bb114b" CHECKSUMTYPE="SHA-1" SIZE="5257025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:21:07" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="498bbf1b3dd33cff7c491f9f423df52f31280936" CHECKSUMTYPE="SHA-1" SIZE="5177829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:21:35" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="e95c06392c5f9be2c2babb37d08dfa1af4123ede" CHECKSUMTYPE="SHA-1" SIZE="5257014">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:22:03" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="e58d75b44bed9aa7526cb69ef7eadcf7711460b8" CHECKSUMTYPE="SHA-1" SIZE="5177826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:22:34" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="dc971751c93ea7825ab90c7ff94f8872a59dc9c0" CHECKSUMTYPE="SHA-1" SIZE="5257026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:23:03" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="abc6f594492e036e8f4ed531292b9083423bfa55" CHECKSUMTYPE="SHA-1" SIZE="5177827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:23:30" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="27d4f048ff7aadcd8b7fa6cfda0c860493fc0301" CHECKSUMTYPE="SHA-1" SIZE="5257029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:23:58" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="361f55ca14be4b601e2c5670c8ffaf3bc5ad9d5b" CHECKSUMTYPE="SHA-1" SIZE="5166976">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:24:24" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="f63b007690df1d7c887e654bee8fb9a8f99ad8b8" CHECKSUMTYPE="SHA-1" SIZE="5257026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:24:50" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="3bb45297363a31782f2493e40a83303fb5efe759" CHECKSUMTYPE="SHA-1" SIZE="5177825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:25:19" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="27b72e5944335be0eb317aab7a34307af0dbdc35" CHECKSUMTYPE="SHA-1" SIZE="5230907">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:25:50" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="e326f07ca3061bf27291887a4b36e30c70f5a42d" CHECKSUMTYPE="SHA-1" SIZE="5145427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:26:18" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="942c4c203e757952eb4207fdbc8606bb74de76a9" CHECKSUMTYPE="SHA-1" SIZE="5253428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:26:48" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="06f237e545e0eaab32176ff232ea6378e265cbff" CHECKSUMTYPE="SHA-1" SIZE="5239858">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:27:22" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="bbc4cd38158f73521518ce4ae71ffdd763bc088f" CHECKSUMTYPE="SHA-1" SIZE="5253429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:27:50" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="b4fe131db7b8a236ef7d4406afc0047bed5b7c9c" CHECKSUMTYPE="SHA-1" SIZE="5145419">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:28:18" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="15e074d9d56357d8c935f6a82ace6368dd970096" CHECKSUMTYPE="SHA-1" SIZE="5253412">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:28:45" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="3d853c90be6606627b523101745f2388ec104722" CHECKSUMTYPE="SHA-1" SIZE="5145418">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:29:16" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="c4cef3ef76bd7c6e48c9deae2fde75283fd339c1" CHECKSUMTYPE="SHA-1" SIZE="5253427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:29:47" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="7a74337578d7657dbb835557ccd338023b7118c8" CHECKSUMTYPE="SHA-1" SIZE="5145383">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:30:18" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="262c33bad46f1e5db68c20b7a3df5d1ecfd93eb2" CHECKSUMTYPE="SHA-1" SIZE="5253401">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:30:49" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="7d330ddb5c2d5fd6646dff7743ac1741ae488259" CHECKSUMTYPE="SHA-1" SIZE="5145425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:31:17" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="75d138fa80bd857db22deb872d0df67a87dc5a75" CHECKSUMTYPE="SHA-1" SIZE="5253394">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:31:45" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="2608ea274ffd7cf37c4be5d238d31ce6c1ed2e0f" CHECKSUMTYPE="SHA-1" SIZE="5145390">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:32:13" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="a783b671e708581e05b060cb9ce7844b87ddd4e7" CHECKSUMTYPE="SHA-1" SIZE="5253404">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:32:44" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="aba39aab94622dbe9d17854dc55d44112d296f2e" CHECKSUMTYPE="SHA-1" SIZE="5145423">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:33:10" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="d6a4725c4f1d1b1ba83369b8a61863e094ccf8c2" CHECKSUMTYPE="SHA-1" SIZE="5253419">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:33:39" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="a3be68f103d6c991c8b5fe3674864012471ff777" CHECKSUMTYPE="SHA-1" SIZE="5145421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:34:05" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="dd7d006ab2b8d89791d167b5803f9210bb627411" CHECKSUMTYPE="SHA-1" SIZE="5253416">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:34:33" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="2f976462c60b272e224646a7208ed9921ae2deef" CHECKSUMTYPE="SHA-1" SIZE="5145406">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:35:00" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="0127012df7b07ccf9159faf5c449db9dcb16fb7a" CHECKSUMTYPE="SHA-1" SIZE="5253429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:35:31" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="8565df91637e4bbc1b15f9ab01236565c87998e6" CHECKSUMTYPE="SHA-1" SIZE="5145427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:36:01" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="e5cb25d544a844f154f7902ffbed2217aab42cfa" CHECKSUMTYPE="SHA-1" SIZE="5253428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:36:30" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="936f1bd804cbd127a49623f539a977c5e49156e6" CHECKSUMTYPE="SHA-1" SIZE="5145427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:36:58" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="4bab5d386629e25bb606018c6724418ffc07f606" CHECKSUMTYPE="SHA-1" SIZE="5222808">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:37:30" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="88e55204372ec216369c4b479241f36c5f8bfbf0" CHECKSUMTYPE="SHA-1" SIZE="5145404">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:38:00" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="166b20960d78f25bf8c6d2501da7f2f252cb4b40" CHECKSUMTYPE="SHA-1" SIZE="5222823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:38:29" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="365ea109d8343cd2a7e46c5581398d1286a7efd0" CHECKSUMTYPE="SHA-1" SIZE="5145429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:38:57" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="a917e5de3bdba67ac65cf2fe8fd374ddf28283e5" CHECKSUMTYPE="SHA-1" SIZE="5222814">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:39:25" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="0a819fd53298948bcb5968ed822f785d1e6da378" CHECKSUMTYPE="SHA-1" SIZE="5124697">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:39:53" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="b780e4ef3de0c92d2a6cffbad11e00ac061aa401" CHECKSUMTYPE="SHA-1" SIZE="5222722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:40:21" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="88cd9b839cb0b75bc6c4e03cd0ef55b3491964c8" CHECKSUMTYPE="SHA-1" SIZE="5124726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:40:51" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="57dea87677b08239108b7b9a9d1d29e44491b7ef" CHECKSUMTYPE="SHA-1" SIZE="5200321">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:41:19" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="19dda2c2733869805b09c9f09b2c3c844d638695" CHECKSUMTYPE="SHA-1" SIZE="5124693">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:41:50" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="f9d76814e76aba78cfe4bd97e86c2fdbc681659e" CHECKSUMTYPE="SHA-1" SIZE="5200314">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:42:20" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="b0c4adaf2fe4351b437c6c39447af62d413512c8" CHECKSUMTYPE="SHA-1" SIZE="5124725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T17:42:48" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="3eeabcefeaea012157be62c47cafe05fbf485432" CHECKSUMTYPE="SHA-1" SIZE="5179595">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T17:43:15" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="9674e026b65d5868b4bc68614d2cd7cc4e741ff0" CHECKSUMTYPE="SHA-1" SIZE="5124725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T17:43:43" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="be7594c9216db3c4d543b59d2702afe915a0ce00" CHECKSUMTYPE="SHA-1" SIZE="5179602">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T17:44:14" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="113f4c07e7bb6bc5178a9dc26ee4fca20e980696" CHECKSUMTYPE="SHA-1" SIZE="5094124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T17:44:42" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="12d11da67542563e2552d4c1fa79912993fccf92" CHECKSUMTYPE="SHA-1" SIZE="5179625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T17:45:09" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="e94ca9e2ccc4332d8e6c970d0bf26a4fe4764976" CHECKSUMTYPE="SHA-1" SIZE="5116620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T17:45:37" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="4f42dee0e8025e709e72ac7b001a5cba8d27269a" CHECKSUMTYPE="SHA-1" SIZE="5179625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T17:46:05" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="30109ccac95d1fbd1a0cc2e0b6cbf55c72337b4e" CHECKSUMTYPE="SHA-1" SIZE="5113923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T17:46:33" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="1680a1ccc21302c4a1ee34ca15b3f950743b14c8" CHECKSUMTYPE="SHA-1" SIZE="5179628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T17:47:08" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="ec766ab2dcd9ea2135f8b4b44c57340a94cbc1f1" CHECKSUMTYPE="SHA-1" SIZE="5135529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T17:47:44" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="5b89b6eca88b8b416604944ffcade21b77863910" CHECKSUMTYPE="SHA-1" SIZE="5169726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T17:48:11" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="916e6942f6f3367a99f849fd7fa9d159aa4cce0e" CHECKSUMTYPE="SHA-1" SIZE="5135503">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T17:48:40" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="cc6853a427d7c8036f0ed9cfbf910b31d2b48ecd" CHECKSUMTYPE="SHA-1" SIZE="5169616">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T17:49:11" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="374a25aa8498efbb678de2b1b91c82ba495c1a4a" CHECKSUMTYPE="SHA-1" SIZE="5145426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T17:49:39" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="41dd1b5e7d5e7fda5f382eac939ea232f8ccfd6b" CHECKSUMTYPE="SHA-1" SIZE="5169718">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T17:50:07" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="7a6411d6974c04116482c7e51560acdc0436144c" CHECKSUMTYPE="SHA-1" SIZE="5145427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T17:50:36" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="6d3f5a097a9ddb3718172667ef89e59f1475be8f" CHECKSUMTYPE="SHA-1" SIZE="5169727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T17:51:05" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="a902cd1bbbee1867ede4fe8c6b7d0dca76775136" CHECKSUMTYPE="SHA-1" SIZE="5145428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T17:51:32" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="7c975ecd2fa1fbbd6bafaa55632ba836ca541a9e" CHECKSUMTYPE="SHA-1" SIZE="5169693">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T17:52:00" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="b447560020ce0a00149994d3955e8d3272aeeded" CHECKSUMTYPE="SHA-1" SIZE="5135422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:52:29" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="5f0840428214d857df076c5b2cae9e3d8ef7ba1e" CHECKSUMTYPE="SHA-1" SIZE="5169727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:52:57" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="d14e18e4576d7c81e93300ed50f6cf2084f6d0f9" CHECKSUMTYPE="SHA-1" SIZE="5135528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:53:25" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="71b2f35f83d486de68bc17bf7dde641b4a561eb6" CHECKSUMTYPE="SHA-1" SIZE="5169728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:53:56" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="01a5bde1027b82eb1782e02801eddec16c570660" CHECKSUMTYPE="SHA-1" SIZE="5135526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:54:24" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="f805c69a671764808074f7734e6414dfeabedf43" CHECKSUMTYPE="SHA-1" SIZE="5159651">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:54:54" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="94ff063ebd9a353fe6f8bbab5c06296d8faeaa7e" CHECKSUMTYPE="SHA-1" SIZE="5135528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:55:22" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="9c49df0a05192c162a66b4dde00dfd8cd152087a" CHECKSUMTYPE="SHA-1" SIZE="5153529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:55:52" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="5561bf143d44912606921b95279caa4519861a64" CHECKSUMTYPE="SHA-1" SIZE="5145413">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:56:22" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="1ebe05fdbf5afb4c94ba153d75632ab34fb07f64" CHECKSUMTYPE="SHA-1" SIZE="5153524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:56:53" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="ae115008f7845123210d94ca4cdc8e25bf701673" CHECKSUMTYPE="SHA-1" SIZE="5135527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:57:21" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="784a13125317b267161b6fcb9c4c1ecd121de3d0" CHECKSUMTYPE="SHA-1" SIZE="5122854">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:57:51" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="100c3f3dc923997c94ccbbc2abc5cd44f50be75e" CHECKSUMTYPE="SHA-1" SIZE="5001337">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:58:17" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="bbe1d79c67a3faaf4cddab7c09920d2f0d32d407" CHECKSUMTYPE="SHA-1" SIZE="5133728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:58:47" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="46210e4ce316795f641af7ccc608dd4be5a25112" CHECKSUMTYPE="SHA-1" SIZE="5001429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T17:59:15" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="af607b1929989c76f6811fc4f2f58e4b9e186ec6" CHECKSUMTYPE="SHA-1" SIZE="5133695">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T17:59:43" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="f642482a191192033cc5533b17818105c572c4dc" CHECKSUMTYPE="SHA-1" SIZE="5001370">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0094.jp2"/>
+			</file>
+			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T18:00:10" MIMETYPE="image/jp2" SEQ="95" CHECKSUM="b58b4a5ece475df527777c48a3f34bd745f2714c" CHECKSUMTYPE="SHA-1" SIZE="5133725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0095.jp2"/>
+			</file>
+			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T18:00:40" MIMETYPE="image/jp2" SEQ="96" CHECKSUM="40bdcbebb9d7ccc203808321d5550f6912642c7a" CHECKSUMTYPE="SHA-1" SIZE="5001427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0096.jp2"/>
+			</file>
+			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T18:01:12" MIMETYPE="image/jp2" SEQ="97" CHECKSUM="8710031a956a1349b7e8cc560d9b8c1465c5fe85" CHECKSUMTYPE="SHA-1" SIZE="5121732">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0097.jp2"/>
+			</file>
+			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T18:01:43" MIMETYPE="image/jp2" SEQ="98" CHECKSUM="c2f31c0ada46a6611e49a1cbdf1361e6b085ebb2" CHECKSUMTYPE="SHA-1" SIZE="5001429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0098.jp2"/>
+			</file>
+			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T18:02:11" MIMETYPE="image/jp2" SEQ="99" CHECKSUM="645ed46ac66bd072026007d94ecf4294597a06e8" CHECKSUMTYPE="SHA-1" SIZE="5122017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0099.jp2"/>
+			</file>
+			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T18:02:38" MIMETYPE="image/jp2" SEQ="100" CHECKSUM="1329f81c0ed7850c96fc674292a203548a0d87c6" CHECKSUMTYPE="SHA-1" SIZE="4941127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0100.jp2"/>
+			</file>
+			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T18:03:04" MIMETYPE="image/jp2" SEQ="101" CHECKSUM="796c97381b6bc91879e63b99045a8ba0e4c2f5e8" CHECKSUMTYPE="SHA-1" SIZE="5107619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0101.jp2"/>
+			</file>
+			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T18:03:30" MIMETYPE="image/jp2" SEQ="102" CHECKSUM="89d35498ab353b4deb96dce75247ab9dfc71d2b9" CHECKSUMTYPE="SHA-1" SIZE="4941103">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0102.jp2"/>
+			</file>
+			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T18:03:54" MIMETYPE="image/jp2" SEQ="103" CHECKSUM="d327110fe7f81f00cb8dcd4c6b6b1c6cdc28af99" CHECKSUMTYPE="SHA-1" SIZE="5098623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0103.jp2"/>
+			</file>
+			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T18:04:23" MIMETYPE="image/jp2" SEQ="104" CHECKSUM="970f39d281a22573a022b72575ac546fbc0b2fe6" CHECKSUMTYPE="SHA-1" SIZE="4941129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0104.jp2"/>
+			</file>
+			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T18:04:52" MIMETYPE="image/jp2" SEQ="105" CHECKSUM="7bb2c061acc7a89e859b91afc55e7ad945b0b856" CHECKSUMTYPE="SHA-1" SIZE="5072529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0105.jp2"/>
+			</file>
+			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T18:05:21" MIMETYPE="image/jp2" SEQ="106" CHECKSUM="b0915a554bec3efbbd89ef4a357d9fe43bbf19ea" CHECKSUMTYPE="SHA-1" SIZE="4941128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0106.jp2"/>
+			</file>
+			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T18:05:49" MIMETYPE="image/jp2" SEQ="107" CHECKSUM="e988f170a5989b2389c6534e4a42058274b0d9c3" CHECKSUMTYPE="SHA-1" SIZE="5059925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0107.jp2"/>
+			</file>
+			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T18:06:21" MIMETYPE="image/jp2" SEQ="108" CHECKSUM="29799e2c431056b001f02b6f1bc79304faaf3024" CHECKSUMTYPE="SHA-1" SIZE="4941128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0108.jp2"/>
+			</file>
+			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T18:06:47" MIMETYPE="image/jp2" SEQ="109" CHECKSUM="c745bb8b3b32d10afb066bc0e662dce5274d1873" CHECKSUMTYPE="SHA-1" SIZE="5059920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0109.jp2"/>
+			</file>
+			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T18:07:14" MIMETYPE="image/jp2" SEQ="110" CHECKSUM="56cd50f0cac9e63f6d2a32d055f07129e26b1abc" CHECKSUMTYPE="SHA-1" SIZE="4941125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0110.jp2"/>
+			</file>
+			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-07-30T18:07:41" MIMETYPE="image/jp2" SEQ="111" CHECKSUM="f1ebfff06739d29f9da127ac006aa6dd36505f59" CHECKSUMTYPE="SHA-1" SIZE="5059925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0111.jp2"/>
+			</file>
+			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-07-30T18:08:12" MIMETYPE="image/jp2" SEQ="112" CHECKSUM="cdf1078f4bfaff4200cde74867c7ff0674d6d752" CHECKSUMTYPE="SHA-1" SIZE="4941128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0112.jp2"/>
+			</file>
+			<file ID="IMG00113" ADMID="techmd113" GROUPID="page113" CREATED="2015-07-30T18:08:40" MIMETYPE="image/jp2" SEQ="113" CHECKSUM="acff170e48a8d5a439d55e74433f89b8b019598f" CHECKSUMTYPE="SHA-1" SIZE="4987918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0113.jp2"/>
+			</file>
+			<file ID="IMG00114" ADMID="techmd114" GROUPID="page114" CREATED="2015-07-30T18:09:11" MIMETYPE="image/jp2" SEQ="114" CHECKSUM="4985ddba9eaae426d0097b7dd7d65fed1c35e310" CHECKSUMTYPE="SHA-1" SIZE="4987024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0114.jp2"/>
+			</file>
+			<file ID="IMG00115" ADMID="techmd115" GROUPID="page115" CREATED="2015-07-30T18:09:38" MIMETYPE="image/jp2" SEQ="115" CHECKSUM="1ef7e0db3e1532626101b85fe4355ca6fd020bfb" CHECKSUMTYPE="SHA-1" SIZE="4987024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0115.jp2"/>
+			</file>
+			<file ID="IMG00116" ADMID="techmd116" GROUPID="page116" CREATED="2015-07-30T18:10:05" MIMETYPE="image/jp2" SEQ="116" CHECKSUM="763186146bb6f8448437280e19e31039e287130f" CHECKSUMTYPE="SHA-1" SIZE="4987022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0116.jp2"/>
+			</file>
+			<file ID="IMG00117" ADMID="techmd117" GROUPID="page117" CREATED="2015-07-30T18:10:32" MIMETYPE="image/jp2" SEQ="117" CHECKSUM="ea1602c87bd6dc83c26081da8e7f81be055a2665" CHECKSUMTYPE="SHA-1" SIZE="5034606">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0117.jp2"/>
+			</file>
+			<file ID="IMG00118" ADMID="techmd118" GROUPID="page118" CREATED="2015-07-30T18:11:00" MIMETYPE="image/jp2" SEQ="118" CHECKSUM="aded7b0c381abaf4915627a22b45fa09059ea4cf" CHECKSUMTYPE="SHA-1" SIZE="4987029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0118.jp2"/>
+			</file>
+			<file ID="IMG00119" ADMID="techmd119" GROUPID="page119" CREATED="2015-07-30T18:11:27" MIMETYPE="image/jp2" SEQ="119" CHECKSUM="1d8698779cd0dce0ec560c7ebdbcb9d94554c13b" CHECKSUMTYPE="SHA-1" SIZE="5019428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0119.jp2"/>
+			</file>
+			<file ID="IMG00120" ADMID="techmd120" GROUPID="page120" CREATED="2015-07-30T18:11:57" MIMETYPE="image/jp2" SEQ="120" CHECKSUM="4987e50f8610286064a3fa2e70c0d6134fc41161" CHECKSUMTYPE="SHA-1" SIZE="4986952">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/delivery/bmtnabe_1897-04_01_0120.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:12:16" MIMETYPE="text/xml" CHECKSUM="94662e310326ba22fb8eafcd447c686d07ab6164"
-				CHECKSUMTYPE="SHA-1" SIZE="2102">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:12:16" MIMETYPE="text/xml" CHECKSUM="94662e310326ba22fb8eafcd447c686d07ab6164" CHECKSUMTYPE="SHA-1" SIZE="2102">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:12:16" MIMETYPE="text/xml" CHECKSUM="6c794f24a715de9f6eeb3f9981e7bfea38ebc9ab"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:12:16" MIMETYPE="text/xml" CHECKSUM="6c794f24a715de9f6eeb3f9981e7bfea38ebc9ab" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:12:16" MIMETYPE="text/xml" CHECKSUM="78a53c9ddd76ba61f64be8c3c55332e46449e235"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:12:16" MIMETYPE="text/xml" CHECKSUM="78a53c9ddd76ba61f64be8c3c55332e46449e235" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:12:16" MIMETYPE="text/xml" CHECKSUM="b3c1ed1f37f1cf3a405847e0e26b261b97825bb4"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:12:16" MIMETYPE="text/xml" CHECKSUM="b3c1ed1f37f1cf3a405847e0e26b261b97825bb4" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:12:17" MIMETYPE="text/xml" CHECKSUM="cb2af3e167a4936a5eae6a7af5ed138945c4cf3c"
-				CHECKSUMTYPE="SHA-1" SIZE="8244">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:12:17" MIMETYPE="text/xml" CHECKSUM="cb2af3e167a4936a5eae6a7af5ed138945c4cf3c" CHECKSUMTYPE="SHA-1" SIZE="8244">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:12:17" MIMETYPE="text/xml" CHECKSUM="700bcbb8bd1c3ed1147c607438a82d4dbadd67f5"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:12:17" MIMETYPE="text/xml" CHECKSUM="700bcbb8bd1c3ed1147c607438a82d4dbadd67f5" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:12:17" MIMETYPE="text/xml" CHECKSUM="2bcb813ea19d6f7fc76aba7b44e7f3f42aa6cb38"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:12:17" MIMETYPE="text/xml" CHECKSUM="2bcb813ea19d6f7fc76aba7b44e7f3f42aa6cb38" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:12:17" MIMETYPE="text/xml" CHECKSUM="223adc8ad15141aa7228458dc607cef397e302b8"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:12:17" MIMETYPE="text/xml" CHECKSUM="223adc8ad15141aa7228458dc607cef397e302b8" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:12:18" MIMETYPE="text/xml" CHECKSUM="6072a06a96dc1353b9bbfbf06fb5655af04d408b"
-				CHECKSUMTYPE="SHA-1" SIZE="12740">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:12:18" MIMETYPE="text/xml" CHECKSUM="6072a06a96dc1353b9bbfbf06fb5655af04d408b" CHECKSUMTYPE="SHA-1" SIZE="12740">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:12:18" MIMETYPE="text/xml"
-				CHECKSUM="bb7de999c67c69d3b2b81279a2e67e94d39791a8" CHECKSUMTYPE="SHA-1" SIZE="3673">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:12:18" MIMETYPE="text/xml" CHECKSUM="bb7de999c67c69d3b2b81279a2e67e94d39791a8" CHECKSUMTYPE="SHA-1" SIZE="3673">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:12:18" MIMETYPE="text/xml"
-				CHECKSUM="e1420f7554fb62227212af23a5b7b8ba7d828d80" CHECKSUMTYPE="SHA-1" SIZE="1713">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:12:18" MIMETYPE="text/xml" CHECKSUM="e1420f7554fb62227212af23a5b7b8ba7d828d80" CHECKSUMTYPE="SHA-1" SIZE="1713">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:12:18" MIMETYPE="text/xml"
-				CHECKSUM="83e9fea2637d12fb2ca787f809fcfa4ffa056aaa" CHECKSUMTYPE="SHA-1" SIZE="4721">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:12:18" MIMETYPE="text/xml" CHECKSUM="83e9fea2637d12fb2ca787f809fcfa4ffa056aaa" CHECKSUMTYPE="SHA-1" SIZE="4721">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:12:19" MIMETYPE="text/xml"
-				CHECKSUM="801343d2684fb5bcb810eaccc478283c14c29b2b" CHECKSUMTYPE="SHA-1" SIZE="12811">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:12:19" MIMETYPE="text/xml" CHECKSUM="801343d2684fb5bcb810eaccc478283c14c29b2b" CHECKSUMTYPE="SHA-1" SIZE="12811">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:12:19" MIMETYPE="text/xml"
-				CHECKSUM="61045219a7ebbb230385dd4e2816aa4cf2c2efef" CHECKSUMTYPE="SHA-1" SIZE="57513">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:12:19" MIMETYPE="text/xml" CHECKSUM="61045219a7ebbb230385dd4e2816aa4cf2c2efef" CHECKSUMTYPE="SHA-1" SIZE="57513">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:12:19" MIMETYPE="text/xml"
-				CHECKSUM="c11c0681b6deae3eb4606b83516bacc6785c0e87" CHECKSUMTYPE="SHA-1" SIZE="19015">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:12:19" MIMETYPE="text/xml" CHECKSUM="c11c0681b6deae3eb4606b83516bacc6785c0e87" CHECKSUMTYPE="SHA-1" SIZE="19015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:12:19" MIMETYPE="text/xml"
-				CHECKSUM="13e65074c3bd348e3760322a7a3547af4365f5b2" CHECKSUMTYPE="SHA-1" SIZE="31339">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:12:19" MIMETYPE="text/xml" CHECKSUM="13e65074c3bd348e3760322a7a3547af4365f5b2" CHECKSUMTYPE="SHA-1" SIZE="31339">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:12:20" MIMETYPE="text/xml"
-				CHECKSUM="1e628b65ffb6ef75e389ee0b694cc159ff3937f2" CHECKSUMTYPE="SHA-1" SIZE="74019">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:12:20" MIMETYPE="text/xml" CHECKSUM="1e628b65ffb6ef75e389ee0b694cc159ff3937f2" CHECKSUMTYPE="SHA-1" SIZE="74019">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:12:20" MIMETYPE="text/xml"
-				CHECKSUM="10f9456ae44cf44888bdeb1aa336e4f16b6a4991" CHECKSUMTYPE="SHA-1" SIZE="122781">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:12:20" MIMETYPE="text/xml" CHECKSUM="10f9456ae44cf44888bdeb1aa336e4f16b6a4991" CHECKSUMTYPE="SHA-1" SIZE="122781">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:12:20" MIMETYPE="text/xml"
-				CHECKSUM="95b0f966cab0f31616bb7d029edc6f323f449027" CHECKSUMTYPE="SHA-1" SIZE="99761">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:12:20" MIMETYPE="text/xml" CHECKSUM="95b0f966cab0f31616bb7d029edc6f323f449027" CHECKSUMTYPE="SHA-1" SIZE="99761">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:12:21" MIMETYPE="text/xml"
-				CHECKSUM="5310f4b43ae53882605568c48b0d076318e1b2a8" CHECKSUMTYPE="SHA-1" SIZE="38645">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:12:21" MIMETYPE="text/xml" CHECKSUM="5310f4b43ae53882605568c48b0d076318e1b2a8" CHECKSUMTYPE="SHA-1" SIZE="38645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:12:21" MIMETYPE="text/xml"
-				CHECKSUM="a4031d077ec2d5a132caf4e14a2aad8dafc0f5ad" CHECKSUMTYPE="SHA-1" SIZE="32285">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:12:21" MIMETYPE="text/xml" CHECKSUM="a4031d077ec2d5a132caf4e14a2aad8dafc0f5ad" CHECKSUMTYPE="SHA-1" SIZE="32285">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:12:21" MIMETYPE="text/xml"
-				CHECKSUM="d05afd5beb7177d2d6a2737fd9b48874e67ce50e" CHECKSUMTYPE="SHA-1" SIZE="48045">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:12:21" MIMETYPE="text/xml" CHECKSUM="d05afd5beb7177d2d6a2737fd9b48874e67ce50e" CHECKSUMTYPE="SHA-1" SIZE="48045">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:12:21" MIMETYPE="text/xml"
-				CHECKSUM="6c975a3161ca38a82337d125e5bd204d7b1014da" CHECKSUMTYPE="SHA-1" SIZE="83701">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:12:21" MIMETYPE="text/xml" CHECKSUM="6c975a3161ca38a82337d125e5bd204d7b1014da" CHECKSUMTYPE="SHA-1" SIZE="83701">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:12:22" MIMETYPE="text/xml"
-				CHECKSUM="de47f63bc0d084c62b869a2976f3106e58a2cf15" CHECKSUMTYPE="SHA-1" SIZE="41643">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:12:22" MIMETYPE="text/xml" CHECKSUM="de47f63bc0d084c62b869a2976f3106e58a2cf15" CHECKSUMTYPE="SHA-1" SIZE="41643">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:12:22" MIMETYPE="text/xml"
-				CHECKSUM="7004c7ab6ba59922864579de9c52c8c439c6b945" CHECKSUMTYPE="SHA-1" SIZE="2411">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:12:22" MIMETYPE="text/xml" CHECKSUM="7004c7ab6ba59922864579de9c52c8c439c6b945" CHECKSUMTYPE="SHA-1" SIZE="2411">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:12:22" MIMETYPE="text/xml"
-				CHECKSUM="efc20ceb0e5c0a1fdaa0df27d798ee9d4aec685d" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:12:22" MIMETYPE="text/xml" CHECKSUM="efc20ceb0e5c0a1fdaa0df27d798ee9d4aec685d" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:12:22" MIMETYPE="text/xml"
-				CHECKSUM="29c6849ee50e178838b04318bea13b10b310c69d" CHECKSUMTYPE="SHA-1" SIZE="160591">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:12:22" MIMETYPE="text/xml" CHECKSUM="29c6849ee50e178838b04318bea13b10b310c69d" CHECKSUMTYPE="SHA-1" SIZE="160591">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:12:23" MIMETYPE="text/xml"
-				CHECKSUM="834bfaf4a142254003b952de6eab25f92622dda0" CHECKSUMTYPE="SHA-1" SIZE="182420">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:12:23" MIMETYPE="text/xml" CHECKSUM="834bfaf4a142254003b952de6eab25f92622dda0" CHECKSUMTYPE="SHA-1" SIZE="182420">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:12:23" MIMETYPE="text/xml"
-				CHECKSUM="6fce51ad8d57a4a322bab94a404645ccc04adba7" CHECKSUMTYPE="SHA-1" SIZE="201332">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:12:23" MIMETYPE="text/xml" CHECKSUM="6fce51ad8d57a4a322bab94a404645ccc04adba7" CHECKSUMTYPE="SHA-1" SIZE="201332">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:12:23" MIMETYPE="text/xml"
-				CHECKSUM="3e61d05e0578f85f42eca379907efc70ba6d8a9c" CHECKSUMTYPE="SHA-1" SIZE="67233">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:12:23" MIMETYPE="text/xml" CHECKSUM="3e61d05e0578f85f42eca379907efc70ba6d8a9c" CHECKSUMTYPE="SHA-1" SIZE="67233">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:12:24" MIMETYPE="text/xml"
-				CHECKSUM="5f8ed962b4ddd899b75b27319d72cc0f1eeb02a3" CHECKSUMTYPE="SHA-1" SIZE="68579">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:12:24" MIMETYPE="text/xml" CHECKSUM="5f8ed962b4ddd899b75b27319d72cc0f1eeb02a3" CHECKSUMTYPE="SHA-1" SIZE="68579">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:12:24" MIMETYPE="text/xml"
-				CHECKSUM="b843b4f56183331dea83f40fff8cc94047e59118" CHECKSUMTYPE="SHA-1" SIZE="25118">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:12:24" MIMETYPE="text/xml" CHECKSUM="b843b4f56183331dea83f40fff8cc94047e59118" CHECKSUMTYPE="SHA-1" SIZE="25118">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:12:24" MIMETYPE="text/xml"
-				CHECKSUM="6750db25a0f95577efb6b595c80bb3ef337a3971" CHECKSUMTYPE="SHA-1" SIZE="87046">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:12:24" MIMETYPE="text/xml" CHECKSUM="6750db25a0f95577efb6b595c80bb3ef337a3971" CHECKSUMTYPE="SHA-1" SIZE="87046">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:12:24" MIMETYPE="text/xml"
-				CHECKSUM="047c84639e55d6bb8d2b50b3fb892f6dd8b53374" CHECKSUMTYPE="SHA-1" SIZE="131646">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:12:24" MIMETYPE="text/xml" CHECKSUM="047c84639e55d6bb8d2b50b3fb892f6dd8b53374" CHECKSUMTYPE="SHA-1" SIZE="131646">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:12:25" MIMETYPE="text/xml"
-				CHECKSUM="745a2fb580c67a50d3006b0305664a2e117a492e" CHECKSUMTYPE="SHA-1" SIZE="55612">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:12:25" MIMETYPE="text/xml" CHECKSUM="745a2fb580c67a50d3006b0305664a2e117a492e" CHECKSUMTYPE="SHA-1" SIZE="55612">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:12:25" MIMETYPE="text/xml"
-				CHECKSUM="6c4ced0b31e80820b2fabb2379ec350abcbd2f08" CHECKSUMTYPE="SHA-1" SIZE="33429">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:12:25" MIMETYPE="text/xml" CHECKSUM="6c4ced0b31e80820b2fabb2379ec350abcbd2f08" CHECKSUMTYPE="SHA-1" SIZE="33429">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:12:25" MIMETYPE="text/xml"
-				CHECKSUM="033e9f9a243a3ca0aa083e35a9db59261f1ccbdf" CHECKSUMTYPE="SHA-1" SIZE="5319">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:12:25" MIMETYPE="text/xml" CHECKSUM="033e9f9a243a3ca0aa083e35a9db59261f1ccbdf" CHECKSUMTYPE="SHA-1" SIZE="5319">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:12:26" MIMETYPE="text/xml"
-				CHECKSUM="7b00114b5e8f2e1e8530f2008525a59294a91513" CHECKSUMTYPE="SHA-1" SIZE="2012">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:12:26" MIMETYPE="text/xml" CHECKSUM="7b00114b5e8f2e1e8530f2008525a59294a91513" CHECKSUMTYPE="SHA-1" SIZE="2012">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:12:26" MIMETYPE="text/xml"
-				CHECKSUM="9a538d7977770c4db2ab01e934771bccab4d4248" CHECKSUMTYPE="SHA-1" SIZE="71884">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:12:26" MIMETYPE="text/xml" CHECKSUM="9a538d7977770c4db2ab01e934771bccab4d4248" CHECKSUMTYPE="SHA-1" SIZE="71884">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:12:26" MIMETYPE="text/xml"
-				CHECKSUM="da56c43f912139a9a01c2ee87a25302b8b99407e" CHECKSUMTYPE="SHA-1" SIZE="92324">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:12:26" MIMETYPE="text/xml" CHECKSUM="da56c43f912139a9a01c2ee87a25302b8b99407e" CHECKSUMTYPE="SHA-1" SIZE="92324">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:12:26" MIMETYPE="text/xml"
-				CHECKSUM="fbed58504d38a5461b63773792128fdac7640afb" CHECKSUMTYPE="SHA-1" SIZE="192506">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:12:26" MIMETYPE="text/xml" CHECKSUM="fbed58504d38a5461b63773792128fdac7640afb" CHECKSUMTYPE="SHA-1" SIZE="192506">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:12:27" MIMETYPE="text/xml"
-				CHECKSUM="37ef68439e54e97ecb7e4100d1bf1d06f7ab9bdd" CHECKSUMTYPE="SHA-1" SIZE="187540">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:12:27" MIMETYPE="text/xml" CHECKSUM="37ef68439e54e97ecb7e4100d1bf1d06f7ab9bdd" CHECKSUMTYPE="SHA-1" SIZE="187540">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:12:27" MIMETYPE="text/xml"
-				CHECKSUM="f71b4510040fb2fb77cc2168d47120c8f8a5bd4c" CHECKSUMTYPE="SHA-1" SIZE="198155">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:12:27" MIMETYPE="text/xml" CHECKSUM="f71b4510040fb2fb77cc2168d47120c8f8a5bd4c" CHECKSUMTYPE="SHA-1" SIZE="198155">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:12:27" MIMETYPE="text/xml"
-				CHECKSUM="7919d76ed77c7789d5d665725ce7b0feb2ae9517" CHECKSUMTYPE="SHA-1" SIZE="41751">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:12:27" MIMETYPE="text/xml" CHECKSUM="7919d76ed77c7789d5d665725ce7b0feb2ae9517" CHECKSUMTYPE="SHA-1" SIZE="41751">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:12:28" MIMETYPE="text/xml"
-				CHECKSUM="86b64a7aaecf17959bdeff4f6166d1a375232c5d" CHECKSUMTYPE="SHA-1" SIZE="85562">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:12:28" MIMETYPE="text/xml" CHECKSUM="86b64a7aaecf17959bdeff4f6166d1a375232c5d" CHECKSUMTYPE="SHA-1" SIZE="85562">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:12:28" MIMETYPE="text/xml"
-				CHECKSUM="3bdbbe6d274428390c57f6ab24c1d5135c251b9b" CHECKSUMTYPE="SHA-1" SIZE="153959">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:12:28" MIMETYPE="text/xml" CHECKSUM="3bdbbe6d274428390c57f6ab24c1d5135c251b9b" CHECKSUMTYPE="SHA-1" SIZE="153959">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:12:28" MIMETYPE="text/xml"
-				CHECKSUM="4b40f423c872504266e1826632d689e20f26c976" CHECKSUMTYPE="SHA-1" SIZE="63647">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:12:28" MIMETYPE="text/xml" CHECKSUM="4b40f423c872504266e1826632d689e20f26c976" CHECKSUMTYPE="SHA-1" SIZE="63647">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:12:29" MIMETYPE="text/xml"
-				CHECKSUM="102a96d7141a9cad3625cd134f27d2e410462530" CHECKSUMTYPE="SHA-1" SIZE="80053">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:12:29" MIMETYPE="text/xml" CHECKSUM="102a96d7141a9cad3625cd134f27d2e410462530" CHECKSUMTYPE="SHA-1" SIZE="80053">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:12:29" MIMETYPE="text/xml"
-				CHECKSUM="36f1dfb30458e73bbdca8b34820f9a2f9607070e" CHECKSUMTYPE="SHA-1" SIZE="5160">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:12:29" MIMETYPE="text/xml" CHECKSUM="36f1dfb30458e73bbdca8b34820f9a2f9607070e" CHECKSUMTYPE="SHA-1" SIZE="5160">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:12:29" MIMETYPE="text/xml"
-				CHECKSUM="64c413d8fdcf97a31f85c1fdb16696feb3c0ceed" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:12:29" MIMETYPE="text/xml" CHECKSUM="64c413d8fdcf97a31f85c1fdb16696feb3c0ceed" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:12:29" MIMETYPE="text/xml"
-				CHECKSUM="97cb31b2f1f52456a9c5da556a15b2d25315d78d" CHECKSUMTYPE="SHA-1" SIZE="99404">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:12:29" MIMETYPE="text/xml" CHECKSUM="97cb31b2f1f52456a9c5da556a15b2d25315d78d" CHECKSUMTYPE="SHA-1" SIZE="99404">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:12:30" MIMETYPE="text/xml"
-				CHECKSUM="041ef11a91a1cfa5a4df301b157cde128efe45a5" CHECKSUMTYPE="SHA-1" SIZE="71511">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:12:30" MIMETYPE="text/xml" CHECKSUM="041ef11a91a1cfa5a4df301b157cde128efe45a5" CHECKSUMTYPE="SHA-1" SIZE="71511">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:12:30" MIMETYPE="text/xml"
-				CHECKSUM="bea1fefb13e23386e49f7a8b77571ee385347640" CHECKSUMTYPE="SHA-1" SIZE="97459">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:12:30" MIMETYPE="text/xml" CHECKSUM="bea1fefb13e23386e49f7a8b77571ee385347640" CHECKSUMTYPE="SHA-1" SIZE="97459">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:12:30" MIMETYPE="text/xml"
-				CHECKSUM="25fa3a1a5833f94858ba42f5eb8d8fa985984ff2" CHECKSUMTYPE="SHA-1" SIZE="132775">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:12:30" MIMETYPE="text/xml" CHECKSUM="25fa3a1a5833f94858ba42f5eb8d8fa985984ff2" CHECKSUMTYPE="SHA-1" SIZE="132775">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:12:31" MIMETYPE="text/xml"
-				CHECKSUM="f2c121ecebd60c88d683edbb609c0e54080ba021" CHECKSUMTYPE="SHA-1" SIZE="95850">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:12:31" MIMETYPE="text/xml" CHECKSUM="f2c121ecebd60c88d683edbb609c0e54080ba021" CHECKSUMTYPE="SHA-1" SIZE="95850">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:12:31" MIMETYPE="text/xml"
-				CHECKSUM="12666ad773314aa397d290ecbe3085d9b45e5f2b" CHECKSUMTYPE="SHA-1" SIZE="132045">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:12:31" MIMETYPE="text/xml" CHECKSUM="12666ad773314aa397d290ecbe3085d9b45e5f2b" CHECKSUMTYPE="SHA-1" SIZE="132045">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:12:31" MIMETYPE="text/xml"
-				CHECKSUM="14166ff94cbe0cdacc5f373325581601afd6b233" CHECKSUMTYPE="SHA-1" SIZE="105310">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:12:31" MIMETYPE="text/xml" CHECKSUM="14166ff94cbe0cdacc5f373325581601afd6b233" CHECKSUMTYPE="SHA-1" SIZE="105310">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:12:32" MIMETYPE="text/xml"
-				CHECKSUM="99deb1e8205527e53cd05abf6eaf26474c7a4452" CHECKSUMTYPE="SHA-1" SIZE="85792">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:12:32" MIMETYPE="text/xml" CHECKSUM="99deb1e8205527e53cd05abf6eaf26474c7a4452" CHECKSUMTYPE="SHA-1" SIZE="85792">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:12:32" MIMETYPE="text/xml"
-				CHECKSUM="0c07195d4ab49f441db3e5964ccfb8a33421acfc" CHECKSUMTYPE="SHA-1" SIZE="9597">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:12:32" MIMETYPE="text/xml" CHECKSUM="0c07195d4ab49f441db3e5964ccfb8a33421acfc" CHECKSUMTYPE="SHA-1" SIZE="9597">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:12:32" MIMETYPE="text/xml"
-				CHECKSUM="5054f91ba25b8264192dbec3c76421e0d20d2871" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:12:32" MIMETYPE="text/xml" CHECKSUM="5054f91ba25b8264192dbec3c76421e0d20d2871" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:12:32" MIMETYPE="text/xml"
-				CHECKSUM="6d3445daf21098024e586ce03ae510c2889699c5" CHECKSUMTYPE="SHA-1" SIZE="184482">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:12:32" MIMETYPE="text/xml" CHECKSUM="6d3445daf21098024e586ce03ae510c2889699c5" CHECKSUMTYPE="SHA-1" SIZE="184482">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:12:33" MIMETYPE="text/xml"
-				CHECKSUM="da203a255bc6e44b851de26a8e0f9f1e9753b2f9" CHECKSUMTYPE="SHA-1" SIZE="200845">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:12:33" MIMETYPE="text/xml" CHECKSUM="da203a255bc6e44b851de26a8e0f9f1e9753b2f9" CHECKSUMTYPE="SHA-1" SIZE="200845">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:12:33" MIMETYPE="text/xml"
-				CHECKSUM="bbc85ab5fd40b05c4536a1d0a4dedaca53f5a6af" CHECKSUMTYPE="SHA-1" SIZE="203523">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:12:33" MIMETYPE="text/xml" CHECKSUM="bbc85ab5fd40b05c4536a1d0a4dedaca53f5a6af" CHECKSUMTYPE="SHA-1" SIZE="203523">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:12:34" MIMETYPE="text/xml"
-				CHECKSUM="dda8e94001f2c848dc4d06192f76cf63eddf444c" CHECKSUMTYPE="SHA-1" SIZE="164407">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:12:34" MIMETYPE="text/xml" CHECKSUM="dda8e94001f2c848dc4d06192f76cf63eddf444c" CHECKSUMTYPE="SHA-1" SIZE="164407">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:12:34" MIMETYPE="text/xml"
-				CHECKSUM="6f8a26f88dd1d2486333e22d1857153528a47579" CHECKSUMTYPE="SHA-1" SIZE="85058">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:12:34" MIMETYPE="text/xml" CHECKSUM="6f8a26f88dd1d2486333e22d1857153528a47579" CHECKSUMTYPE="SHA-1" SIZE="85058">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:12:35" MIMETYPE="text/xml"
-				CHECKSUM="48d0e8dd1d30c0b96a941136593d02e99513784d" CHECKSUMTYPE="SHA-1" SIZE="189201">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:12:35" MIMETYPE="text/xml" CHECKSUM="48d0e8dd1d30c0b96a941136593d02e99513784d" CHECKSUMTYPE="SHA-1" SIZE="189201">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:12:35" MIMETYPE="text/xml"
-				CHECKSUM="e5706bcc6f03516ca4fc08974c701ff7c3e9de2b" CHECKSUMTYPE="SHA-1" SIZE="166504">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:12:35" MIMETYPE="text/xml" CHECKSUM="e5706bcc6f03516ca4fc08974c701ff7c3e9de2b" CHECKSUMTYPE="SHA-1" SIZE="166504">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:12:36" MIMETYPE="text/xml"
-				CHECKSUM="784009e2d859c9ff7bfcf5014015395c7288e0c5" CHECKSUMTYPE="SHA-1" SIZE="180987">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:12:36" MIMETYPE="text/xml" CHECKSUM="784009e2d859c9ff7bfcf5014015395c7288e0c5" CHECKSUMTYPE="SHA-1" SIZE="180987">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:12:36" MIMETYPE="text/xml"
-				CHECKSUM="c725d1ad6b87e715fe5cae9a00222fee3d133fab" CHECKSUMTYPE="SHA-1" SIZE="178859">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:12:36" MIMETYPE="text/xml" CHECKSUM="c725d1ad6b87e715fe5cae9a00222fee3d133fab" CHECKSUMTYPE="SHA-1" SIZE="178859">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:12:36" MIMETYPE="text/xml"
-				CHECKSUM="d64dc9112dce2ecb3e979d0c988fcaa202b78568" CHECKSUMTYPE="SHA-1" SIZE="180265">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:12:36" MIMETYPE="text/xml" CHECKSUM="d64dc9112dce2ecb3e979d0c988fcaa202b78568" CHECKSUMTYPE="SHA-1" SIZE="180265">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:12:37" MIMETYPE="text/xml"
-				CHECKSUM="d947fd689280ec2d24d3fa114151274799b593c5" CHECKSUMTYPE="SHA-1" SIZE="108205">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:12:37" MIMETYPE="text/xml" CHECKSUM="d947fd689280ec2d24d3fa114151274799b593c5" CHECKSUMTYPE="SHA-1" SIZE="108205">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:12:37" MIMETYPE="text/xml"
-				CHECKSUM="95c22d6c6d2ca405687a40ec0018daea33264535" CHECKSUMTYPE="SHA-1" SIZE="182344">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:12:37" MIMETYPE="text/xml" CHECKSUM="95c22d6c6d2ca405687a40ec0018daea33264535" CHECKSUMTYPE="SHA-1" SIZE="182344">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:12:37" MIMETYPE="text/xml"
-				CHECKSUM="6e0414048ae367801b577fcb3ca1baf92ecfad3d" CHECKSUMTYPE="SHA-1" SIZE="163554">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:12:37" MIMETYPE="text/xml" CHECKSUM="6e0414048ae367801b577fcb3ca1baf92ecfad3d" CHECKSUMTYPE="SHA-1" SIZE="163554">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:12:38" MIMETYPE="text/xml"
-				CHECKSUM="e28e53e8d10885f69cd2b21b6f280817bbd8fc8e" CHECKSUMTYPE="SHA-1" SIZE="185213">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:12:38" MIMETYPE="text/xml" CHECKSUM="e28e53e8d10885f69cd2b21b6f280817bbd8fc8e" CHECKSUMTYPE="SHA-1" SIZE="185213">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:12:39" MIMETYPE="text/xml"
-				CHECKSUM="221bc59826a7718b15f23d3453dbaa487487f3c7" CHECKSUMTYPE="SHA-1" SIZE="127194">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:12:39" MIMETYPE="text/xml" CHECKSUM="221bc59826a7718b15f23d3453dbaa487487f3c7" CHECKSUMTYPE="SHA-1" SIZE="127194">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:12:41" MIMETYPE="text/xml"
-				CHECKSUM="a398fe07acfcc4f9ef8b1fab8e893476c8e779c6" CHECKSUMTYPE="SHA-1" SIZE="61669">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:12:41" MIMETYPE="text/xml" CHECKSUM="a398fe07acfcc4f9ef8b1fab8e893476c8e779c6" CHECKSUMTYPE="SHA-1" SIZE="61669">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:12:41" MIMETYPE="text/xml"
-				CHECKSUM="5f8b5acf05c866e10b1908d9f0dead432c392997" CHECKSUMTYPE="SHA-1" SIZE="4659">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:12:41" MIMETYPE="text/xml" CHECKSUM="5f8b5acf05c866e10b1908d9f0dead432c392997" CHECKSUMTYPE="SHA-1" SIZE="4659">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:12:41" MIMETYPE="text/xml"
-				CHECKSUM="c09595c4745df40aea865253d99f04ff2355705a" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:12:41" MIMETYPE="text/xml" CHECKSUM="c09595c4745df40aea865253d99f04ff2355705a" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:12:41" MIMETYPE="text/xml"
-				CHECKSUM="6d77256cad8bdb4d819fa54deb362688fed8ddc7" CHECKSUMTYPE="SHA-1" SIZE="98704">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:12:41" MIMETYPE="text/xml" CHECKSUM="6d77256cad8bdb4d819fa54deb362688fed8ddc7" CHECKSUMTYPE="SHA-1" SIZE="98704">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:12:42" MIMETYPE="text/xml"
-				CHECKSUM="ae1fc12abdc3918b86cea6d3ab084a39935453d1" CHECKSUMTYPE="SHA-1" SIZE="139796">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:12:42" MIMETYPE="text/xml" CHECKSUM="ae1fc12abdc3918b86cea6d3ab084a39935453d1" CHECKSUMTYPE="SHA-1" SIZE="139796">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:12:42" MIMETYPE="text/xml"
-				CHECKSUM="3c67f9125d0bbb75328bd65a001393fa1765abd6" CHECKSUMTYPE="SHA-1" SIZE="141595">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:12:42" MIMETYPE="text/xml" CHECKSUM="3c67f9125d0bbb75328bd65a001393fa1765abd6" CHECKSUMTYPE="SHA-1" SIZE="141595">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:12:42" MIMETYPE="text/xml"
-				CHECKSUM="2bd947a054edb7056f0285c20f7ccbea45283d39" CHECKSUMTYPE="SHA-1" SIZE="93649">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:12:42" MIMETYPE="text/xml" CHECKSUM="2bd947a054edb7056f0285c20f7ccbea45283d39" CHECKSUMTYPE="SHA-1" SIZE="93649">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:12:43" MIMETYPE="text/xml"
-				CHECKSUM="3fb9fe74ca9e1c058e9707927b8462b0b7b6f541" CHECKSUMTYPE="SHA-1" SIZE="4617">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:12:43" MIMETYPE="text/xml" CHECKSUM="3fb9fe74ca9e1c058e9707927b8462b0b7b6f541" CHECKSUMTYPE="SHA-1" SIZE="4617">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:12:43" MIMETYPE="text/xml"
-				CHECKSUM="9c673e311a1a75697725ca555e85d037e9473b96" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:12:43" MIMETYPE="text/xml" CHECKSUM="9c673e311a1a75697725ca555e85d037e9473b96" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:12:43" MIMETYPE="text/xml"
-				CHECKSUM="8a2259f282113ee9336e10ce2c8c39a9b453e6f0" CHECKSUMTYPE="SHA-1" SIZE="81458">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:12:43" MIMETYPE="text/xml" CHECKSUM="8a2259f282113ee9336e10ce2c8c39a9b453e6f0" CHECKSUMTYPE="SHA-1" SIZE="81458">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:12:44" MIMETYPE="text/xml"
-				CHECKSUM="14ba338e504f6aee0c1da2c62f9b7a77a703b6e5" CHECKSUMTYPE="SHA-1" SIZE="196493">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:12:44" MIMETYPE="text/xml" CHECKSUM="14ba338e504f6aee0c1da2c62f9b7a77a703b6e5" CHECKSUMTYPE="SHA-1" SIZE="196493">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:12:44" MIMETYPE="text/xml"
-				CHECKSUM="8a03a455deb742ca31fffc23e2a93e3df37c362b" CHECKSUMTYPE="SHA-1" SIZE="138459">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:12:44" MIMETYPE="text/xml" CHECKSUM="8a03a455deb742ca31fffc23e2a93e3df37c362b" CHECKSUMTYPE="SHA-1" SIZE="138459">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:12:44" MIMETYPE="text/xml"
-				CHECKSUM="aeeb141d0d3b3cd43108776853efbcf9d7f85746" CHECKSUMTYPE="SHA-1" SIZE="138558">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:12:44" MIMETYPE="text/xml" CHECKSUM="aeeb141d0d3b3cd43108776853efbcf9d7f85746" CHECKSUMTYPE="SHA-1" SIZE="138558">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:12:45" MIMETYPE="text/xml"
-				CHECKSUM="c8e50034e6cdfd21275ed8f877bd33fdea488232" CHECKSUMTYPE="SHA-1" SIZE="4925">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:12:45" MIMETYPE="text/xml" CHECKSUM="c8e50034e6cdfd21275ed8f877bd33fdea488232" CHECKSUMTYPE="SHA-1" SIZE="4925">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:12:45" MIMETYPE="text/xml"
-				CHECKSUM="9558dc2875e54c9ba80ef93ecd349aa4c8417602" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:12:45" MIMETYPE="text/xml" CHECKSUM="9558dc2875e54c9ba80ef93ecd349aa4c8417602" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:12:45" MIMETYPE="text/xml"
-				CHECKSUM="e1ff6e2cc8840bfb27a5d37a5a417e1029da5783" CHECKSUMTYPE="SHA-1" SIZE="118997">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:12:45" MIMETYPE="text/xml" CHECKSUM="e1ff6e2cc8840bfb27a5d37a5a417e1029da5783" CHECKSUMTYPE="SHA-1" SIZE="118997">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:12:46" MIMETYPE="text/xml"
-				CHECKSUM="767cc6ae691e2cccf999a51cc942f27564309dba" CHECKSUMTYPE="SHA-1" SIZE="133078">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:12:46" MIMETYPE="text/xml" CHECKSUM="767cc6ae691e2cccf999a51cc942f27564309dba" CHECKSUMTYPE="SHA-1" SIZE="133078">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T18:12:46" MIMETYPE="text/xml"
-				CHECKSUM="cc784c1df366a03b02a3dca388177938861cf8f4" CHECKSUMTYPE="SHA-1" SIZE="102629">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T18:12:46" MIMETYPE="text/xml" CHECKSUM="cc784c1df366a03b02a3dca388177938861cf8f4" CHECKSUMTYPE="SHA-1" SIZE="102629">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T18:12:46" MIMETYPE="text/xml"
-				CHECKSUM="140c047a12b393954a762c72bf834a6a02f20f14" CHECKSUMTYPE="SHA-1" SIZE="47741">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T18:12:46" MIMETYPE="text/xml" CHECKSUM="140c047a12b393954a762c72bf834a6a02f20f14" CHECKSUMTYPE="SHA-1" SIZE="47741">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0094.alto.xml"/>
 			</file>
-			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T18:12:47" MIMETYPE="text/xml"
-				CHECKSUM="001479131ad70f089cdfed26564b3a8b97835388" CHECKSUMTYPE="SHA-1" SIZE="5471">
+			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T18:12:47" MIMETYPE="text/xml" CHECKSUM="001479131ad70f089cdfed26564b3a8b97835388" CHECKSUMTYPE="SHA-1" SIZE="5471">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0095.alto.xml"/>
 			</file>
-			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T18:12:47" MIMETYPE="text/xml"
-				CHECKSUM="98b785cf03d98b0826ccf9010d922388501123e5" CHECKSUMTYPE="SHA-1" SIZE="3918">
+			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T18:12:47" MIMETYPE="text/xml" CHECKSUM="98b785cf03d98b0826ccf9010d922388501123e5" CHECKSUMTYPE="SHA-1" SIZE="3918">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0096.alto.xml"/>
 			</file>
-			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T18:12:47" MIMETYPE="text/xml"
-				CHECKSUM="4539ba4e4d8f37c3dfeb1288e76c449a0bbd415a" CHECKSUMTYPE="SHA-1" SIZE="83308">
+			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T18:12:47" MIMETYPE="text/xml" CHECKSUM="4539ba4e4d8f37c3dfeb1288e76c449a0bbd415a" CHECKSUMTYPE="SHA-1" SIZE="83308">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0097.alto.xml"/>
 			</file>
-			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T18:12:47" MIMETYPE="text/xml"
-				CHECKSUM="63ec88545c6002ad79105727e4615cd76039cde9" CHECKSUMTYPE="SHA-1" SIZE="148807">
+			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T18:12:47" MIMETYPE="text/xml" CHECKSUM="63ec88545c6002ad79105727e4615cd76039cde9" CHECKSUMTYPE="SHA-1" SIZE="148807">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0098.alto.xml"/>
 			</file>
-			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T18:12:48" MIMETYPE="text/xml"
-				CHECKSUM="9c760fc0c3f11a21f8e08f901f8809e2fcec7651" CHECKSUMTYPE="SHA-1" SIZE="142691">
+			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T18:12:48" MIMETYPE="text/xml" CHECKSUM="9c760fc0c3f11a21f8e08f901f8809e2fcec7651" CHECKSUMTYPE="SHA-1" SIZE="142691">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0099.alto.xml"/>
 			</file>
-			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T18:12:48" MIMETYPE="text/xml"
-				CHECKSUM="916cb578627f1a08d82b7d7970bcb1ebe072521e" CHECKSUMTYPE="SHA-1" SIZE="28691">
+			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T18:12:48" MIMETYPE="text/xml" CHECKSUM="916cb578627f1a08d82b7d7970bcb1ebe072521e" CHECKSUMTYPE="SHA-1" SIZE="28691">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0100.alto.xml"/>
 			</file>
-			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T18:12:48" MIMETYPE="text/xml"
-				CHECKSUM="d2cb33b9c7afb0edce2f48c244c0693cb9d873e5" CHECKSUMTYPE="SHA-1" SIZE="4495">
+			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T18:12:48" MIMETYPE="text/xml" CHECKSUM="d2cb33b9c7afb0edce2f48c244c0693cb9d873e5" CHECKSUMTYPE="SHA-1" SIZE="4495">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0101.alto.xml"/>
 			</file>
-			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T18:12:49" MIMETYPE="text/xml"
-				CHECKSUM="c0c25312bde84aacbc365a15b6c8dad23b48f7fc" CHECKSUMTYPE="SHA-1" SIZE="2022">
+			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T18:12:49" MIMETYPE="text/xml" CHECKSUM="c0c25312bde84aacbc365a15b6c8dad23b48f7fc" CHECKSUMTYPE="SHA-1" SIZE="2022">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0102.alto.xml"/>
 			</file>
-			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T18:12:49" MIMETYPE="text/xml"
-				CHECKSUM="d72e02ac22e8ea2796389d5abd65f54b18b3557b" CHECKSUMTYPE="SHA-1" SIZE="115452">
+			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T18:12:49" MIMETYPE="text/xml" CHECKSUM="d72e02ac22e8ea2796389d5abd65f54b18b3557b" CHECKSUMTYPE="SHA-1" SIZE="115452">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0103.alto.xml"/>
 			</file>
-			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T18:12:49" MIMETYPE="text/xml"
-				CHECKSUM="af85b2a6d06cf789339c9ec862b6f2bfee715831" CHECKSUMTYPE="SHA-1" SIZE="198987">
+			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T18:12:49" MIMETYPE="text/xml" CHECKSUM="af85b2a6d06cf789339c9ec862b6f2bfee715831" CHECKSUMTYPE="SHA-1" SIZE="198987">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0104.alto.xml"/>
 			</file>
-			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T18:12:50" MIMETYPE="text/xml"
-				CHECKSUM="4ae547eaac7ebe963b569904bbfef2054525d758" CHECKSUMTYPE="SHA-1" SIZE="195837">
+			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T18:12:50" MIMETYPE="text/xml" CHECKSUM="4ae547eaac7ebe963b569904bbfef2054525d758" CHECKSUMTYPE="SHA-1" SIZE="195837">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0105.alto.xml"/>
 			</file>
-			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T18:12:50" MIMETYPE="text/xml"
-				CHECKSUM="c3acf3bfe2eff19941f9495c8b026b0f2f7e7e5e" CHECKSUMTYPE="SHA-1" SIZE="140378">
+			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T18:12:50" MIMETYPE="text/xml" CHECKSUM="c3acf3bfe2eff19941f9495c8b026b0f2f7e7e5e" CHECKSUMTYPE="SHA-1" SIZE="140378">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0106.alto.xml"/>
 			</file>
-			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T18:12:51" MIMETYPE="text/xml"
-				CHECKSUM="a9e1ef056f50e6faa4d5f236a96cdfe84598c0dd" CHECKSUMTYPE="SHA-1" SIZE="4028">
+			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T18:12:51" MIMETYPE="text/xml" CHECKSUM="a9e1ef056f50e6faa4d5f236a96cdfe84598c0dd" CHECKSUMTYPE="SHA-1" SIZE="4028">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0107.alto.xml"/>
 			</file>
-			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T18:12:51" MIMETYPE="text/xml"
-				CHECKSUM="48ecab29477825aaf1a39a5373b2d86fccae999f" CHECKSUMTYPE="SHA-1" SIZE="2022">
+			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T18:12:51" MIMETYPE="text/xml" CHECKSUM="48ecab29477825aaf1a39a5373b2d86fccae999f" CHECKSUMTYPE="SHA-1" SIZE="2022">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0108.alto.xml"/>
 			</file>
-			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T18:12:51" MIMETYPE="text/xml"
-				CHECKSUM="ea105230801c75c832f5c609211db6b617978664" CHECKSUMTYPE="SHA-1" SIZE="100134">
+			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T18:12:51" MIMETYPE="text/xml" CHECKSUM="ea105230801c75c832f5c609211db6b617978664" CHECKSUMTYPE="SHA-1" SIZE="100134">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0109.alto.xml"/>
 			</file>
-			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T18:12:51" MIMETYPE="text/xml"
-				CHECKSUM="1f16249379bbe95c085d7f20ff61bb7bfdf709b5" CHECKSUMTYPE="SHA-1" SIZE="157798">
+			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T18:12:51" MIMETYPE="text/xml" CHECKSUM="1f16249379bbe95c085d7f20ff61bb7bfdf709b5" CHECKSUMTYPE="SHA-1" SIZE="157798">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0110.alto.xml"/>
 			</file>
-			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-07-30T18:12:52" MIMETYPE="text/xml"
-				CHECKSUM="4d23f32bd181392d15af91232c8045c0afa4391f" CHECKSUMTYPE="SHA-1" SIZE="103635">
+			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-07-30T18:12:52" MIMETYPE="text/xml" CHECKSUM="4d23f32bd181392d15af91232c8045c0afa4391f" CHECKSUMTYPE="SHA-1" SIZE="103635">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0111.alto.xml"/>
 			</file>
-			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-07-30T18:12:52" MIMETYPE="text/xml"
-				CHECKSUM="d4e52be747ff4f7c8f0ab12a90fdd6b4e62736ad" CHECKSUMTYPE="SHA-1" SIZE="112464">
+			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-07-30T18:12:52" MIMETYPE="text/xml" CHECKSUM="d4e52be747ff4f7c8f0ab12a90fdd6b4e62736ad" CHECKSUMTYPE="SHA-1" SIZE="112464">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0112.alto.xml"/>
 			</file>
-			<file ID="ALTO00113" GROUPID="page113" CREATED="2015-07-30T18:12:52" MIMETYPE="text/xml"
-				CHECKSUM="8884c6baf3d6d370617cf7bd6556a0a6f2b2d2ab" CHECKSUMTYPE="SHA-1" SIZE="4499">
+			<file ID="ALTO00113" GROUPID="page113" CREATED="2015-07-30T18:12:52" MIMETYPE="text/xml" CHECKSUM="8884c6baf3d6d370617cf7bd6556a0a6f2b2d2ab" CHECKSUMTYPE="SHA-1" SIZE="4499">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0113.alto.xml"/>
 			</file>
-			<file ID="ALTO00114" GROUPID="page114" CREATED="2015-07-30T18:12:52" MIMETYPE="text/xml"
-				CHECKSUM="e536bc1e2e2365fedaf22abb09ecbd9a328dc7ef" CHECKSUMTYPE="SHA-1" SIZE="2022">
+			<file ID="ALTO00114" GROUPID="page114" CREATED="2015-07-30T18:12:52" MIMETYPE="text/xml" CHECKSUM="e536bc1e2e2365fedaf22abb09ecbd9a328dc7ef" CHECKSUMTYPE="SHA-1" SIZE="2022">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0114.alto.xml"/>
 			</file>
-			<file ID="ALTO00115" GROUPID="page115" CREATED="2015-07-30T18:12:53" MIMETYPE="text/xml"
-				CHECKSUM="74c8a980b52b5d469a335a7ff70c5dd1f62b4a57" CHECKSUMTYPE="SHA-1" SIZE="61250">
+			<file ID="ALTO00115" GROUPID="page115" CREATED="2015-07-30T18:12:53" MIMETYPE="text/xml" CHECKSUM="74c8a980b52b5d469a335a7ff70c5dd1f62b4a57" CHECKSUMTYPE="SHA-1" SIZE="61250">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0115.alto.xml"/>
 			</file>
-			<file ID="ALTO00116" GROUPID="page116" CREATED="2015-07-30T18:12:53" MIMETYPE="text/xml"
-				CHECKSUM="06b80c88d9e5144419a1ff45d05b3c8dafa37d90" CHECKSUMTYPE="SHA-1" SIZE="60510">
+			<file ID="ALTO00116" GROUPID="page116" CREATED="2015-07-30T18:12:53" MIMETYPE="text/xml" CHECKSUM="06b80c88d9e5144419a1ff45d05b3c8dafa37d90" CHECKSUMTYPE="SHA-1" SIZE="60510">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0116.alto.xml"/>
 			</file>
-			<file ID="ALTO00117" GROUPID="page117" CREATED="2015-07-30T18:12:53" MIMETYPE="text/xml"
-				CHECKSUM="1c4ed8f94755e81869318489c4d31a0dc941a433" CHECKSUMTYPE="SHA-1" SIZE="18155">
+			<file ID="ALTO00117" GROUPID="page117" CREATED="2015-07-30T18:12:53" MIMETYPE="text/xml" CHECKSUM="1c4ed8f94755e81869318489c4d31a0dc941a433" CHECKSUMTYPE="SHA-1" SIZE="18155">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0117.alto.xml"/>
 			</file>
-			<file ID="ALTO00118" GROUPID="page118" CREATED="2015-07-30T18:12:54" MIMETYPE="text/xml"
-				CHECKSUM="3461139703937aafe2f2d913d7a133b2c41655f8" CHECKSUMTYPE="SHA-1" SIZE="48752">
+			<file ID="ALTO00118" GROUPID="page118" CREATED="2015-07-30T18:12:54" MIMETYPE="text/xml" CHECKSUM="3461139703937aafe2f2d913d7a133b2c41655f8" CHECKSUMTYPE="SHA-1" SIZE="48752">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0118.alto.xml"/>
 			</file>
-			<file ID="ALTO00119" GROUPID="page119" CREATED="2015-07-30T18:12:54" MIMETYPE="text/xml"
-				CHECKSUM="17897075787588494627e5aa700dc0c58e2044a3" CHECKSUMTYPE="SHA-1" SIZE="2012">
+			<file ID="ALTO00119" GROUPID="page119" CREATED="2015-07-30T18:12:54" MIMETYPE="text/xml" CHECKSUM="17897075787588494627e5aa700dc0c58e2044a3" CHECKSUMTYPE="SHA-1" SIZE="2012">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0119.alto.xml"/>
 			</file>
-			<file ID="ALTO00120" GROUPID="page120" CREATED="2015-07-30T18:12:54" MIMETYPE="text/xml"
-				CHECKSUM="4502abf873e6fe57a45cc4395f604b7f9ba1898e" CHECKSUMTYPE="SHA-1" SIZE="6171">
+			<file ID="ALTO00120" GROUPID="page120" CREATED="2015-07-30T18:12:54" MIMETYPE="text/xml" CHECKSUM="4502abf873e6fe57a45cc4395f604b7f9ba1898e" CHECKSUMTYPE="SHA-1" SIZE="6171">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-04_01_0120.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:17:21" MIMETYPE="application/pdf" CHECKSUM="18a8645158bbfe531ca7fa6d5b2f19c5b297b525"
-				CHECKSUMTYPE="SHA-1" SIZE="77463151">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/bmtnabe_1897-04_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:17:21" MIMETYPE="application/pdf" CHECKSUM="18a8645158bbfe531ca7fa6d5b2f19c5b297b525" CHECKSUMTYPE="SHA-1" SIZE="77463151">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/04_01/bmtnabe_1897-04_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -15197,8 +14831,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.35.10" TYPE="Illustration" ORDER="1" DMDID="c132"
-						LABEL="SCHMUCKFASSUNG SCHULE IN BIRMINGHAM für den pan GEZEICHNET">
+					<div ID="L.1.1.35.10" TYPE="Illustration" ORDER="1" DMDID="c132" LABEL="SCHMUCKFASSUNG SCHULE IN BIRMINGHAM für den pan GEZEICHNET">
 						<div ID="L.1.1.35.10.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00092" BEGIN="P92_CB00001"/>
@@ -15210,8 +14843,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.35.11" TYPE="Illustration" ORDER="1" DMDID="c133"
-						LABEL="HARRISON TOWNSEND KAPITÄL IN HOLZ GESCHNITTEN FÜR DEN PAN GEZEICHNET">
+					<div ID="L.1.1.35.11" TYPE="Illustration" ORDER="1" DMDID="c133" LABEL="HARRISON TOWNSEND KAPITÄL IN HOLZ GESCHNITTEN FÜR DEN PAN GEZEICHNET">
 						<div ID="L.1.1.35.11.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00092" BEGIN="P92_CB00002"/>
@@ -15223,8 +14855,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.35.12" TYPE="Illustration" ORDER="1" DMDID="c134"
-						LABEL="HARRISON TOWNSEND AUS DEM ENTWURF ZUR BILDERGALERIE IN WHITECHAPEL FÜR DEN PAN GEZEICHNET">
+					<div ID="L.1.1.35.12" TYPE="Illustration" ORDER="1" DMDID="c134" LABEL="HARRISON TOWNSEND AUS DEM ENTWURF ZUR BILDERGALERIE IN WHITECHAPEL FÜR DEN PAN GEZEICHNET">
 						<div ID="L.1.1.35.12.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00093" BEGIN="P93_CB00001"/>

--- a/metadata/periodicals/bmtnabe/issues/1897/05_01/bmtnabe_1897-05_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1897/05_01/bmtnabe_1897-05_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1897-05_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1897-05_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-05_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-05_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1897-05_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1897-05_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-05_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -8717,878 +8713,588 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:23:38" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="935b490cc2ab6e794314ffddcd0e43c4d6a31896" CHECKSUMTYPE="SHA-1" SIZE="4735887">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:24:01" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="23718ca5e49089046a2a3eb6a154769e923c22d6" CHECKSUMTYPE="SHA-1" SIZE="5022129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:24:26" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="f06a0dad8ee4eb5e4f8c31d85e927517d17efd2d" CHECKSUMTYPE="SHA-1" SIZE="4735924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:24:49" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="9f11a3755de43f1491a42c0fbcff660f33c7c464" CHECKSUMTYPE="SHA-1" SIZE="5022129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:25:10" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="06547e5be3a101d60e4dfbe2dcdff0711dd6f7a9" CHECKSUMTYPE="SHA-1" SIZE="4760227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:25:33" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="060b3d7f3e3f9fd1b347cc10a1d371975b79fe71" CHECKSUMTYPE="SHA-1" SIZE="5022106">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:25:55" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="949a933467b158d3d6a5dee0a9753ffe832149a9" CHECKSUMTYPE="SHA-1" SIZE="4720611">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:26:20" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="a373784aaf49bf0ab9a1be044d8f18c578ef21d4" CHECKSUMTYPE="SHA-1" SIZE="5022126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:26:43" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="c0223f5d25e440ec72b2fa6b6079c0e130bcc16d" CHECKSUMTYPE="SHA-1" SIZE="4724225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:27:09" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="f91cab28e99ac0d8d2680a214f0549c6fb57b23a" CHECKSUMTYPE="SHA-1" SIZE="5024826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:27:31" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="2805222a0029c5d2a35b161c8d55c93dfe062a91" CHECKSUMTYPE="SHA-1" SIZE="4690021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:27:54" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="9d02b2a3c9c7a5ddbac1ca0be77365636cac77dd" CHECKSUMTYPE="SHA-1" SIZE="5024758">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:28:17" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="e2e10d64a928d69ec013debef2869b4d4662a940" CHECKSUMTYPE="SHA-1" SIZE="4700829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:28:41" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="e3b9aebb09b119eaa5d416597adebe8df6c783fc" CHECKSUMTYPE="SHA-1" SIZE="5024826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:29:02" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="5f1fc996afd7429187e3de67e3070b31a2738d58" CHECKSUMTYPE="SHA-1" SIZE="4667528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:29:23" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="8fb197d6b51157a8dbf8e28c6a6ac1c696fdd133" CHECKSUMTYPE="SHA-1" SIZE="5069829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:29:45" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="5157c3d4dfb48b79b393fecb760211c3d79383e6" CHECKSUMTYPE="SHA-1" SIZE="4679229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:30:06" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="1b697e7cda4d5d8a25b47d541300839e647fd7dc" CHECKSUMTYPE="SHA-1" SIZE="5069829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:30:28" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="8c6c5e992af324c3d9fa5ae7611e4e52e6ecfcb0" CHECKSUMTYPE="SHA-1" SIZE="4654915">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:30:50" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="a957e8e9199f6e0f949cfca4ccdd4d74807ce9af" CHECKSUMTYPE="SHA-1" SIZE="5069822">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:31:12" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="d9f262c01c8991cd852fde5eff0a19f58d4497ef" CHECKSUMTYPE="SHA-1" SIZE="4672917">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:31:33" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="6c2762881f67527487eacb1603c6c93bd837fde3" CHECKSUMTYPE="SHA-1" SIZE="5085120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:31:54" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="e93564ff4cad5c5a36e9bdbe768048b3b19a3f7a" CHECKSUMTYPE="SHA-1" SIZE="4672927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:32:17" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="c885f37531a0f91e4b6a4322d7e238767a5e6c10" CHECKSUMTYPE="SHA-1" SIZE="5097724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:32:42" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="823db4732aaa4a3ec36a412a02c5abf255f7b760" CHECKSUMTYPE="SHA-1" SIZE="4672927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:33:04" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="950ea29a2f92b07e12d16d411dca0c21ae7516d7" CHECKSUMTYPE="SHA-1" SIZE="5059928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:33:25" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="2086346a26eefa1dcf5b2489fa3132b3920a0d7f" CHECKSUMTYPE="SHA-1" SIZE="4841885">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:33:49" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="e7a3e5c0c65215761bf7de200fc4faa86f51e236" CHECKSUMTYPE="SHA-1" SIZE="5059922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:34:12" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="77d59278a87502522240f91d00aa5782f4c65353" CHECKSUMTYPE="SHA-1" SIZE="4742226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:34:34" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="bd46188d64ce8c50b85643dd81b39612151cf5e2" CHECKSUMTYPE="SHA-1" SIZE="5059928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:34:56" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="1b3d9da8a2b04ed45b95b720c14282e531deb85e" CHECKSUMTYPE="SHA-1" SIZE="4715229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:35:19" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="4c790f3d224face5ae366f59cf39ebf649eb03ba" CHECKSUMTYPE="SHA-1" SIZE="5059926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:35:42" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="eae6aecfee67ec465107a9bbc6b8fdd63a45e8b0" CHECKSUMTYPE="SHA-1" SIZE="4715229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:36:05" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="b5d4e528b95f9ede8cb831b829a1d593e7654e42" CHECKSUMTYPE="SHA-1" SIZE="5068029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:36:26" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="219628971087d708b4302418f60ff61a5dc17373" CHECKSUMTYPE="SHA-1" SIZE="4715224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:36:48" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="d7936f609eb1e8bb2bf42542f30a753791ee2139" CHECKSUMTYPE="SHA-1" SIZE="5068025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:37:10" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="5bfc562394273624760673719a0ce4bc6e6140f1" CHECKSUMTYPE="SHA-1" SIZE="4705954">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:37:33" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="a25eb39ee74a67a5a2d1413da72bfcea4122a96f" CHECKSUMTYPE="SHA-1" SIZE="5068029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:37:56" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="fcda6d234229552bef28820d04f1edd5d44f2ea1" CHECKSUMTYPE="SHA-1" SIZE="4738629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:38:19" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="d4ca38b00bb1e10f9ae5479ff415e1b775a80b9e" CHECKSUMTYPE="SHA-1" SIZE="5068027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:38:43" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="ccf80a10d2b9dcb5d7fdbca98b2509cb357a40e0" CHECKSUMTYPE="SHA-1" SIZE="4715096">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:39:07" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="048b1bf72900b575a2103546ffcadeaa670697e1" CHECKSUMTYPE="SHA-1" SIZE="5165227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:39:31" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="d4a564e5e415e8cca543f110e2182d82be7bb8b1" CHECKSUMTYPE="SHA-1" SIZE="4649526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:39:54" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="22eb6b4ae9302ea8678f13a898490a95dc1c2efd" CHECKSUMTYPE="SHA-1" SIZE="5106696">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:40:16" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="d925bafe87388729ce21500f5a0ec0f0555fa870" CHECKSUMTYPE="SHA-1" SIZE="4672029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:40:39" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="798ad52d01392acb56b12a7c36efe4c8f95db0e9" CHECKSUMTYPE="SHA-1" SIZE="5106713">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:41:02" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="94e39f8a25c06336bfbe7704dfba9670f6c1ec78" CHECKSUMTYPE="SHA-1" SIZE="4672027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:41:25" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="6aeceb97449d1a60860ee71c4ebb0ce4ba3b1583" CHECKSUMTYPE="SHA-1" SIZE="5106690">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:41:51" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="08af118b4b5ffceb31a8cd2e22f4e2e998b87b1d" CHECKSUMTYPE="SHA-1" SIZE="4740393">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:42:15" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="b175d5a06c4672a5963ac622c9bf9d1b4a6ea4bf" CHECKSUMTYPE="SHA-1" SIZE="5132828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:42:38" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="3dcb0f4268777306f8d945a2e1212835edaf8d74" CHECKSUMTYPE="SHA-1" SIZE="4740428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:43:03" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="979791a357c7b548eab6e8b3a78fbb338ce6fe18" CHECKSUMTYPE="SHA-1" SIZE="5132819">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:43:27" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="ba859cca642d2cd87f57ae9b3931a3a7e089168a" CHECKSUMTYPE="SHA-1" SIZE="4740427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:43:49" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="6d2a26d19951d32461f33e83d80994d947ff8824" CHECKSUMTYPE="SHA-1" SIZE="5122927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:44:12" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="390fe2e3623c1457b64367de933d92325727b67c" CHECKSUMTYPE="SHA-1" SIZE="4740424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:44:36" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="9575f2fdc4bb04013c726041bb829ce2153ec63e" CHECKSUMTYPE="SHA-1" SIZE="5133728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:45:00" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="0c2b2b914894954782346f2a406ee27c787d7b7e" CHECKSUMTYPE="SHA-1" SIZE="4740412">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:45:26" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="bd0220089c0b247e34cbd5448bb2248cab594fc9" CHECKSUMTYPE="SHA-1" SIZE="5133728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T17:45:52" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="cd02ca30a5d7f4c0283d92b5cb3c33fd0f34718e" CHECKSUMTYPE="SHA-1" SIZE="4749417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T17:46:18" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="845346e783cbe318885d3e9dcdcc194bd6ccca38" CHECKSUMTYPE="SHA-1" SIZE="5165190">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T17:46:41" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="2b3f0071dfd56fc22da43e52532042e6fd102569" CHECKSUMTYPE="SHA-1" SIZE="4898829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T17:47:03" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="4f7e7b437fa719c0a3f13e2f8aa5ea0db23e6f40" CHECKSUMTYPE="SHA-1" SIZE="5133729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T17:47:29" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="4e8ee8fab5f4807a4af52cb01b098b5bf4c2eca6" CHECKSUMTYPE="SHA-1" SIZE="4973525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T17:47:55" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="af9ad1503a298fd42cbcd310cbb21ac7ce01e405" CHECKSUMTYPE="SHA-1" SIZE="5147229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T17:48:21" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="aa33ac89bc9536dfc74746c8ece6452353737d36" CHECKSUMTYPE="SHA-1" SIZE="4971702">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T17:48:45" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="52bfc61f88808cec3d1d8d4d46f908bd4bc31a62" CHECKSUMTYPE="SHA-1" SIZE="5147228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T17:49:15" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="ddddba7151cc3d9ad3bf8339ec682d7f7f2a1d56" CHECKSUMTYPE="SHA-1" SIZE="4971723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T17:49:44" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="141c5068e20291d56755bd286d501ce73f8281bc" CHECKSUMTYPE="SHA-1" SIZE="5147227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T17:50:09" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="f8e450b30f9d633fc7056faa9c67c45128edfb50" CHECKSUMTYPE="SHA-1" SIZE="4971727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T17:50:33" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="c780df9a7e763ca972f65803869a146253476084" CHECKSUMTYPE="SHA-1" SIZE="5147227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T17:50:57" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="aa4ed05b9880e2e2cb14a655a3ea02c1bda0e6dd" CHECKSUMTYPE="SHA-1" SIZE="4971726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T17:51:20" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="3f37f570c76f922fdcf0adddb1fec81ced63de32" CHECKSUMTYPE="SHA-1" SIZE="5147224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T17:51:45" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="8125c8e393d1f4991772e318effe09c755c4e0b2" CHECKSUMTYPE="SHA-1" SIZE="4971718">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T17:52:10" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="36cdc9e1de392961f19be996cb009966085b23c2" CHECKSUMTYPE="SHA-1" SIZE="5226426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T17:52:41" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="a24f70b114ca76670223a48e4172f3e72558c5a2" CHECKSUMTYPE="SHA-1" SIZE="4971729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T17:53:07" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="714d72a6bda28012aee4b7749b3e37b97b69bd17" CHECKSUMTYPE="SHA-1" SIZE="5207527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T17:53:31" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="5dd606b2bec9fc30429f38a8742ddc0f2ff11560" CHECKSUMTYPE="SHA-1" SIZE="5050026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T17:53:56" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="79bc56c385f77e6577e3e9bc3be56f69c419fafa" CHECKSUMTYPE="SHA-1" SIZE="5207517">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:54:21" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="09f015647cf168f2e66f24ff5665374bf1326947" CHECKSUMTYPE="SHA-1" SIZE="5056324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:54:44" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="ed7f9154fe9c95d9b68a4bb8131f8288c2a79afb" CHECKSUMTYPE="SHA-1" SIZE="5207529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:55:11" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="f605b29d666b05196bffd512678d77f7df6740f0" CHECKSUMTYPE="SHA-1" SIZE="5008622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:55:35" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="c6cdda8ffbb729d505a0d57ab60fed51943c5e0f" CHECKSUMTYPE="SHA-1" SIZE="5207508">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:56:00" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="4452e4920b3c86d353396f1b7ae732d434f604f1" CHECKSUMTYPE="SHA-1" SIZE="5025726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:56:27" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="b603403a22bb227bb1914da08df6d485eed90b11" CHECKSUMTYPE="SHA-1" SIZE="5207527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:56:49" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="d1006ad21766c7a7caebc719f25de243215fc96a" CHECKSUMTYPE="SHA-1" SIZE="5025659">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:57:15" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="911117f5ff0691c44e9d635b80c15cffa4d24ce1" CHECKSUMTYPE="SHA-1" SIZE="5202129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:57:42" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="df0ffa73d130b76e080a25ddd05200928975b150" CHECKSUMTYPE="SHA-1" SIZE="5025725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:58:07" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="71e8795e6b168a70cea8d4186f31b87f30d5bdce" CHECKSUMTYPE="SHA-1" SIZE="5192224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:58:33" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="b0a51eecddc0e2d90648dcf78cc3e907883ad947" CHECKSUMTYPE="SHA-1" SIZE="5030199">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:58:57" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="67bb146ce8cd2d37dd960a2139a96dab2706027b" CHECKSUMTYPE="SHA-1" SIZE="5196729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:59:20" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="094aac67b01f6491bcb8826c2af4a8211ac59d8e" CHECKSUMTYPE="SHA-1" SIZE="4960920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:59:44" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="4cd9e17177f4f5db5f53165a04516934492fad4e" CHECKSUMTYPE="SHA-1" SIZE="5225526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T18:00:06" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="8b0d8dac8849b10b094179a9474a51a580815522" CHECKSUMTYPE="SHA-1" SIZE="4969026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T18:00:31" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="c9e3a2621108c826318e4d0d3519ab2bdbbbdccc" CHECKSUMTYPE="SHA-1" SIZE="5225525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0094.jp2"/>
-			</file>
-			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T18:00:54" MIMETYPE="image/jp2" SEQ="95"
-				CHECKSUM="5ab299718a8893fae7151cdfe56350a7269de0af" CHECKSUMTYPE="SHA-1" SIZE="4912237">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0095.jp2"/>
-			</file>
-			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T18:01:19" MIMETYPE="image/jp2" SEQ="96"
-				CHECKSUM="e13fb6c6c07a6036f3d7fdc372bcb2a4076b184a" CHECKSUMTYPE="SHA-1" SIZE="5203882">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0096.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:23:38" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="935b490cc2ab6e794314ffddcd0e43c4d6a31896" CHECKSUMTYPE="SHA-1" SIZE="4735887">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:24:01" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="23718ca5e49089046a2a3eb6a154769e923c22d6" CHECKSUMTYPE="SHA-1" SIZE="5022129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:24:26" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="f06a0dad8ee4eb5e4f8c31d85e927517d17efd2d" CHECKSUMTYPE="SHA-1" SIZE="4735924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:24:49" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="9f11a3755de43f1491a42c0fbcff660f33c7c464" CHECKSUMTYPE="SHA-1" SIZE="5022129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:25:10" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="06547e5be3a101d60e4dfbe2dcdff0711dd6f7a9" CHECKSUMTYPE="SHA-1" SIZE="4760227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:25:33" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="060b3d7f3e3f9fd1b347cc10a1d371975b79fe71" CHECKSUMTYPE="SHA-1" SIZE="5022106">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:25:55" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="949a933467b158d3d6a5dee0a9753ffe832149a9" CHECKSUMTYPE="SHA-1" SIZE="4720611">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:26:20" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a373784aaf49bf0ab9a1be044d8f18c578ef21d4" CHECKSUMTYPE="SHA-1" SIZE="5022126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:26:43" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="c0223f5d25e440ec72b2fa6b6079c0e130bcc16d" CHECKSUMTYPE="SHA-1" SIZE="4724225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:27:09" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="f91cab28e99ac0d8d2680a214f0549c6fb57b23a" CHECKSUMTYPE="SHA-1" SIZE="5024826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:27:31" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="2805222a0029c5d2a35b161c8d55c93dfe062a91" CHECKSUMTYPE="SHA-1" SIZE="4690021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:27:54" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="9d02b2a3c9c7a5ddbac1ca0be77365636cac77dd" CHECKSUMTYPE="SHA-1" SIZE="5024758">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:28:17" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="e2e10d64a928d69ec013debef2869b4d4662a940" CHECKSUMTYPE="SHA-1" SIZE="4700829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:28:41" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="e3b9aebb09b119eaa5d416597adebe8df6c783fc" CHECKSUMTYPE="SHA-1" SIZE="5024826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:29:02" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="5f1fc996afd7429187e3de67e3070b31a2738d58" CHECKSUMTYPE="SHA-1" SIZE="4667528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:29:23" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="8fb197d6b51157a8dbf8e28c6a6ac1c696fdd133" CHECKSUMTYPE="SHA-1" SIZE="5069829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:29:45" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="5157c3d4dfb48b79b393fecb760211c3d79383e6" CHECKSUMTYPE="SHA-1" SIZE="4679229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:30:06" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="1b697e7cda4d5d8a25b47d541300839e647fd7dc" CHECKSUMTYPE="SHA-1" SIZE="5069829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:30:28" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="8c6c5e992af324c3d9fa5ae7611e4e52e6ecfcb0" CHECKSUMTYPE="SHA-1" SIZE="4654915">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:30:50" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="a957e8e9199f6e0f949cfca4ccdd4d74807ce9af" CHECKSUMTYPE="SHA-1" SIZE="5069822">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:31:12" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="d9f262c01c8991cd852fde5eff0a19f58d4497ef" CHECKSUMTYPE="SHA-1" SIZE="4672917">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:31:33" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="6c2762881f67527487eacb1603c6c93bd837fde3" CHECKSUMTYPE="SHA-1" SIZE="5085120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:31:54" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="e93564ff4cad5c5a36e9bdbe768048b3b19a3f7a" CHECKSUMTYPE="SHA-1" SIZE="4672927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:32:17" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="c885f37531a0f91e4b6a4322d7e238767a5e6c10" CHECKSUMTYPE="SHA-1" SIZE="5097724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:32:42" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="823db4732aaa4a3ec36a412a02c5abf255f7b760" CHECKSUMTYPE="SHA-1" SIZE="4672927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:33:04" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="950ea29a2f92b07e12d16d411dca0c21ae7516d7" CHECKSUMTYPE="SHA-1" SIZE="5059928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:33:25" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="2086346a26eefa1dcf5b2489fa3132b3920a0d7f" CHECKSUMTYPE="SHA-1" SIZE="4841885">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:33:49" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="e7a3e5c0c65215761bf7de200fc4faa86f51e236" CHECKSUMTYPE="SHA-1" SIZE="5059922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:34:12" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="77d59278a87502522240f91d00aa5782f4c65353" CHECKSUMTYPE="SHA-1" SIZE="4742226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:34:34" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="bd46188d64ce8c50b85643dd81b39612151cf5e2" CHECKSUMTYPE="SHA-1" SIZE="5059928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:34:56" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="1b3d9da8a2b04ed45b95b720c14282e531deb85e" CHECKSUMTYPE="SHA-1" SIZE="4715229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:35:19" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="4c790f3d224face5ae366f59cf39ebf649eb03ba" CHECKSUMTYPE="SHA-1" SIZE="5059926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:35:42" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="eae6aecfee67ec465107a9bbc6b8fdd63a45e8b0" CHECKSUMTYPE="SHA-1" SIZE="4715229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:36:05" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="b5d4e528b95f9ede8cb831b829a1d593e7654e42" CHECKSUMTYPE="SHA-1" SIZE="5068029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:36:26" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="219628971087d708b4302418f60ff61a5dc17373" CHECKSUMTYPE="SHA-1" SIZE="4715224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:36:48" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="d7936f609eb1e8bb2bf42542f30a753791ee2139" CHECKSUMTYPE="SHA-1" SIZE="5068025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:37:10" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="5bfc562394273624760673719a0ce4bc6e6140f1" CHECKSUMTYPE="SHA-1" SIZE="4705954">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:37:33" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="a25eb39ee74a67a5a2d1413da72bfcea4122a96f" CHECKSUMTYPE="SHA-1" SIZE="5068029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:37:56" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="fcda6d234229552bef28820d04f1edd5d44f2ea1" CHECKSUMTYPE="SHA-1" SIZE="4738629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:38:19" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="d4ca38b00bb1e10f9ae5479ff415e1b775a80b9e" CHECKSUMTYPE="SHA-1" SIZE="5068027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:38:43" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="ccf80a10d2b9dcb5d7fdbca98b2509cb357a40e0" CHECKSUMTYPE="SHA-1" SIZE="4715096">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:39:07" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="048b1bf72900b575a2103546ffcadeaa670697e1" CHECKSUMTYPE="SHA-1" SIZE="5165227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:39:31" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="d4a564e5e415e8cca543f110e2182d82be7bb8b1" CHECKSUMTYPE="SHA-1" SIZE="4649526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:39:54" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="22eb6b4ae9302ea8678f13a898490a95dc1c2efd" CHECKSUMTYPE="SHA-1" SIZE="5106696">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:40:16" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="d925bafe87388729ce21500f5a0ec0f0555fa870" CHECKSUMTYPE="SHA-1" SIZE="4672029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:40:39" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="798ad52d01392acb56b12a7c36efe4c8f95db0e9" CHECKSUMTYPE="SHA-1" SIZE="5106713">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:41:02" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="94e39f8a25c06336bfbe7704dfba9670f6c1ec78" CHECKSUMTYPE="SHA-1" SIZE="4672027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:41:25" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="6aeceb97449d1a60860ee71c4ebb0ce4ba3b1583" CHECKSUMTYPE="SHA-1" SIZE="5106690">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:41:51" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="08af118b4b5ffceb31a8cd2e22f4e2e998b87b1d" CHECKSUMTYPE="SHA-1" SIZE="4740393">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:42:15" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="b175d5a06c4672a5963ac622c9bf9d1b4a6ea4bf" CHECKSUMTYPE="SHA-1" SIZE="5132828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:42:38" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="3dcb0f4268777306f8d945a2e1212835edaf8d74" CHECKSUMTYPE="SHA-1" SIZE="4740428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:43:03" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="979791a357c7b548eab6e8b3a78fbb338ce6fe18" CHECKSUMTYPE="SHA-1" SIZE="5132819">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:43:27" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="ba859cca642d2cd87f57ae9b3931a3a7e089168a" CHECKSUMTYPE="SHA-1" SIZE="4740427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:43:49" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="6d2a26d19951d32461f33e83d80994d947ff8824" CHECKSUMTYPE="SHA-1" SIZE="5122927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:44:12" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="390fe2e3623c1457b64367de933d92325727b67c" CHECKSUMTYPE="SHA-1" SIZE="4740424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:44:36" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="9575f2fdc4bb04013c726041bb829ce2153ec63e" CHECKSUMTYPE="SHA-1" SIZE="5133728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:45:00" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="0c2b2b914894954782346f2a406ee27c787d7b7e" CHECKSUMTYPE="SHA-1" SIZE="4740412">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:45:26" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="bd0220089c0b247e34cbd5448bb2248cab594fc9" CHECKSUMTYPE="SHA-1" SIZE="5133728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T17:45:52" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="cd02ca30a5d7f4c0283d92b5cb3c33fd0f34718e" CHECKSUMTYPE="SHA-1" SIZE="4749417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T17:46:18" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="845346e783cbe318885d3e9dcdcc194bd6ccca38" CHECKSUMTYPE="SHA-1" SIZE="5165190">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T17:46:41" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="2b3f0071dfd56fc22da43e52532042e6fd102569" CHECKSUMTYPE="SHA-1" SIZE="4898829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T17:47:03" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="4f7e7b437fa719c0a3f13e2f8aa5ea0db23e6f40" CHECKSUMTYPE="SHA-1" SIZE="5133729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T17:47:29" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="4e8ee8fab5f4807a4af52cb01b098b5bf4c2eca6" CHECKSUMTYPE="SHA-1" SIZE="4973525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T17:47:55" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="af9ad1503a298fd42cbcd310cbb21ac7ce01e405" CHECKSUMTYPE="SHA-1" SIZE="5147229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T17:48:21" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="aa33ac89bc9536dfc74746c8ece6452353737d36" CHECKSUMTYPE="SHA-1" SIZE="4971702">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T17:48:45" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="52bfc61f88808cec3d1d8d4d46f908bd4bc31a62" CHECKSUMTYPE="SHA-1" SIZE="5147228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T17:49:15" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="ddddba7151cc3d9ad3bf8339ec682d7f7f2a1d56" CHECKSUMTYPE="SHA-1" SIZE="4971723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T17:49:44" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="141c5068e20291d56755bd286d501ce73f8281bc" CHECKSUMTYPE="SHA-1" SIZE="5147227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T17:50:09" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="f8e450b30f9d633fc7056faa9c67c45128edfb50" CHECKSUMTYPE="SHA-1" SIZE="4971727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T17:50:33" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="c780df9a7e763ca972f65803869a146253476084" CHECKSUMTYPE="SHA-1" SIZE="5147227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T17:50:57" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="aa4ed05b9880e2e2cb14a655a3ea02c1bda0e6dd" CHECKSUMTYPE="SHA-1" SIZE="4971726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T17:51:20" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="3f37f570c76f922fdcf0adddb1fec81ced63de32" CHECKSUMTYPE="SHA-1" SIZE="5147224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T17:51:45" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="8125c8e393d1f4991772e318effe09c755c4e0b2" CHECKSUMTYPE="SHA-1" SIZE="4971718">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T17:52:10" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="36cdc9e1de392961f19be996cb009966085b23c2" CHECKSUMTYPE="SHA-1" SIZE="5226426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T17:52:41" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="a24f70b114ca76670223a48e4172f3e72558c5a2" CHECKSUMTYPE="SHA-1" SIZE="4971729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T17:53:07" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="714d72a6bda28012aee4b7749b3e37b97b69bd17" CHECKSUMTYPE="SHA-1" SIZE="5207527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T17:53:31" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="5dd606b2bec9fc30429f38a8742ddc0f2ff11560" CHECKSUMTYPE="SHA-1" SIZE="5050026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T17:53:56" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="79bc56c385f77e6577e3e9bc3be56f69c419fafa" CHECKSUMTYPE="SHA-1" SIZE="5207517">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T17:54:21" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="09f015647cf168f2e66f24ff5665374bf1326947" CHECKSUMTYPE="SHA-1" SIZE="5056324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T17:54:44" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="ed7f9154fe9c95d9b68a4bb8131f8288c2a79afb" CHECKSUMTYPE="SHA-1" SIZE="5207529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T17:55:11" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="f605b29d666b05196bffd512678d77f7df6740f0" CHECKSUMTYPE="SHA-1" SIZE="5008622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T17:55:35" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="c6cdda8ffbb729d505a0d57ab60fed51943c5e0f" CHECKSUMTYPE="SHA-1" SIZE="5207508">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T17:56:00" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="4452e4920b3c86d353396f1b7ae732d434f604f1" CHECKSUMTYPE="SHA-1" SIZE="5025726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T17:56:27" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="b603403a22bb227bb1914da08df6d485eed90b11" CHECKSUMTYPE="SHA-1" SIZE="5207527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T17:56:49" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="d1006ad21766c7a7caebc719f25de243215fc96a" CHECKSUMTYPE="SHA-1" SIZE="5025659">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T17:57:15" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="911117f5ff0691c44e9d635b80c15cffa4d24ce1" CHECKSUMTYPE="SHA-1" SIZE="5202129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T17:57:42" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="df0ffa73d130b76e080a25ddd05200928975b150" CHECKSUMTYPE="SHA-1" SIZE="5025725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T17:58:07" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="71e8795e6b168a70cea8d4186f31b87f30d5bdce" CHECKSUMTYPE="SHA-1" SIZE="5192224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T17:58:33" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="b0a51eecddc0e2d90648dcf78cc3e907883ad947" CHECKSUMTYPE="SHA-1" SIZE="5030199">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T17:58:57" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="67bb146ce8cd2d37dd960a2139a96dab2706027b" CHECKSUMTYPE="SHA-1" SIZE="5196729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T17:59:20" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="094aac67b01f6491bcb8826c2af4a8211ac59d8e" CHECKSUMTYPE="SHA-1" SIZE="4960920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T17:59:44" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="4cd9e17177f4f5db5f53165a04516934492fad4e" CHECKSUMTYPE="SHA-1" SIZE="5225526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T18:00:06" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="8b0d8dac8849b10b094179a9474a51a580815522" CHECKSUMTYPE="SHA-1" SIZE="4969026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T18:00:31" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="c9e3a2621108c826318e4d0d3519ab2bdbbbdccc" CHECKSUMTYPE="SHA-1" SIZE="5225525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0094.jp2"/>
+			</file>
+			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T18:00:54" MIMETYPE="image/jp2" SEQ="95" CHECKSUM="5ab299718a8893fae7151cdfe56350a7269de0af" CHECKSUMTYPE="SHA-1" SIZE="4912237">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0095.jp2"/>
+			</file>
+			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T18:01:19" MIMETYPE="image/jp2" SEQ="96" CHECKSUM="e13fb6c6c07a6036f3d7fdc372bcb2a4076b184a" CHECKSUMTYPE="SHA-1" SIZE="5203882">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/delivery/bmtnabe_1897-05_01_0096.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:01:34" MIMETYPE="text/xml" CHECKSUM="27406650dc80a326dc86d310b142f97fcd56f430"
-				CHECKSUMTYPE="SHA-1" SIZE="2108">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:01:34" MIMETYPE="text/xml" CHECKSUM="27406650dc80a326dc86d310b142f97fcd56f430" CHECKSUMTYPE="SHA-1" SIZE="2108">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:01:34" MIMETYPE="text/xml" CHECKSUM="e496025a9687403fe9507afa7e3bd1e323df092b"
-				CHECKSUMTYPE="SHA-1" SIZE="1715">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:01:34" MIMETYPE="text/xml" CHECKSUM="e496025a9687403fe9507afa7e3bd1e323df092b" CHECKSUMTYPE="SHA-1" SIZE="1715">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:01:34" MIMETYPE="text/xml" CHECKSUM="81468cfefbb836d3a5e2caae26184855299b558c"
-				CHECKSUMTYPE="SHA-1" SIZE="1714">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:01:34" MIMETYPE="text/xml" CHECKSUM="81468cfefbb836d3a5e2caae26184855299b558c" CHECKSUMTYPE="SHA-1" SIZE="1714">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:01:34" MIMETYPE="text/xml" CHECKSUM="6886c06ac0c7d7d91bbdf8264013f90a7e165c50"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:01:34" MIMETYPE="text/xml" CHECKSUM="6886c06ac0c7d7d91bbdf8264013f90a7e165c50" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:01:35" MIMETYPE="text/xml" CHECKSUM="95c1de7a6868f05e97759784a5dbe06e15a87f19"
-				CHECKSUMTYPE="SHA-1" SIZE="7911">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:01:35" MIMETYPE="text/xml" CHECKSUM="95c1de7a6868f05e97759784a5dbe06e15a87f19" CHECKSUMTYPE="SHA-1" SIZE="7911">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:01:35" MIMETYPE="text/xml" CHECKSUM="b34d1ca12c04d5f9a51acfd6f45400c4f1d5aa2d"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:01:35" MIMETYPE="text/xml" CHECKSUM="b34d1ca12c04d5f9a51acfd6f45400c4f1d5aa2d" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:01:35" MIMETYPE="text/xml" CHECKSUM="23299037fa07090918e70269b62d0cf31d92b385"
-				CHECKSUMTYPE="SHA-1" SIZE="1714">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:01:35" MIMETYPE="text/xml" CHECKSUM="23299037fa07090918e70269b62d0cf31d92b385" CHECKSUMTYPE="SHA-1" SIZE="1714">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:01:35" MIMETYPE="text/xml" CHECKSUM="d04130ba56fd904a4d19019dc242f4309dcc4b8a"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:01:35" MIMETYPE="text/xml" CHECKSUM="d04130ba56fd904a4d19019dc242f4309dcc4b8a" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:01:35" MIMETYPE="text/xml" CHECKSUM="7ae190562baa9bfb6b6ec086e622c15d3c5c46cd"
-				CHECKSUMTYPE="SHA-1" SIZE="13462">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:01:35" MIMETYPE="text/xml" CHECKSUM="7ae190562baa9bfb6b6ec086e622c15d3c5c46cd" CHECKSUMTYPE="SHA-1" SIZE="13462">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:01:36" MIMETYPE="text/xml"
-				CHECKSUM="85d1d24100b5d45c016287ad2b4549c214e98826" CHECKSUMTYPE="SHA-1" SIZE="3402">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:01:36" MIMETYPE="text/xml" CHECKSUM="85d1d24100b5d45c016287ad2b4549c214e98826" CHECKSUMTYPE="SHA-1" SIZE="3402">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:01:36" MIMETYPE="text/xml"
-				CHECKSUM="187021808bf5e1eb8d29f55ceb2045e47fbf3ca7" CHECKSUMTYPE="SHA-1" SIZE="1721">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:01:36" MIMETYPE="text/xml" CHECKSUM="187021808bf5e1eb8d29f55ceb2045e47fbf3ca7" CHECKSUMTYPE="SHA-1" SIZE="1721">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:01:36" MIMETYPE="text/xml"
-				CHECKSUM="0bcd7094cbe237a68ba1dffde7197180c31923f4" CHECKSUMTYPE="SHA-1" SIZE="4596">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:01:36" MIMETYPE="text/xml" CHECKSUM="0bcd7094cbe237a68ba1dffde7197180c31923f4" CHECKSUMTYPE="SHA-1" SIZE="4596">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:01:36" MIMETYPE="text/xml"
-				CHECKSUM="ba7cb5d59fffea38b37db8609d1ab2421b9ddba9" CHECKSUMTYPE="SHA-1" SIZE="20916">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:01:36" MIMETYPE="text/xml" CHECKSUM="ba7cb5d59fffea38b37db8609d1ab2421b9ddba9" CHECKSUMTYPE="SHA-1" SIZE="20916">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:01:37" MIMETYPE="text/xml"
-				CHECKSUM="f6eaa08f6a4a6326505da5679bfbc08382d651f6" CHECKSUMTYPE="SHA-1" SIZE="42399">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:01:37" MIMETYPE="text/xml" CHECKSUM="f6eaa08f6a4a6326505da5679bfbc08382d651f6" CHECKSUMTYPE="SHA-1" SIZE="42399">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:01:37" MIMETYPE="text/xml"
-				CHECKSUM="1c600050ae4c912e9b0e281efba5ccf3b9d9546f" CHECKSUMTYPE="SHA-1" SIZE="21377">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:01:37" MIMETYPE="text/xml" CHECKSUM="1c600050ae4c912e9b0e281efba5ccf3b9d9546f" CHECKSUMTYPE="SHA-1" SIZE="21377">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:01:39" MIMETYPE="text/xml"
-				CHECKSUM="c17053be37dcf4876b617844f15c8a9fdfd0c221" CHECKSUMTYPE="SHA-1" SIZE="26357">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:01:39" MIMETYPE="text/xml" CHECKSUM="c17053be37dcf4876b617844f15c8a9fdfd0c221" CHECKSUMTYPE="SHA-1" SIZE="26357">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:01:39" MIMETYPE="text/xml"
-				CHECKSUM="75d14cf4dd92670604ba2356bb823c512ca50799" CHECKSUMTYPE="SHA-1" SIZE="36584">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:01:39" MIMETYPE="text/xml" CHECKSUM="75d14cf4dd92670604ba2356bb823c512ca50799" CHECKSUMTYPE="SHA-1" SIZE="36584">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:01:39" MIMETYPE="text/xml"
-				CHECKSUM="81f0abdf5b7b594d97ea527fc07b6436928febaf" CHECKSUMTYPE="SHA-1" SIZE="16758">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:01:39" MIMETYPE="text/xml" CHECKSUM="81f0abdf5b7b594d97ea527fc07b6436928febaf" CHECKSUMTYPE="SHA-1" SIZE="16758">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:01:40" MIMETYPE="text/xml"
-				CHECKSUM="136711a784433c762e21cbfb9ceaa64b45640168" CHECKSUMTYPE="SHA-1" SIZE="4557">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:01:40" MIMETYPE="text/xml" CHECKSUM="136711a784433c762e21cbfb9ceaa64b45640168" CHECKSUMTYPE="SHA-1" SIZE="4557">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:01:40" MIMETYPE="text/xml"
-				CHECKSUM="8d640da7835678ca64a45ee558ebfb5da7dd935b" CHECKSUMTYPE="SHA-1" SIZE="2016">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:01:40" MIMETYPE="text/xml" CHECKSUM="8d640da7835678ca64a45ee558ebfb5da7dd935b" CHECKSUMTYPE="SHA-1" SIZE="2016">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:01:40" MIMETYPE="text/xml"
-				CHECKSUM="68f2cc0572258acb710391e368b6314aef0661ff" CHECKSUMTYPE="SHA-1" SIZE="55666">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:01:40" MIMETYPE="text/xml" CHECKSUM="68f2cc0572258acb710391e368b6314aef0661ff" CHECKSUMTYPE="SHA-1" SIZE="55666">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:01:41" MIMETYPE="text/xml"
-				CHECKSUM="5bb6f0216533e630518377a33d32abb06905ecea" CHECKSUMTYPE="SHA-1" SIZE="153402">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:01:41" MIMETYPE="text/xml" CHECKSUM="5bb6f0216533e630518377a33d32abb06905ecea" CHECKSUMTYPE="SHA-1" SIZE="153402">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:01:41" MIMETYPE="text/xml"
-				CHECKSUM="4d0c1bb5d10a3ac50ad24d2247360220e0669111" CHECKSUMTYPE="SHA-1" SIZE="150156">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:01:41" MIMETYPE="text/xml" CHECKSUM="4d0c1bb5d10a3ac50ad24d2247360220e0669111" CHECKSUMTYPE="SHA-1" SIZE="150156">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:01:41" MIMETYPE="text/xml"
-				CHECKSUM="fff22e040e5ad00b15c3c167ef352dc2ef4e5988" CHECKSUMTYPE="SHA-1" SIZE="135672">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:01:41" MIMETYPE="text/xml" CHECKSUM="fff22e040e5ad00b15c3c167ef352dc2ef4e5988" CHECKSUMTYPE="SHA-1" SIZE="135672">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:01:42" MIMETYPE="text/xml"
-				CHECKSUM="6b42c4fc3d351714d93e1e4e6820e4a91d3e9b5f" CHECKSUMTYPE="SHA-1" SIZE="79295">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:01:42" MIMETYPE="text/xml" CHECKSUM="6b42c4fc3d351714d93e1e4e6820e4a91d3e9b5f" CHECKSUMTYPE="SHA-1" SIZE="79295">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:01:42" MIMETYPE="text/xml"
-				CHECKSUM="5e38fda1aca1bd4eb73651bc2116bdb4bbc732a1" CHECKSUMTYPE="SHA-1" SIZE="21217">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:01:42" MIMETYPE="text/xml" CHECKSUM="5e38fda1aca1bd4eb73651bc2116bdb4bbc732a1" CHECKSUMTYPE="SHA-1" SIZE="21217">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:01:42" MIMETYPE="text/xml"
-				CHECKSUM="74693f6efc56793f924d8a911360b7f5c9d8f99e" CHECKSUMTYPE="SHA-1" SIZE="4939">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:01:42" MIMETYPE="text/xml" CHECKSUM="74693f6efc56793f924d8a911360b7f5c9d8f99e" CHECKSUMTYPE="SHA-1" SIZE="4939">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:01:42" MIMETYPE="text/xml"
-				CHECKSUM="17f5b56a4098f4a2c6a3541d3ae144d06058dd05" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:01:42" MIMETYPE="text/xml" CHECKSUM="17f5b56a4098f4a2c6a3541d3ae144d06058dd05" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:01:44" MIMETYPE="text/xml"
-				CHECKSUM="211400901a23e7ff170485b34eaebd4c16ccc05f" CHECKSUMTYPE="SHA-1" SIZE="15949">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:01:44" MIMETYPE="text/xml" CHECKSUM="211400901a23e7ff170485b34eaebd4c16ccc05f" CHECKSUMTYPE="SHA-1" SIZE="15949">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:01:44" MIMETYPE="text/xml"
-				CHECKSUM="5aeea42144d04c7e405c9d4db69334b00415505a" CHECKSUMTYPE="SHA-1" SIZE="41874">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:01:44" MIMETYPE="text/xml" CHECKSUM="5aeea42144d04c7e405c9d4db69334b00415505a" CHECKSUMTYPE="SHA-1" SIZE="41874">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:01:45" MIMETYPE="text/xml"
-				CHECKSUM="8264407dea7ecf40d9160ed73d5d97b30762e436" CHECKSUMTYPE="SHA-1" SIZE="41041">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:01:45" MIMETYPE="text/xml" CHECKSUM="8264407dea7ecf40d9160ed73d5d97b30762e436" CHECKSUMTYPE="SHA-1" SIZE="41041">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:01:45" MIMETYPE="text/xml"
-				CHECKSUM="4fa97c04295722097efa92450c91b8cc5083187a" CHECKSUMTYPE="SHA-1" SIZE="70541">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:01:45" MIMETYPE="text/xml" CHECKSUM="4fa97c04295722097efa92450c91b8cc5083187a" CHECKSUMTYPE="SHA-1" SIZE="70541">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:01:45" MIMETYPE="text/xml"
-				CHECKSUM="4c3c30348cf15e925863bcbea5ee4d592265a6f7" CHECKSUMTYPE="SHA-1" SIZE="29495">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:01:45" MIMETYPE="text/xml" CHECKSUM="4c3c30348cf15e925863bcbea5ee4d592265a6f7" CHECKSUMTYPE="SHA-1" SIZE="29495">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:01:46" MIMETYPE="text/xml"
-				CHECKSUM="df1849bf20ff9b61e20f692448adcb134c1243a6" CHECKSUMTYPE="SHA-1" SIZE="26745">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:01:46" MIMETYPE="text/xml" CHECKSUM="df1849bf20ff9b61e20f692448adcb134c1243a6" CHECKSUMTYPE="SHA-1" SIZE="26745">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:01:46" MIMETYPE="text/xml"
-				CHECKSUM="ee36fe83ece8802854666e6abf2dbc53d8662155" CHECKSUMTYPE="SHA-1" SIZE="34804">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:01:46" MIMETYPE="text/xml" CHECKSUM="ee36fe83ece8802854666e6abf2dbc53d8662155" CHECKSUMTYPE="SHA-1" SIZE="34804">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:01:46" MIMETYPE="text/xml"
-				CHECKSUM="f3cc08c979ca2b2f5fcbbbd802f10bff9303c76b" CHECKSUMTYPE="SHA-1" SIZE="63966">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:01:46" MIMETYPE="text/xml" CHECKSUM="f3cc08c979ca2b2f5fcbbbd802f10bff9303c76b" CHECKSUMTYPE="SHA-1" SIZE="63966">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:01:46" MIMETYPE="text/xml"
-				CHECKSUM="d752d9d06d5c30e9801e63aac7e09d170cf81765" CHECKSUMTYPE="SHA-1" SIZE="74829">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:01:46" MIMETYPE="text/xml" CHECKSUM="d752d9d06d5c30e9801e63aac7e09d170cf81765" CHECKSUMTYPE="SHA-1" SIZE="74829">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:01:47" MIMETYPE="text/xml"
-				CHECKSUM="400da2c341e258ee9affa8d38f717e59678dc5e1" CHECKSUMTYPE="SHA-1" SIZE="83467">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:01:47" MIMETYPE="text/xml" CHECKSUM="400da2c341e258ee9affa8d38f717e59678dc5e1" CHECKSUMTYPE="SHA-1" SIZE="83467">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:01:47" MIMETYPE="text/xml"
-				CHECKSUM="8de82a006d1e437d0798959546c334ce586dc729" CHECKSUMTYPE="SHA-1" SIZE="28625">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:01:47" MIMETYPE="text/xml" CHECKSUM="8de82a006d1e437d0798959546c334ce586dc729" CHECKSUMTYPE="SHA-1" SIZE="28625">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:01:47" MIMETYPE="text/xml"
-				CHECKSUM="fcf0d05c5934d27c3daaea6ef04a90afc7f22b63" CHECKSUMTYPE="SHA-1" SIZE="37638">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:01:47" MIMETYPE="text/xml" CHECKSUM="fcf0d05c5934d27c3daaea6ef04a90afc7f22b63" CHECKSUMTYPE="SHA-1" SIZE="37638">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:01:47" MIMETYPE="text/xml"
-				CHECKSUM="94c1d68e99c20173f4244e22ea9662e231195581" CHECKSUMTYPE="SHA-1" SIZE="2011">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:01:47" MIMETYPE="text/xml" CHECKSUM="94c1d68e99c20173f4244e22ea9662e231195581" CHECKSUMTYPE="SHA-1" SIZE="2011">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:01:48" MIMETYPE="text/xml"
-				CHECKSUM="d7c10059fff98b8f310d0787f2f9078228c9cea8" CHECKSUMTYPE="SHA-1" SIZE="4504">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:01:48" MIMETYPE="text/xml" CHECKSUM="d7c10059fff98b8f310d0787f2f9078228c9cea8" CHECKSUMTYPE="SHA-1" SIZE="4504">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:01:48" MIMETYPE="text/xml"
-				CHECKSUM="655d5198e5199941877105706471e899b3dfbc71" CHECKSUMTYPE="SHA-1" SIZE="28774">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:01:48" MIMETYPE="text/xml" CHECKSUM="655d5198e5199941877105706471e899b3dfbc71" CHECKSUMTYPE="SHA-1" SIZE="28774">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:01:48" MIMETYPE="text/xml"
-				CHECKSUM="a727ac733a08fcf8e09b02e8f73ebe637506b6de" CHECKSUMTYPE="SHA-1" SIZE="31229">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:01:48" MIMETYPE="text/xml" CHECKSUM="a727ac733a08fcf8e09b02e8f73ebe637506b6de" CHECKSUMTYPE="SHA-1" SIZE="31229">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:01:49" MIMETYPE="text/xml"
-				CHECKSUM="b0aeb6aca192074c56d07edfb8036b3634b89bdb" CHECKSUMTYPE="SHA-1" SIZE="6732">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:01:49" MIMETYPE="text/xml" CHECKSUM="b0aeb6aca192074c56d07edfb8036b3634b89bdb" CHECKSUMTYPE="SHA-1" SIZE="6732">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:01:49" MIMETYPE="text/xml"
-				CHECKSUM="ff5554a2517be77743f504cdfec1dcda88891003" CHECKSUMTYPE="SHA-1" SIZE="2407">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:01:49" MIMETYPE="text/xml" CHECKSUM="ff5554a2517be77743f504cdfec1dcda88891003" CHECKSUMTYPE="SHA-1" SIZE="2407">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:01:49" MIMETYPE="text/xml"
-				CHECKSUM="24beefa3f0ed65f3fc1da79a1d1fd7c44c1e2ab3" CHECKSUMTYPE="SHA-1" SIZE="2396">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:01:49" MIMETYPE="text/xml" CHECKSUM="24beefa3f0ed65f3fc1da79a1d1fd7c44c1e2ab3" CHECKSUMTYPE="SHA-1" SIZE="2396">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:01:49" MIMETYPE="text/xml"
-				CHECKSUM="5eb487cb400a0f5353a5e192638530ca2ed3b747" CHECKSUMTYPE="SHA-1" SIZE="4366">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:01:49" MIMETYPE="text/xml" CHECKSUM="5eb487cb400a0f5353a5e192638530ca2ed3b747" CHECKSUMTYPE="SHA-1" SIZE="4366">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:01:50" MIMETYPE="text/xml"
-				CHECKSUM="c78e15a0ad733002ec798ebbaeb79e0c82d63917" CHECKSUMTYPE="SHA-1" SIZE="90443">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:01:50" MIMETYPE="text/xml" CHECKSUM="c78e15a0ad733002ec798ebbaeb79e0c82d63917" CHECKSUMTYPE="SHA-1" SIZE="90443">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:01:50" MIMETYPE="text/xml"
-				CHECKSUM="b63cebe1607dd218a9f8f5e9b57e04d4eb762b58" CHECKSUMTYPE="SHA-1" SIZE="202731">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:01:50" MIMETYPE="text/xml" CHECKSUM="b63cebe1607dd218a9f8f5e9b57e04d4eb762b58" CHECKSUMTYPE="SHA-1" SIZE="202731">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:01:50" MIMETYPE="text/xml"
-				CHECKSUM="f45abc7ab825fbaf24e4b5a1808e831944db91db" CHECKSUMTYPE="SHA-1" SIZE="157715">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:01:50" MIMETYPE="text/xml" CHECKSUM="f45abc7ab825fbaf24e4b5a1808e831944db91db" CHECKSUMTYPE="SHA-1" SIZE="157715">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:01:51" MIMETYPE="text/xml"
-				CHECKSUM="aa54a172accd38610e423633fdc39250329ab52d" CHECKSUMTYPE="SHA-1" SIZE="88948">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:01:51" MIMETYPE="text/xml" CHECKSUM="aa54a172accd38610e423633fdc39250329ab52d" CHECKSUMTYPE="SHA-1" SIZE="88948">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:01:51" MIMETYPE="text/xml"
-				CHECKSUM="25a57eeec95edbd5705b2ab11e9c44e6f7abc083" CHECKSUMTYPE="SHA-1" SIZE="183507">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:01:51" MIMETYPE="text/xml" CHECKSUM="25a57eeec95edbd5705b2ab11e9c44e6f7abc083" CHECKSUMTYPE="SHA-1" SIZE="183507">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:01:51" MIMETYPE="text/xml"
-				CHECKSUM="b88692ba00fc22289e8171e6ce6a4016bad38d84" CHECKSUMTYPE="SHA-1" SIZE="200262">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:01:51" MIMETYPE="text/xml" CHECKSUM="b88692ba00fc22289e8171e6ce6a4016bad38d84" CHECKSUMTYPE="SHA-1" SIZE="200262">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:01:52" MIMETYPE="text/xml"
-				CHECKSUM="3dc778b7b07c0776135bed82372cab5675aa5ae3" CHECKSUMTYPE="SHA-1" SIZE="204162">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:01:52" MIMETYPE="text/xml" CHECKSUM="3dc778b7b07c0776135bed82372cab5675aa5ae3" CHECKSUMTYPE="SHA-1" SIZE="204162">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:01:52" MIMETYPE="text/xml"
-				CHECKSUM="0a633dfc5dd3d94b2b03d877d551b77604e0e240" CHECKSUMTYPE="SHA-1" SIZE="187984">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:01:52" MIMETYPE="text/xml" CHECKSUM="0a633dfc5dd3d94b2b03d877d551b77604e0e240" CHECKSUMTYPE="SHA-1" SIZE="187984">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:01:52" MIMETYPE="text/xml"
-				CHECKSUM="b7975feeacdc91fb73de9d660a6c59d74a8cf04f" CHECKSUMTYPE="SHA-1" SIZE="88484">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:01:52" MIMETYPE="text/xml" CHECKSUM="b7975feeacdc91fb73de9d660a6c59d74a8cf04f" CHECKSUMTYPE="SHA-1" SIZE="88484">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:01:53" MIMETYPE="text/xml"
-				CHECKSUM="2c505c2ac8d66ab59cef7c665b1c2980e7f5c551" CHECKSUMTYPE="SHA-1" SIZE="92123">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:01:53" MIMETYPE="text/xml" CHECKSUM="2c505c2ac8d66ab59cef7c665b1c2980e7f5c551" CHECKSUMTYPE="SHA-1" SIZE="92123">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:01:53" MIMETYPE="text/xml"
-				CHECKSUM="4ff66643ac00d06ecb5b216ff7dd37d885f875f2" CHECKSUMTYPE="SHA-1" SIZE="141540">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:01:53" MIMETYPE="text/xml" CHECKSUM="4ff66643ac00d06ecb5b216ff7dd37d885f875f2" CHECKSUMTYPE="SHA-1" SIZE="141540">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:01:53" MIMETYPE="text/xml"
-				CHECKSUM="0beefc0b2f283c726eabd23e738499c894c685ad" CHECKSUMTYPE="SHA-1" SIZE="186853">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:01:53" MIMETYPE="text/xml" CHECKSUM="0beefc0b2f283c726eabd23e738499c894c685ad" CHECKSUMTYPE="SHA-1" SIZE="186853">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:01:54" MIMETYPE="text/xml"
-				CHECKSUM="f1f38254438b480e0d2c606485491d4f0ab2d3d1" CHECKSUMTYPE="SHA-1" SIZE="5024">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:01:54" MIMETYPE="text/xml" CHECKSUM="f1f38254438b480e0d2c606485491d4f0ab2d3d1" CHECKSUMTYPE="SHA-1" SIZE="5024">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:01:54" MIMETYPE="text/xml"
-				CHECKSUM="96945f1442cb2fffc1f6ec1df56b8b104774e8d4" CHECKSUMTYPE="SHA-1" SIZE="2016">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:01:54" MIMETYPE="text/xml" CHECKSUM="96945f1442cb2fffc1f6ec1df56b8b104774e8d4" CHECKSUMTYPE="SHA-1" SIZE="2016">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:01:54" MIMETYPE="text/xml"
-				CHECKSUM="02923c15066175870a25033bcd051bf3c53fe6f3" CHECKSUMTYPE="SHA-1" SIZE="105836">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:01:54" MIMETYPE="text/xml" CHECKSUM="02923c15066175870a25033bcd051bf3c53fe6f3" CHECKSUMTYPE="SHA-1" SIZE="105836">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:01:54" MIMETYPE="text/xml"
-				CHECKSUM="a479b37750493f7bc429cd2c010c7c82eb4f53ae" CHECKSUMTYPE="SHA-1" SIZE="171980">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:01:54" MIMETYPE="text/xml" CHECKSUM="a479b37750493f7bc429cd2c010c7c82eb4f53ae" CHECKSUMTYPE="SHA-1" SIZE="171980">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:01:55" MIMETYPE="text/xml"
-				CHECKSUM="fdfa9028a08752f76dc33bffb2461d53221b067c" CHECKSUMTYPE="SHA-1" SIZE="6056">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:01:55" MIMETYPE="text/xml" CHECKSUM="fdfa9028a08752f76dc33bffb2461d53221b067c" CHECKSUMTYPE="SHA-1" SIZE="6056">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:01:55" MIMETYPE="text/xml"
-				CHECKSUM="58ae5b18c688eaa8d79785dcef92ed3868b15e6a" CHECKSUMTYPE="SHA-1" SIZE="144624">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:01:55" MIMETYPE="text/xml" CHECKSUM="58ae5b18c688eaa8d79785dcef92ed3868b15e6a" CHECKSUMTYPE="SHA-1" SIZE="144624">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:01:55" MIMETYPE="text/xml"
-				CHECKSUM="264dce38b0979c9ff7619d778de024536126d71f" CHECKSUMTYPE="SHA-1" SIZE="104526">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:01:55" MIMETYPE="text/xml" CHECKSUM="264dce38b0979c9ff7619d778de024536126d71f" CHECKSUMTYPE="SHA-1" SIZE="104526">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:01:56" MIMETYPE="text/xml"
-				CHECKSUM="849be2dc97122d58b2041cf23c60b9537de59861" CHECKSUMTYPE="SHA-1" SIZE="184131">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:01:56" MIMETYPE="text/xml" CHECKSUM="849be2dc97122d58b2041cf23c60b9537de59861" CHECKSUMTYPE="SHA-1" SIZE="184131">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:01:56" MIMETYPE="text/xml"
-				CHECKSUM="7b919d55b7b891307d1d28c2d85d9a9c89a69fde" CHECKSUMTYPE="SHA-1" SIZE="183579">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:01:56" MIMETYPE="text/xml" CHECKSUM="7b919d55b7b891307d1d28c2d85d9a9c89a69fde" CHECKSUMTYPE="SHA-1" SIZE="183579">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:01:56" MIMETYPE="text/xml"
-				CHECKSUM="481f1acb484d020ab1aec8db69c259341b6664a4" CHECKSUMTYPE="SHA-1" SIZE="183925">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:01:56" MIMETYPE="text/xml" CHECKSUM="481f1acb484d020ab1aec8db69c259341b6664a4" CHECKSUMTYPE="SHA-1" SIZE="183925">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:01:57" MIMETYPE="text/xml"
-				CHECKSUM="68dea491e8bf1d8d05c21c335627734747e322c1" CHECKSUMTYPE="SHA-1" SIZE="172605">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:01:57" MIMETYPE="text/xml" CHECKSUM="68dea491e8bf1d8d05c21c335627734747e322c1" CHECKSUMTYPE="SHA-1" SIZE="172605">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:01:57" MIMETYPE="text/xml"
-				CHECKSUM="4724b5d63534c15a9fbc10c4ae13e94cf91a58ad" CHECKSUMTYPE="SHA-1" SIZE="177785">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:01:57" MIMETYPE="text/xml" CHECKSUM="4724b5d63534c15a9fbc10c4ae13e94cf91a58ad" CHECKSUMTYPE="SHA-1" SIZE="177785">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:01:57" MIMETYPE="text/xml"
-				CHECKSUM="3c595e966400fa976b698c79041edbe513d6b7ce" CHECKSUMTYPE="SHA-1" SIZE="143685">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:01:57" MIMETYPE="text/xml" CHECKSUM="3c595e966400fa976b698c79041edbe513d6b7ce" CHECKSUMTYPE="SHA-1" SIZE="143685">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:01:58" MIMETYPE="text/xml"
-				CHECKSUM="9d10e09249a24b9e35c0c6e97612c0d719de98fd" CHECKSUMTYPE="SHA-1" SIZE="89402">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:01:58" MIMETYPE="text/xml" CHECKSUM="9d10e09249a24b9e35c0c6e97612c0d719de98fd" CHECKSUMTYPE="SHA-1" SIZE="89402">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:01:58" MIMETYPE="text/xml"
-				CHECKSUM="0ec3ed583d5b9ae08b9e53be88051bfa402a7acd" CHECKSUMTYPE="SHA-1" SIZE="182076">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:01:58" MIMETYPE="text/xml" CHECKSUM="0ec3ed583d5b9ae08b9e53be88051bfa402a7acd" CHECKSUMTYPE="SHA-1" SIZE="182076">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:01:58" MIMETYPE="text/xml"
-				CHECKSUM="1f05610352c4cbf103aaeea55fddf20d514a2a52" CHECKSUMTYPE="SHA-1" SIZE="42374">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:01:58" MIMETYPE="text/xml" CHECKSUM="1f05610352c4cbf103aaeea55fddf20d514a2a52" CHECKSUMTYPE="SHA-1" SIZE="42374">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:01:58" MIMETYPE="text/xml"
-				CHECKSUM="30d66b20b0536a1cb216b5195c1229a7019f334d" CHECKSUMTYPE="SHA-1" SIZE="4571">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:01:58" MIMETYPE="text/xml" CHECKSUM="30d66b20b0536a1cb216b5195c1229a7019f334d" CHECKSUMTYPE="SHA-1" SIZE="4571">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:01:59" MIMETYPE="text/xml"
-				CHECKSUM="9283346518e9ee70c03546cdf043531a65aee1d8" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:01:59" MIMETYPE="text/xml" CHECKSUM="9283346518e9ee70c03546cdf043531a65aee1d8" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:01:59" MIMETYPE="text/xml"
-				CHECKSUM="480a0b304181f247684da769d31cc819bf2b7ae3" CHECKSUMTYPE="SHA-1" SIZE="74560">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:01:59" MIMETYPE="text/xml" CHECKSUM="480a0b304181f247684da769d31cc819bf2b7ae3" CHECKSUMTYPE="SHA-1" SIZE="74560">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:01:59" MIMETYPE="text/xml"
-				CHECKSUM="0cba7a37cb17b4be2f0f5cabb9657abed4912f2d" CHECKSUMTYPE="SHA-1" SIZE="205539">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:01:59" MIMETYPE="text/xml" CHECKSUM="0cba7a37cb17b4be2f0f5cabb9657abed4912f2d" CHECKSUMTYPE="SHA-1" SIZE="205539">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:02:00" MIMETYPE="text/xml"
-				CHECKSUM="d2573c92cbf8ed0cdfbff8b9ab0dc9630d0c94c2" CHECKSUMTYPE="SHA-1" SIZE="142827">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:02:00" MIMETYPE="text/xml" CHECKSUM="d2573c92cbf8ed0cdfbff8b9ab0dc9630d0c94c2" CHECKSUMTYPE="SHA-1" SIZE="142827">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:02:00" MIMETYPE="text/xml"
-				CHECKSUM="0002361012732a431e1ac599fb7e1069adeaf705" CHECKSUMTYPE="SHA-1" SIZE="34672">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:02:00" MIMETYPE="text/xml" CHECKSUM="0002361012732a431e1ac599fb7e1069adeaf705" CHECKSUMTYPE="SHA-1" SIZE="34672">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:02:00" MIMETYPE="text/xml"
-				CHECKSUM="9208a24fa85cc3978d3b997224cd697cf1a25e10" CHECKSUMTYPE="SHA-1" SIZE="4848">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:02:00" MIMETYPE="text/xml" CHECKSUM="9208a24fa85cc3978d3b997224cd697cf1a25e10" CHECKSUMTYPE="SHA-1" SIZE="4848">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:02:00" MIMETYPE="text/xml"
-				CHECKSUM="2b99819e6f90ed74238729dd5b98ccd355aaae03" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:02:00" MIMETYPE="text/xml" CHECKSUM="2b99819e6f90ed74238729dd5b98ccd355aaae03" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:02:01" MIMETYPE="text/xml"
-				CHECKSUM="fe5bf409d6079421b3e1e6dded6ee704cbbc4169" CHECKSUMTYPE="SHA-1" SIZE="55991">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:02:01" MIMETYPE="text/xml" CHECKSUM="fe5bf409d6079421b3e1e6dded6ee704cbbc4169" CHECKSUMTYPE="SHA-1" SIZE="55991">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:02:01" MIMETYPE="text/xml"
-				CHECKSUM="660f70e46cb8e2e98523256b83f3c9f606278c41" CHECKSUMTYPE="SHA-1" SIZE="191044">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:02:01" MIMETYPE="text/xml" CHECKSUM="660f70e46cb8e2e98523256b83f3c9f606278c41" CHECKSUMTYPE="SHA-1" SIZE="191044">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:02:01" MIMETYPE="text/xml"
-				CHECKSUM="2c7edb310de4eec17762c7de5f6740c1b77744ae" CHECKSUMTYPE="SHA-1" SIZE="191103">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:02:01" MIMETYPE="text/xml" CHECKSUM="2c7edb310de4eec17762c7de5f6740c1b77744ae" CHECKSUMTYPE="SHA-1" SIZE="191103">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:02:02" MIMETYPE="text/xml"
-				CHECKSUM="6bdf8b2cef565d3a9511f4b42422c1f3f7235ef4" CHECKSUMTYPE="SHA-1" SIZE="41416">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:02:02" MIMETYPE="text/xml" CHECKSUM="6bdf8b2cef565d3a9511f4b42422c1f3f7235ef4" CHECKSUMTYPE="SHA-1" SIZE="41416">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:02:02" MIMETYPE="text/xml"
-				CHECKSUM="139b1700fa6e40c9f5e5aa7bd4771e91bdc990c8" CHECKSUMTYPE="SHA-1" SIZE="4339">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:02:02" MIMETYPE="text/xml" CHECKSUM="139b1700fa6e40c9f5e5aa7bd4771e91bdc990c8" CHECKSUMTYPE="SHA-1" SIZE="4339">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:02:02" MIMETYPE="text/xml"
-				CHECKSUM="70c9dfce22ed5816a094becb13fcf11e0647512e" CHECKSUMTYPE="SHA-1" SIZE="2012">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:02:02" MIMETYPE="text/xml" CHECKSUM="70c9dfce22ed5816a094becb13fcf11e0647512e" CHECKSUMTYPE="SHA-1" SIZE="2012">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:02:03" MIMETYPE="text/xml"
-				CHECKSUM="7195902603819a65ab6f6f9abeb03fa7b4f4575b" CHECKSUMTYPE="SHA-1" SIZE="46897">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:02:03" MIMETYPE="text/xml" CHECKSUM="7195902603819a65ab6f6f9abeb03fa7b4f4575b" CHECKSUMTYPE="SHA-1" SIZE="46897">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:02:04" MIMETYPE="text/xml"
-				CHECKSUM="0e1658934870ed08667f518dce95b738e72d96d1" CHECKSUMTYPE="SHA-1" SIZE="27132">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:02:04" MIMETYPE="text/xml" CHECKSUM="0e1658934870ed08667f518dce95b738e72d96d1" CHECKSUMTYPE="SHA-1" SIZE="27132">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T18:02:04" MIMETYPE="text/xml"
-				CHECKSUM="acb6aa03211068b18ffa90204b1176fb0dc8c24f" CHECKSUMTYPE="SHA-1" SIZE="16390">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T18:02:04" MIMETYPE="text/xml" CHECKSUM="acb6aa03211068b18ffa90204b1176fb0dc8c24f" CHECKSUMTYPE="SHA-1" SIZE="16390">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T18:02:05" MIMETYPE="text/xml"
-				CHECKSUM="454adb8ba832ca00d208b58002a798d0bf34e19f" CHECKSUMTYPE="SHA-1" SIZE="43529">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T18:02:05" MIMETYPE="text/xml" CHECKSUM="454adb8ba832ca00d208b58002a798d0bf34e19f" CHECKSUMTYPE="SHA-1" SIZE="43529">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0094.alto.xml"/>
 			</file>
-			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T18:02:05" MIMETYPE="text/xml"
-				CHECKSUM="5aab01f5d40f760b79ab3c33a64293055ae708ed" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T18:02:05" MIMETYPE="text/xml" CHECKSUM="5aab01f5d40f760b79ab3c33a64293055ae708ed" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0095.alto.xml"/>
 			</file>
-			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T18:02:06" MIMETYPE="text/xml"
-				CHECKSUM="a3a2fb559f73ee544638c0a92b215c0dad4fceff" CHECKSUMTYPE="SHA-1" SIZE="5327">
+			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T18:02:06" MIMETYPE="text/xml" CHECKSUM="a3a2fb559f73ee544638c0a92b215c0dad4fceff" CHECKSUMTYPE="SHA-1" SIZE="5327">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-05_01_0096.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:04:56" MIMETYPE="application/pdf" CHECKSUM="63c0913809a6abef1d1a7751a7605e294ee591df"
-				CHECKSUMTYPE="SHA-1" SIZE="40551098">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/bmtnabe_1897-05_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:04:56" MIMETYPE="application/pdf" CHECKSUM="63c0913809a6abef1d1a7751a7605e294ee591df" CHECKSUMTYPE="SHA-1" SIZE="40551098">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/05_01/bmtnabe_1897-05_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>

--- a/metadata/periodicals/bmtnabe/issues/1897/10_01/bmtnabe_1897-10_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1897/10_01/bmtnabe_1897-10_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1897-10_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1897-10_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-10_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-10_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1897-10_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1897-10_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-10_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -8588,860 +8584,576 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-08-01T18:31:48" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="08286ca83fa7f0a6d304146ee3a832087e7d70a5" CHECKSUMTYPE="SHA-1" SIZE="4930286">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-08-01T18:32:14" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="dc25e355836ada5dbf5bb1e4b6655c86f5714012" CHECKSUMTYPE="SHA-1" SIZE="5238129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-08-01T18:32:39" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="2d787a83bd3dfb7b88e87c10e99541f8884ddce4" CHECKSUMTYPE="SHA-1" SIZE="4930327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-08-01T18:33:01" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="757f6f747548b607767892f40f6f470c67124b39" CHECKSUMTYPE="SHA-1" SIZE="5274125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-08-01T18:33:24" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="7e249c5bc37af941b55b05fa09e0fd587bfd45e3" CHECKSUMTYPE="SHA-1" SIZE="4930325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-08-01T18:33:49" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="ae29a201a5dcd534683a363421a5abfd9b8979f7" CHECKSUMTYPE="SHA-1" SIZE="5268726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-08-01T18:34:13" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="45043e24c8ec47b1e1f7e1439c57b7d48da31100" CHECKSUMTYPE="SHA-1" SIZE="4930318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-08-01T18:34:38" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="f23935fea30775185cfe41955dd7e76d5ac34150" CHECKSUMTYPE="SHA-1" SIZE="5287620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-08-01T18:35:02" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="72ca3031a12155eb65ffd31ca3b290364f87f327" CHECKSUMTYPE="SHA-1" SIZE="4935722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-08-01T18:35:27" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="b65c20d14686a5a83e9fc15a54064db7bcc001fa" CHECKSUMTYPE="SHA-1" SIZE="5279529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-08-01T18:35:51" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="dcc1067b144ff3b0fa44a0228d80df59ad49928c" CHECKSUMTYPE="SHA-1" SIZE="4978006">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-08-01T18:36:16" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="cffc3ade332a1960c79d4641fa517015dadc744d" CHECKSUMTYPE="SHA-1" SIZE="5327223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-08-01T18:36:42" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="070216da0191364ed251f0c4fa6f4090cb6a0780" CHECKSUMTYPE="SHA-1" SIZE="4978027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-08-01T18:37:07" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="75cf33e7f8a6879567e51bb213c6dea6128a1915" CHECKSUMTYPE="SHA-1" SIZE="5380316">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-08-01T18:37:34" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="84d14217199e0e110f7763af34b10bac2f1dcd50" CHECKSUMTYPE="SHA-1" SIZE="4977939">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-08-01T18:37:59" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="66f90de98e1242fdf591975da6cac9027468a730" CHECKSUMTYPE="SHA-1" SIZE="5380325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-08-01T18:38:25" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="a3cb87db5c8b3e17fd0c0182987ebd7e1bf1895b" CHECKSUMTYPE="SHA-1" SIZE="4978020">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-08-01T18:38:50" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="a5f454a52cc2ca1945b77af821eb970a590d58e4" CHECKSUMTYPE="SHA-1" SIZE="5326325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-08-01T18:39:15" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="5db21e324299ae814e4a994aa1ba058a5631aac6" CHECKSUMTYPE="SHA-1" SIZE="4978023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-08-01T18:39:40" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="5ad045ea93b3078ae8a8d71fa1adb4ada17f8812" CHECKSUMTYPE="SHA-1" SIZE="5326329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-08-01T18:40:03" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="06bce5392f5cad2282feb5ff4d813b194b033409" CHECKSUMTYPE="SHA-1" SIZE="4978028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-08-01T18:40:28" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="6d6f0805c72fb54f7fba1a34b1ebfde5959e36a7" CHECKSUMTYPE="SHA-1" SIZE="5298429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-08-01T18:40:52" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="6aca48eb3a462ad44ee75a5f3a93fca08fb7c0c5" CHECKSUMTYPE="SHA-1" SIZE="4978027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-08-01T18:41:15" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="bcd5d59008e38df1a98814bc6d890c02a294bc3b" CHECKSUMTYPE="SHA-1" SIZE="5277711">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-08-01T18:41:40" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="59dcf42a8633d126b906c2e9c32af9c4d05ba23f" CHECKSUMTYPE="SHA-1" SIZE="4978028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-08-01T18:42:03" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="3cfdd70ad0d14b276286c6e928dbd3d7e6853fd7" CHECKSUMTYPE="SHA-1" SIZE="5298427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-08-01T18:42:28" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="d59acfd268f30bc828b902f7219cdcd2a9568238" CHECKSUMTYPE="SHA-1" SIZE="4978002">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-08-01T18:42:55" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="51680b544fa3df31c37577b281bc7c94cf18779f" CHECKSUMTYPE="SHA-1" SIZE="5303828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-08-01T18:43:21" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="9b933d86474c5ebaa2e349734b61d0cc79c77b88" CHECKSUMTYPE="SHA-1" SIZE="4978025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-08-01T18:43:45" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="3b8a58b69ae09886ef7afabd0d52633f2c568968" CHECKSUMTYPE="SHA-1" SIZE="5303829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-08-01T18:44:11" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="b6e449d44ad5078f8381fb0e97c3619f7af11bd4" CHECKSUMTYPE="SHA-1" SIZE="4978010">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-08-01T18:44:34" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="830a026c55dabe0901e4f813eda64c77b7c71551" CHECKSUMTYPE="SHA-1" SIZE="5303816">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-08-01T18:44:58" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="3a6990a7d2e827d21db658de9917d0af72207dcf" CHECKSUMTYPE="SHA-1" SIZE="4978026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-08-01T18:45:23" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="1fbe3fc29b2ebe0e21279a21085b8c347a25d67c" CHECKSUMTYPE="SHA-1" SIZE="5293025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-08-01T18:45:47" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="03697620fe076df369dbd812b43655390e839aeb" CHECKSUMTYPE="SHA-1" SIZE="4978028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-08-01T18:46:10" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="7d7acc6c680faba1bc83230a20481bea388c8eae" CHECKSUMTYPE="SHA-1" SIZE="5293029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-08-01T18:46:35" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="6f3e2dcd0c1ec97b423e3c3af2219e43ea0ecb80" CHECKSUMTYPE="SHA-1" SIZE="4991353">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-08-01T18:46:58" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="557168f0ee9dd5f13f9105621e6f224ae6a6d781" CHECKSUMTYPE="SHA-1" SIZE="5293027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-08-01T18:47:21" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="db5efd5bfc47698155e7662385db972b207e6116" CHECKSUMTYPE="SHA-1" SIZE="4954625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-08-01T18:47:46" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="54f1b789e2737d90e91fddfcf7ec5f28e14a89ff" CHECKSUMTYPE="SHA-1" SIZE="5293029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-08-01T18:48:10" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="7bcda983af64731ac12effa816b74dcc77cf2994" CHECKSUMTYPE="SHA-1" SIZE="4954586">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-08-01T18:48:38" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="27f0c79362c800a0a1738dbb3fb61d25c7cb8eaf" CHECKSUMTYPE="SHA-1" SIZE="5293028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-08-01T18:49:02" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="10443294e729cd773f5a29d9388a4c710a478338" CHECKSUMTYPE="SHA-1" SIZE="4954627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-08-01T18:49:25" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="2b709bd25476c034021121c5c0d09d262604a8ce" CHECKSUMTYPE="SHA-1" SIZE="5293028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-08-01T18:49:48" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="f887db63f7e5ba81f511c1e4690720890ab19080" CHECKSUMTYPE="SHA-1" SIZE="4948312">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-08-01T18:50:11" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="0bda8b95943bcff49efe1263d3de47b1981c6804" CHECKSUMTYPE="SHA-1" SIZE="5293026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-08-01T18:50:34" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="b3f5c1f65e213340621f757b719a3e2996f79df8" CHECKSUMTYPE="SHA-1" SIZE="4929429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-08-01T18:50:58" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="645826bceb4a6dc3fb23a08bc2d5726f893af042" CHECKSUMTYPE="SHA-1" SIZE="5288524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-08-01T18:51:22" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="1be2518c5a0b7efdd1df8f6f91b1f9157468a63a" CHECKSUMTYPE="SHA-1" SIZE="5169721">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-08-01T18:51:45" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="0d341afc9f3ab89a6612647fe172f95b2a8cbff7" CHECKSUMTYPE="SHA-1" SIZE="5288529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-08-01T18:52:07" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="cf71b0e2f00ad4497b6c4a42c1ef235743127fc8" CHECKSUMTYPE="SHA-1" SIZE="5127420">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-08-01T18:52:32" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="157bcc4b41313d542f17003cfad4b70ae77be6ea" CHECKSUMTYPE="SHA-1" SIZE="5334428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-08-01T18:52:57" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="49dd25514a196c7b5ca1cbd54e1b6ef3743f7574" CHECKSUMTYPE="SHA-1" SIZE="5127394">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-08-01T18:53:22" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="400b5810f4542813b06dd6ad8afab7228e69333b" CHECKSUMTYPE="SHA-1" SIZE="5269627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-08-01T18:53:47" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="ea4e657e1410868938e2fc06d49338c91d9f7cd2" CHECKSUMTYPE="SHA-1" SIZE="5140869">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-08-01T18:54:12" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="2ea233302b0ca75c9373c6f9e34f8f811d015888" CHECKSUMTYPE="SHA-1" SIZE="5349729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-08-01T18:54:36" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="de8b502ce244436129bc815f7f4477d49b98b6dd" CHECKSUMTYPE="SHA-1" SIZE="5140927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-08-01T18:55:02" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="c0e5fc447751250c35d5abd2632598c302e91e8f" CHECKSUMTYPE="SHA-1" SIZE="5349723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-08-01T18:55:28" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="a54e3323973d9f9d0f257283bd59bb50f756867b" CHECKSUMTYPE="SHA-1" SIZE="5140925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-08-01T18:55:54" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="1f85152adca0ecf08c9973234d5929e2fb6bd1e9" CHECKSUMTYPE="SHA-1" SIZE="5349729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-08-01T18:56:21" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="e15cd0d35768aab0823de0589514ef35076ac33f" CHECKSUMTYPE="SHA-1" SIZE="5140919">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-08-01T18:56:47" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="4055568b15283c9f22803473865b452fb31e2129" CHECKSUMTYPE="SHA-1" SIZE="5349729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-08-01T18:57:13" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="6c880ad3169cc9db2ee1ed9ea2b9d6a42f7a7e6d" CHECKSUMTYPE="SHA-1" SIZE="5140920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-08-01T18:57:39" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="3e65ef640775bfbc38489a585cb0392c232a9197" CHECKSUMTYPE="SHA-1" SIZE="5375822">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-08-01T18:58:05" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="f08dd9de4d12c3cfeb91cad0150a728dbc12881d" CHECKSUMTYPE="SHA-1" SIZE="5140927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-08-01T18:58:31" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="064d3a7dd4089384bfe1cbb15664aa0f4afce072" CHECKSUMTYPE="SHA-1" SIZE="5336225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-08-01T18:58:58" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="c43f211ac01d167edac5fe34b078c28071a626bd" CHECKSUMTYPE="SHA-1" SIZE="5140928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-08-01T18:59:23" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="76610d4fd2f173c91bc58fc6623bba91cce0d356" CHECKSUMTYPE="SHA-1" SIZE="5306477">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-08-01T18:59:49" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="4e47d5f88cd6b2b58f629961a1b95d18aea398bf" CHECKSUMTYPE="SHA-1" SIZE="5140920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-08-01T19:00:17" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="a7c614b2c41583d737f8c70d5129c810fedcfe80" CHECKSUMTYPE="SHA-1" SIZE="5349723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-08-01T19:00:43" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="68b4ce016a46b8551c0e77575cc4343081b1a4cf" CHECKSUMTYPE="SHA-1" SIZE="5140926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-08-01T19:01:12" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="544557b41a7e21cbac1b23908bc68d34229f8492" CHECKSUMTYPE="SHA-1" SIZE="5289425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-08-01T19:01:38" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="716a8b946166faf932014ba3723a276cbaeda9b2" CHECKSUMTYPE="SHA-1" SIZE="5140914">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-08-01T19:02:05" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="c855e2f1b7531e843d119e026b9f177fad95f437" CHECKSUMTYPE="SHA-1" SIZE="5335327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-08-01T19:02:30" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="9bfdbb172162908c2a6fe3ddd804d17fb16d207e" CHECKSUMTYPE="SHA-1" SIZE="5167927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-08-01T19:02:57" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="1066325361722b50e959355060c2b2c83fd40edf" CHECKSUMTYPE="SHA-1" SIZE="5287624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-08-01T19:03:24" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="cf7ce3256c154d32e50cd48e505b1482e8feb2d0" CHECKSUMTYPE="SHA-1" SIZE="5167897">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-08-01T19:03:50" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="835fbbccfd3cca42038962d56116a6ae18cf979e" CHECKSUMTYPE="SHA-1" SIZE="5287623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-08-01T19:04:16" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="9fc874938167fde33bea768b850e991e05c25275" CHECKSUMTYPE="SHA-1" SIZE="5167929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-08-01T19:04:43" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="3300981061f9df54d4423a272aabcade4f53d30b" CHECKSUMTYPE="SHA-1" SIZE="5287627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-08-01T19:05:09" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="e98d55e46e0fc85b1f1c84ad6822cc2799e64d98" CHECKSUMTYPE="SHA-1" SIZE="5167928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-08-01T19:05:35" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="a4330271c8d025038e832dabca6d913828b3906d" CHECKSUMTYPE="SHA-1" SIZE="5287620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-08-01T19:06:02" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="23efd8dc7a21c520abe2f2106f9836561822097d" CHECKSUMTYPE="SHA-1" SIZE="5167904">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-08-01T19:06:32" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="c08b24d356aa90ec4ce9061b1f686964e2d9b53b" CHECKSUMTYPE="SHA-1" SIZE="5313724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-08-01T19:06:59" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="f9a33c376e0024e17a1a6739a58b19653b0b99e0" CHECKSUMTYPE="SHA-1" SIZE="5167648">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-08-01T19:07:25" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="73e7dc9c590d6b73c1f106411adfa29a244054be" CHECKSUMTYPE="SHA-1" SIZE="5313726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-08-01T19:07:50" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="e258a609e31dc3d2588b37edfe9c661536c1faf4" CHECKSUMTYPE="SHA-1" SIZE="5167929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-08-01T19:08:17" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="bf607f8b190ac2aff658dae9b1b5132bf63783d5" CHECKSUMTYPE="SHA-1" SIZE="5285829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-08-01T19:08:42" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="3bdbe28e42a96771901d7072c51ace6fb3b7e827" CHECKSUMTYPE="SHA-1" SIZE="5167925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-08-01T19:09:06" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="6e23ec95b054ff413e8867c09105a566198ae1f9" CHECKSUMTYPE="SHA-1" SIZE="5285820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-08-01T19:09:31" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="cbef62ce6914ae425b2e2b9db9950a2dc7006f71" CHECKSUMTYPE="SHA-1" SIZE="5167927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-08-01T19:09:55" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="debec1a162f388925ce9a7650837dc341a262bc7" CHECKSUMTYPE="SHA-1" SIZE="5285829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-08-01T19:10:19" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="c850c853f27c96d14d2570bb2177ce23c720c157" CHECKSUMTYPE="SHA-1" SIZE="5167925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-08-01T19:10:48" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="29560b896ea13d31e23b329825bc1ad5bb2c4c13" CHECKSUMTYPE="SHA-1" SIZE="5285817">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0094.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-08-01T18:31:48" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="08286ca83fa7f0a6d304146ee3a832087e7d70a5" CHECKSUMTYPE="SHA-1" SIZE="4930286">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-08-01T18:32:14" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="dc25e355836ada5dbf5bb1e4b6655c86f5714012" CHECKSUMTYPE="SHA-1" SIZE="5238129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-08-01T18:32:39" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="2d787a83bd3dfb7b88e87c10e99541f8884ddce4" CHECKSUMTYPE="SHA-1" SIZE="4930327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-08-01T18:33:01" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="757f6f747548b607767892f40f6f470c67124b39" CHECKSUMTYPE="SHA-1" SIZE="5274125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-08-01T18:33:24" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="7e249c5bc37af941b55b05fa09e0fd587bfd45e3" CHECKSUMTYPE="SHA-1" SIZE="4930325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-08-01T18:33:49" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="ae29a201a5dcd534683a363421a5abfd9b8979f7" CHECKSUMTYPE="SHA-1" SIZE="5268726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-08-01T18:34:13" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="45043e24c8ec47b1e1f7e1439c57b7d48da31100" CHECKSUMTYPE="SHA-1" SIZE="4930318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-08-01T18:34:38" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="f23935fea30775185cfe41955dd7e76d5ac34150" CHECKSUMTYPE="SHA-1" SIZE="5287620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-08-01T18:35:02" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="72ca3031a12155eb65ffd31ca3b290364f87f327" CHECKSUMTYPE="SHA-1" SIZE="4935722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-08-01T18:35:27" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="b65c20d14686a5a83e9fc15a54064db7bcc001fa" CHECKSUMTYPE="SHA-1" SIZE="5279529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-08-01T18:35:51" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="dcc1067b144ff3b0fa44a0228d80df59ad49928c" CHECKSUMTYPE="SHA-1" SIZE="4978006">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-08-01T18:36:16" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="cffc3ade332a1960c79d4641fa517015dadc744d" CHECKSUMTYPE="SHA-1" SIZE="5327223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-08-01T18:36:42" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="070216da0191364ed251f0c4fa6f4090cb6a0780" CHECKSUMTYPE="SHA-1" SIZE="4978027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-08-01T18:37:07" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="75cf33e7f8a6879567e51bb213c6dea6128a1915" CHECKSUMTYPE="SHA-1" SIZE="5380316">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-08-01T18:37:34" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="84d14217199e0e110f7763af34b10bac2f1dcd50" CHECKSUMTYPE="SHA-1" SIZE="4977939">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-08-01T18:37:59" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="66f90de98e1242fdf591975da6cac9027468a730" CHECKSUMTYPE="SHA-1" SIZE="5380325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-08-01T18:38:25" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="a3cb87db5c8b3e17fd0c0182987ebd7e1bf1895b" CHECKSUMTYPE="SHA-1" SIZE="4978020">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-08-01T18:38:50" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="a5f454a52cc2ca1945b77af821eb970a590d58e4" CHECKSUMTYPE="SHA-1" SIZE="5326325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-08-01T18:39:15" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="5db21e324299ae814e4a994aa1ba058a5631aac6" CHECKSUMTYPE="SHA-1" SIZE="4978023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-08-01T18:39:40" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="5ad045ea93b3078ae8a8d71fa1adb4ada17f8812" CHECKSUMTYPE="SHA-1" SIZE="5326329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-08-01T18:40:03" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="06bce5392f5cad2282feb5ff4d813b194b033409" CHECKSUMTYPE="SHA-1" SIZE="4978028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-08-01T18:40:28" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="6d6f0805c72fb54f7fba1a34b1ebfde5959e36a7" CHECKSUMTYPE="SHA-1" SIZE="5298429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-08-01T18:40:52" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="6aca48eb3a462ad44ee75a5f3a93fca08fb7c0c5" CHECKSUMTYPE="SHA-1" SIZE="4978027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-08-01T18:41:15" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="bcd5d59008e38df1a98814bc6d890c02a294bc3b" CHECKSUMTYPE="SHA-1" SIZE="5277711">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-08-01T18:41:40" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="59dcf42a8633d126b906c2e9c32af9c4d05ba23f" CHECKSUMTYPE="SHA-1" SIZE="4978028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-08-01T18:42:03" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="3cfdd70ad0d14b276286c6e928dbd3d7e6853fd7" CHECKSUMTYPE="SHA-1" SIZE="5298427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-08-01T18:42:28" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="d59acfd268f30bc828b902f7219cdcd2a9568238" CHECKSUMTYPE="SHA-1" SIZE="4978002">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-08-01T18:42:55" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="51680b544fa3df31c37577b281bc7c94cf18779f" CHECKSUMTYPE="SHA-1" SIZE="5303828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-08-01T18:43:21" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="9b933d86474c5ebaa2e349734b61d0cc79c77b88" CHECKSUMTYPE="SHA-1" SIZE="4978025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-08-01T18:43:45" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="3b8a58b69ae09886ef7afabd0d52633f2c568968" CHECKSUMTYPE="SHA-1" SIZE="5303829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-08-01T18:44:11" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="b6e449d44ad5078f8381fb0e97c3619f7af11bd4" CHECKSUMTYPE="SHA-1" SIZE="4978010">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-08-01T18:44:34" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="830a026c55dabe0901e4f813eda64c77b7c71551" CHECKSUMTYPE="SHA-1" SIZE="5303816">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-08-01T18:44:58" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="3a6990a7d2e827d21db658de9917d0af72207dcf" CHECKSUMTYPE="SHA-1" SIZE="4978026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-08-01T18:45:23" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="1fbe3fc29b2ebe0e21279a21085b8c347a25d67c" CHECKSUMTYPE="SHA-1" SIZE="5293025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-08-01T18:45:47" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="03697620fe076df369dbd812b43655390e839aeb" CHECKSUMTYPE="SHA-1" SIZE="4978028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-08-01T18:46:10" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="7d7acc6c680faba1bc83230a20481bea388c8eae" CHECKSUMTYPE="SHA-1" SIZE="5293029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-08-01T18:46:35" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="6f3e2dcd0c1ec97b423e3c3af2219e43ea0ecb80" CHECKSUMTYPE="SHA-1" SIZE="4991353">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-08-01T18:46:58" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="557168f0ee9dd5f13f9105621e6f224ae6a6d781" CHECKSUMTYPE="SHA-1" SIZE="5293027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-08-01T18:47:21" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="db5efd5bfc47698155e7662385db972b207e6116" CHECKSUMTYPE="SHA-1" SIZE="4954625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-08-01T18:47:46" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="54f1b789e2737d90e91fddfcf7ec5f28e14a89ff" CHECKSUMTYPE="SHA-1" SIZE="5293029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-08-01T18:48:10" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="7bcda983af64731ac12effa816b74dcc77cf2994" CHECKSUMTYPE="SHA-1" SIZE="4954586">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-08-01T18:48:38" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="27f0c79362c800a0a1738dbb3fb61d25c7cb8eaf" CHECKSUMTYPE="SHA-1" SIZE="5293028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-08-01T18:49:02" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="10443294e729cd773f5a29d9388a4c710a478338" CHECKSUMTYPE="SHA-1" SIZE="4954627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-08-01T18:49:25" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="2b709bd25476c034021121c5c0d09d262604a8ce" CHECKSUMTYPE="SHA-1" SIZE="5293028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-08-01T18:49:48" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="f887db63f7e5ba81f511c1e4690720890ab19080" CHECKSUMTYPE="SHA-1" SIZE="4948312">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-08-01T18:50:11" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="0bda8b95943bcff49efe1263d3de47b1981c6804" CHECKSUMTYPE="SHA-1" SIZE="5293026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-08-01T18:50:34" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="b3f5c1f65e213340621f757b719a3e2996f79df8" CHECKSUMTYPE="SHA-1" SIZE="4929429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-08-01T18:50:58" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="645826bceb4a6dc3fb23a08bc2d5726f893af042" CHECKSUMTYPE="SHA-1" SIZE="5288524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-08-01T18:51:22" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="1be2518c5a0b7efdd1df8f6f91b1f9157468a63a" CHECKSUMTYPE="SHA-1" SIZE="5169721">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-08-01T18:51:45" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="0d341afc9f3ab89a6612647fe172f95b2a8cbff7" CHECKSUMTYPE="SHA-1" SIZE="5288529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-08-01T18:52:07" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="cf71b0e2f00ad4497b6c4a42c1ef235743127fc8" CHECKSUMTYPE="SHA-1" SIZE="5127420">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-08-01T18:52:32" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="157bcc4b41313d542f17003cfad4b70ae77be6ea" CHECKSUMTYPE="SHA-1" SIZE="5334428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-08-01T18:52:57" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="49dd25514a196c7b5ca1cbd54e1b6ef3743f7574" CHECKSUMTYPE="SHA-1" SIZE="5127394">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-08-01T18:53:22" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="400b5810f4542813b06dd6ad8afab7228e69333b" CHECKSUMTYPE="SHA-1" SIZE="5269627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-08-01T18:53:47" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="ea4e657e1410868938e2fc06d49338c91d9f7cd2" CHECKSUMTYPE="SHA-1" SIZE="5140869">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-08-01T18:54:12" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="2ea233302b0ca75c9373c6f9e34f8f811d015888" CHECKSUMTYPE="SHA-1" SIZE="5349729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-08-01T18:54:36" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="de8b502ce244436129bc815f7f4477d49b98b6dd" CHECKSUMTYPE="SHA-1" SIZE="5140927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-08-01T18:55:02" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="c0e5fc447751250c35d5abd2632598c302e91e8f" CHECKSUMTYPE="SHA-1" SIZE="5349723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-08-01T18:55:28" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="a54e3323973d9f9d0f257283bd59bb50f756867b" CHECKSUMTYPE="SHA-1" SIZE="5140925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-08-01T18:55:54" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="1f85152adca0ecf08c9973234d5929e2fb6bd1e9" CHECKSUMTYPE="SHA-1" SIZE="5349729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-08-01T18:56:21" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="e15cd0d35768aab0823de0589514ef35076ac33f" CHECKSUMTYPE="SHA-1" SIZE="5140919">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-08-01T18:56:47" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="4055568b15283c9f22803473865b452fb31e2129" CHECKSUMTYPE="SHA-1" SIZE="5349729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-08-01T18:57:13" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="6c880ad3169cc9db2ee1ed9ea2b9d6a42f7a7e6d" CHECKSUMTYPE="SHA-1" SIZE="5140920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-08-01T18:57:39" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="3e65ef640775bfbc38489a585cb0392c232a9197" CHECKSUMTYPE="SHA-1" SIZE="5375822">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-08-01T18:58:05" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="f08dd9de4d12c3cfeb91cad0150a728dbc12881d" CHECKSUMTYPE="SHA-1" SIZE="5140927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-08-01T18:58:31" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="064d3a7dd4089384bfe1cbb15664aa0f4afce072" CHECKSUMTYPE="SHA-1" SIZE="5336225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-08-01T18:58:58" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="c43f211ac01d167edac5fe34b078c28071a626bd" CHECKSUMTYPE="SHA-1" SIZE="5140928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-08-01T18:59:23" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="76610d4fd2f173c91bc58fc6623bba91cce0d356" CHECKSUMTYPE="SHA-1" SIZE="5306477">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-08-01T18:59:49" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="4e47d5f88cd6b2b58f629961a1b95d18aea398bf" CHECKSUMTYPE="SHA-1" SIZE="5140920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-08-01T19:00:17" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="a7c614b2c41583d737f8c70d5129c810fedcfe80" CHECKSUMTYPE="SHA-1" SIZE="5349723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-08-01T19:00:43" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="68b4ce016a46b8551c0e77575cc4343081b1a4cf" CHECKSUMTYPE="SHA-1" SIZE="5140926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-08-01T19:01:12" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="544557b41a7e21cbac1b23908bc68d34229f8492" CHECKSUMTYPE="SHA-1" SIZE="5289425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-08-01T19:01:38" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="716a8b946166faf932014ba3723a276cbaeda9b2" CHECKSUMTYPE="SHA-1" SIZE="5140914">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-08-01T19:02:05" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="c855e2f1b7531e843d119e026b9f177fad95f437" CHECKSUMTYPE="SHA-1" SIZE="5335327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-08-01T19:02:30" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="9bfdbb172162908c2a6fe3ddd804d17fb16d207e" CHECKSUMTYPE="SHA-1" SIZE="5167927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-08-01T19:02:57" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="1066325361722b50e959355060c2b2c83fd40edf" CHECKSUMTYPE="SHA-1" SIZE="5287624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-08-01T19:03:24" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="cf7ce3256c154d32e50cd48e505b1482e8feb2d0" CHECKSUMTYPE="SHA-1" SIZE="5167897">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-08-01T19:03:50" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="835fbbccfd3cca42038962d56116a6ae18cf979e" CHECKSUMTYPE="SHA-1" SIZE="5287623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-08-01T19:04:16" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="9fc874938167fde33bea768b850e991e05c25275" CHECKSUMTYPE="SHA-1" SIZE="5167929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-08-01T19:04:43" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="3300981061f9df54d4423a272aabcade4f53d30b" CHECKSUMTYPE="SHA-1" SIZE="5287627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-08-01T19:05:09" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="e98d55e46e0fc85b1f1c84ad6822cc2799e64d98" CHECKSUMTYPE="SHA-1" SIZE="5167928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-08-01T19:05:35" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="a4330271c8d025038e832dabca6d913828b3906d" CHECKSUMTYPE="SHA-1" SIZE="5287620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-08-01T19:06:02" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="23efd8dc7a21c520abe2f2106f9836561822097d" CHECKSUMTYPE="SHA-1" SIZE="5167904">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-08-01T19:06:32" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="c08b24d356aa90ec4ce9061b1f686964e2d9b53b" CHECKSUMTYPE="SHA-1" SIZE="5313724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-08-01T19:06:59" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="f9a33c376e0024e17a1a6739a58b19653b0b99e0" CHECKSUMTYPE="SHA-1" SIZE="5167648">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-08-01T19:07:25" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="73e7dc9c590d6b73c1f106411adfa29a244054be" CHECKSUMTYPE="SHA-1" SIZE="5313726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-08-01T19:07:50" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="e258a609e31dc3d2588b37edfe9c661536c1faf4" CHECKSUMTYPE="SHA-1" SIZE="5167929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-08-01T19:08:17" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="bf607f8b190ac2aff658dae9b1b5132bf63783d5" CHECKSUMTYPE="SHA-1" SIZE="5285829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-08-01T19:08:42" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="3bdbe28e42a96771901d7072c51ace6fb3b7e827" CHECKSUMTYPE="SHA-1" SIZE="5167925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-08-01T19:09:06" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="6e23ec95b054ff413e8867c09105a566198ae1f9" CHECKSUMTYPE="SHA-1" SIZE="5285820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-08-01T19:09:31" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="cbef62ce6914ae425b2e2b9db9950a2dc7006f71" CHECKSUMTYPE="SHA-1" SIZE="5167927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-08-01T19:09:55" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="debec1a162f388925ce9a7650837dc341a262bc7" CHECKSUMTYPE="SHA-1" SIZE="5285829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-08-01T19:10:19" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="c850c853f27c96d14d2570bb2177ce23c720c157" CHECKSUMTYPE="SHA-1" SIZE="5167925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-08-01T19:10:48" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="29560b896ea13d31e23b329825bc1ad5bb2c4c13" CHECKSUMTYPE="SHA-1" SIZE="5285817">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/delivery/bmtnabe_1897-10_01_0094.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-08-01T19:11:04" MIMETYPE="text/xml" CHECKSUM="a5d35197a7b381bb4b6685cebe5b1163cbda64b1"
-				CHECKSUMTYPE="SHA-1" SIZE="2108">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-08-01T19:11:04" MIMETYPE="text/xml" CHECKSUM="a5d35197a7b381bb4b6685cebe5b1163cbda64b1" CHECKSUMTYPE="SHA-1" SIZE="2108">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-08-01T19:11:04" MIMETYPE="text/xml" CHECKSUM="87e6260f2d1635af7b5f3c81d14720e9be6bafb7"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-08-01T19:11:04" MIMETYPE="text/xml" CHECKSUM="87e6260f2d1635af7b5f3c81d14720e9be6bafb7" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-08-01T19:11:04" MIMETYPE="text/xml" CHECKSUM="ddc33eaf4b8badfa89009015e7f35e17f3040df0"
-				CHECKSUMTYPE="SHA-1" SIZE="1717">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-08-01T19:11:04" MIMETYPE="text/xml" CHECKSUM="ddc33eaf4b8badfa89009015e7f35e17f3040df0" CHECKSUMTYPE="SHA-1" SIZE="1717">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-08-01T19:11:04" MIMETYPE="text/xml" CHECKSUM="3897e886c463e7ea4614d5f169f0dd53befa87dd"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-08-01T19:11:04" MIMETYPE="text/xml" CHECKSUM="3897e886c463e7ea4614d5f169f0dd53befa87dd" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-08-01T19:11:05" MIMETYPE="text/xml" CHECKSUM="4cf586ddb6ae7004c398d5fa208a48b54df7b236"
-				CHECKSUMTYPE="SHA-1" SIZE="13583">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-08-01T19:11:05" MIMETYPE="text/xml" CHECKSUM="4cf586ddb6ae7004c398d5fa208a48b54df7b236" CHECKSUMTYPE="SHA-1" SIZE="13583">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-08-01T19:11:05" MIMETYPE="text/xml" CHECKSUM="cc90611a5f59f982936d9c432984a0d2ac4b4bf1"
-				CHECKSUMTYPE="SHA-1" SIZE="3390">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-08-01T19:11:05" MIMETYPE="text/xml" CHECKSUM="cc90611a5f59f982936d9c432984a0d2ac4b4bf1" CHECKSUMTYPE="SHA-1" SIZE="3390">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-08-01T19:11:05" MIMETYPE="text/xml" CHECKSUM="3bf3a4060393e92ff4c0845a635600dd1d8a7050"
-				CHECKSUMTYPE="SHA-1" SIZE="2102">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-08-01T19:11:05" MIMETYPE="text/xml" CHECKSUM="3bf3a4060393e92ff4c0845a635600dd1d8a7050" CHECKSUMTYPE="SHA-1" SIZE="2102">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-08-01T19:11:05" MIMETYPE="text/xml" CHECKSUM="99363dad4f73c8241a01138dda73455a28057d13"
-				CHECKSUMTYPE="SHA-1" SIZE="9569">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-08-01T19:11:05" MIMETYPE="text/xml" CHECKSUM="99363dad4f73c8241a01138dda73455a28057d13" CHECKSUMTYPE="SHA-1" SIZE="9569">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-08-01T19:11:06" MIMETYPE="text/xml" CHECKSUM="e034af160b73d8842c34a045ee7316bc95b900fc"
-				CHECKSUMTYPE="SHA-1" SIZE="5981">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-08-01T19:11:06" MIMETYPE="text/xml" CHECKSUM="e034af160b73d8842c34a045ee7316bc95b900fc" CHECKSUMTYPE="SHA-1" SIZE="5981">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-08-01T19:11:06" MIMETYPE="text/xml"
-				CHECKSUM="02b0399828dddb586af796944bda68572ed38071" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-08-01T19:11:06" MIMETYPE="text/xml" CHECKSUM="02b0399828dddb586af796944bda68572ed38071" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-08-01T19:11:06" MIMETYPE="text/xml"
-				CHECKSUM="30a3f4d966542840d46486ced7f0ecbc0fbac315" CHECKSUMTYPE="SHA-1" SIZE="83440">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-08-01T19:11:06" MIMETYPE="text/xml" CHECKSUM="30a3f4d966542840d46486ced7f0ecbc0fbac315" CHECKSUMTYPE="SHA-1" SIZE="83440">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-08-01T19:11:07" MIMETYPE="text/xml"
-				CHECKSUM="c9118a63789169f9675dc4e9042e705c92d5a254" CHECKSUMTYPE="SHA-1" SIZE="182195">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-08-01T19:11:07" MIMETYPE="text/xml" CHECKSUM="c9118a63789169f9675dc4e9042e705c92d5a254" CHECKSUMTYPE="SHA-1" SIZE="182195">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-08-01T19:11:07" MIMETYPE="text/xml"
-				CHECKSUM="91216cb2963dcd36f42bcee24ea9787cfe99fb35" CHECKSUMTYPE="SHA-1" SIZE="187190">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-08-01T19:11:07" MIMETYPE="text/xml" CHECKSUM="91216cb2963dcd36f42bcee24ea9787cfe99fb35" CHECKSUMTYPE="SHA-1" SIZE="187190">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-08-01T19:11:08" MIMETYPE="text/xml"
-				CHECKSUM="8e11c2af3da52c1a192a77f08e745d6b7cb275bf" CHECKSUMTYPE="SHA-1" SIZE="207362">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-08-01T19:11:08" MIMETYPE="text/xml" CHECKSUM="8e11c2af3da52c1a192a77f08e745d6b7cb275bf" CHECKSUMTYPE="SHA-1" SIZE="207362">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-08-01T19:11:08" MIMETYPE="text/xml"
-				CHECKSUM="856495e60a74cc3609598f754fbdfb0c51a31976" CHECKSUMTYPE="SHA-1" SIZE="103078">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-08-01T19:11:08" MIMETYPE="text/xml" CHECKSUM="856495e60a74cc3609598f754fbdfb0c51a31976" CHECKSUMTYPE="SHA-1" SIZE="103078">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-08-01T19:11:08" MIMETYPE="text/xml"
-				CHECKSUM="d292680468b341315c0b8dd2c23b82b62d7beb00" CHECKSUMTYPE="SHA-1" SIZE="189885">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-08-01T19:11:08" MIMETYPE="text/xml" CHECKSUM="d292680468b341315c0b8dd2c23b82b62d7beb00" CHECKSUMTYPE="SHA-1" SIZE="189885">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-08-01T19:11:09" MIMETYPE="text/xml"
-				CHECKSUM="67fbfacff84b037d22e7385f0b488ad2201f9b09" CHECKSUMTYPE="SHA-1" SIZE="194648">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-08-01T19:11:09" MIMETYPE="text/xml" CHECKSUM="67fbfacff84b037d22e7385f0b488ad2201f9b09" CHECKSUMTYPE="SHA-1" SIZE="194648">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-08-01T19:11:09" MIMETYPE="text/xml"
-				CHECKSUM="c95f8b3b51a1d6400ed2c0e1362ac8978acba50c" CHECKSUMTYPE="SHA-1" SIZE="119221">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-08-01T19:11:09" MIMETYPE="text/xml" CHECKSUM="c95f8b3b51a1d6400ed2c0e1362ac8978acba50c" CHECKSUMTYPE="SHA-1" SIZE="119221">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-08-01T19:11:10" MIMETYPE="text/xml"
-				CHECKSUM="1ea759690df89fbef7cb13f069c81351d7dbdc83" CHECKSUMTYPE="SHA-1" SIZE="6310">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-08-01T19:11:10" MIMETYPE="text/xml" CHECKSUM="1ea759690df89fbef7cb13f069c81351d7dbdc83" CHECKSUMTYPE="SHA-1" SIZE="6310">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-08-01T19:11:10" MIMETYPE="text/xml"
-				CHECKSUM="1cd6ebe1a6bd0ff7d2fb60b3a4c17123bef79e5e" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-08-01T19:11:10" MIMETYPE="text/xml" CHECKSUM="1cd6ebe1a6bd0ff7d2fb60b3a4c17123bef79e5e" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-08-01T19:11:10" MIMETYPE="text/xml"
-				CHECKSUM="60fcf506e40297837bafe3b3df53bf1725d27b19" CHECKSUMTYPE="SHA-1" SIZE="16468">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-08-01T19:11:10" MIMETYPE="text/xml" CHECKSUM="60fcf506e40297837bafe3b3df53bf1725d27b19" CHECKSUMTYPE="SHA-1" SIZE="16468">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-08-01T19:11:10" MIMETYPE="text/xml"
-				CHECKSUM="94722802f106c86d7a124263d5fcd2b3693626e3" CHECKSUMTYPE="SHA-1" SIZE="33774">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-08-01T19:11:10" MIMETYPE="text/xml" CHECKSUM="94722802f106c86d7a124263d5fcd2b3693626e3" CHECKSUMTYPE="SHA-1" SIZE="33774">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-08-01T19:11:11" MIMETYPE="text/xml"
-				CHECKSUM="f03f69b167ef6b1e2ffeb7533a8973b2eb506a04" CHECKSUMTYPE="SHA-1" SIZE="27695">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-08-01T19:11:11" MIMETYPE="text/xml" CHECKSUM="f03f69b167ef6b1e2ffeb7533a8973b2eb506a04" CHECKSUMTYPE="SHA-1" SIZE="27695">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-08-01T19:11:11" MIMETYPE="text/xml"
-				CHECKSUM="08d04f5bd2bcbc18285308b7c43a7c6282d7bfde" CHECKSUMTYPE="SHA-1" SIZE="33540">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-08-01T19:11:11" MIMETYPE="text/xml" CHECKSUM="08d04f5bd2bcbc18285308b7c43a7c6282d7bfde" CHECKSUMTYPE="SHA-1" SIZE="33540">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-08-01T19:11:11" MIMETYPE="text/xml"
-				CHECKSUM="ce821cf1d0e83a96be56d881c227f850fbc93361" CHECKSUMTYPE="SHA-1" SIZE="27512">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-08-01T19:11:11" MIMETYPE="text/xml" CHECKSUM="ce821cf1d0e83a96be56d881c227f850fbc93361" CHECKSUMTYPE="SHA-1" SIZE="27512">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-08-01T19:11:12" MIMETYPE="text/xml"
-				CHECKSUM="a95bdfefc6826d5430cf2dc51c69b4213ab8af2b" CHECKSUMTYPE="SHA-1" SIZE="25174">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-08-01T19:11:12" MIMETYPE="text/xml" CHECKSUM="a95bdfefc6826d5430cf2dc51c69b4213ab8af2b" CHECKSUMTYPE="SHA-1" SIZE="25174">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-08-01T19:11:12" MIMETYPE="text/xml"
-				CHECKSUM="6a5ec08b60ad0b7779176ae4d43a225c07f57e17" CHECKSUMTYPE="SHA-1" SIZE="87581">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-08-01T19:11:12" MIMETYPE="text/xml" CHECKSUM="6a5ec08b60ad0b7779176ae4d43a225c07f57e17" CHECKSUMTYPE="SHA-1" SIZE="87581">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-08-01T19:11:12" MIMETYPE="text/xml"
-				CHECKSUM="5462fcb274e492fcd5f169cfe5362d13f988351a" CHECKSUMTYPE="SHA-1" SIZE="140665">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-08-01T19:11:12" MIMETYPE="text/xml" CHECKSUM="5462fcb274e492fcd5f169cfe5362d13f988351a" CHECKSUMTYPE="SHA-1" SIZE="140665">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-08-01T19:11:13" MIMETYPE="text/xml"
-				CHECKSUM="e3c98f91e88b12b4de7ae3c97f477195849a49ba" CHECKSUMTYPE="SHA-1" SIZE="4850">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-08-01T19:11:13" MIMETYPE="text/xml" CHECKSUM="e3c98f91e88b12b4de7ae3c97f477195849a49ba" CHECKSUMTYPE="SHA-1" SIZE="4850">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-08-01T19:11:13" MIMETYPE="text/xml"
-				CHECKSUM="c643a5312b2dd99a7c9d6e144e0b5408df2942e6" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-08-01T19:11:13" MIMETYPE="text/xml" CHECKSUM="c643a5312b2dd99a7c9d6e144e0b5408df2942e6" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-08-01T19:11:13" MIMETYPE="text/xml"
-				CHECKSUM="c4edfdb737cab17ab3b17d6816f750235e853eda" CHECKSUMTYPE="SHA-1" SIZE="25910">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-08-01T19:11:13" MIMETYPE="text/xml" CHECKSUM="c4edfdb737cab17ab3b17d6816f750235e853eda" CHECKSUMTYPE="SHA-1" SIZE="25910">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-08-01T19:11:13" MIMETYPE="text/xml"
-				CHECKSUM="c7e85e0529040b217d76195b384b0e8c80dcd931" CHECKSUMTYPE="SHA-1" SIZE="41085">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-08-01T19:11:13" MIMETYPE="text/xml" CHECKSUM="c7e85e0529040b217d76195b384b0e8c80dcd931" CHECKSUMTYPE="SHA-1" SIZE="41085">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-08-01T19:11:14" MIMETYPE="text/xml"
-				CHECKSUM="c28cb42133f82bb064ad2fa0cb1787dc780cbb5e" CHECKSUMTYPE="SHA-1" SIZE="40931">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-08-01T19:11:14" MIMETYPE="text/xml" CHECKSUM="c28cb42133f82bb064ad2fa0cb1787dc780cbb5e" CHECKSUMTYPE="SHA-1" SIZE="40931">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-08-01T19:11:14" MIMETYPE="text/xml"
-				CHECKSUM="65092ce066c99ad6ab186c2cf795cd013141609b" CHECKSUMTYPE="SHA-1" SIZE="35606">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-08-01T19:11:14" MIMETYPE="text/xml" CHECKSUM="65092ce066c99ad6ab186c2cf795cd013141609b" CHECKSUMTYPE="SHA-1" SIZE="35606">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-08-01T19:11:14" MIMETYPE="text/xml"
-				CHECKSUM="91e6d113db1f998832c9a30963531d6dc594071b" CHECKSUMTYPE="SHA-1" SIZE="38554">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-08-01T19:11:14" MIMETYPE="text/xml" CHECKSUM="91e6d113db1f998832c9a30963531d6dc594071b" CHECKSUMTYPE="SHA-1" SIZE="38554">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-08-01T19:11:15" MIMETYPE="text/xml"
-				CHECKSUM="a457728f9fe599386d7fe1013a72560f41ef8a89" CHECKSUMTYPE="SHA-1" SIZE="25785">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-08-01T19:11:15" MIMETYPE="text/xml" CHECKSUM="a457728f9fe599386d7fe1013a72560f41ef8a89" CHECKSUMTYPE="SHA-1" SIZE="25785">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-08-01T19:11:15" MIMETYPE="text/xml"
-				CHECKSUM="651b4ec2c9f166b1b35374fe739a08dfb032c0f7" CHECKSUMTYPE="SHA-1" SIZE="4991">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-08-01T19:11:15" MIMETYPE="text/xml" CHECKSUM="651b4ec2c9f166b1b35374fe739a08dfb032c0f7" CHECKSUMTYPE="SHA-1" SIZE="4991">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-08-01T19:11:15" MIMETYPE="text/xml"
-				CHECKSUM="b67b94f0e3103164ccc117f82250caa95a0772ad" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-08-01T19:11:15" MIMETYPE="text/xml" CHECKSUM="b67b94f0e3103164ccc117f82250caa95a0772ad" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-08-01T19:11:16" MIMETYPE="text/xml"
-				CHECKSUM="94c350522023f5f948e75354b613112a72f365e2" CHECKSUMTYPE="SHA-1" SIZE="25594">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-08-01T19:11:16" MIMETYPE="text/xml" CHECKSUM="94c350522023f5f948e75354b613112a72f365e2" CHECKSUMTYPE="SHA-1" SIZE="25594">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-08-01T19:11:16" MIMETYPE="text/xml"
-				CHECKSUM="3c0062879bc7409a6306348fd7aa8568baf77a0c" CHECKSUMTYPE="SHA-1" SIZE="18921">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-08-01T19:11:16" MIMETYPE="text/xml" CHECKSUM="3c0062879bc7409a6306348fd7aa8568baf77a0c" CHECKSUMTYPE="SHA-1" SIZE="18921">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-08-01T19:11:16" MIMETYPE="text/xml"
-				CHECKSUM="309d1ba2bc310cc87242dc92e61172919ef64024" CHECKSUMTYPE="SHA-1" SIZE="33961">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-08-01T19:11:16" MIMETYPE="text/xml" CHECKSUM="309d1ba2bc310cc87242dc92e61172919ef64024" CHECKSUMTYPE="SHA-1" SIZE="33961">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-08-01T19:11:16" MIMETYPE="text/xml"
-				CHECKSUM="09a039eaaee4d6b5033e1bba6bc54e28272f9c16" CHECKSUMTYPE="SHA-1" SIZE="56757">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-08-01T19:11:16" MIMETYPE="text/xml" CHECKSUM="09a039eaaee4d6b5033e1bba6bc54e28272f9c16" CHECKSUMTYPE="SHA-1" SIZE="56757">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-08-01T19:11:17" MIMETYPE="text/xml"
-				CHECKSUM="8155b102e800f300a97a0ee59523b966e3e3124e" CHECKSUMTYPE="SHA-1" SIZE="75939">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-08-01T19:11:17" MIMETYPE="text/xml" CHECKSUM="8155b102e800f300a97a0ee59523b966e3e3124e" CHECKSUMTYPE="SHA-1" SIZE="75939">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-08-01T19:11:17" MIMETYPE="text/xml"
-				CHECKSUM="a861b5d2d940096f889010a9f8ad00d4c6913148" CHECKSUMTYPE="SHA-1" SIZE="43830">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-08-01T19:11:17" MIMETYPE="text/xml" CHECKSUM="a861b5d2d940096f889010a9f8ad00d4c6913148" CHECKSUMTYPE="SHA-1" SIZE="43830">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-08-01T19:11:17" MIMETYPE="text/xml"
-				CHECKSUM="8135833ac5c10a2734c8edeeee8354783a95039c" CHECKSUMTYPE="SHA-1" SIZE="4668">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-08-01T19:11:17" MIMETYPE="text/xml" CHECKSUM="8135833ac5c10a2734c8edeeee8354783a95039c" CHECKSUMTYPE="SHA-1" SIZE="4668">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-08-01T19:11:18" MIMETYPE="text/xml"
-				CHECKSUM="b44d2aef4f25ecfb4cbc892e5844015f64cbf88a" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-08-01T19:11:18" MIMETYPE="text/xml" CHECKSUM="b44d2aef4f25ecfb4cbc892e5844015f64cbf88a" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-08-01T19:11:19" MIMETYPE="text/xml"
-				CHECKSUM="2719b8f28f553975a7491d9b80a97ca993fd803f" CHECKSUMTYPE="SHA-1" SIZE="30785">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-08-01T19:11:19" MIMETYPE="text/xml" CHECKSUM="2719b8f28f553975a7491d9b80a97ca993fd803f" CHECKSUMTYPE="SHA-1" SIZE="30785">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-08-01T19:11:19" MIMETYPE="text/xml"
-				CHECKSUM="2062ebed26467b2aac33d1b3917b21741fc7b55c" CHECKSUMTYPE="SHA-1" SIZE="14983">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-08-01T19:11:19" MIMETYPE="text/xml" CHECKSUM="2062ebed26467b2aac33d1b3917b21741fc7b55c" CHECKSUMTYPE="SHA-1" SIZE="14983">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-08-01T19:11:19" MIMETYPE="text/xml"
-				CHECKSUM="6841a66509a150c6efdbf7f8ad0d685de3047d5f" CHECKSUMTYPE="SHA-1" SIZE="4994">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-08-01T19:11:19" MIMETYPE="text/xml" CHECKSUM="6841a66509a150c6efdbf7f8ad0d685de3047d5f" CHECKSUMTYPE="SHA-1" SIZE="4994">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-08-01T19:11:20" MIMETYPE="text/xml"
-				CHECKSUM="20b2cbbd749c44f2fd4285492d58f184f8d622d0" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-08-01T19:11:20" MIMETYPE="text/xml" CHECKSUM="20b2cbbd749c44f2fd4285492d58f184f8d622d0" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-08-01T19:11:20" MIMETYPE="text/xml"
-				CHECKSUM="6457a133559890c489cc6b5b70e3f6f4e583d206" CHECKSUMTYPE="SHA-1" SIZE="57208">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-08-01T19:11:20" MIMETYPE="text/xml" CHECKSUM="6457a133559890c489cc6b5b70e3f6f4e583d206" CHECKSUMTYPE="SHA-1" SIZE="57208">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-08-01T19:11:20" MIMETYPE="text/xml"
-				CHECKSUM="3d8cbb7fc226dedc5d97b17a2324b7e750ab74d7" CHECKSUMTYPE="SHA-1" SIZE="19032">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-08-01T19:11:20" MIMETYPE="text/xml" CHECKSUM="3d8cbb7fc226dedc5d97b17a2324b7e750ab74d7" CHECKSUMTYPE="SHA-1" SIZE="19032">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-08-01T19:11:21" MIMETYPE="text/xml"
-				CHECKSUM="4b96f74a916cd6edc84b6a79bd9802451e9750de" CHECKSUMTYPE="SHA-1" SIZE="6034">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-08-01T19:11:21" MIMETYPE="text/xml" CHECKSUM="4b96f74a916cd6edc84b6a79bd9802451e9750de" CHECKSUMTYPE="SHA-1" SIZE="6034">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-08-01T19:11:21" MIMETYPE="text/xml"
-				CHECKSUM="acb80908c54200c747ab19984b134898f16a5b4b" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-08-01T19:11:21" MIMETYPE="text/xml" CHECKSUM="acb80908c54200c747ab19984b134898f16a5b4b" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-08-01T19:11:21" MIMETYPE="text/xml"
-				CHECKSUM="913a5773e2ad542deb3df61f234d1ec446ba858d" CHECKSUMTYPE="SHA-1" SIZE="85295">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-08-01T19:11:21" MIMETYPE="text/xml" CHECKSUM="913a5773e2ad542deb3df61f234d1ec446ba858d" CHECKSUMTYPE="SHA-1" SIZE="85295">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-08-01T19:11:22" MIMETYPE="text/xml"
-				CHECKSUM="d0a071ce565eb4f7b244b1c3365db31c01477f3d" CHECKSUMTYPE="SHA-1" SIZE="189675">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-08-01T19:11:22" MIMETYPE="text/xml" CHECKSUM="d0a071ce565eb4f7b244b1c3365db31c01477f3d" CHECKSUMTYPE="SHA-1" SIZE="189675">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-08-01T19:11:22" MIMETYPE="text/xml"
-				CHECKSUM="c52d9a4815878d7b8bd1f0dafd373193baf713bf" CHECKSUMTYPE="SHA-1" SIZE="94631">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-08-01T19:11:22" MIMETYPE="text/xml" CHECKSUM="c52d9a4815878d7b8bd1f0dafd373193baf713bf" CHECKSUMTYPE="SHA-1" SIZE="94631">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-08-01T19:11:22" MIMETYPE="text/xml"
-				CHECKSUM="7ee8c4eeecc61d3d2fce4c521454b25231c1c6b9" CHECKSUMTYPE="SHA-1" SIZE="101658">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-08-01T19:11:22" MIMETYPE="text/xml" CHECKSUM="7ee8c4eeecc61d3d2fce4c521454b25231c1c6b9" CHECKSUMTYPE="SHA-1" SIZE="101658">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-08-01T19:11:23" MIMETYPE="text/xml"
-				CHECKSUM="91265db50b853a3c56758eb3d9f1bbff23d3c8c0" CHECKSUMTYPE="SHA-1" SIZE="148292">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-08-01T19:11:23" MIMETYPE="text/xml" CHECKSUM="91265db50b853a3c56758eb3d9f1bbff23d3c8c0" CHECKSUMTYPE="SHA-1" SIZE="148292">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-08-01T19:11:23" MIMETYPE="text/xml"
-				CHECKSUM="a68a8807c067e2032d0e82984b5fd77aabb90a83" CHECKSUMTYPE="SHA-1" SIZE="87007">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-08-01T19:11:23" MIMETYPE="text/xml" CHECKSUM="a68a8807c067e2032d0e82984b5fd77aabb90a83" CHECKSUMTYPE="SHA-1" SIZE="87007">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-08-01T19:11:23" MIMETYPE="text/xml"
-				CHECKSUM="59a4cc23c28ac85311c0df672fa85eafeededd6d" CHECKSUMTYPE="SHA-1" SIZE="5249">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-08-01T19:11:23" MIMETYPE="text/xml" CHECKSUM="59a4cc23c28ac85311c0df672fa85eafeededd6d" CHECKSUMTYPE="SHA-1" SIZE="5249">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-08-01T19:11:24" MIMETYPE="text/xml"
-				CHECKSUM="5f09f137b86d1b9d8a5a21534e63ded6ccb6efc6" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-08-01T19:11:24" MIMETYPE="text/xml" CHECKSUM="5f09f137b86d1b9d8a5a21534e63ded6ccb6efc6" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-08-01T19:11:24" MIMETYPE="text/xml"
-				CHECKSUM="cade6f4e6a352dc214fe34d71a4fe25cdb8fef6f" CHECKSUMTYPE="SHA-1" SIZE="59581">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-08-01T19:11:24" MIMETYPE="text/xml" CHECKSUM="cade6f4e6a352dc214fe34d71a4fe25cdb8fef6f" CHECKSUMTYPE="SHA-1" SIZE="59581">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-08-01T19:11:24" MIMETYPE="text/xml"
-				CHECKSUM="0e72a06e1af781bac82f83f96b704573ed8f5247" CHECKSUMTYPE="SHA-1" SIZE="108157">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-08-01T19:11:24" MIMETYPE="text/xml" CHECKSUM="0e72a06e1af781bac82f83f96b704573ed8f5247" CHECKSUMTYPE="SHA-1" SIZE="108157">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-08-01T19:11:25" MIMETYPE="text/xml"
-				CHECKSUM="7091c38c56dd91c1e91ab92370fae76178e3913a" CHECKSUMTYPE="SHA-1" SIZE="190099">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-08-01T19:11:25" MIMETYPE="text/xml" CHECKSUM="7091c38c56dd91c1e91ab92370fae76178e3913a" CHECKSUMTYPE="SHA-1" SIZE="190099">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-08-01T19:11:25" MIMETYPE="text/xml"
-				CHECKSUM="feaa04021ed5a8116515c21af033d489a97ecce5" CHECKSUMTYPE="SHA-1" SIZE="147126">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-08-01T19:11:25" MIMETYPE="text/xml" CHECKSUM="feaa04021ed5a8116515c21af033d489a97ecce5" CHECKSUMTYPE="SHA-1" SIZE="147126">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-08-01T19:11:26" MIMETYPE="text/xml"
-				CHECKSUM="b82ce70755e76bf516941ca3e715d467e5b255df" CHECKSUMTYPE="SHA-1" SIZE="190544">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-08-01T19:11:26" MIMETYPE="text/xml" CHECKSUM="b82ce70755e76bf516941ca3e715d467e5b255df" CHECKSUMTYPE="SHA-1" SIZE="190544">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-08-01T19:11:26" MIMETYPE="text/xml"
-				CHECKSUM="bad433b906e2a91e4483fc52699eaacf8c9c5d57" CHECKSUMTYPE="SHA-1" SIZE="135583">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-08-01T19:11:26" MIMETYPE="text/xml" CHECKSUM="bad433b906e2a91e4483fc52699eaacf8c9c5d57" CHECKSUMTYPE="SHA-1" SIZE="135583">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-08-01T19:11:26" MIMETYPE="text/xml"
-				CHECKSUM="8757cbb3d6ee3c5a0ce9d0cf4226393b12539733" CHECKSUMTYPE="SHA-1" SIZE="182764">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-08-01T19:11:26" MIMETYPE="text/xml" CHECKSUM="8757cbb3d6ee3c5a0ce9d0cf4226393b12539733" CHECKSUMTYPE="SHA-1" SIZE="182764">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-08-01T19:11:27" MIMETYPE="text/xml"
-				CHECKSUM="894e8ea378e5063156a78d6b05fa20768567201c" CHECKSUMTYPE="SHA-1" SIZE="132440">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-08-01T19:11:27" MIMETYPE="text/xml" CHECKSUM="894e8ea378e5063156a78d6b05fa20768567201c" CHECKSUMTYPE="SHA-1" SIZE="132440">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-08-01T19:11:27" MIMETYPE="text/xml"
-				CHECKSUM="ec71bf1c412952bcb53b9d456095684c056dd564" CHECKSUMTYPE="SHA-1" SIZE="144545">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-08-01T19:11:27" MIMETYPE="text/xml" CHECKSUM="ec71bf1c412952bcb53b9d456095684c056dd564" CHECKSUMTYPE="SHA-1" SIZE="144545">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-08-01T19:11:28" MIMETYPE="text/xml"
-				CHECKSUM="793e434aafec9518c185166fbae8e6513cac15b2" CHECKSUMTYPE="SHA-1" SIZE="53854">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-08-01T19:11:28" MIMETYPE="text/xml" CHECKSUM="793e434aafec9518c185166fbae8e6513cac15b2" CHECKSUMTYPE="SHA-1" SIZE="53854">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-08-01T19:11:28" MIMETYPE="text/xml"
-				CHECKSUM="f8551d733699c12c8817ff4b01577d45e2558c51" CHECKSUMTYPE="SHA-1" SIZE="5050">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-08-01T19:11:28" MIMETYPE="text/xml" CHECKSUM="f8551d733699c12c8817ff4b01577d45e2558c51" CHECKSUMTYPE="SHA-1" SIZE="5050">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-08-01T19:11:28" MIMETYPE="text/xml"
-				CHECKSUM="fe5e3cad408c5337eb315deb7dada5730464b145" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-08-01T19:11:28" MIMETYPE="text/xml" CHECKSUM="fe5e3cad408c5337eb315deb7dada5730464b145" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-08-01T19:11:28" MIMETYPE="text/xml"
-				CHECKSUM="5876fe3f3c31e6b557db7c561a834e628501e69a" CHECKSUMTYPE="SHA-1" SIZE="94173">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-08-01T19:11:28" MIMETYPE="text/xml" CHECKSUM="5876fe3f3c31e6b557db7c561a834e628501e69a" CHECKSUMTYPE="SHA-1" SIZE="94173">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-08-01T19:11:29" MIMETYPE="text/xml"
-				CHECKSUM="ef17bce7354f9e4cde6f10ad3032c7aa85d69a51" CHECKSUMTYPE="SHA-1" SIZE="192824">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-08-01T19:11:29" MIMETYPE="text/xml" CHECKSUM="ef17bce7354f9e4cde6f10ad3032c7aa85d69a51" CHECKSUMTYPE="SHA-1" SIZE="192824">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-08-01T19:11:29" MIMETYPE="text/xml"
-				CHECKSUM="3a29df8ca360f5e74efb7ce2d81b861cefaf6cc6" CHECKSUMTYPE="SHA-1" SIZE="61276">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-08-01T19:11:29" MIMETYPE="text/xml" CHECKSUM="3a29df8ca360f5e74efb7ce2d81b861cefaf6cc6" CHECKSUMTYPE="SHA-1" SIZE="61276">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-08-01T19:11:30" MIMETYPE="text/xml"
-				CHECKSUM="0049c20f290f9f007bf789b34e9dcd7fee651222" CHECKSUMTYPE="SHA-1" SIZE="194867">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-08-01T19:11:30" MIMETYPE="text/xml" CHECKSUM="0049c20f290f9f007bf789b34e9dcd7fee651222" CHECKSUMTYPE="SHA-1" SIZE="194867">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-08-01T19:11:30" MIMETYPE="text/xml"
-				CHECKSUM="824bd30ad5999e8e40df723c0799297cd3c363a0" CHECKSUMTYPE="SHA-1" SIZE="139088">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-08-01T19:11:30" MIMETYPE="text/xml" CHECKSUM="824bd30ad5999e8e40df723c0799297cd3c363a0" CHECKSUMTYPE="SHA-1" SIZE="139088">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-08-01T19:11:30" MIMETYPE="text/xml"
-				CHECKSUM="2322649d4b22b166c714817b6cb88b5293c44412" CHECKSUMTYPE="SHA-1" SIZE="197412">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-08-01T19:11:30" MIMETYPE="text/xml" CHECKSUM="2322649d4b22b166c714817b6cb88b5293c44412" CHECKSUMTYPE="SHA-1" SIZE="197412">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-08-01T19:11:31" MIMETYPE="text/xml"
-				CHECKSUM="afad084fd62ad08ce5a91633cb86867028975626" CHECKSUMTYPE="SHA-1" SIZE="93085">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-08-01T19:11:31" MIMETYPE="text/xml" CHECKSUM="afad084fd62ad08ce5a91633cb86867028975626" CHECKSUMTYPE="SHA-1" SIZE="93085">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-08-01T19:11:31" MIMETYPE="text/xml"
-				CHECKSUM="ede73fc1c3d6239fd67e24f1a779d86fd900ecd0" CHECKSUMTYPE="SHA-1" SIZE="208730">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-08-01T19:11:31" MIMETYPE="text/xml" CHECKSUM="ede73fc1c3d6239fd67e24f1a779d86fd900ecd0" CHECKSUMTYPE="SHA-1" SIZE="208730">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-08-01T19:11:32" MIMETYPE="text/xml"
-				CHECKSUM="d182e8676d0a768f981afac80c1e8f72e2a94485" CHECKSUMTYPE="SHA-1" SIZE="93777">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-08-01T19:11:32" MIMETYPE="text/xml" CHECKSUM="d182e8676d0a768f981afac80c1e8f72e2a94485" CHECKSUMTYPE="SHA-1" SIZE="93777">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-08-01T19:11:32" MIMETYPE="text/xml"
-				CHECKSUM="6daaee2e13e3e04b7464d6fabe24048ce419a884" CHECKSUMTYPE="SHA-1" SIZE="49870">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-08-01T19:11:32" MIMETYPE="text/xml" CHECKSUM="6daaee2e13e3e04b7464d6fabe24048ce419a884" CHECKSUMTYPE="SHA-1" SIZE="49870">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-08-01T19:11:32" MIMETYPE="text/xml"
-				CHECKSUM="6bf6742649025aeae54c5af81469a5f93c108cdf" CHECKSUMTYPE="SHA-1" SIZE="4523">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-08-01T19:11:32" MIMETYPE="text/xml" CHECKSUM="6bf6742649025aeae54c5af81469a5f93c108cdf" CHECKSUMTYPE="SHA-1" SIZE="4523">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-08-01T19:11:33" MIMETYPE="text/xml"
-				CHECKSUM="b4bc8f3ae7ddc47bf5fd2b0d0af67ed6bb229db0" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-08-01T19:11:33" MIMETYPE="text/xml" CHECKSUM="b4bc8f3ae7ddc47bf5fd2b0d0af67ed6bb229db0" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-08-01T19:11:33" MIMETYPE="text/xml"
-				CHECKSUM="c83dbfcfbc598ed6f7c1d3ebcaae6737b8ef4d8c" CHECKSUMTYPE="SHA-1" SIZE="107585">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-08-01T19:11:33" MIMETYPE="text/xml" CHECKSUM="c83dbfcfbc598ed6f7c1d3ebcaae6737b8ef4d8c" CHECKSUMTYPE="SHA-1" SIZE="107585">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-08-01T19:11:33" MIMETYPE="text/xml"
-				CHECKSUM="38c00ce902476867ae9195a5d7b78d95601ddc16" CHECKSUMTYPE="SHA-1" SIZE="118864">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-08-01T19:11:33" MIMETYPE="text/xml" CHECKSUM="38c00ce902476867ae9195a5d7b78d95601ddc16" CHECKSUMTYPE="SHA-1" SIZE="118864">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-08-01T19:11:34" MIMETYPE="text/xml"
-				CHECKSUM="3f91a9a959eeacd76d34b9d1c710807366246f87" CHECKSUMTYPE="SHA-1" SIZE="51770">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-08-01T19:11:34" MIMETYPE="text/xml" CHECKSUM="3f91a9a959eeacd76d34b9d1c710807366246f87" CHECKSUMTYPE="SHA-1" SIZE="51770">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-08-01T19:11:34" MIMETYPE="text/xml"
-				CHECKSUM="e46f377e7cf44360ed90722c7d912ea6b0442b34" CHECKSUMTYPE="SHA-1" SIZE="36899">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-08-01T19:11:34" MIMETYPE="text/xml" CHECKSUM="e46f377e7cf44360ed90722c7d912ea6b0442b34" CHECKSUMTYPE="SHA-1" SIZE="36899">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-08-01T19:11:34" MIMETYPE="text/xml"
-				CHECKSUM="b64aa5578c4d9bccdc36afcbb38adc3fe71733e4" CHECKSUMTYPE="SHA-1" SIZE="17149">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-08-01T19:11:34" MIMETYPE="text/xml" CHECKSUM="b64aa5578c4d9bccdc36afcbb38adc3fe71733e4" CHECKSUMTYPE="SHA-1" SIZE="17149">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-08-01T19:11:35" MIMETYPE="text/xml"
-				CHECKSUM="bb3ff9d0d613cbc9875ba141f509f7c3af2d1a66" CHECKSUMTYPE="SHA-1" SIZE="43064">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-08-01T19:11:35" MIMETYPE="text/xml" CHECKSUM="bb3ff9d0d613cbc9875ba141f509f7c3af2d1a66" CHECKSUMTYPE="SHA-1" SIZE="43064">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-08-01T19:11:35" MIMETYPE="text/xml"
-				CHECKSUM="8de2b415a84662502f07a3b5de8b7997dcdfacf5" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-08-01T19:11:35" MIMETYPE="text/xml" CHECKSUM="8de2b415a84662502f07a3b5de8b7997dcdfacf5" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-08-01T19:11:35" MIMETYPE="text/xml"
-				CHECKSUM="1f7401f5839cc8a9337b3b74cbd74b207d2e58c9" CHECKSUMTYPE="SHA-1" SIZE="7627">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-08-01T19:11:35" MIMETYPE="text/xml" CHECKSUM="1f7401f5839cc8a9337b3b74cbd74b207d2e58c9" CHECKSUMTYPE="SHA-1" SIZE="7627">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-10_01_0094.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-08-01T19:14:56" MIMETYPE="application/pdf" CHECKSUM="feee4b4facf74b1b72f375a82473b6e0f8d6c8cb"
-				CHECKSUMTYPE="SHA-1" SIZE="41999534">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/bmtnabe_1897-10_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-08-01T19:14:56" MIMETYPE="application/pdf" CHECKSUM="feee4b4facf74b1b72f375a82473b6e0f8d6c8cb" CHECKSUMTYPE="SHA-1" SIZE="41999534">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/10_01/bmtnabe_1897-10_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -10279,8 +9991,7 @@
 					</div>
 
 				</div>
-				<div ID="L.1.1.4" TYPE="TextContent" ORDER="4" DMDID="c005"
-					LABEL="VOM HIMMEL FORDERT ER DIE SCHOENSTEN STERNE, UND VON DER ERDE JEDE HOECHSTE LUST">
+				<div ID="L.1.1.4" TYPE="TextContent" ORDER="4" DMDID="c005" LABEL="VOM HIMMEL FORDERT ER DIE SCHOENSTEN STERNE, UND VON DER ERDE JEDE HOECHSTE LUST">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00004"/>
@@ -10356,8 +10067,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c009"
-						LABEL="ARNOLD BOECKLIN, LIEBESSCENE, FARBIGER ENTWURF VERMUTLICH AUS DEN SECHZIGER JAHREN">
+					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c009" LABEL="ARNOLD BOECKLIN, LIEBESSCENE, FARBIGER ENTWURF VERMUTLICH AUS DEN SECHZIGER JAHREN">
 						<div ID="L.1.1.6.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00001"/>
@@ -11656,8 +11366,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.28" TYPE="TextContent" ORDER="28" DMDID="c088"
-						LABEL="NIEDERLAENDISCHE KUNST BELGIEN UND HOLLAND VAN DE VELDE, MEUNIER, ISRAELS">
+					<div ID="L.1.1.28" TYPE="TextContent" ORDER="28" DMDID="c088" LABEL="NIEDERLAENDISCHE KUNST BELGIEN UND HOLLAND VAN DE VELDE, MEUNIER, ISRAELS">
 						<div ID="L.1.1.28.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00075" BEGIN="P75_TB00002"/>

--- a/metadata/periodicals/bmtnabe/issues/1897/11_01/bmtnabe_1897-11_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1897/11_01/bmtnabe_1897-11_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1897-11_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1897-11_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-11_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-11_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1897-11_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1897-11_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,7 +46,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1897-11_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -7989,824 +7985,552 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-11-11T07:49:45" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="a6dea1729205ef17158969708ff3f68c064b8d2c" CHECKSUMTYPE="SHA-1" SIZE="5167921">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-11-11T07:50:15" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="a9b4b826c8c77f000374d3483ebe0d5994da8d06" CHECKSUMTYPE="SHA-1" SIZE="5320920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-11-11T07:50:43" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="ac27bd97141ac31417fb0d1888cc8fb8a5a8297f" CHECKSUMTYPE="SHA-1" SIZE="5167924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-11-11T07:51:06" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="e9c3aad13d46fba04c14d5ce9c000120c44ab672" CHECKSUMTYPE="SHA-1" SIZE="5320924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-11-11T07:51:28" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="11862a1c18fde1ddbc7d58b50a3de3c1c081fff5" CHECKSUMTYPE="SHA-1" SIZE="5177810">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-11-11T07:51:53" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="73c289cf4e24c3da89a8ad9cf6d4bd365e0b1dba" CHECKSUMTYPE="SHA-1" SIZE="5320926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-11-11T07:52:17" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="23e75cdd0814878ce2a6d239964ca7851796fd49" CHECKSUMTYPE="SHA-1" SIZE="5177821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-11-11T07:52:42" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="1c0136bc2fa012d9aec23b559f260a93afc91694" CHECKSUMTYPE="SHA-1" SIZE="5320926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-11-11T07:53:05" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="d74cbc16e6f55e4e66d4b74c808f9ff17d46e3f8" CHECKSUMTYPE="SHA-1" SIZE="5177826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-11-11T07:53:30" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="c633fc40f168891f7843c964f6a2cea1158ba33c" CHECKSUMTYPE="SHA-1" SIZE="5320921">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-11-11T07:53:53" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="3779144ee857bea76c531c571ae89a31a1014d08" CHECKSUMTYPE="SHA-1" SIZE="5177828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-11-11T07:54:18" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="4cd517f1e7557ee03d81a7d56a5322e777679b62" CHECKSUMTYPE="SHA-1" SIZE="5499124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-11-11T07:54:45" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="b9e67b21fa8d822fe32ce1eb9930ea34e6845779" CHECKSUMTYPE="SHA-1" SIZE="5177763">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-11-11T07:55:10" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="a096072940538d9699ef13a79d59de4e8d7a10c6" CHECKSUMTYPE="SHA-1" SIZE="5499129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-11-11T07:55:34" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="56693f227e906ad2dd65298daba52bd99b980a97" CHECKSUMTYPE="SHA-1" SIZE="5177829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-11-11T07:56:00" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="dffdb60aba8370a2e8ca079b80aad80b389a8b50" CHECKSUMTYPE="SHA-1" SIZE="5467629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-11-11T07:56:25" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="e2b1cf6f17719e7442bb6dc300f98d1e4d1f20f1" CHECKSUMTYPE="SHA-1" SIZE="5177828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-11-11T07:56:50" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="95ac65d9614a99cd962451521584c94db2c1c132" CHECKSUMTYPE="SHA-1" SIZE="5462228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-11-11T07:57:15" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="87cf76036f9aae475e2e3a4e472e5db1d86f2bd5" CHECKSUMTYPE="SHA-1" SIZE="5177829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-11-11T07:57:40" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="9b2cf04762a0a0b8cd5e26340cf086ebb9ad781d" CHECKSUMTYPE="SHA-1" SIZE="5499069">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-11-11T07:58:05" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="30d7a88df6e08abda646bd50d7956910981be4eb" CHECKSUMTYPE="SHA-1" SIZE="5177822">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-11-11T07:58:31" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="977a079b5b3005bfbfd1d7d3eaad81025c6c2c03" CHECKSUMTYPE="SHA-1" SIZE="5441528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-11-11T07:58:58" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="b16451b1074dd7af469000c4991667570c0b3940" CHECKSUMTYPE="SHA-1" SIZE="5177826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-11-11T07:59:25" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="45778b2d1a37643632f8395fc5197c9a495e2445" CHECKSUMTYPE="SHA-1" SIZE="5457729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-11-11T07:59:52" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="1c6237110b8daad0023333f1e1cbfe53b243f860" CHECKSUMTYPE="SHA-1" SIZE="5177776">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-11-11T08:00:20" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="230f3d354e956d2746a8fc1bb64526b2323143f8" CHECKSUMTYPE="SHA-1" SIZE="5432517">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-11-11T08:00:47" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="f90525e24f422f3e3c64fcdc5243e9512b0c9e2c" CHECKSUMTYPE="SHA-1" SIZE="5177827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-11-11T08:01:11" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="ed7bffbac6bbc24538914d323c450d7987d04ebb" CHECKSUMTYPE="SHA-1" SIZE="5425307">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-11-11T08:01:41" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="93666b8420a7faac77af74b4a6f1ed0e61ed4d02" CHECKSUMTYPE="SHA-1" SIZE="5091426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-11-11T08:02:09" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="392a7277f5a4d127cb0fe140826e4f17a8552232" CHECKSUMTYPE="SHA-1" SIZE="5448723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-11-11T08:02:36" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="482b30c5069d9817fcdba0e0c568726338bae30d" CHECKSUMTYPE="SHA-1" SIZE="5091427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-11-11T08:03:03" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="e5ee29e68151611cbcce1f1e973629f077e249d5" CHECKSUMTYPE="SHA-1" SIZE="5481034">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-11-11T08:03:31" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="82a15ceb3d18abc056c81d81898658bf8213d275" CHECKSUMTYPE="SHA-1" SIZE="5091429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-11-11T08:03:59" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="80dea20effd644b66a750070349a9b25a923c0be" CHECKSUMTYPE="SHA-1" SIZE="5481129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-11-11T08:04:28" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="3f7255b75e1b266a3a7d3a6811c2b6f3bd1bc48a" CHECKSUMTYPE="SHA-1" SIZE="5091395">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-11-11T08:04:56" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="a5ebdb8e74210fb2e4ee82c7c1f2ea5b3cddf5a3" CHECKSUMTYPE="SHA-1" SIZE="5477528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-11-11T08:05:23" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="82799900ef8dbeeb81760c07b227b65d4cde5724" CHECKSUMTYPE="SHA-1" SIZE="5091422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-11-11T08:05:51" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="0773afef82489bd03b03b7a0f31fec5797b05e7d" CHECKSUMTYPE="SHA-1" SIZE="5477517">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-11-11T08:06:19" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="5a6a0278b284f823b234daa3e552200778b4087a" CHECKSUMTYPE="SHA-1" SIZE="5091422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-11-11T08:06:47" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="22538cc322639f652526ee200f8774f1a40c845d" CHECKSUMTYPE="SHA-1" SIZE="5420828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-11-11T08:07:15" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="841e1fd6c4c8e9c88a1e676db9a0f7b8ce237755" CHECKSUMTYPE="SHA-1" SIZE="5091380">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-11-11T08:07:44" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="6c07fe11c01503acc02c298d0ebc175113fc7b41" CHECKSUMTYPE="SHA-1" SIZE="5456824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-11-11T08:08:14" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="10fcd30cb240c423d1946dfe924eee48b29cd041" CHECKSUMTYPE="SHA-1" SIZE="5091426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-11-11T08:08:44" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="2de1fa6fa261b3c092649e1ee9d541a82f95fa76" CHECKSUMTYPE="SHA-1" SIZE="5456827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-11-11T08:09:12" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="33140a8f8c56badcdb422c3ef63d2478ab8ccab9" CHECKSUMTYPE="SHA-1" SIZE="5091424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-11-11T08:09:40" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="778863948fe0cded014db6fc6b0b669fbdc1d3f3" CHECKSUMTYPE="SHA-1" SIZE="5476629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-11-11T08:10:07" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="9358a7529f5f966632953aed2da4293c87deb1cf" CHECKSUMTYPE="SHA-1" SIZE="5155327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-11-11T08:10:36" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="dc89f271b5256b680f119cc7d809cab64fb161f9" CHECKSUMTYPE="SHA-1" SIZE="5476628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-11-11T08:11:05" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="7ac523a196b3fc702b804b62d5f90fda3a7ea3c5" CHECKSUMTYPE="SHA-1" SIZE="5155329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-11-11T08:11:34" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="bbb2fb76852f55db96553171539a5da32dc798fc" CHECKSUMTYPE="SHA-1" SIZE="5476628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-11-11T08:12:04" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="bc69b3f1c912b1ddb3b6326ace39e2eefb2fb055" CHECKSUMTYPE="SHA-1" SIZE="5155329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-11-11T08:12:32" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="d42d5b0e1876b44d048ad88b8d8c0dda41a4dd65" CHECKSUMTYPE="SHA-1" SIZE="5476629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-11-11T08:13:01" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="5c13af9d6dad94d2a0dad753961eb00abd344db2" CHECKSUMTYPE="SHA-1" SIZE="5155323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-11-11T08:13:30" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="6a2854312ae871e34d817882855fb68b7ef57458" CHECKSUMTYPE="SHA-1" SIZE="5476526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-11-11T08:14:00" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="7d17a75dcb3abc5b41019e6dcddd3e18dfaa7df3" CHECKSUMTYPE="SHA-1" SIZE="5135222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-11-11T08:14:30" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="5d48546c4b8863d36ce4cb7151c3595ceb5d7352" CHECKSUMTYPE="SHA-1" SIZE="5476620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-11-11T08:14:57" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="132409f3aed829b5a37a6759329e71098fcf9d45" CHECKSUMTYPE="SHA-1" SIZE="5135529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-11-11T08:15:25" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="b1c6f07681f46c39e5dff3e25cf45117f06fa218" CHECKSUMTYPE="SHA-1" SIZE="5476625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-11-11T08:15:56" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="b70ccd6d9a801fd384998a3a944c33999cabf391" CHECKSUMTYPE="SHA-1" SIZE="5135527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-11-11T08:16:28" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="0a71f273a7523ed9fa561595e190cf565fabc8cf" CHECKSUMTYPE="SHA-1" SIZE="5476629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-11-11T08:16:59" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="110f9a40c2bf324c1cc45d55bb60dbd0340ab8ba" CHECKSUMTYPE="SHA-1" SIZE="5135527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-11-11T08:17:30" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="a1b5a3815fb31a5d69ae4d4e1f0dafb39b9ecbf9" CHECKSUMTYPE="SHA-1" SIZE="5476610">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-11-11T08:18:00" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="96c18b0c012d3c3fba409915104516489076ad8d" CHECKSUMTYPE="SHA-1" SIZE="5135512">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-11-11T08:18:30" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="68c78ed2e2506f1021654d831989ed2d91dc202b" CHECKSUMTYPE="SHA-1" SIZE="5476626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-11-11T08:19:00" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="1af6d868ad8c0000a44b65eff58be7563bb49a58" CHECKSUMTYPE="SHA-1" SIZE="5135529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-11-11T08:19:28" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="372da787019d92ae7eb04f49a8ad5e157c77d3f8" CHECKSUMTYPE="SHA-1" SIZE="5476621">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-11-11T08:19:56" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="0cd8e521dfeb00581ff74a69125b864142a0f7c3" CHECKSUMTYPE="SHA-1" SIZE="5135493">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-11-11T08:20:25" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="b265bb7d5873dcda789b89f39a692db2abbc5b7b" CHECKSUMTYPE="SHA-1" SIZE="5476626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-11-11T08:20:54" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="12af03c66d00e23f86a941322dae1fc3c15a9467" CHECKSUMTYPE="SHA-1" SIZE="5135529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-11-11T08:21:24" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="8e2b947712a33da91555b633ebf9d09587fad317" CHECKSUMTYPE="SHA-1" SIZE="5476605">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-11-11T08:21:54" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="53d7f93b583942424c0d9b3011b97fe48198331e" CHECKSUMTYPE="SHA-1" SIZE="5135510">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-11-11T08:22:22" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="09e6573561a6c3d837b76bffa08cf1ad50b671a0" CHECKSUMTYPE="SHA-1" SIZE="5476626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-11-11T08:22:51" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="4583cbc33600fcd6072129687fc85547a21ce8b2" CHECKSUMTYPE="SHA-1" SIZE="5135526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-11-11T08:23:17" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="80a9fe7c6e19f926d1ac9c1578f81c72e3883198" CHECKSUMTYPE="SHA-1" SIZE="5476620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-11-11T08:23:44" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="d6ac0935c7c13446fd972ee67a8a4d2f76f68955" CHECKSUMTYPE="SHA-1" SIZE="5135423">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-11-11T08:24:13" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="bf4f2674ce423c6d4501311b940acb3ebf460ab2" CHECKSUMTYPE="SHA-1" SIZE="5477523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-11-11T08:24:42" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="4bdd29a68fbae05828a38c4b8507bd44badf95d3" CHECKSUMTYPE="SHA-1" SIZE="5135504">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-11-11T08:25:09" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="583c0ad730d2ca6b11177d30aca88f623c6e454c" CHECKSUMTYPE="SHA-1" SIZE="5445122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-11-11T08:25:37" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="4eb4b69e052ca0df835ec4fbe0564d6d4895c122" CHECKSUMTYPE="SHA-1" SIZE="5135526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-11-11T08:26:07" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="b7a08fa2a0207d15495264f733fe0e3768a5e5f2" CHECKSUMTYPE="SHA-1" SIZE="5476629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-11-11T08:26:37" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="f86b08df0abf85707424b041ae3a8386b0085ebc" CHECKSUMTYPE="SHA-1" SIZE="5135515">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-11-11T08:27:05" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="0009ed2115a02979211da11ea5a16755b66b37dd" CHECKSUMTYPE="SHA-1" SIZE="5476622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-11-11T08:27:32" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="cadec775da5c20def5caca42af87dda7e2edec31" CHECKSUMTYPE="SHA-1" SIZE="5135470">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-11-11T08:28:00" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="b708c0dcb9978c26d926292a5b2aebd6e71a79e2" CHECKSUMTYPE="SHA-1" SIZE="5476627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-11-11T08:28:26" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="e21e7b6417a0fb8327d0cd5880e11f011ded3c31" CHECKSUMTYPE="SHA-1" SIZE="5135527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-11-11T08:28:52" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="eb43de89323e78b9a0ee772ca186ffef79aff877" CHECKSUMTYPE="SHA-1" SIZE="5476628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-11-11T08:29:19" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="aeb98297ab9cec52464a40bb58df9a6bf3b591a5" CHECKSUMTYPE="SHA-1" SIZE="5135528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-11-11T08:29:46" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="59d5e93c2cc9a4b1ddcd6c3bad20e858ed0eb6b9" CHECKSUMTYPE="SHA-1" SIZE="5476629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-11-11T08:30:14" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="a2a174b25edf0d493d0fb7230ed615b9038fd534" CHECKSUMTYPE="SHA-1" SIZE="5121098">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-11-11T08:30:46" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="f36254a3b50ebb4924d8e89dfaa1433b5296d0c8" CHECKSUMTYPE="SHA-1" SIZE="5476588">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0090.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-11-11T07:49:45" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a6dea1729205ef17158969708ff3f68c064b8d2c" CHECKSUMTYPE="SHA-1" SIZE="5167921">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-11-11T07:50:15" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="a9b4b826c8c77f000374d3483ebe0d5994da8d06" CHECKSUMTYPE="SHA-1" SIZE="5320920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-11-11T07:50:43" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="ac27bd97141ac31417fb0d1888cc8fb8a5a8297f" CHECKSUMTYPE="SHA-1" SIZE="5167924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-11-11T07:51:06" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="e9c3aad13d46fba04c14d5ce9c000120c44ab672" CHECKSUMTYPE="SHA-1" SIZE="5320924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-11-11T07:51:28" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="11862a1c18fde1ddbc7d58b50a3de3c1c081fff5" CHECKSUMTYPE="SHA-1" SIZE="5177810">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-11-11T07:51:53" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="73c289cf4e24c3da89a8ad9cf6d4bd365e0b1dba" CHECKSUMTYPE="SHA-1" SIZE="5320926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-11-11T07:52:17" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="23e75cdd0814878ce2a6d239964ca7851796fd49" CHECKSUMTYPE="SHA-1" SIZE="5177821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-11-11T07:52:42" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="1c0136bc2fa012d9aec23b559f260a93afc91694" CHECKSUMTYPE="SHA-1" SIZE="5320926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-11-11T07:53:05" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="d74cbc16e6f55e4e66d4b74c808f9ff17d46e3f8" CHECKSUMTYPE="SHA-1" SIZE="5177826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-11-11T07:53:30" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="c633fc40f168891f7843c964f6a2cea1158ba33c" CHECKSUMTYPE="SHA-1" SIZE="5320921">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-11-11T07:53:53" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="3779144ee857bea76c531c571ae89a31a1014d08" CHECKSUMTYPE="SHA-1" SIZE="5177828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-11-11T07:54:18" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="4cd517f1e7557ee03d81a7d56a5322e777679b62" CHECKSUMTYPE="SHA-1" SIZE="5499124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-11-11T07:54:45" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="b9e67b21fa8d822fe32ce1eb9930ea34e6845779" CHECKSUMTYPE="SHA-1" SIZE="5177763">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-11-11T07:55:10" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="a096072940538d9699ef13a79d59de4e8d7a10c6" CHECKSUMTYPE="SHA-1" SIZE="5499129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-11-11T07:55:34" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="56693f227e906ad2dd65298daba52bd99b980a97" CHECKSUMTYPE="SHA-1" SIZE="5177829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-11-11T07:56:00" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="dffdb60aba8370a2e8ca079b80aad80b389a8b50" CHECKSUMTYPE="SHA-1" SIZE="5467629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-11-11T07:56:25" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e2b1cf6f17719e7442bb6dc300f98d1e4d1f20f1" CHECKSUMTYPE="SHA-1" SIZE="5177828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-11-11T07:56:50" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="95ac65d9614a99cd962451521584c94db2c1c132" CHECKSUMTYPE="SHA-1" SIZE="5462228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-11-11T07:57:15" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="87cf76036f9aae475e2e3a4e472e5db1d86f2bd5" CHECKSUMTYPE="SHA-1" SIZE="5177829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-11-11T07:57:40" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="9b2cf04762a0a0b8cd5e26340cf086ebb9ad781d" CHECKSUMTYPE="SHA-1" SIZE="5499069">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-11-11T07:58:05" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="30d7a88df6e08abda646bd50d7956910981be4eb" CHECKSUMTYPE="SHA-1" SIZE="5177822">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-11-11T07:58:31" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="977a079b5b3005bfbfd1d7d3eaad81025c6c2c03" CHECKSUMTYPE="SHA-1" SIZE="5441528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-11-11T07:58:58" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="b16451b1074dd7af469000c4991667570c0b3940" CHECKSUMTYPE="SHA-1" SIZE="5177826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-11-11T07:59:25" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="45778b2d1a37643632f8395fc5197c9a495e2445" CHECKSUMTYPE="SHA-1" SIZE="5457729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-11-11T07:59:52" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="1c6237110b8daad0023333f1e1cbfe53b243f860" CHECKSUMTYPE="SHA-1" SIZE="5177776">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-11-11T08:00:20" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="230f3d354e956d2746a8fc1bb64526b2323143f8" CHECKSUMTYPE="SHA-1" SIZE="5432517">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-11-11T08:00:47" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="f90525e24f422f3e3c64fcdc5243e9512b0c9e2c" CHECKSUMTYPE="SHA-1" SIZE="5177827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-11-11T08:01:11" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="ed7bffbac6bbc24538914d323c450d7987d04ebb" CHECKSUMTYPE="SHA-1" SIZE="5425307">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-11-11T08:01:41" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="93666b8420a7faac77af74b4a6f1ed0e61ed4d02" CHECKSUMTYPE="SHA-1" SIZE="5091426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-11-11T08:02:09" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="392a7277f5a4d127cb0fe140826e4f17a8552232" CHECKSUMTYPE="SHA-1" SIZE="5448723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-11-11T08:02:36" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="482b30c5069d9817fcdba0e0c568726338bae30d" CHECKSUMTYPE="SHA-1" SIZE="5091427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-11-11T08:03:03" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="e5ee29e68151611cbcce1f1e973629f077e249d5" CHECKSUMTYPE="SHA-1" SIZE="5481034">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-11-11T08:03:31" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="82a15ceb3d18abc056c81d81898658bf8213d275" CHECKSUMTYPE="SHA-1" SIZE="5091429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-11-11T08:03:59" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="80dea20effd644b66a750070349a9b25a923c0be" CHECKSUMTYPE="SHA-1" SIZE="5481129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-11-11T08:04:28" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="3f7255b75e1b266a3a7d3a6811c2b6f3bd1bc48a" CHECKSUMTYPE="SHA-1" SIZE="5091395">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-11-11T08:04:56" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="a5ebdb8e74210fb2e4ee82c7c1f2ea5b3cddf5a3" CHECKSUMTYPE="SHA-1" SIZE="5477528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-11-11T08:05:23" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="82799900ef8dbeeb81760c07b227b65d4cde5724" CHECKSUMTYPE="SHA-1" SIZE="5091422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-11-11T08:05:51" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="0773afef82489bd03b03b7a0f31fec5797b05e7d" CHECKSUMTYPE="SHA-1" SIZE="5477517">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-11-11T08:06:19" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="5a6a0278b284f823b234daa3e552200778b4087a" CHECKSUMTYPE="SHA-1" SIZE="5091422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-11-11T08:06:47" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="22538cc322639f652526ee200f8774f1a40c845d" CHECKSUMTYPE="SHA-1" SIZE="5420828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-11-11T08:07:15" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="841e1fd6c4c8e9c88a1e676db9a0f7b8ce237755" CHECKSUMTYPE="SHA-1" SIZE="5091380">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-11-11T08:07:44" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="6c07fe11c01503acc02c298d0ebc175113fc7b41" CHECKSUMTYPE="SHA-1" SIZE="5456824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-11-11T08:08:14" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="10fcd30cb240c423d1946dfe924eee48b29cd041" CHECKSUMTYPE="SHA-1" SIZE="5091426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-11-11T08:08:44" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="2de1fa6fa261b3c092649e1ee9d541a82f95fa76" CHECKSUMTYPE="SHA-1" SIZE="5456827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-11-11T08:09:12" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="33140a8f8c56badcdb422c3ef63d2478ab8ccab9" CHECKSUMTYPE="SHA-1" SIZE="5091424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-11-11T08:09:40" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="778863948fe0cded014db6fc6b0b669fbdc1d3f3" CHECKSUMTYPE="SHA-1" SIZE="5476629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-11-11T08:10:07" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="9358a7529f5f966632953aed2da4293c87deb1cf" CHECKSUMTYPE="SHA-1" SIZE="5155327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-11-11T08:10:36" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="dc89f271b5256b680f119cc7d809cab64fb161f9" CHECKSUMTYPE="SHA-1" SIZE="5476628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-11-11T08:11:05" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="7ac523a196b3fc702b804b62d5f90fda3a7ea3c5" CHECKSUMTYPE="SHA-1" SIZE="5155329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-11-11T08:11:34" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="bbb2fb76852f55db96553171539a5da32dc798fc" CHECKSUMTYPE="SHA-1" SIZE="5476628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-11-11T08:12:04" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="bc69b3f1c912b1ddb3b6326ace39e2eefb2fb055" CHECKSUMTYPE="SHA-1" SIZE="5155329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-11-11T08:12:32" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="d42d5b0e1876b44d048ad88b8d8c0dda41a4dd65" CHECKSUMTYPE="SHA-1" SIZE="5476629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-11-11T08:13:01" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="5c13af9d6dad94d2a0dad753961eb00abd344db2" CHECKSUMTYPE="SHA-1" SIZE="5155323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-11-11T08:13:30" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="6a2854312ae871e34d817882855fb68b7ef57458" CHECKSUMTYPE="SHA-1" SIZE="5476526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-11-11T08:14:00" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="7d17a75dcb3abc5b41019e6dcddd3e18dfaa7df3" CHECKSUMTYPE="SHA-1" SIZE="5135222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-11-11T08:14:30" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="5d48546c4b8863d36ce4cb7151c3595ceb5d7352" CHECKSUMTYPE="SHA-1" SIZE="5476620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-11-11T08:14:57" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="132409f3aed829b5a37a6759329e71098fcf9d45" CHECKSUMTYPE="SHA-1" SIZE="5135529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-11-11T08:15:25" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="b1c6f07681f46c39e5dff3e25cf45117f06fa218" CHECKSUMTYPE="SHA-1" SIZE="5476625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-11-11T08:15:56" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="b70ccd6d9a801fd384998a3a944c33999cabf391" CHECKSUMTYPE="SHA-1" SIZE="5135527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-11-11T08:16:28" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="0a71f273a7523ed9fa561595e190cf565fabc8cf" CHECKSUMTYPE="SHA-1" SIZE="5476629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-11-11T08:16:59" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="110f9a40c2bf324c1cc45d55bb60dbd0340ab8ba" CHECKSUMTYPE="SHA-1" SIZE="5135527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-11-11T08:17:30" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="a1b5a3815fb31a5d69ae4d4e1f0dafb39b9ecbf9" CHECKSUMTYPE="SHA-1" SIZE="5476610">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-11-11T08:18:00" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="96c18b0c012d3c3fba409915104516489076ad8d" CHECKSUMTYPE="SHA-1" SIZE="5135512">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-11-11T08:18:30" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="68c78ed2e2506f1021654d831989ed2d91dc202b" CHECKSUMTYPE="SHA-1" SIZE="5476626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-11-11T08:19:00" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="1af6d868ad8c0000a44b65eff58be7563bb49a58" CHECKSUMTYPE="SHA-1" SIZE="5135529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-11-11T08:19:28" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="372da787019d92ae7eb04f49a8ad5e157c77d3f8" CHECKSUMTYPE="SHA-1" SIZE="5476621">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-11-11T08:19:56" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="0cd8e521dfeb00581ff74a69125b864142a0f7c3" CHECKSUMTYPE="SHA-1" SIZE="5135493">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-11-11T08:20:25" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="b265bb7d5873dcda789b89f39a692db2abbc5b7b" CHECKSUMTYPE="SHA-1" SIZE="5476626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-11-11T08:20:54" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="12af03c66d00e23f86a941322dae1fc3c15a9467" CHECKSUMTYPE="SHA-1" SIZE="5135529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-11-11T08:21:24" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="8e2b947712a33da91555b633ebf9d09587fad317" CHECKSUMTYPE="SHA-1" SIZE="5476605">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-11-11T08:21:54" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="53d7f93b583942424c0d9b3011b97fe48198331e" CHECKSUMTYPE="SHA-1" SIZE="5135510">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-11-11T08:22:22" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="09e6573561a6c3d837b76bffa08cf1ad50b671a0" CHECKSUMTYPE="SHA-1" SIZE="5476626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-11-11T08:22:51" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="4583cbc33600fcd6072129687fc85547a21ce8b2" CHECKSUMTYPE="SHA-1" SIZE="5135526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-11-11T08:23:17" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="80a9fe7c6e19f926d1ac9c1578f81c72e3883198" CHECKSUMTYPE="SHA-1" SIZE="5476620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-11-11T08:23:44" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="d6ac0935c7c13446fd972ee67a8a4d2f76f68955" CHECKSUMTYPE="SHA-1" SIZE="5135423">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-11-11T08:24:13" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="bf4f2674ce423c6d4501311b940acb3ebf460ab2" CHECKSUMTYPE="SHA-1" SIZE="5477523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-11-11T08:24:42" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="4bdd29a68fbae05828a38c4b8507bd44badf95d3" CHECKSUMTYPE="SHA-1" SIZE="5135504">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-11-11T08:25:09" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="583c0ad730d2ca6b11177d30aca88f623c6e454c" CHECKSUMTYPE="SHA-1" SIZE="5445122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-11-11T08:25:37" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="4eb4b69e052ca0df835ec4fbe0564d6d4895c122" CHECKSUMTYPE="SHA-1" SIZE="5135526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-11-11T08:26:07" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="b7a08fa2a0207d15495264f733fe0e3768a5e5f2" CHECKSUMTYPE="SHA-1" SIZE="5476629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-11-11T08:26:37" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="f86b08df0abf85707424b041ae3a8386b0085ebc" CHECKSUMTYPE="SHA-1" SIZE="5135515">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-11-11T08:27:05" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="0009ed2115a02979211da11ea5a16755b66b37dd" CHECKSUMTYPE="SHA-1" SIZE="5476622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-11-11T08:27:32" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="cadec775da5c20def5caca42af87dda7e2edec31" CHECKSUMTYPE="SHA-1" SIZE="5135470">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-11-11T08:28:00" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="b708c0dcb9978c26d926292a5b2aebd6e71a79e2" CHECKSUMTYPE="SHA-1" SIZE="5476627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-11-11T08:28:26" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="e21e7b6417a0fb8327d0cd5880e11f011ded3c31" CHECKSUMTYPE="SHA-1" SIZE="5135527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-11-11T08:28:52" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="eb43de89323e78b9a0ee772ca186ffef79aff877" CHECKSUMTYPE="SHA-1" SIZE="5476628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-11-11T08:29:19" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="aeb98297ab9cec52464a40bb58df9a6bf3b591a5" CHECKSUMTYPE="SHA-1" SIZE="5135528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-11-11T08:29:46" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="59d5e93c2cc9a4b1ddcd6c3bad20e858ed0eb6b9" CHECKSUMTYPE="SHA-1" SIZE="5476629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-11-11T08:30:14" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="a2a174b25edf0d493d0fb7230ed615b9038fd534" CHECKSUMTYPE="SHA-1" SIZE="5121098">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-11-11T08:30:46" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="f36254a3b50ebb4924d8e89dfaa1433b5296d0c8" CHECKSUMTYPE="SHA-1" SIZE="5476588">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/delivery/bmtnabe_1897-11_01_0090.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-11-11T08:31:04" MIMETYPE="text/xml" CHECKSUM="c678aae5b8f96fb368095345c045625d2621937c"
-				CHECKSUMTYPE="SHA-1" SIZE="2049">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-11-11T08:31:04" MIMETYPE="text/xml" CHECKSUM="c678aae5b8f96fb368095345c045625d2621937c" CHECKSUMTYPE="SHA-1" SIZE="2049">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-11-11T08:31:04" MIMETYPE="text/xml" CHECKSUM="45bd9d4971239adc687e8c8a3f2af2b2110159a5"
-				CHECKSUMTYPE="SHA-1" SIZE="1645">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-11-11T08:31:04" MIMETYPE="text/xml" CHECKSUM="45bd9d4971239adc687e8c8a3f2af2b2110159a5" CHECKSUMTYPE="SHA-1" SIZE="1645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-11-11T08:31:04" MIMETYPE="text/xml" CHECKSUM="42bed53dd001632eaca269b1ce5745f2fabb76a5"
-				CHECKSUMTYPE="SHA-1" SIZE="1645">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-11-11T08:31:04" MIMETYPE="text/xml" CHECKSUM="42bed53dd001632eaca269b1ce5745f2fabb76a5" CHECKSUMTYPE="SHA-1" SIZE="1645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-11-11T08:31:04" MIMETYPE="text/xml" CHECKSUM="259bbe5204a6d88013e169c672f4f59257a82a12"
-				CHECKSUMTYPE="SHA-1" SIZE="1645">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-11-11T08:31:04" MIMETYPE="text/xml" CHECKSUM="259bbe5204a6d88013e169c672f4f59257a82a12" CHECKSUMTYPE="SHA-1" SIZE="1645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-11-11T08:31:05" MIMETYPE="text/xml" CHECKSUM="76e3ff564c27c8fff333e5cba8f7e2e2d6886f14"
-				CHECKSUMTYPE="SHA-1" SIZE="7864">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-11-11T08:31:05" MIMETYPE="text/xml" CHECKSUM="76e3ff564c27c8fff333e5cba8f7e2e2d6886f14" CHECKSUMTYPE="SHA-1" SIZE="7864">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-11-11T08:31:05" MIMETYPE="text/xml" CHECKSUM="4582b50f09f20e6e383014dea0e14ad5cd6fa924"
-				CHECKSUMTYPE="SHA-1" SIZE="1645">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-11-11T08:31:05" MIMETYPE="text/xml" CHECKSUM="4582b50f09f20e6e383014dea0e14ad5cd6fa924" CHECKSUMTYPE="SHA-1" SIZE="1645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-11-11T08:31:05" MIMETYPE="text/xml" CHECKSUM="5b5cd9810e2d73357c1d76156a2c9f86b4713415"
-				CHECKSUMTYPE="SHA-1" SIZE="1645">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-11-11T08:31:05" MIMETYPE="text/xml" CHECKSUM="5b5cd9810e2d73357c1d76156a2c9f86b4713415" CHECKSUMTYPE="SHA-1" SIZE="1645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-11-11T08:31:05" MIMETYPE="text/xml" CHECKSUM="382567dadfaec677272116331239e581a3083fb2"
-				CHECKSUMTYPE="SHA-1" SIZE="1645">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-11-11T08:31:05" MIMETYPE="text/xml" CHECKSUM="382567dadfaec677272116331239e581a3083fb2" CHECKSUMTYPE="SHA-1" SIZE="1645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-11-11T08:31:06" MIMETYPE="text/xml" CHECKSUM="04bcd90283737e4af76d2eb6c5f36d9a5849ff48"
-				CHECKSUMTYPE="SHA-1" SIZE="13486">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-11-11T08:31:06" MIMETYPE="text/xml" CHECKSUM="04bcd90283737e4af76d2eb6c5f36d9a5849ff48" CHECKSUMTYPE="SHA-1" SIZE="13486">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-11-11T08:31:06" MIMETYPE="text/xml"
-				CHECKSUM="6996455fbad70b040c1b88d2c579a77e23f1db95" CHECKSUMTYPE="SHA-1" SIZE="3353">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-11-11T08:31:06" MIMETYPE="text/xml" CHECKSUM="6996455fbad70b040c1b88d2c579a77e23f1db95" CHECKSUMTYPE="SHA-1" SIZE="3353">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-11-11T08:31:06" MIMETYPE="text/xml"
-				CHECKSUM="63f33e7be9bd8c655e593dd8391908b4e682d003" CHECKSUMTYPE="SHA-1" SIZE="1652">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-11-11T08:31:06" MIMETYPE="text/xml" CHECKSUM="63f33e7be9bd8c655e593dd8391908b4e682d003" CHECKSUMTYPE="SHA-1" SIZE="1652">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-11-11T08:31:06" MIMETYPE="text/xml"
-				CHECKSUM="0f72819dbc4c21657f1725c36868f6559198c8b8" CHECKSUMTYPE="SHA-1" SIZE="4941">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-11-11T08:31:06" MIMETYPE="text/xml" CHECKSUM="0f72819dbc4c21657f1725c36868f6559198c8b8" CHECKSUMTYPE="SHA-1" SIZE="4941">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-11-11T08:31:07" MIMETYPE="text/xml"
-				CHECKSUM="8531d1b5daf66be2723f23b27efe9370f6f588ee" CHECKSUMTYPE="SHA-1" SIZE="21698">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-11-11T08:31:07" MIMETYPE="text/xml" CHECKSUM="8531d1b5daf66be2723f23b27efe9370f6f588ee" CHECKSUMTYPE="SHA-1" SIZE="21698">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-11-11T08:31:07" MIMETYPE="text/xml"
-				CHECKSUM="e5d05e2c58b92d075742594cc3c64f9e15b749a3" CHECKSUMTYPE="SHA-1" SIZE="83618">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-11-11T08:31:07" MIMETYPE="text/xml" CHECKSUM="e5d05e2c58b92d075742594cc3c64f9e15b749a3" CHECKSUMTYPE="SHA-1" SIZE="83618">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-11-11T08:31:07" MIMETYPE="text/xml"
-				CHECKSUM="c355fb90e1f34edba84099fdcb5f6cf26db61562" CHECKSUMTYPE="SHA-1" SIZE="81075">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-11-11T08:31:07" MIMETYPE="text/xml" CHECKSUM="c355fb90e1f34edba84099fdcb5f6cf26db61562" CHECKSUMTYPE="SHA-1" SIZE="81075">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-11-11T08:31:08" MIMETYPE="text/xml"
-				CHECKSUM="29e7c013f4fd8839ec24162c5beb7eb24135a88c" CHECKSUMTYPE="SHA-1" SIZE="70498">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-11-11T08:31:08" MIMETYPE="text/xml" CHECKSUM="29e7c013f4fd8839ec24162c5beb7eb24135a88c" CHECKSUMTYPE="SHA-1" SIZE="70498">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-11-11T08:31:08" MIMETYPE="text/xml"
-				CHECKSUM="16c9d9e4ed08a73cde015b651d2378bb5ffbc1e1" CHECKSUMTYPE="SHA-1" SIZE="53717">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-11-11T08:31:08" MIMETYPE="text/xml" CHECKSUM="16c9d9e4ed08a73cde015b651d2378bb5ffbc1e1" CHECKSUMTYPE="SHA-1" SIZE="53717">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-11-11T08:31:08" MIMETYPE="text/xml"
-				CHECKSUM="2e9a5c169fb6dde4ccf52f1c01ee2193b3a0923d" CHECKSUMTYPE="SHA-1" SIZE="61265">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-11-11T08:31:08" MIMETYPE="text/xml" CHECKSUM="2e9a5c169fb6dde4ccf52f1c01ee2193b3a0923d" CHECKSUMTYPE="SHA-1" SIZE="61265">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-11-11T08:31:09" MIMETYPE="text/xml"
-				CHECKSUM="fd57a42da3f9d83636f00af05e1b5b3d62ac4cf8" CHECKSUMTYPE="SHA-1" SIZE="5317">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-11-11T08:31:09" MIMETYPE="text/xml" CHECKSUM="fd57a42da3f9d83636f00af05e1b5b3d62ac4cf8" CHECKSUMTYPE="SHA-1" SIZE="5317">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-11-11T08:31:09" MIMETYPE="text/xml"
-				CHECKSUM="337ec8fea6e64a2db21696e8e90d11150daf8f09" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-11-11T08:31:09" MIMETYPE="text/xml" CHECKSUM="337ec8fea6e64a2db21696e8e90d11150daf8f09" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-11-11T08:31:09" MIMETYPE="text/xml"
-				CHECKSUM="e2146b9557263816f5d854b0ad3e12c86b4ba593" CHECKSUMTYPE="SHA-1" SIZE="38982">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-11-11T08:31:09" MIMETYPE="text/xml" CHECKSUM="e2146b9557263816f5d854b0ad3e12c86b4ba593" CHECKSUMTYPE="SHA-1" SIZE="38982">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-11-11T08:31:09" MIMETYPE="text/xml"
-				CHECKSUM="383b06604361da7a6bd3ca2f12fd9d11d536cee2" CHECKSUMTYPE="SHA-1" SIZE="93651">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-11-11T08:31:09" MIMETYPE="text/xml" CHECKSUM="383b06604361da7a6bd3ca2f12fd9d11d536cee2" CHECKSUMTYPE="SHA-1" SIZE="93651">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-11-11T08:31:10" MIMETYPE="text/xml"
-				CHECKSUM="be9aee26be5152d8321b305b00500fa88810fa6b" CHECKSUMTYPE="SHA-1" SIZE="80123">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-11-11T08:31:10" MIMETYPE="text/xml" CHECKSUM="be9aee26be5152d8321b305b00500fa88810fa6b" CHECKSUMTYPE="SHA-1" SIZE="80123">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-11-11T08:31:10" MIMETYPE="text/xml"
-				CHECKSUM="bab10c83d05db4239216430c6c79eb5ff468a563" CHECKSUMTYPE="SHA-1" SIZE="79975">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-11-11T08:31:10" MIMETYPE="text/xml" CHECKSUM="bab10c83d05db4239216430c6c79eb5ff468a563" CHECKSUMTYPE="SHA-1" SIZE="79975">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-11-11T08:31:10" MIMETYPE="text/xml"
-				CHECKSUM="872700ffbd0089510e94e9f61651cf61cd21369a" CHECKSUMTYPE="SHA-1" SIZE="76570">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-11-11T08:31:10" MIMETYPE="text/xml" CHECKSUM="872700ffbd0089510e94e9f61651cf61cd21369a" CHECKSUMTYPE="SHA-1" SIZE="76570">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-11-11T08:31:11" MIMETYPE="text/xml"
-				CHECKSUM="34bcbb8d76b816a60937c385d682693b649fa6f7" CHECKSUMTYPE="SHA-1" SIZE="50138">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-11-11T08:31:11" MIMETYPE="text/xml" CHECKSUM="34bcbb8d76b816a60937c385d682693b649fa6f7" CHECKSUMTYPE="SHA-1" SIZE="50138">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-11-11T08:31:11" MIMETYPE="text/xml"
-				CHECKSUM="9c0ae059c8abda6c88e009d8853fc84afe0de53a" CHECKSUMTYPE="SHA-1" SIZE="31556">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-11-11T08:31:11" MIMETYPE="text/xml" CHECKSUM="9c0ae059c8abda6c88e009d8853fc84afe0de53a" CHECKSUMTYPE="SHA-1" SIZE="31556">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-11-11T08:31:11" MIMETYPE="text/xml"
-				CHECKSUM="4da13ce6b227258d54c34ccf4ae7e39d308bc7f6" CHECKSUMTYPE="SHA-1" SIZE="33720">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-11-11T08:31:11" MIMETYPE="text/xml" CHECKSUM="4da13ce6b227258d54c34ccf4ae7e39d308bc7f6" CHECKSUMTYPE="SHA-1" SIZE="33720">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-11-11T08:31:12" MIMETYPE="text/xml"
-				CHECKSUM="a1ddb5f3afd5b78b2a8fed268d70f5344e0d40b6" CHECKSUMTYPE="SHA-1" SIZE="4743">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-11-11T08:31:12" MIMETYPE="text/xml" CHECKSUM="a1ddb5f3afd5b78b2a8fed268d70f5344e0d40b6" CHECKSUMTYPE="SHA-1" SIZE="4743">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-11-11T08:31:12" MIMETYPE="text/xml"
-				CHECKSUM="1ac3da967699cdd35acb9d5b139d201102f185ef" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-11-11T08:31:12" MIMETYPE="text/xml" CHECKSUM="1ac3da967699cdd35acb9d5b139d201102f185ef" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-11-11T08:31:12" MIMETYPE="text/xml"
-				CHECKSUM="bdc7aab95353f8d542cd1eaae3699af768e8f040" CHECKSUMTYPE="SHA-1" SIZE="70958">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-11-11T08:31:12" MIMETYPE="text/xml" CHECKSUM="bdc7aab95353f8d542cd1eaae3699af768e8f040" CHECKSUMTYPE="SHA-1" SIZE="70958">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-11-11T08:31:13" MIMETYPE="text/xml"
-				CHECKSUM="3bb605eb4d38e20d67d352e38f51c317394dc313" CHECKSUMTYPE="SHA-1" SIZE="127079">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-11-11T08:31:13" MIMETYPE="text/xml" CHECKSUM="3bb605eb4d38e20d67d352e38f51c317394dc313" CHECKSUMTYPE="SHA-1" SIZE="127079">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-11-11T08:31:13" MIMETYPE="text/xml"
-				CHECKSUM="3206d95cf47b9da32ae57444c70d0b5023507741" CHECKSUMTYPE="SHA-1" SIZE="131371">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-11-11T08:31:13" MIMETYPE="text/xml" CHECKSUM="3206d95cf47b9da32ae57444c70d0b5023507741" CHECKSUMTYPE="SHA-1" SIZE="131371">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-11-11T08:31:13" MIMETYPE="text/xml"
-				CHECKSUM="5f56245cda809f310acbb87bff057ae227eea5cf" CHECKSUMTYPE="SHA-1" SIZE="113718">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-11-11T08:31:13" MIMETYPE="text/xml" CHECKSUM="5f56245cda809f310acbb87bff057ae227eea5cf" CHECKSUMTYPE="SHA-1" SIZE="113718">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-11-11T08:31:14" MIMETYPE="text/xml"
-				CHECKSUM="35a93583c5c10dae74f87c25170106ece43f4d0b" CHECKSUMTYPE="SHA-1" SIZE="47484">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-11-11T08:31:14" MIMETYPE="text/xml" CHECKSUM="35a93583c5c10dae74f87c25170106ece43f4d0b" CHECKSUMTYPE="SHA-1" SIZE="47484">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-11-11T08:31:14" MIMETYPE="text/xml"
-				CHECKSUM="7db56938e8455e0bcdea67ff2afee2a6c6bb6ea3" CHECKSUMTYPE="SHA-1" SIZE="31374">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-11-11T08:31:14" MIMETYPE="text/xml" CHECKSUM="7db56938e8455e0bcdea67ff2afee2a6c6bb6ea3" CHECKSUMTYPE="SHA-1" SIZE="31374">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-11-11T08:31:14" MIMETYPE="text/xml"
-				CHECKSUM="8ecbda04f5b29135f73e25d426c3a8ffc4725de7" CHECKSUMTYPE="SHA-1" SIZE="30785">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-11-11T08:31:14" MIMETYPE="text/xml" CHECKSUM="8ecbda04f5b29135f73e25d426c3a8ffc4725de7" CHECKSUMTYPE="SHA-1" SIZE="30785">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-11-11T08:31:14" MIMETYPE="text/xml"
-				CHECKSUM="ddc86595a0ba1e43ee70ed660bde6242fac1c180" CHECKSUMTYPE="SHA-1" SIZE="19257">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-11-11T08:31:14" MIMETYPE="text/xml" CHECKSUM="ddc86595a0ba1e43ee70ed660bde6242fac1c180" CHECKSUMTYPE="SHA-1" SIZE="19257">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-11-11T08:31:15" MIMETYPE="text/xml"
-				CHECKSUM="9cdc727ed15256b0428f19950091e01d6f57b035" CHECKSUMTYPE="SHA-1" SIZE="37107">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-11-11T08:31:15" MIMETYPE="text/xml" CHECKSUM="9cdc727ed15256b0428f19950091e01d6f57b035" CHECKSUMTYPE="SHA-1" SIZE="37107">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-11-11T08:31:15" MIMETYPE="text/xml"
-				CHECKSUM="5fc89e2dfe387ef829635684f813083f6d209db8" CHECKSUMTYPE="SHA-1" SIZE="87796">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-11-11T08:31:15" MIMETYPE="text/xml" CHECKSUM="5fc89e2dfe387ef829635684f813083f6d209db8" CHECKSUMTYPE="SHA-1" SIZE="87796">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-11-11T08:31:16" MIMETYPE="text/xml"
-				CHECKSUM="dcf174633b8fc082ca604d00ffad0110f96feb68" CHECKSUMTYPE="SHA-1" SIZE="144830">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-11-11T08:31:16" MIMETYPE="text/xml" CHECKSUM="dcf174633b8fc082ca604d00ffad0110f96feb68" CHECKSUMTYPE="SHA-1" SIZE="144830">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-11-11T08:31:16" MIMETYPE="text/xml"
-				CHECKSUM="7e5d3817227d8950207e958cc36e5c4c7a491168" CHECKSUMTYPE="SHA-1" SIZE="152344">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-11-11T08:31:16" MIMETYPE="text/xml" CHECKSUM="7e5d3817227d8950207e958cc36e5c4c7a491168" CHECKSUMTYPE="SHA-1" SIZE="152344">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-11-11T08:31:16" MIMETYPE="text/xml"
-				CHECKSUM="bf6b223a68ec595f3243e94fa6e66328d9ef3f12" CHECKSUMTYPE="SHA-1" SIZE="148190">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-11-11T08:31:16" MIMETYPE="text/xml" CHECKSUM="bf6b223a68ec595f3243e94fa6e66328d9ef3f12" CHECKSUMTYPE="SHA-1" SIZE="148190">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-11-11T08:31:17" MIMETYPE="text/xml"
-				CHECKSUM="83fc5b750a2b503417d82f7ec24cb5bdbc75178f" CHECKSUMTYPE="SHA-1" SIZE="145180">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-11-11T08:31:17" MIMETYPE="text/xml" CHECKSUM="83fc5b750a2b503417d82f7ec24cb5bdbc75178f" CHECKSUMTYPE="SHA-1" SIZE="145180">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-11-11T08:31:17" MIMETYPE="text/xml"
-				CHECKSUM="99d2679982cb5538b7e6df1a7f62aa68a2e3e2b0" CHECKSUMTYPE="SHA-1" SIZE="4905">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-11-11T08:31:17" MIMETYPE="text/xml" CHECKSUM="99d2679982cb5538b7e6df1a7f62aa68a2e3e2b0" CHECKSUMTYPE="SHA-1" SIZE="4905">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-11-11T08:31:18" MIMETYPE="text/xml"
-				CHECKSUM="2af1c9029189d9fab9bd31ad644ba8ba7ee8f621" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-11-11T08:31:18" MIMETYPE="text/xml" CHECKSUM="2af1c9029189d9fab9bd31ad644ba8ba7ee8f621" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-11-11T08:31:18" MIMETYPE="text/xml"
-				CHECKSUM="e1e57d541e2ea7633e824078f51ab14849883a7f" CHECKSUMTYPE="SHA-1" SIZE="96288">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-11-11T08:31:18" MIMETYPE="text/xml" CHECKSUM="e1e57d541e2ea7633e824078f51ab14849883a7f" CHECKSUMTYPE="SHA-1" SIZE="96288">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-11-11T08:31:18" MIMETYPE="text/xml"
-				CHECKSUM="3e5741e593e756f3c174d13951f9adcd25f3c52c" CHECKSUMTYPE="SHA-1" SIZE="181052">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-11-11T08:31:18" MIMETYPE="text/xml" CHECKSUM="3e5741e593e756f3c174d13951f9adcd25f3c52c" CHECKSUMTYPE="SHA-1" SIZE="181052">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-11-11T08:31:19" MIMETYPE="text/xml"
-				CHECKSUM="d2d579fc32cbb34541f218170425529a5bab4cfc" CHECKSUMTYPE="SHA-1" SIZE="187622">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-11-11T08:31:19" MIMETYPE="text/xml" CHECKSUM="d2d579fc32cbb34541f218170425529a5bab4cfc" CHECKSUMTYPE="SHA-1" SIZE="187622">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-11-11T08:31:19" MIMETYPE="text/xml"
-				CHECKSUM="329cb712e5e69770b8769ec54e61c2423865634c" CHECKSUMTYPE="SHA-1" SIZE="187879">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-11-11T08:31:19" MIMETYPE="text/xml" CHECKSUM="329cb712e5e69770b8769ec54e61c2423865634c" CHECKSUMTYPE="SHA-1" SIZE="187879">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-11-11T08:31:19" MIMETYPE="text/xml"
-				CHECKSUM="d5cc99aef2d50bb9ea7d53f7592ef8008dae5358" CHECKSUMTYPE="SHA-1" SIZE="135596">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-11-11T08:31:19" MIMETYPE="text/xml" CHECKSUM="d5cc99aef2d50bb9ea7d53f7592ef8008dae5358" CHECKSUMTYPE="SHA-1" SIZE="135596">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-11-11T08:31:20" MIMETYPE="text/xml"
-				CHECKSUM="8e83a50161f989ceedcf098f77010e09cf534d3f" CHECKSUMTYPE="SHA-1" SIZE="58731">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-11-11T08:31:20" MIMETYPE="text/xml" CHECKSUM="8e83a50161f989ceedcf098f77010e09cf534d3f" CHECKSUMTYPE="SHA-1" SIZE="58731">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-11-11T08:31:20" MIMETYPE="text/xml"
-				CHECKSUM="7c6cc10bf199bfffddc98d6fe1d3ab89fdc604e9" CHECKSUMTYPE="SHA-1" SIZE="183296">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-11-11T08:31:20" MIMETYPE="text/xml" CHECKSUM="7c6cc10bf199bfffddc98d6fe1d3ab89fdc604e9" CHECKSUMTYPE="SHA-1" SIZE="183296">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-11-11T08:31:21" MIMETYPE="text/xml"
-				CHECKSUM="058ba9876c4aa1271ccf6c07451de45fb9455d22" CHECKSUMTYPE="SHA-1" SIZE="25316">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-11-11T08:31:21" MIMETYPE="text/xml" CHECKSUM="058ba9876c4aa1271ccf6c07451de45fb9455d22" CHECKSUMTYPE="SHA-1" SIZE="25316">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-11-11T08:31:21" MIMETYPE="text/xml"
-				CHECKSUM="26314e79fb23e88862def016a28bfb1e1726edaf" CHECKSUMTYPE="SHA-1" SIZE="4768">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-11-11T08:31:21" MIMETYPE="text/xml" CHECKSUM="26314e79fb23e88862def016a28bfb1e1726edaf" CHECKSUMTYPE="SHA-1" SIZE="4768">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-11-11T08:31:21" MIMETYPE="text/xml"
-				CHECKSUM="42d21f607d50821e40f075090a2d9dc212f847f5" CHECKSUMTYPE="SHA-1" SIZE="1954">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-11-11T08:31:21" MIMETYPE="text/xml" CHECKSUM="42d21f607d50821e40f075090a2d9dc212f847f5" CHECKSUMTYPE="SHA-1" SIZE="1954">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-11-11T08:31:21" MIMETYPE="text/xml"
-				CHECKSUM="d27b4e34fc9551ab69b973b14046b61d79c9d6be" CHECKSUMTYPE="SHA-1" SIZE="81043">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-11-11T08:31:21" MIMETYPE="text/xml" CHECKSUM="d27b4e34fc9551ab69b973b14046b61d79c9d6be" CHECKSUMTYPE="SHA-1" SIZE="81043">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-11-11T08:31:22" MIMETYPE="text/xml"
-				CHECKSUM="559c2e6424447a994534cfe970a993941bb37fa0" CHECKSUMTYPE="SHA-1" SIZE="80168">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-11-11T08:31:22" MIMETYPE="text/xml" CHECKSUM="559c2e6424447a994534cfe970a993941bb37fa0" CHECKSUMTYPE="SHA-1" SIZE="80168">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-11-11T08:31:22" MIMETYPE="text/xml"
-				CHECKSUM="b0323f6835c0624f4b43f51b648748aa8d7e11ef" CHECKSUMTYPE="SHA-1" SIZE="85440">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-11-11T08:31:22" MIMETYPE="text/xml" CHECKSUM="b0323f6835c0624f4b43f51b648748aa8d7e11ef" CHECKSUMTYPE="SHA-1" SIZE="85440">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-11-11T08:31:23" MIMETYPE="text/xml"
-				CHECKSUM="e70523a2681b65779f227485d4b0c431bde98436" CHECKSUMTYPE="SHA-1" SIZE="201284">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-11-11T08:31:23" MIMETYPE="text/xml" CHECKSUM="e70523a2681b65779f227485d4b0c431bde98436" CHECKSUMTYPE="SHA-1" SIZE="201284">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-11-11T08:31:23" MIMETYPE="text/xml"
-				CHECKSUM="e1380fda2481a86f63cd001bb6b24f808c113223" CHECKSUMTYPE="SHA-1" SIZE="131150">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-11-11T08:31:23" MIMETYPE="text/xml" CHECKSUM="e1380fda2481a86f63cd001bb6b24f808c113223" CHECKSUMTYPE="SHA-1" SIZE="131150">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-11-11T08:31:23" MIMETYPE="text/xml"
-				CHECKSUM="5b561adc793559beabd072df079dd387925752d2" CHECKSUMTYPE="SHA-1" SIZE="129302">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-11-11T08:31:23" MIMETYPE="text/xml" CHECKSUM="5b561adc793559beabd072df079dd387925752d2" CHECKSUMTYPE="SHA-1" SIZE="129302">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-11-11T08:31:24" MIMETYPE="text/xml"
-				CHECKSUM="b7e02f4e9981af88d97a0c3902b5627251fa09e9" CHECKSUMTYPE="SHA-1" SIZE="126446">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-11-11T08:31:24" MIMETYPE="text/xml" CHECKSUM="b7e02f4e9981af88d97a0c3902b5627251fa09e9" CHECKSUMTYPE="SHA-1" SIZE="126446">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-11-11T08:31:24" MIMETYPE="text/xml"
-				CHECKSUM="656b442f086e2f53c9bc13ecf23d7d4827a7e7d7" CHECKSUMTYPE="SHA-1" SIZE="57245">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-11-11T08:31:24" MIMETYPE="text/xml" CHECKSUM="656b442f086e2f53c9bc13ecf23d7d4827a7e7d7" CHECKSUMTYPE="SHA-1" SIZE="57245">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-11-11T08:31:24" MIMETYPE="text/xml"
-				CHECKSUM="a90a6365823c727b5398515c4517f3630ec7e56c" CHECKSUMTYPE="SHA-1" SIZE="4118">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-11-11T08:31:24" MIMETYPE="text/xml" CHECKSUM="a90a6365823c727b5398515c4517f3630ec7e56c" CHECKSUMTYPE="SHA-1" SIZE="4118">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-11-11T08:31:25" MIMETYPE="text/xml"
-				CHECKSUM="d379e8c545fbe8960c39047faab2eb7b18095774" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-11-11T08:31:25" MIMETYPE="text/xml" CHECKSUM="d379e8c545fbe8960c39047faab2eb7b18095774" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-11-11T08:31:25" MIMETYPE="text/xml"
-				CHECKSUM="f670ed162b76d5628da7b35d6566905dc0a4b570" CHECKSUMTYPE="SHA-1" SIZE="71590">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-11-11T08:31:25" MIMETYPE="text/xml" CHECKSUM="f670ed162b76d5628da7b35d6566905dc0a4b570" CHECKSUMTYPE="SHA-1" SIZE="71590">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-11-11T08:31:25" MIMETYPE="text/xml"
-				CHECKSUM="ed2afd29ad4284597b9225c88126d1290319a60f" CHECKSUMTYPE="SHA-1" SIZE="199574">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-11-11T08:31:25" MIMETYPE="text/xml" CHECKSUM="ed2afd29ad4284597b9225c88126d1290319a60f" CHECKSUMTYPE="SHA-1" SIZE="199574">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-11-11T08:31:26" MIMETYPE="text/xml"
-				CHECKSUM="76242f7d8eddbf63cc7bee7de4ae78448b494e78" CHECKSUMTYPE="SHA-1" SIZE="180892">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-11-11T08:31:26" MIMETYPE="text/xml" CHECKSUM="76242f7d8eddbf63cc7bee7de4ae78448b494e78" CHECKSUMTYPE="SHA-1" SIZE="180892">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-11-11T08:31:26" MIMETYPE="text/xml"
-				CHECKSUM="f410a452e1e6099090db8e63ffce2b4f674005d1" CHECKSUMTYPE="SHA-1" SIZE="183952">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-11-11T08:31:26" MIMETYPE="text/xml" CHECKSUM="f410a452e1e6099090db8e63ffce2b4f674005d1" CHECKSUMTYPE="SHA-1" SIZE="183952">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-11-11T08:31:27" MIMETYPE="text/xml"
-				CHECKSUM="b2e99a839d31ea0336d4b873919ffc4192e69e56" CHECKSUMTYPE="SHA-1" SIZE="172598">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-11-11T08:31:27" MIMETYPE="text/xml" CHECKSUM="b2e99a839d31ea0336d4b873919ffc4192e69e56" CHECKSUMTYPE="SHA-1" SIZE="172598">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-11-11T08:31:27" MIMETYPE="text/xml"
-				CHECKSUM="32871b8d6ebb19fde8cf8864abd77593a66017dd" CHECKSUMTYPE="SHA-1" SIZE="35091">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-11-11T08:31:27" MIMETYPE="text/xml" CHECKSUM="32871b8d6ebb19fde8cf8864abd77593a66017dd" CHECKSUMTYPE="SHA-1" SIZE="35091">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-11-11T08:31:28" MIMETYPE="text/xml"
-				CHECKSUM="3671973f204c8d4b608ea5e1bbd8df5df2ee81b2" CHECKSUMTYPE="SHA-1" SIZE="4545">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-11-11T08:31:28" MIMETYPE="text/xml" CHECKSUM="3671973f204c8d4b608ea5e1bbd8df5df2ee81b2" CHECKSUMTYPE="SHA-1" SIZE="4545">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-11-11T08:31:28" MIMETYPE="text/xml"
-				CHECKSUM="e47da1e24426134459c94ea24656d4c1e157400e" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-11-11T08:31:28" MIMETYPE="text/xml" CHECKSUM="e47da1e24426134459c94ea24656d4c1e157400e" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-11-11T08:31:28" MIMETYPE="text/xml"
-				CHECKSUM="8fe546e5aeb2e5d718af67aaed0cc393782e0361" CHECKSUMTYPE="SHA-1" SIZE="76715">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-11-11T08:31:28" MIMETYPE="text/xml" CHECKSUM="8fe546e5aeb2e5d718af67aaed0cc393782e0361" CHECKSUMTYPE="SHA-1" SIZE="76715">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-11-11T08:31:28" MIMETYPE="text/xml"
-				CHECKSUM="177b0e76bea5d8ff8da31b3bb91eb0b6a0fd9aca" CHECKSUMTYPE="SHA-1" SIZE="187655">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-11-11T08:31:28" MIMETYPE="text/xml" CHECKSUM="177b0e76bea5d8ff8da31b3bb91eb0b6a0fd9aca" CHECKSUMTYPE="SHA-1" SIZE="187655">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-11-11T08:31:29" MIMETYPE="text/xml"
-				CHECKSUM="7c066e1aa470043cb34c1b17f356fc333254d86c" CHECKSUMTYPE="SHA-1" SIZE="4580">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-11-11T08:31:29" MIMETYPE="text/xml" CHECKSUM="7c066e1aa470043cb34c1b17f356fc333254d86c" CHECKSUMTYPE="SHA-1" SIZE="4580">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-11-11T08:31:29" MIMETYPE="text/xml"
-				CHECKSUM="afb100834edec633147f7cd1d13b926465cb98a0" CHECKSUMTYPE="SHA-1" SIZE="1954">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-11-11T08:31:29" MIMETYPE="text/xml" CHECKSUM="afb100834edec633147f7cd1d13b926465cb98a0" CHECKSUMTYPE="SHA-1" SIZE="1954">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-11-11T08:31:29" MIMETYPE="text/xml"
-				CHECKSUM="e09e8d224e416244d5524a4d3f097fe4c6f26797" CHECKSUMTYPE="SHA-1" SIZE="191058">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-11-11T08:31:29" MIMETYPE="text/xml" CHECKSUM="e09e8d224e416244d5524a4d3f097fe4c6f26797" CHECKSUMTYPE="SHA-1" SIZE="191058">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-11-11T08:31:30" MIMETYPE="text/xml"
-				CHECKSUM="f031934088240b1ba8db94aa0428eee6ef7a8dbf" CHECKSUMTYPE="SHA-1" SIZE="144249">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-11-11T08:31:30" MIMETYPE="text/xml" CHECKSUM="f031934088240b1ba8db94aa0428eee6ef7a8dbf" CHECKSUMTYPE="SHA-1" SIZE="144249">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-11-11T08:31:30" MIMETYPE="text/xml"
-				CHECKSUM="7829e6234cdac5c74d4dd623372cd0c08dbff82f" CHECKSUMTYPE="SHA-1" SIZE="148433">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-11-11T08:31:30" MIMETYPE="text/xml" CHECKSUM="7829e6234cdac5c74d4dd623372cd0c08dbff82f" CHECKSUMTYPE="SHA-1" SIZE="148433">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-11-11T08:31:31" MIMETYPE="text/xml"
-				CHECKSUM="f99842b75a5c81e3183400e3a70814b90616c744" CHECKSUMTYPE="SHA-1" SIZE="63880">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-11-11T08:31:31" MIMETYPE="text/xml" CHECKSUM="f99842b75a5c81e3183400e3a70814b90616c744" CHECKSUMTYPE="SHA-1" SIZE="63880">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-11-11T08:31:31" MIMETYPE="text/xml"
-				CHECKSUM="a07a5c532658b30675ba78076d0a6b742928151a" CHECKSUMTYPE="SHA-1" SIZE="4495">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-11-11T08:31:31" MIMETYPE="text/xml" CHECKSUM="a07a5c532658b30675ba78076d0a6b742928151a" CHECKSUMTYPE="SHA-1" SIZE="4495">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-11-11T08:31:31" MIMETYPE="text/xml"
-				CHECKSUM="33e2242a6a9b06f167556c8780dd07914464eac5" CHECKSUMTYPE="SHA-1" SIZE="1951">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-11-11T08:31:31" MIMETYPE="text/xml" CHECKSUM="33e2242a6a9b06f167556c8780dd07914464eac5" CHECKSUMTYPE="SHA-1" SIZE="1951">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-11-11T08:31:31" MIMETYPE="text/xml"
-				CHECKSUM="e2db503270bad0f753f29c95f5007ff33060d3e1" CHECKSUMTYPE="SHA-1" SIZE="45171">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-11-11T08:31:31" MIMETYPE="text/xml" CHECKSUM="e2db503270bad0f753f29c95f5007ff33060d3e1" CHECKSUMTYPE="SHA-1" SIZE="45171">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-11-11T08:31:32" MIMETYPE="text/xml"
-				CHECKSUM="16126aedcdc7f6eab7aac7d722d43e80a1642d2b" CHECKSUMTYPE="SHA-1" SIZE="20173">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-11-11T08:31:32" MIMETYPE="text/xml" CHECKSUM="16126aedcdc7f6eab7aac7d722d43e80a1642d2b" CHECKSUMTYPE="SHA-1" SIZE="20173">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-11-11T08:31:32" MIMETYPE="text/xml"
-				CHECKSUM="c3404e03e7f7cb0e5791ee2758e046d2a69e8efd" CHECKSUMTYPE="SHA-1" SIZE="19491">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-11-11T08:31:32" MIMETYPE="text/xml" CHECKSUM="c3404e03e7f7cb0e5791ee2758e046d2a69e8efd" CHECKSUMTYPE="SHA-1" SIZE="19491">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-11-11T08:31:32" MIMETYPE="text/xml"
-				CHECKSUM="f7f9e7a112315aab05ab95c4da8bb23312f67b76" CHECKSUMTYPE="SHA-1" SIZE="40027">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-11-11T08:31:32" MIMETYPE="text/xml" CHECKSUM="f7f9e7a112315aab05ab95c4da8bb23312f67b76" CHECKSUMTYPE="SHA-1" SIZE="40027">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-11-11T08:31:32" MIMETYPE="text/xml"
-				CHECKSUM="169564e3d4fada9f2643fad317ad431d4fc4ad16" CHECKSUMTYPE="SHA-1" SIZE="1944">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-11-11T08:31:32" MIMETYPE="text/xml" CHECKSUM="169564e3d4fada9f2643fad317ad431d4fc4ad16" CHECKSUMTYPE="SHA-1" SIZE="1944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-11-11T08:31:33" MIMETYPE="text/xml"
-				CHECKSUM="fb5a963dd65a7f1fd0c12321f94de16bb5e07f02" CHECKSUMTYPE="SHA-1" SIZE="3311">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-11-11T08:31:33" MIMETYPE="text/xml" CHECKSUM="fb5a963dd65a7f1fd0c12321f94de16bb5e07f02" CHECKSUMTYPE="SHA-1" SIZE="3311">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1897-11_01_0090.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-11-11T08:35:07" MIMETYPE="application/pdf" CHECKSUM="459f39d61433d7f0a10a488f5b7eebb674d290ed"
-				CHECKSUMTYPE="SHA-1" SIZE="40156595">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/bmtnabe_1897-11_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-11-11T08:35:07" MIMETYPE="application/pdf" CHECKSUM="459f39d61433d7f0a10a488f5b7eebb674d290ed" CHECKSUMTYPE="SHA-1" SIZE="40156595">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1897/11_01/bmtnabe_1897-11_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -10540,8 +10264,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.19" TYPE="TextContent" ORDER="18" DMDID="c041"
-					LABEL="AUS MUENCHEN LUDWIG DILL UND DIE NEUEREN BESTREBUNGEN DER MUENCHENER LANDSCHAFTERSCHULE">
+				<div ID="L.1.1.19" TYPE="TextContent" ORDER="18" DMDID="c041" LABEL="AUS MUENCHEN LUDWIG DILL UND DIE NEUEREN BESTREBUNGEN DER MUENCHENER LANDSCHAFTERSCHULE">
 					<div ID="L.1.1.19.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00052" BEGIN="P52_TB00002"/>

--- a/metadata/periodicals/bmtnabe/issues/1898/04_01/bmtnabe_1898-04_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1898/04_01/bmtnabe_1898-04_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1898-04_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1898-04_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-04_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-04_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1898-04_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1898-04_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-04_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -8269,824 +8265,552 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:33:32" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="62ca04c2e09c2e27e46aa499b9319a7257f2a1d4" CHECKSUMTYPE="SHA-1" SIZE="5196723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:33:57" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="457bb48717e04a1f516ba8de87336680c38e35a8" CHECKSUMTYPE="SHA-1" SIZE="5476601">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:34:22" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="3d363ca45e04327b9e9a200155ffca9dce7bf6d4" CHECKSUMTYPE="SHA-1" SIZE="5164326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:34:46" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="b10e1578b607c33f5cd1286d7a09864107d02d40" CHECKSUMTYPE="SHA-1" SIZE="5476626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:35:09" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="adefd0425c255f7306ae378a8499608cadb6fba7" CHECKSUMTYPE="SHA-1" SIZE="5176927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:35:34" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="e9a46893a9be0565bb20767ff990ba71d352cb86" CHECKSUMTYPE="SHA-1" SIZE="5476626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:36:03" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="47a148cd21d22e5d071c2d5be17f735571713dfc" CHECKSUMTYPE="SHA-1" SIZE="6962243">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:36:30" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="93c4a7bd92181490c9dcd184f94b1c290a86631b" CHECKSUMTYPE="SHA-1" SIZE="5476624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:36:58" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="6e385e680cf9386a04c84a71d6da87ff1dfc88bb" CHECKSUMTYPE="SHA-1" SIZE="5176026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:37:26" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="894c8922bd539c86793b5acd31277fcf312c2e72" CHECKSUMTYPE="SHA-1" SIZE="5476481">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:37:51" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="65882cdfc0d82a872e0e3ecbc2d8473e30923509" CHECKSUMTYPE="SHA-1" SIZE="5170629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:38:15" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="61ccde239be43f10ba62c57884cc18d418f11fbe" CHECKSUMTYPE="SHA-1" SIZE="5476629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:38:40" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="deb89efdd85e697b381f03d44bd1a89f652c740d" CHECKSUMTYPE="SHA-1" SIZE="5130999">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:39:07" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="d218daa6c9a1fd44b7b0b0f23583637bff9ec81f" CHECKSUMTYPE="SHA-1" SIZE="5476628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:39:35" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="1c28e72272583412068b98fb3f83a29337d67599" CHECKSUMTYPE="SHA-1" SIZE="5156226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:39:58" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="d6845a08698d4af5fa6766cf091b706c50ed08f2" CHECKSUMTYPE="SHA-1" SIZE="5476629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:40:27" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="ba1512eee45ca5b8d3b0dddbd97daa7057b79abd" CHECKSUMTYPE="SHA-1" SIZE="6817498">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:40:52" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="eb45f9cdff2b62d2eeffc631b1c0b3955d1d69d0" CHECKSUMTYPE="SHA-1" SIZE="5476627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:41:15" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="ff307a2c63c6bcffdb6b6603fce1020e85e6d479" CHECKSUMTYPE="SHA-1" SIZE="5129223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:41:41" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="5ccffd64fb3343a91a2a31c129876f41bbcf075b" CHECKSUMTYPE="SHA-1" SIZE="5462229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:42:05" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="4b3d27151706bff0b3690ea070120fffced2724e" CHECKSUMTYPE="SHA-1" SIZE="5167928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:42:30" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="fd25cf937ea505b9c58673e7503db9ea5a86e236" CHECKSUMTYPE="SHA-1" SIZE="5514428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:42:54" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="06c4ecddc001393b0b1ad62e749a54e0e64b9bc1" CHECKSUMTYPE="SHA-1" SIZE="5093227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:43:20" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="4b66abb6817eac30b886fdc1135efc28e8a7f34d" CHECKSUMTYPE="SHA-1" SIZE="5516213">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:43:43" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="51ea83492f64615feac271e86a9ef374e9ae948f" CHECKSUMTYPE="SHA-1" SIZE="5093228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:44:09" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="eda1e0c6e493d2fe8abb5017c089b421b5c185f9" CHECKSUMTYPE="SHA-1" SIZE="5531523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:44:34" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="115698182fd84396f490352897fc036da01fc9c3" CHECKSUMTYPE="SHA-1" SIZE="5093160">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:44:58" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="21ca1f0dd93abd81984de3ef678f1c411752ecad" CHECKSUMTYPE="SHA-1" SIZE="5470328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:45:25" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="0a49d83f80ed8ae7bec57dc84815fa9cb1b3f080" CHECKSUMTYPE="SHA-1" SIZE="5093227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:45:49" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="96fbfe73f32667487141c79be783e8abe4731d8c" CHECKSUMTYPE="SHA-1" SIZE="5470311">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:46:17" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="80518106514062d0535822cb828d7664023b11c7" CHECKSUMTYPE="SHA-1" SIZE="5093228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:46:41" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="02c6e9dcc9fcecfdd2fa1c1b73c50d8f1b1a9e0d" CHECKSUMTYPE="SHA-1" SIZE="5470329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:47:07" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="a887fb2fa590cea12a7ca9590ab72e807056d9ae" CHECKSUMTYPE="SHA-1" SIZE="5093223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:47:32" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="40f9cc8f22561aad2b79f5826700718bdafa687d" CHECKSUMTYPE="SHA-1" SIZE="5516228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:47:56" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="2e773f08033ddbd26996f05a9ff212d73856aafd" CHECKSUMTYPE="SHA-1" SIZE="5093229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:48:22" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="1696e3a9b019aab31fe46333d4a71b8638daf500" CHECKSUMTYPE="SHA-1" SIZE="5516229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:48:48" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="bf4cdc3ea6c3a0ebbd11f610988f6a27907d404a" CHECKSUMTYPE="SHA-1" SIZE="5068025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:49:15" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="07d574c1a4635a6e7fca8bcd4964c9963d4a3cf9" CHECKSUMTYPE="SHA-1" SIZE="5516229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:49:39" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="8f3365ff628d6861c56b9cf8f609908e23104887" CHECKSUMTYPE="SHA-1" SIZE="5056329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:50:04" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="d5835b7dc440a0722cb52f20499c6d236ad6d8a9" CHECKSUMTYPE="SHA-1" SIZE="5477526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:50:30" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="36fe1466bb66f920c0ebc8c0fc242917e7e2de98" CHECKSUMTYPE="SHA-1" SIZE="5061726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:50:57" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="6394a0d1802d704001a503c638444ce07395c592" CHECKSUMTYPE="SHA-1" SIZE="5476606">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:51:23" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="6ba69d456771a4be9e35442a70d771212e3bf4aa" CHECKSUMTYPE="SHA-1" SIZE="5060829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:51:50" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="d4bb5ed8880385621e01052a4f7803c94d4bee68" CHECKSUMTYPE="SHA-1" SIZE="5448727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:52:14" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="c72b63def1c1887fc80e3e764bb2ab6c3fb80d22" CHECKSUMTYPE="SHA-1" SIZE="5058104">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:52:39" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="a22062467c5254b05289c8f42abff12fb24e8f49" CHECKSUMTYPE="SHA-1" SIZE="5491927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:53:03" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="eec5646934d3384082543b1a4e4e1c923dea9b68" CHECKSUMTYPE="SHA-1" SIZE="5034718">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:53:31" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="b2dd530a66bdb10e8a2418703647af7b02594ef0" CHECKSUMTYPE="SHA-1" SIZE="5470328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:53:58" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="dc7e0d5a7f11620b8536a8471165051ad048a587" CHECKSUMTYPE="SHA-1" SIZE="5034725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:54:24" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="30ce7ff33aa648a9ee17bca03cf528559f73cf5b" CHECKSUMTYPE="SHA-1" SIZE="5465828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:54:50" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="487686cdaa1af714448dea92c29e1d6b94eb762c" CHECKSUMTYPE="SHA-1" SIZE="5034666">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:55:17" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="f43f0ec124c47c2722ab52692fd29a39b2bcd398" CHECKSUMTYPE="SHA-1" SIZE="5374017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:55:41" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="9e8c5bd2fc8c90ead67fbf023bcee3bb067eebaa" CHECKSUMTYPE="SHA-1" SIZE="5122013">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:56:06" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="cf10dd01f33b2323e8ee320b8b7d00cba3bd7874" CHECKSUMTYPE="SHA-1" SIZE="5380329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:56:31" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="b6106843b549adaebac3ba6a4bac49cca734650a" CHECKSUMTYPE="SHA-1" SIZE="5085128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:57:00" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="e309595664eb62a17dba1a7483cce677672dc570" CHECKSUMTYPE="SHA-1" SIZE="5380329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:57:26" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="a5e46c19857290888c6ed371f23af61ebc6d6110" CHECKSUMTYPE="SHA-1" SIZE="5069827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:57:50" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="d24f71d8125641c20289d2c8581fd755845ee9d1" CHECKSUMTYPE="SHA-1" SIZE="5380327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T17:58:16" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="7379ad57fa3b12c1d44e77482402169ff0a309d9" CHECKSUMTYPE="SHA-1" SIZE="5058118">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T17:58:40" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="2cbaa2fceb6fa435bb921d0b8225d935b0c1bf2d" CHECKSUMTYPE="SHA-1" SIZE="5380329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T17:59:10" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="08695764ca99b2cef30580eedb41e4f284e744bd" CHECKSUMTYPE="SHA-1" SIZE="6707626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T17:59:39" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="0e1b7b53d7423f1ffb5f1b0d728151d79503e17f" CHECKSUMTYPE="SHA-1" SIZE="5380288">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:00:03" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="77dae5b25f043ba0195deb8d66226f154dbea21f" CHECKSUMTYPE="SHA-1" SIZE="5007720">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:00:30" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="5a6679fd8a9130382e7df5ab53374c5a7538517d" CHECKSUMTYPE="SHA-1" SIZE="5380328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:00:56" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="5a83500efd995eed035124b216f7a0c566d917d3" CHECKSUMTYPE="SHA-1" SIZE="5049129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:01:22" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="fc82707845546f5574f84dde5908959fdf0bae20" CHECKSUMTYPE="SHA-1" SIZE="5380327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:01:46" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="b2842618911e8821bb8737bac72162de10f28ad6" CHECKSUMTYPE="SHA-1" SIZE="5034729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:02:10" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="2e4ac0f7a792a59d28b6dac915cd8239684148f9" CHECKSUMTYPE="SHA-1" SIZE="5380326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:02:36" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="17fb3076625e013393055c5e01e3d9d4a46d4ba9" CHECKSUMTYPE="SHA-1" SIZE="5034723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:03:03" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="464f93a8a07423025cb2dde49a3e968bb6e2cc40" CHECKSUMTYPE="SHA-1" SIZE="5380317">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:03:27" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="579702c1465ccf51a0ba861b138e66fe6b3b5bdc" CHECKSUMTYPE="SHA-1" SIZE="5059928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:03:51" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="69f07c44d3ab4670afb9933788638c44b2ac4ec6" CHECKSUMTYPE="SHA-1" SIZE="5380244">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:04:14" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="3694e409e32d9c5b6787fee140ad8b1c50409de2" CHECKSUMTYPE="SHA-1" SIZE="5031128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:04:38" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="ef819fe9a9178266b4259fa1504ebc573db3d6d6" CHECKSUMTYPE="SHA-1" SIZE="5380304">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:05:02" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="abbd5e0a3f63475e9f7413e4adcb2bf19f317e64" CHECKSUMTYPE="SHA-1" SIZE="5023028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:05:28" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="a2167ed2827c7165a20dc6c86a25cf7445df3e47" CHECKSUMTYPE="SHA-1" SIZE="5380324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:05:54" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="be343331c4ef636c0a6e43a6a4394751b940a4d6" CHECKSUMTYPE="SHA-1" SIZE="5025727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:06:19" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="4888c3c166cd9081f01650066dfa033d3a914a4e" CHECKSUMTYPE="SHA-1" SIZE="5380329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:06:42" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="8ce83f136949247abb63272eeb661e0de356027e" CHECKSUMTYPE="SHA-1" SIZE="5019426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:07:07" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="92a42d30fba6142e465174672c8e64a964211728" CHECKSUMTYPE="SHA-1" SIZE="5380243">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:07:37" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="1866a9cae9ee168f6c5ec1f01a69ae2b99f2c310" CHECKSUMTYPE="SHA-1" SIZE="6835934">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:08:07" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="e02d47b92f46176a11352089cf9eaffcfd3a994c" CHECKSUMTYPE="SHA-1" SIZE="5380323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:08:31" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="aaff7e7eaa70456667e03adb2501e2c5fb6db5fd" CHECKSUMTYPE="SHA-1" SIZE="5004123">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:08:56" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="cde07bfa6b68a5958a8e34ba6f67088c996c32e5" CHECKSUMTYPE="SHA-1" SIZE="5380326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:09:19" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="8535db08c22522b674244ac2837ea0a5c8f6d952" CHECKSUMTYPE="SHA-1" SIZE="5004128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:09:43" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="6aad9afa7cba057ed3a35f7f4b7dc93a592cc173" CHECKSUMTYPE="SHA-1" SIZE="5380327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T18:10:06" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="8059d44e36602f5848ecc6b5a13735960284ff92" CHECKSUMTYPE="SHA-1" SIZE="5004129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T18:10:32" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="6b4b0e81e8a87764244bdc232c594ba027db7b00" CHECKSUMTYPE="SHA-1" SIZE="5380326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T18:10:56" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="743d8a9ea716d12000bd11781f0fa8f841356b0f" CHECKSUMTYPE="SHA-1" SIZE="5004044">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T18:11:23" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="601b6ca768f27ae7853ee7fb4b1ca3f4b1f70074" CHECKSUMTYPE="SHA-1" SIZE="5380323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0090.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:33:32" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="62ca04c2e09c2e27e46aa499b9319a7257f2a1d4" CHECKSUMTYPE="SHA-1" SIZE="5196723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:33:57" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="457bb48717e04a1f516ba8de87336680c38e35a8" CHECKSUMTYPE="SHA-1" SIZE="5476601">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:34:22" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="3d363ca45e04327b9e9a200155ffca9dce7bf6d4" CHECKSUMTYPE="SHA-1" SIZE="5164326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:34:46" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="b10e1578b607c33f5cd1286d7a09864107d02d40" CHECKSUMTYPE="SHA-1" SIZE="5476626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:35:09" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="adefd0425c255f7306ae378a8499608cadb6fba7" CHECKSUMTYPE="SHA-1" SIZE="5176927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:35:34" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="e9a46893a9be0565bb20767ff990ba71d352cb86" CHECKSUMTYPE="SHA-1" SIZE="5476626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:36:03" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="47a148cd21d22e5d071c2d5be17f735571713dfc" CHECKSUMTYPE="SHA-1" SIZE="6962243">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:36:30" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="93c4a7bd92181490c9dcd184f94b1c290a86631b" CHECKSUMTYPE="SHA-1" SIZE="5476624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:36:58" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="6e385e680cf9386a04c84a71d6da87ff1dfc88bb" CHECKSUMTYPE="SHA-1" SIZE="5176026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:37:26" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="894c8922bd539c86793b5acd31277fcf312c2e72" CHECKSUMTYPE="SHA-1" SIZE="5476481">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:37:51" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="65882cdfc0d82a872e0e3ecbc2d8473e30923509" CHECKSUMTYPE="SHA-1" SIZE="5170629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:38:15" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="61ccde239be43f10ba62c57884cc18d418f11fbe" CHECKSUMTYPE="SHA-1" SIZE="5476629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:38:40" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="deb89efdd85e697b381f03d44bd1a89f652c740d" CHECKSUMTYPE="SHA-1" SIZE="5130999">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:39:07" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="d218daa6c9a1fd44b7b0b0f23583637bff9ec81f" CHECKSUMTYPE="SHA-1" SIZE="5476628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:39:35" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="1c28e72272583412068b98fb3f83a29337d67599" CHECKSUMTYPE="SHA-1" SIZE="5156226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:39:58" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d6845a08698d4af5fa6766cf091b706c50ed08f2" CHECKSUMTYPE="SHA-1" SIZE="5476629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:40:27" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="ba1512eee45ca5b8d3b0dddbd97daa7057b79abd" CHECKSUMTYPE="SHA-1" SIZE="6817498">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:40:52" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="eb45f9cdff2b62d2eeffc631b1c0b3955d1d69d0" CHECKSUMTYPE="SHA-1" SIZE="5476627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:41:15" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="ff307a2c63c6bcffdb6b6603fce1020e85e6d479" CHECKSUMTYPE="SHA-1" SIZE="5129223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:41:41" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="5ccffd64fb3343a91a2a31c129876f41bbcf075b" CHECKSUMTYPE="SHA-1" SIZE="5462229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:42:05" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="4b3d27151706bff0b3690ea070120fffced2724e" CHECKSUMTYPE="SHA-1" SIZE="5167928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:42:30" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="fd25cf937ea505b9c58673e7503db9ea5a86e236" CHECKSUMTYPE="SHA-1" SIZE="5514428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:42:54" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="06c4ecddc001393b0b1ad62e749a54e0e64b9bc1" CHECKSUMTYPE="SHA-1" SIZE="5093227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:43:20" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="4b66abb6817eac30b886fdc1135efc28e8a7f34d" CHECKSUMTYPE="SHA-1" SIZE="5516213">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:43:43" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="51ea83492f64615feac271e86a9ef374e9ae948f" CHECKSUMTYPE="SHA-1" SIZE="5093228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:44:09" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="eda1e0c6e493d2fe8abb5017c089b421b5c185f9" CHECKSUMTYPE="SHA-1" SIZE="5531523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:44:34" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="115698182fd84396f490352897fc036da01fc9c3" CHECKSUMTYPE="SHA-1" SIZE="5093160">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:44:58" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="21ca1f0dd93abd81984de3ef678f1c411752ecad" CHECKSUMTYPE="SHA-1" SIZE="5470328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:45:25" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="0a49d83f80ed8ae7bec57dc84815fa9cb1b3f080" CHECKSUMTYPE="SHA-1" SIZE="5093227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:45:49" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="96fbfe73f32667487141c79be783e8abe4731d8c" CHECKSUMTYPE="SHA-1" SIZE="5470311">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:46:17" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="80518106514062d0535822cb828d7664023b11c7" CHECKSUMTYPE="SHA-1" SIZE="5093228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:46:41" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="02c6e9dcc9fcecfdd2fa1c1b73c50d8f1b1a9e0d" CHECKSUMTYPE="SHA-1" SIZE="5470329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:47:07" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="a887fb2fa590cea12a7ca9590ab72e807056d9ae" CHECKSUMTYPE="SHA-1" SIZE="5093223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:47:32" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="40f9cc8f22561aad2b79f5826700718bdafa687d" CHECKSUMTYPE="SHA-1" SIZE="5516228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:47:56" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="2e773f08033ddbd26996f05a9ff212d73856aafd" CHECKSUMTYPE="SHA-1" SIZE="5093229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:48:22" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="1696e3a9b019aab31fe46333d4a71b8638daf500" CHECKSUMTYPE="SHA-1" SIZE="5516229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:48:48" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="bf4cdc3ea6c3a0ebbd11f610988f6a27907d404a" CHECKSUMTYPE="SHA-1" SIZE="5068025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:49:15" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="07d574c1a4635a6e7fca8bcd4964c9963d4a3cf9" CHECKSUMTYPE="SHA-1" SIZE="5516229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:49:39" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="8f3365ff628d6861c56b9cf8f609908e23104887" CHECKSUMTYPE="SHA-1" SIZE="5056329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:50:04" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="d5835b7dc440a0722cb52f20499c6d236ad6d8a9" CHECKSUMTYPE="SHA-1" SIZE="5477526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:50:30" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="36fe1466bb66f920c0ebc8c0fc242917e7e2de98" CHECKSUMTYPE="SHA-1" SIZE="5061726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:50:57" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="6394a0d1802d704001a503c638444ce07395c592" CHECKSUMTYPE="SHA-1" SIZE="5476606">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:51:23" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="6ba69d456771a4be9e35442a70d771212e3bf4aa" CHECKSUMTYPE="SHA-1" SIZE="5060829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:51:50" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="d4bb5ed8880385621e01052a4f7803c94d4bee68" CHECKSUMTYPE="SHA-1" SIZE="5448727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:52:14" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="c72b63def1c1887fc80e3e764bb2ab6c3fb80d22" CHECKSUMTYPE="SHA-1" SIZE="5058104">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:52:39" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="a22062467c5254b05289c8f42abff12fb24e8f49" CHECKSUMTYPE="SHA-1" SIZE="5491927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:53:03" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="eec5646934d3384082543b1a4e4e1c923dea9b68" CHECKSUMTYPE="SHA-1" SIZE="5034718">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:53:31" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="b2dd530a66bdb10e8a2418703647af7b02594ef0" CHECKSUMTYPE="SHA-1" SIZE="5470328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:53:58" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="dc7e0d5a7f11620b8536a8471165051ad048a587" CHECKSUMTYPE="SHA-1" SIZE="5034725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:54:24" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="30ce7ff33aa648a9ee17bca03cf528559f73cf5b" CHECKSUMTYPE="SHA-1" SIZE="5465828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:54:50" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="487686cdaa1af714448dea92c29e1d6b94eb762c" CHECKSUMTYPE="SHA-1" SIZE="5034666">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:55:17" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="f43f0ec124c47c2722ab52692fd29a39b2bcd398" CHECKSUMTYPE="SHA-1" SIZE="5374017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:55:41" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="9e8c5bd2fc8c90ead67fbf023bcee3bb067eebaa" CHECKSUMTYPE="SHA-1" SIZE="5122013">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:56:06" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="cf10dd01f33b2323e8ee320b8b7d00cba3bd7874" CHECKSUMTYPE="SHA-1" SIZE="5380329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:56:31" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="b6106843b549adaebac3ba6a4bac49cca734650a" CHECKSUMTYPE="SHA-1" SIZE="5085128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:57:00" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="e309595664eb62a17dba1a7483cce677672dc570" CHECKSUMTYPE="SHA-1" SIZE="5380329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:57:26" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="a5e46c19857290888c6ed371f23af61ebc6d6110" CHECKSUMTYPE="SHA-1" SIZE="5069827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:57:50" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="d24f71d8125641c20289d2c8581fd755845ee9d1" CHECKSUMTYPE="SHA-1" SIZE="5380327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T17:58:16" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="7379ad57fa3b12c1d44e77482402169ff0a309d9" CHECKSUMTYPE="SHA-1" SIZE="5058118">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T17:58:40" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="2cbaa2fceb6fa435bb921d0b8225d935b0c1bf2d" CHECKSUMTYPE="SHA-1" SIZE="5380329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T17:59:10" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="08695764ca99b2cef30580eedb41e4f284e744bd" CHECKSUMTYPE="SHA-1" SIZE="6707626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T17:59:39" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="0e1b7b53d7423f1ffb5f1b0d728151d79503e17f" CHECKSUMTYPE="SHA-1" SIZE="5380288">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:00:03" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="77dae5b25f043ba0195deb8d66226f154dbea21f" CHECKSUMTYPE="SHA-1" SIZE="5007720">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:00:30" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="5a6679fd8a9130382e7df5ab53374c5a7538517d" CHECKSUMTYPE="SHA-1" SIZE="5380328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:00:56" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="5a83500efd995eed035124b216f7a0c566d917d3" CHECKSUMTYPE="SHA-1" SIZE="5049129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:01:22" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="fc82707845546f5574f84dde5908959fdf0bae20" CHECKSUMTYPE="SHA-1" SIZE="5380327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:01:46" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="b2842618911e8821bb8737bac72162de10f28ad6" CHECKSUMTYPE="SHA-1" SIZE="5034729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:02:10" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="2e4ac0f7a792a59d28b6dac915cd8239684148f9" CHECKSUMTYPE="SHA-1" SIZE="5380326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:02:36" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="17fb3076625e013393055c5e01e3d9d4a46d4ba9" CHECKSUMTYPE="SHA-1" SIZE="5034723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:03:03" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="464f93a8a07423025cb2dde49a3e968bb6e2cc40" CHECKSUMTYPE="SHA-1" SIZE="5380317">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:03:27" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="579702c1465ccf51a0ba861b138e66fe6b3b5bdc" CHECKSUMTYPE="SHA-1" SIZE="5059928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:03:51" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="69f07c44d3ab4670afb9933788638c44b2ac4ec6" CHECKSUMTYPE="SHA-1" SIZE="5380244">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:04:14" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="3694e409e32d9c5b6787fee140ad8b1c50409de2" CHECKSUMTYPE="SHA-1" SIZE="5031128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:04:38" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="ef819fe9a9178266b4259fa1504ebc573db3d6d6" CHECKSUMTYPE="SHA-1" SIZE="5380304">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:05:02" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="abbd5e0a3f63475e9f7413e4adcb2bf19f317e64" CHECKSUMTYPE="SHA-1" SIZE="5023028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:05:28" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="a2167ed2827c7165a20dc6c86a25cf7445df3e47" CHECKSUMTYPE="SHA-1" SIZE="5380324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:05:54" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="be343331c4ef636c0a6e43a6a4394751b940a4d6" CHECKSUMTYPE="SHA-1" SIZE="5025727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:06:19" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="4888c3c166cd9081f01650066dfa033d3a914a4e" CHECKSUMTYPE="SHA-1" SIZE="5380329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:06:42" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="8ce83f136949247abb63272eeb661e0de356027e" CHECKSUMTYPE="SHA-1" SIZE="5019426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:07:07" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="92a42d30fba6142e465174672c8e64a964211728" CHECKSUMTYPE="SHA-1" SIZE="5380243">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:07:37" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="1866a9cae9ee168f6c5ec1f01a69ae2b99f2c310" CHECKSUMTYPE="SHA-1" SIZE="6835934">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:08:07" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="e02d47b92f46176a11352089cf9eaffcfd3a994c" CHECKSUMTYPE="SHA-1" SIZE="5380323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:08:31" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="aaff7e7eaa70456667e03adb2501e2c5fb6db5fd" CHECKSUMTYPE="SHA-1" SIZE="5004123">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:08:56" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="cde07bfa6b68a5958a8e34ba6f67088c996c32e5" CHECKSUMTYPE="SHA-1" SIZE="5380326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:09:19" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="8535db08c22522b674244ac2837ea0a5c8f6d952" CHECKSUMTYPE="SHA-1" SIZE="5004128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:09:43" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="6aad9afa7cba057ed3a35f7f4b7dc93a592cc173" CHECKSUMTYPE="SHA-1" SIZE="5380327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T18:10:06" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="8059d44e36602f5848ecc6b5a13735960284ff92" CHECKSUMTYPE="SHA-1" SIZE="5004129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T18:10:32" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="6b4b0e81e8a87764244bdc232c594ba027db7b00" CHECKSUMTYPE="SHA-1" SIZE="5380326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T18:10:56" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="743d8a9ea716d12000bd11781f0fa8f841356b0f" CHECKSUMTYPE="SHA-1" SIZE="5004044">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T18:11:23" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="601b6ca768f27ae7853ee7fb4b1ca3f4b1f70074" CHECKSUMTYPE="SHA-1" SIZE="5380323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/delivery/bmtnabe_1898-04_01_0090.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:11:37" MIMETYPE="text/xml" CHECKSUM="7a9cf6f8b2c387db5ad4e4cfd69c8782df28bd04"
-				CHECKSUMTYPE="SHA-1" SIZE="2113">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:11:37" MIMETYPE="text/xml" CHECKSUM="7a9cf6f8b2c387db5ad4e4cfd69c8782df28bd04" CHECKSUMTYPE="SHA-1" SIZE="2113">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:11:38" MIMETYPE="text/xml" CHECKSUM="d7de7e4cde7f99a81c84a5a09a1fe357aaea9c08"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:11:38" MIMETYPE="text/xml" CHECKSUM="d7de7e4cde7f99a81c84a5a09a1fe357aaea9c08" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:11:38" MIMETYPE="text/xml" CHECKSUM="ee765c5efdcaef83e26970dd546e5bac96715ca8"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:11:38" MIMETYPE="text/xml" CHECKSUM="ee765c5efdcaef83e26970dd546e5bac96715ca8" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:11:38" MIMETYPE="text/xml" CHECKSUM="748ac1c64a22444b2a60dc4f7dad4d7088148b93"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:11:38" MIMETYPE="text/xml" CHECKSUM="748ac1c64a22444b2a60dc4f7dad4d7088148b93" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:11:39" MIMETYPE="text/xml" CHECKSUM="fe7bbca8223761cc2b050188172cf752ba719aee"
-				CHECKSUMTYPE="SHA-1" SIZE="12826">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:11:39" MIMETYPE="text/xml" CHECKSUM="fe7bbca8223761cc2b050188172cf752ba719aee" CHECKSUMTYPE="SHA-1" SIZE="12826">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:11:39" MIMETYPE="text/xml" CHECKSUM="e916a54a3f27b6d10f78b9dc590c9520407ffd0b"
-				CHECKSUMTYPE="SHA-1" SIZE="3388">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:11:39" MIMETYPE="text/xml" CHECKSUM="e916a54a3f27b6d10f78b9dc590c9520407ffd0b" CHECKSUMTYPE="SHA-1" SIZE="3388">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:11:39" MIMETYPE="text/xml" CHECKSUM="cae2be779ee66676a56faaf86d90ae6d558a82a4"
-				CHECKSUMTYPE="SHA-1" SIZE="1717">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:11:39" MIMETYPE="text/xml" CHECKSUM="cae2be779ee66676a56faaf86d90ae6d558a82a4" CHECKSUMTYPE="SHA-1" SIZE="1717">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:11:39" MIMETYPE="text/xml" CHECKSUM="babb3d0d4a65e3031914f493b3eac6846cc9e497"
-				CHECKSUMTYPE="SHA-1" SIZE="4965">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:11:39" MIMETYPE="text/xml" CHECKSUM="babb3d0d4a65e3031914f493b3eac6846cc9e497" CHECKSUMTYPE="SHA-1" SIZE="4965">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:11:40" MIMETYPE="text/xml" CHECKSUM="bec8367609fc0f69e80f7d9c097a089ad36dad12"
-				CHECKSUMTYPE="SHA-1" SIZE="24603">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:11:40" MIMETYPE="text/xml" CHECKSUM="bec8367609fc0f69e80f7d9c097a089ad36dad12" CHECKSUMTYPE="SHA-1" SIZE="24603">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:11:40" MIMETYPE="text/xml"
-				CHECKSUM="ed21b2217e5a2db61df4f6d6c42471096125e2c1" CHECKSUMTYPE="SHA-1" SIZE="56456">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:11:40" MIMETYPE="text/xml" CHECKSUM="ed21b2217e5a2db61df4f6d6c42471096125e2c1" CHECKSUMTYPE="SHA-1" SIZE="56456">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:11:40" MIMETYPE="text/xml"
-				CHECKSUM="863cbcf78f1fd4e8ff7f8027f75e88b23257d51b" CHECKSUMTYPE="SHA-1" SIZE="38080">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:11:40" MIMETYPE="text/xml" CHECKSUM="863cbcf78f1fd4e8ff7f8027f75e88b23257d51b" CHECKSUMTYPE="SHA-1" SIZE="38080">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:11:40" MIMETYPE="text/xml"
-				CHECKSUM="3bfe79183836d6e5319e0587ec57175b9041428a" CHECKSUMTYPE="SHA-1" SIZE="16285">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:11:40" MIMETYPE="text/xml" CHECKSUM="3bfe79183836d6e5319e0587ec57175b9041428a" CHECKSUMTYPE="SHA-1" SIZE="16285">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:11:41" MIMETYPE="text/xml"
-				CHECKSUM="6e25ff1ccb0bf6da385c5b8c415c9e2646dc9902" CHECKSUMTYPE="SHA-1" SIZE="65960">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:11:41" MIMETYPE="text/xml" CHECKSUM="6e25ff1ccb0bf6da385c5b8c415c9e2646dc9902" CHECKSUMTYPE="SHA-1" SIZE="65960">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:11:41" MIMETYPE="text/xml"
-				CHECKSUM="95577adaf6fc644cc33decb156e878ae02bba7dc" CHECKSUMTYPE="SHA-1" SIZE="92530">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:11:41" MIMETYPE="text/xml" CHECKSUM="95577adaf6fc644cc33decb156e878ae02bba7dc" CHECKSUMTYPE="SHA-1" SIZE="92530">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:11:41" MIMETYPE="text/xml"
-				CHECKSUM="8759df2a29ae6a60886db83f248c0545f0c9420a" CHECKSUMTYPE="SHA-1" SIZE="44231">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:11:41" MIMETYPE="text/xml" CHECKSUM="8759df2a29ae6a60886db83f248c0545f0c9420a" CHECKSUMTYPE="SHA-1" SIZE="44231">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:11:41" MIMETYPE="text/xml"
-				CHECKSUM="3187ba233d951d53e874965f1019f6b88d01324a" CHECKSUMTYPE="SHA-1" SIZE="38833">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:11:41" MIMETYPE="text/xml" CHECKSUM="3187ba233d951d53e874965f1019f6b88d01324a" CHECKSUMTYPE="SHA-1" SIZE="38833">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:11:42" MIMETYPE="text/xml"
-				CHECKSUM="63373fe68dd042383c1a109749967ddc0ed1aff4" CHECKSUMTYPE="SHA-1" SIZE="4793">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:11:42" MIMETYPE="text/xml" CHECKSUM="63373fe68dd042383c1a109749967ddc0ed1aff4" CHECKSUMTYPE="SHA-1" SIZE="4793">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:11:42" MIMETYPE="text/xml"
-				CHECKSUM="7ee520d40a978150f6797f597f31224f2f027d36" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:11:42" MIMETYPE="text/xml" CHECKSUM="7ee520d40a978150f6797f597f31224f2f027d36" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:11:43" MIMETYPE="text/xml"
-				CHECKSUM="1b4a46d23b0b008f87ebef3d9eaf6222ab8187c6" CHECKSUMTYPE="SHA-1" SIZE="43174">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:11:43" MIMETYPE="text/xml" CHECKSUM="1b4a46d23b0b008f87ebef3d9eaf6222ab8187c6" CHECKSUMTYPE="SHA-1" SIZE="43174">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:11:43" MIMETYPE="text/xml"
-				CHECKSUM="c5d7a174961027c6c1ac89651888613cd16df691" CHECKSUMTYPE="SHA-1" SIZE="61348">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:11:43" MIMETYPE="text/xml" CHECKSUM="c5d7a174961027c6c1ac89651888613cd16df691" CHECKSUMTYPE="SHA-1" SIZE="61348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:11:44" MIMETYPE="text/xml"
-				CHECKSUM="25057cb05f46b43b1bb6785d49af019baf5dfe79" CHECKSUMTYPE="SHA-1" SIZE="115177">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:11:44" MIMETYPE="text/xml" CHECKSUM="25057cb05f46b43b1bb6785d49af019baf5dfe79" CHECKSUMTYPE="SHA-1" SIZE="115177">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:11:44" MIMETYPE="text/xml"
-				CHECKSUM="93551448ea6287d965cb2b97d02e1944c8baebcc" CHECKSUMTYPE="SHA-1" SIZE="142601">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:11:44" MIMETYPE="text/xml" CHECKSUM="93551448ea6287d965cb2b97d02e1944c8baebcc" CHECKSUMTYPE="SHA-1" SIZE="142601">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:11:45" MIMETYPE="text/xml"
-				CHECKSUM="66ef26a0d246ea69655c794a32e4ba03f90e88f2" CHECKSUMTYPE="SHA-1" SIZE="6395">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:11:45" MIMETYPE="text/xml" CHECKSUM="66ef26a0d246ea69655c794a32e4ba03f90e88f2" CHECKSUMTYPE="SHA-1" SIZE="6395">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:11:45" MIMETYPE="text/xml"
-				CHECKSUM="e6b205dcb0bdab592f963b51b8f5d39134aa3681" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:11:45" MIMETYPE="text/xml" CHECKSUM="e6b205dcb0bdab592f963b51b8f5d39134aa3681" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:11:45" MIMETYPE="text/xml"
-				CHECKSUM="2bd3637b7aa15efc2fe67f9c73592db559aabc60" CHECKSUMTYPE="SHA-1" SIZE="21169">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:11:45" MIMETYPE="text/xml" CHECKSUM="2bd3637b7aa15efc2fe67f9c73592db559aabc60" CHECKSUMTYPE="SHA-1" SIZE="21169">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:11:46" MIMETYPE="text/xml"
-				CHECKSUM="048acf9f37b7fd2372e5ea266dd6d05fcf18e519" CHECKSUMTYPE="SHA-1" SIZE="33166">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:11:46" MIMETYPE="text/xml" CHECKSUM="048acf9f37b7fd2372e5ea266dd6d05fcf18e519" CHECKSUMTYPE="SHA-1" SIZE="33166">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:11:46" MIMETYPE="text/xml"
-				CHECKSUM="a5302967b519ea05cd3a2c1175c2d547bb099de2" CHECKSUMTYPE="SHA-1" SIZE="75541">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:11:46" MIMETYPE="text/xml" CHECKSUM="a5302967b519ea05cd3a2c1175c2d547bb099de2" CHECKSUMTYPE="SHA-1" SIZE="75541">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:11:46" MIMETYPE="text/xml"
-				CHECKSUM="6c2ac51bcaeb343d883da18406ec96bfd389d48f" CHECKSUMTYPE="SHA-1" SIZE="119606">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:11:46" MIMETYPE="text/xml" CHECKSUM="6c2ac51bcaeb343d883da18406ec96bfd389d48f" CHECKSUMTYPE="SHA-1" SIZE="119606">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:11:47" MIMETYPE="text/xml"
-				CHECKSUM="775e5e5d38deec389268b8c336dabb54d8f0cdb2" CHECKSUMTYPE="SHA-1" SIZE="127473">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:11:47" MIMETYPE="text/xml" CHECKSUM="775e5e5d38deec389268b8c336dabb54d8f0cdb2" CHECKSUMTYPE="SHA-1" SIZE="127473">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:11:47" MIMETYPE="text/xml"
-				CHECKSUM="e1218f06abe14556235dd2ce3f271a3cd028d4f3" CHECKSUMTYPE="SHA-1" SIZE="129728">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:11:47" MIMETYPE="text/xml" CHECKSUM="e1218f06abe14556235dd2ce3f271a3cd028d4f3" CHECKSUMTYPE="SHA-1" SIZE="129728">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:11:47" MIMETYPE="text/xml"
-				CHECKSUM="35f0d9080f0be02ea17920778e88d2b22350d7fa" CHECKSUMTYPE="SHA-1" SIZE="134451">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:11:47" MIMETYPE="text/xml" CHECKSUM="35f0d9080f0be02ea17920778e88d2b22350d7fa" CHECKSUMTYPE="SHA-1" SIZE="134451">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:11:47" MIMETYPE="text/xml"
-				CHECKSUM="3131709fb9c50c4a05b7669f6a29d826b14f0cc4" CHECKSUMTYPE="SHA-1" SIZE="127384">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:11:47" MIMETYPE="text/xml" CHECKSUM="3131709fb9c50c4a05b7669f6a29d826b14f0cc4" CHECKSUMTYPE="SHA-1" SIZE="127384">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:11:48" MIMETYPE="text/xml"
-				CHECKSUM="c6cf86020ff33e110719da7065ee384f0057d870" CHECKSUMTYPE="SHA-1" SIZE="45147">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:11:48" MIMETYPE="text/xml" CHECKSUM="c6cf86020ff33e110719da7065ee384f0057d870" CHECKSUMTYPE="SHA-1" SIZE="45147">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:11:48" MIMETYPE="text/xml"
-				CHECKSUM="b522ad792baa5c89b6bb6b8f1d9b2dfd08e6cff8" CHECKSUMTYPE="SHA-1" SIZE="19771">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:11:48" MIMETYPE="text/xml" CHECKSUM="b522ad792baa5c89b6bb6b8f1d9b2dfd08e6cff8" CHECKSUMTYPE="SHA-1" SIZE="19771">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:11:48" MIMETYPE="text/xml"
-				CHECKSUM="59a768d565adb836df7f4f660c231cd70ef806c3" CHECKSUMTYPE="SHA-1" SIZE="28349">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:11:48" MIMETYPE="text/xml" CHECKSUM="59a768d565adb836df7f4f660c231cd70ef806c3" CHECKSUMTYPE="SHA-1" SIZE="28349">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:11:49" MIMETYPE="text/xml"
-				CHECKSUM="eb17ddd4294cfbbdfd3c639557a5646f135a5556" CHECKSUMTYPE="SHA-1" SIZE="69837">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:11:49" MIMETYPE="text/xml" CHECKSUM="eb17ddd4294cfbbdfd3c639557a5646f135a5556" CHECKSUMTYPE="SHA-1" SIZE="69837">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:11:49" MIMETYPE="text/xml"
-				CHECKSUM="d01f9c68a070fdebfef0e188b247bd3ac89ffce6" CHECKSUMTYPE="SHA-1" SIZE="5342">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:11:49" MIMETYPE="text/xml" CHECKSUM="d01f9c68a070fdebfef0e188b247bd3ac89ffce6" CHECKSUMTYPE="SHA-1" SIZE="5342">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:11:49" MIMETYPE="text/xml"
-				CHECKSUM="8d83fdc07cf1548f8d86e57f246cdc71b5d8acfb" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:11:49" MIMETYPE="text/xml" CHECKSUM="8d83fdc07cf1548f8d86e57f246cdc71b5d8acfb" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:11:50" MIMETYPE="text/xml"
-				CHECKSUM="748d880dd78059a1d791c840767f4bc087f2bf53" CHECKSUMTYPE="SHA-1" SIZE="96298">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:11:50" MIMETYPE="text/xml" CHECKSUM="748d880dd78059a1d791c840767f4bc087f2bf53" CHECKSUMTYPE="SHA-1" SIZE="96298">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:11:50" MIMETYPE="text/xml"
-				CHECKSUM="08663bab27f51341bf2b7f5e17b09e63079c5141" CHECKSUMTYPE="SHA-1" SIZE="181596">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:11:50" MIMETYPE="text/xml" CHECKSUM="08663bab27f51341bf2b7f5e17b09e63079c5141" CHECKSUMTYPE="SHA-1" SIZE="181596">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:11:50" MIMETYPE="text/xml"
-				CHECKSUM="f31a52b354d269389f88b3c159a90f4516e03c97" CHECKSUMTYPE="SHA-1" SIZE="178948">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:11:50" MIMETYPE="text/xml" CHECKSUM="f31a52b354d269389f88b3c159a90f4516e03c97" CHECKSUMTYPE="SHA-1" SIZE="178948">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:11:51" MIMETYPE="text/xml"
-				CHECKSUM="5e55aae7590edd6eeb72e09e17ce436db79f2f63" CHECKSUMTYPE="SHA-1" SIZE="174255">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:11:51" MIMETYPE="text/xml" CHECKSUM="5e55aae7590edd6eeb72e09e17ce436db79f2f63" CHECKSUMTYPE="SHA-1" SIZE="174255">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:11:51" MIMETYPE="text/xml"
-				CHECKSUM="58c2f3ba1a6e8d140e40eddc2f2645b1484812f3" CHECKSUMTYPE="SHA-1" SIZE="176122">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:11:51" MIMETYPE="text/xml" CHECKSUM="58c2f3ba1a6e8d140e40eddc2f2645b1484812f3" CHECKSUMTYPE="SHA-1" SIZE="176122">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:11:51" MIMETYPE="text/xml"
-				CHECKSUM="4e6035e5aae68c62893838e6600cc555d6d1905b" CHECKSUMTYPE="SHA-1" SIZE="122717">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:11:51" MIMETYPE="text/xml" CHECKSUM="4e6035e5aae68c62893838e6600cc555d6d1905b" CHECKSUMTYPE="SHA-1" SIZE="122717">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:11:52" MIMETYPE="text/xml"
-				CHECKSUM="17a126eb03cb8638b9ccc86f8da9ea1a544fbfce" CHECKSUMTYPE="SHA-1" SIZE="4980">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:11:52" MIMETYPE="text/xml" CHECKSUM="17a126eb03cb8638b9ccc86f8da9ea1a544fbfce" CHECKSUMTYPE="SHA-1" SIZE="4980">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:11:52" MIMETYPE="text/xml"
-				CHECKSUM="bae9943d9e3ed5acf72e1785cecca7f2305cdb3a" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:11:52" MIMETYPE="text/xml" CHECKSUM="bae9943d9e3ed5acf72e1785cecca7f2305cdb3a" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:11:52" MIMETYPE="text/xml"
-				CHECKSUM="e2802feeae6d00480046d45e29d32f6cd21086d9" CHECKSUMTYPE="SHA-1" SIZE="91207">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:11:52" MIMETYPE="text/xml" CHECKSUM="e2802feeae6d00480046d45e29d32f6cd21086d9" CHECKSUMTYPE="SHA-1" SIZE="91207">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:11:53" MIMETYPE="text/xml"
-				CHECKSUM="ffff3d493bdd9d77adf093a42ec5a4275924417e" CHECKSUMTYPE="SHA-1" SIZE="194626">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:11:53" MIMETYPE="text/xml" CHECKSUM="ffff3d493bdd9d77adf093a42ec5a4275924417e" CHECKSUMTYPE="SHA-1" SIZE="194626">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:11:53" MIMETYPE="text/xml"
-				CHECKSUM="6807ba6b80124904f41124f0ca1bf889795845de" CHECKSUMTYPE="SHA-1" SIZE="144252">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:11:53" MIMETYPE="text/xml" CHECKSUM="6807ba6b80124904f41124f0ca1bf889795845de" CHECKSUMTYPE="SHA-1" SIZE="144252">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:11:53" MIMETYPE="text/xml"
-				CHECKSUM="5687b5ad5c1f4af6e41f2824fb6c42ec37ffe1d6" CHECKSUMTYPE="SHA-1" SIZE="70093">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:11:53" MIMETYPE="text/xml" CHECKSUM="5687b5ad5c1f4af6e41f2824fb6c42ec37ffe1d6" CHECKSUMTYPE="SHA-1" SIZE="70093">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:11:54" MIMETYPE="text/xml"
-				CHECKSUM="ed99c08f156d49ad80ae12810f6c231d2db329a1" CHECKSUMTYPE="SHA-1" SIZE="6667">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:11:54" MIMETYPE="text/xml" CHECKSUM="ed99c08f156d49ad80ae12810f6c231d2db329a1" CHECKSUMTYPE="SHA-1" SIZE="6667">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:11:54" MIMETYPE="text/xml"
-				CHECKSUM="db7d5617a49903c4abc36ebbcfa582dc35918740" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:11:54" MIMETYPE="text/xml" CHECKSUM="db7d5617a49903c4abc36ebbcfa582dc35918740" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:11:54" MIMETYPE="text/xml"
-				CHECKSUM="2aef61395427ea3de737e61f3a7f2c2affcef7b5" CHECKSUMTYPE="SHA-1" SIZE="111053">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:11:54" MIMETYPE="text/xml" CHECKSUM="2aef61395427ea3de737e61f3a7f2c2affcef7b5" CHECKSUMTYPE="SHA-1" SIZE="111053">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:11:55" MIMETYPE="text/xml"
-				CHECKSUM="9583281e1e056ba7f5095cc34e022434898c516e" CHECKSUMTYPE="SHA-1" SIZE="164956">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:11:55" MIMETYPE="text/xml" CHECKSUM="9583281e1e056ba7f5095cc34e022434898c516e" CHECKSUMTYPE="SHA-1" SIZE="164956">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:11:55" MIMETYPE="text/xml"
-				CHECKSUM="7447cf3d794610739ef04b502b5dbe616e30d983" CHECKSUMTYPE="SHA-1" SIZE="150371">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:11:55" MIMETYPE="text/xml" CHECKSUM="7447cf3d794610739ef04b502b5dbe616e30d983" CHECKSUMTYPE="SHA-1" SIZE="150371">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:11:55" MIMETYPE="text/xml"
-				CHECKSUM="ff4721e53eb230a1c1b8da9e2400dd14d4181085" CHECKSUMTYPE="SHA-1" SIZE="165980">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:11:55" MIMETYPE="text/xml" CHECKSUM="ff4721e53eb230a1c1b8da9e2400dd14d4181085" CHECKSUMTYPE="SHA-1" SIZE="165980">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:11:56" MIMETYPE="text/xml"
-				CHECKSUM="b2062795926ba451907277d7494c7f96292155a9" CHECKSUMTYPE="SHA-1" SIZE="198240">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:11:56" MIMETYPE="text/xml" CHECKSUM="b2062795926ba451907277d7494c7f96292155a9" CHECKSUMTYPE="SHA-1" SIZE="198240">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:11:56" MIMETYPE="text/xml"
-				CHECKSUM="37e8836c96af8f6662432b8bcf2e4cf773b4cef0" CHECKSUMTYPE="SHA-1" SIZE="80154">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:11:56" MIMETYPE="text/xml" CHECKSUM="37e8836c96af8f6662432b8bcf2e4cf773b4cef0" CHECKSUMTYPE="SHA-1" SIZE="80154">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:11:56" MIMETYPE="text/xml"
-				CHECKSUM="447f5144ada471a6c83b7936ab60e634c48d102b" CHECKSUMTYPE="SHA-1" SIZE="4472">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:11:56" MIMETYPE="text/xml" CHECKSUM="447f5144ada471a6c83b7936ab60e634c48d102b" CHECKSUMTYPE="SHA-1" SIZE="4472">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:11:57" MIMETYPE="text/xml"
-				CHECKSUM="6346591337c818bc2bd6fcc0f1238639c0eedb70" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:11:57" MIMETYPE="text/xml" CHECKSUM="6346591337c818bc2bd6fcc0f1238639c0eedb70" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:11:57" MIMETYPE="text/xml"
-				CHECKSUM="cb634232f5a42c259fbd52303819cfcdb704bcbc" CHECKSUMTYPE="SHA-1" SIZE="74832">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:11:57" MIMETYPE="text/xml" CHECKSUM="cb634232f5a42c259fbd52303819cfcdb704bcbc" CHECKSUMTYPE="SHA-1" SIZE="74832">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:11:57" MIMETYPE="text/xml"
-				CHECKSUM="73c1a5315959cbd141729c8db12cfd6ee1f8296a" CHECKSUMTYPE="SHA-1" SIZE="186612">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:11:57" MIMETYPE="text/xml" CHECKSUM="73c1a5315959cbd141729c8db12cfd6ee1f8296a" CHECKSUMTYPE="SHA-1" SIZE="186612">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:11:58" MIMETYPE="text/xml"
-				CHECKSUM="1b0be227660fea3187b196ec71743b66167b042a" CHECKSUMTYPE="SHA-1" SIZE="182147">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:11:58" MIMETYPE="text/xml" CHECKSUM="1b0be227660fea3187b196ec71743b66167b042a" CHECKSUMTYPE="SHA-1" SIZE="182147">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:11:58" MIMETYPE="text/xml"
-				CHECKSUM="5118cee8b048b907239e3545b4bf5cae27cf691e" CHECKSUMTYPE="SHA-1" SIZE="179382">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:11:58" MIMETYPE="text/xml" CHECKSUM="5118cee8b048b907239e3545b4bf5cae27cf691e" CHECKSUMTYPE="SHA-1" SIZE="179382">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:11:59" MIMETYPE="text/xml"
-				CHECKSUM="f99068d3a5472626d7bfe13285828b2b82287ff4" CHECKSUMTYPE="SHA-1" SIZE="189690">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:11:59" MIMETYPE="text/xml" CHECKSUM="f99068d3a5472626d7bfe13285828b2b82287ff4" CHECKSUMTYPE="SHA-1" SIZE="189690">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:11:59" MIMETYPE="text/xml"
-				CHECKSUM="0f46681607d5d01bb00b246620fedd31c56e8b2f" CHECKSUMTYPE="SHA-1" SIZE="111004">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:11:59" MIMETYPE="text/xml" CHECKSUM="0f46681607d5d01bb00b246620fedd31c56e8b2f" CHECKSUMTYPE="SHA-1" SIZE="111004">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:11:59" MIMETYPE="text/xml"
-				CHECKSUM="337cbafbe3295a0b13354724d72a01597045d1d5" CHECKSUMTYPE="SHA-1" SIZE="144837">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:11:59" MIMETYPE="text/xml" CHECKSUM="337cbafbe3295a0b13354724d72a01597045d1d5" CHECKSUMTYPE="SHA-1" SIZE="144837">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:12:00" MIMETYPE="text/xml"
-				CHECKSUM="8ddab36c85fe1ec5facad28c50711efec263d92b" CHECKSUMTYPE="SHA-1" SIZE="84702">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:12:00" MIMETYPE="text/xml" CHECKSUM="8ddab36c85fe1ec5facad28c50711efec263d92b" CHECKSUMTYPE="SHA-1" SIZE="84702">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:12:00" MIMETYPE="text/xml"
-				CHECKSUM="b67790a60f79089dd6f417e79832d4facec4b558" CHECKSUMTYPE="SHA-1" SIZE="5984">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:12:00" MIMETYPE="text/xml" CHECKSUM="b67790a60f79089dd6f417e79832d4facec4b558" CHECKSUMTYPE="SHA-1" SIZE="5984">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:12:00" MIMETYPE="text/xml"
-				CHECKSUM="40bf583e43bf56a40edbf0e427ec878969d7854a" CHECKSUMTYPE="SHA-1" SIZE="2012">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:12:00" MIMETYPE="text/xml" CHECKSUM="40bf583e43bf56a40edbf0e427ec878969d7854a" CHECKSUMTYPE="SHA-1" SIZE="2012">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:12:01" MIMETYPE="text/xml"
-				CHECKSUM="4abb40fc5b07ccd6a238be8b4b3fb8dba9186588" CHECKSUMTYPE="SHA-1" SIZE="44870">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:12:01" MIMETYPE="text/xml" CHECKSUM="4abb40fc5b07ccd6a238be8b4b3fb8dba9186588" CHECKSUMTYPE="SHA-1" SIZE="44870">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:12:01" MIMETYPE="text/xml"
-				CHECKSUM="56778b3d71a2e8c5173d51c9abbe38b3dad822ed" CHECKSUMTYPE="SHA-1" SIZE="66304">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:12:01" MIMETYPE="text/xml" CHECKSUM="56778b3d71a2e8c5173d51c9abbe38b3dad822ed" CHECKSUMTYPE="SHA-1" SIZE="66304">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:12:01" MIMETYPE="text/xml"
-				CHECKSUM="c4b67f442052be8e315abf074c33b9dc2374c5ea" CHECKSUMTYPE="SHA-1" SIZE="197063">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:12:01" MIMETYPE="text/xml" CHECKSUM="c4b67f442052be8e315abf074c33b9dc2374c5ea" CHECKSUMTYPE="SHA-1" SIZE="197063">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:12:01" MIMETYPE="text/xml"
-				CHECKSUM="8e3ae99eae4b741f8f3bef5e0da48e48e93caa19" CHECKSUMTYPE="SHA-1" SIZE="185092">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:12:01" MIMETYPE="text/xml" CHECKSUM="8e3ae99eae4b741f8f3bef5e0da48e48e93caa19" CHECKSUMTYPE="SHA-1" SIZE="185092">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:12:02" MIMETYPE="text/xml"
-				CHECKSUM="f23643b875bccd058d1f275a426e0139588b6144" CHECKSUMTYPE="SHA-1" SIZE="193721">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:12:02" MIMETYPE="text/xml" CHECKSUM="f23643b875bccd058d1f275a426e0139588b6144" CHECKSUMTYPE="SHA-1" SIZE="193721">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:12:02" MIMETYPE="text/xml"
-				CHECKSUM="99bcdd0f5f3655d0bd80e5f864f64414e93ab87d" CHECKSUMTYPE="SHA-1" SIZE="180938">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:12:02" MIMETYPE="text/xml" CHECKSUM="99bcdd0f5f3655d0bd80e5f864f64414e93ab87d" CHECKSUMTYPE="SHA-1" SIZE="180938">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:12:02" MIMETYPE="text/xml"
-				CHECKSUM="65e2cda069ed41ff13faa73987b4170bd176baaf" CHECKSUMTYPE="SHA-1" SIZE="4629">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:12:02" MIMETYPE="text/xml" CHECKSUM="65e2cda069ed41ff13faa73987b4170bd176baaf" CHECKSUMTYPE="SHA-1" SIZE="4629">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:12:03" MIMETYPE="text/xml"
-				CHECKSUM="1a4f4dbd330a4c042778a9f03f02148a8ace3fab" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:12:03" MIMETYPE="text/xml" CHECKSUM="1a4f4dbd330a4c042778a9f03f02148a8ace3fab" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:12:03" MIMETYPE="text/xml"
-				CHECKSUM="c8e64c9bb98faca3b586170409d5747f47066990" CHECKSUMTYPE="SHA-1" SIZE="46613">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:12:03" MIMETYPE="text/xml" CHECKSUM="c8e64c9bb98faca3b586170409d5747f47066990" CHECKSUMTYPE="SHA-1" SIZE="46613">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:12:03" MIMETYPE="text/xml"
-				CHECKSUM="cdbb7aa60a2105deea40528cb6dd7ca41f9aec70" CHECKSUMTYPE="SHA-1" SIZE="92843">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:12:03" MIMETYPE="text/xml" CHECKSUM="cdbb7aa60a2105deea40528cb6dd7ca41f9aec70" CHECKSUMTYPE="SHA-1" SIZE="92843">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:12:03" MIMETYPE="text/xml"
-				CHECKSUM="43ceab0190c0d86b86498ca79d50f1c52a685095" CHECKSUMTYPE="SHA-1" SIZE="141048">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:12:03" MIMETYPE="text/xml" CHECKSUM="43ceab0190c0d86b86498ca79d50f1c52a685095" CHECKSUMTYPE="SHA-1" SIZE="141048">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:12:04" MIMETYPE="text/xml"
-				CHECKSUM="cb56325709cdef9a7ec1e696866460b4b53b3b30" CHECKSUMTYPE="SHA-1" SIZE="99337">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:12:04" MIMETYPE="text/xml" CHECKSUM="cb56325709cdef9a7ec1e696866460b4b53b3b30" CHECKSUMTYPE="SHA-1" SIZE="99337">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:12:04" MIMETYPE="text/xml"
-				CHECKSUM="614055c7b4a8b23f8689a35d5be4248a641eb1a1" CHECKSUMTYPE="SHA-1" SIZE="136878">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:12:04" MIMETYPE="text/xml" CHECKSUM="614055c7b4a8b23f8689a35d5be4248a641eb1a1" CHECKSUMTYPE="SHA-1" SIZE="136878">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:12:04" MIMETYPE="text/xml"
-				CHECKSUM="667a8571f31a36ee714289f275b37727248c9738" CHECKSUMTYPE="SHA-1" SIZE="22953">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:12:04" MIMETYPE="text/xml" CHECKSUM="667a8571f31a36ee714289f275b37727248c9738" CHECKSUMTYPE="SHA-1" SIZE="22953">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:12:05" MIMETYPE="text/xml"
-				CHECKSUM="017828c98de06052eaf668e016443ac4f616b172" CHECKSUMTYPE="SHA-1" SIZE="58299">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:12:05" MIMETYPE="text/xml" CHECKSUM="017828c98de06052eaf668e016443ac4f616b172" CHECKSUMTYPE="SHA-1" SIZE="58299">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:12:05" MIMETYPE="text/xml"
-				CHECKSUM="f95a3d040e3d272a3b60b29f381bb575024db96a" CHECKSUMTYPE="SHA-1" SIZE="36463">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:12:05" MIMETYPE="text/xml" CHECKSUM="f95a3d040e3d272a3b60b29f381bb575024db96a" CHECKSUMTYPE="SHA-1" SIZE="36463">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:12:05" MIMETYPE="text/xml"
-				CHECKSUM="5dcaa6f86cd41d2b74860ded35b0e9ad5ffbf565" CHECKSUMTYPE="SHA-1" SIZE="21026">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:12:05" MIMETYPE="text/xml" CHECKSUM="5dcaa6f86cd41d2b74860ded35b0e9ad5ffbf565" CHECKSUMTYPE="SHA-1" SIZE="21026">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:12:05" MIMETYPE="text/xml"
-				CHECKSUM="5bb4d1cb546679f9d88f29a97eda8d8b2b79ccde" CHECKSUMTYPE="SHA-1" SIZE="46209">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:12:05" MIMETYPE="text/xml" CHECKSUM="5bb4d1cb546679f9d88f29a97eda8d8b2b79ccde" CHECKSUMTYPE="SHA-1" SIZE="46209">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:12:06" MIMETYPE="text/xml"
-				CHECKSUM="b8285020e5e8dda4c04fcc23b4744a48df92e8bd" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:12:06" MIMETYPE="text/xml" CHECKSUM="b8285020e5e8dda4c04fcc23b4744a48df92e8bd" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:12:06" MIMETYPE="text/xml"
-				CHECKSUM="b4ce427f5e1348fcde119ab158ccce8a5b56b994" CHECKSUMTYPE="SHA-1" SIZE="3616">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:12:06" MIMETYPE="text/xml" CHECKSUM="b4ce427f5e1348fcde119ab158ccce8a5b56b994" CHECKSUMTYPE="SHA-1" SIZE="3616">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-04_01_0090.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:15:18" MIMETYPE="application/pdf" CHECKSUM="66fed1094ba7d8b216b29d5095c5f20f881f2d10"
-				CHECKSUMTYPE="SHA-1" SIZE="43443617">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/bmtnabe_1898-04_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:15:18" MIMETYPE="application/pdf" CHECKSUM="66fed1094ba7d8b216b29d5095c5f20f881f2d10" CHECKSUMTYPE="SHA-1" SIZE="43443617">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/04_01/bmtnabe_1898-04_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -11790,8 +11514,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00080" BEGIN="P80_TB00003"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.36.3" TYPE="Illustration" ORDER="1" DMDID="c105"
-						LABEL="DIESE FRAGMENTZEICHNUNGEN NACH VAN DE VELDE’SCHEN MOEBELN SIND VON HUGO ULBRICH">
+					<div ID="L.1.1.36.3" TYPE="Illustration" ORDER="1" DMDID="c105" LABEL="DIESE FRAGMENTZEICHNUNGEN NACH VAN DE VELDE’SCHEN MOEBELN SIND VON HUGO ULBRICH">
 						<div ID="L.1.1.36.3.1" TYPE="Image">
 							<fptr>
 								<seq>

--- a/metadata/periodicals/bmtnabe/issues/1898/05_01/bmtnabe_1898-05_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1898/05_01/bmtnabe_1898-05_01.mets.xml
@@ -18,9 +18,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1998-05_01</recordIdentifier>
+						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-05_01</recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1998-05_01</identifier>
+					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1898-05_01</identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -33,7 +33,7 @@
 					</part>
 					<originInfo>
 						<dateIssued/>
-						<dateIssued keyDate="yes" encoding="w3cdtf">1998-05</dateIssued>
+						<dateIssued keyDate="yes" encoding="w3cdtf">1898-05</dateIssued>
 					</originInfo>
 					<location>
 						<physicalLocation type="text">Princeton University. Marquand Library</physicalLocation>

--- a/metadata/periodicals/bmtnabe/issues/1898/05_01/bmtnabe_1898-05_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1898/05_01/bmtnabe_1898-05_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1898-05_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1898-05_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-05_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-05_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1898-05_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1898-05_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-05_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -8719,878 +8715,588 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-08-01T18:33:32" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="93cd13b3c2dc82b6fbd5647ec215574c92326fda" CHECKSUMTYPE="SHA-1" SIZE="4842125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-08-01T18:34:01" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="f1123329268b35369449abbff92bdc5d099c4786" CHECKSUMTYPE="SHA-1" SIZE="4993326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-08-01T18:34:31" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="b930447e4cef2463d067ef168113ddba29e2eda3" CHECKSUMTYPE="SHA-1" SIZE="4830336">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-08-01T18:34:54" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="f64288e75ec38d4ed051f7a7190f555b11483c33" CHECKSUMTYPE="SHA-1" SIZE="4973443">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-08-01T18:35:16" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="21959f92ccc438a53f070e67398d10cd5289ea21" CHECKSUMTYPE="SHA-1" SIZE="4816925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-08-01T18:35:39" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="60d0d60efa53bcf10ce7ce32ea55d7df3d6dfeec" CHECKSUMTYPE="SHA-1" SIZE="4979827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-08-01T18:36:02" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="6213821c4e005ef3dd416a8a67be83744922628d" CHECKSUMTYPE="SHA-1" SIZE="4806968">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-08-01T18:36:24" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="eee72627cdbc602b261308b4fe760f4b72c145ad" CHECKSUMTYPE="SHA-1" SIZE="4980721">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-08-01T18:36:47" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="ced75ea40729da8af7e141f11cb08bad6864460b" CHECKSUMTYPE="SHA-1" SIZE="4780929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-08-01T18:37:12" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="85cabddf733a4842b14ec2d4fbbd4bc7c533be7e" CHECKSUMTYPE="SHA-1" SIZE="4985225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-08-01T18:37:35" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="941246cc7b72e39558883904888baba0537eaa09" CHECKSUMTYPE="SHA-1" SIZE="4761991">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-08-01T18:37:58" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="57a218204e5b9beb6114732eda4d6b6963bd38e2" CHECKSUMTYPE="SHA-1" SIZE="4986111">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-08-01T18:38:25" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="994fab74f670ab439da26ff5a548bdb2e4544b60" CHECKSUMTYPE="SHA-1" SIZE="4765628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-08-01T18:38:50" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="4c2ac8fc1320d6f3a2d471f42ef8112c39357e5d" CHECKSUMTYPE="SHA-1" SIZE="4946513">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-08-01T18:39:15" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="343988099cbdc1bbdba09d90211249cb7ad0817a" CHECKSUMTYPE="SHA-1" SIZE="4700829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-08-01T18:39:38" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="4fd316494a2218a90a268146e7e81cfdd624db0d" CHECKSUMTYPE="SHA-1" SIZE="4990629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-08-01T18:40:00" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="2f03dad3ff12408671e888c0b7da599e4152184e" CHECKSUMTYPE="SHA-1" SIZE="4724226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-08-01T18:40:26" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="96e62d5c3569b05c21b3eac1cd9db20bbda94bd5" CHECKSUMTYPE="SHA-1" SIZE="5022128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-08-01T18:40:52" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="6c21bb8c67d0d880bdbbb817f109f7358b97df10" CHECKSUMTYPE="SHA-1" SIZE="4762929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-08-01T18:41:14" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="662d70e3309eefa3fa9a9925107f9f1880953261" CHECKSUMTYPE="SHA-1" SIZE="4969900">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-08-01T18:41:38" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="8a9ff59438a95f297b750ec586f2ded63704cb96" CHECKSUMTYPE="SHA-1" SIZE="4702431">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-08-01T18:42:02" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="9b724c1d9e482f57d25f06de18f28d22de2a4d06" CHECKSUMTYPE="SHA-1" SIZE="4975329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-08-01T18:42:27" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="e809fd220511f3916cfb1d11b07eca0981bc9f3c" CHECKSUMTYPE="SHA-1" SIZE="4710729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-08-01T18:42:52" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="5d817d5c574e2280b13d56036a212b521e85be35" CHECKSUMTYPE="SHA-1" SIZE="5016729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-08-01T18:43:17" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="31f4db5a795c7f2bc0680840ac82333ea160c486" CHECKSUMTYPE="SHA-1" SIZE="4738628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-08-01T18:43:41" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="3561feb37447910ce8c29586db0633bba0f9f064" CHECKSUMTYPE="SHA-1" SIZE="5046428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-08-01T18:44:05" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="e20b6cc4f0406d15f9943386582067daab296523" CHECKSUMTYPE="SHA-1" SIZE="4715229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-08-01T18:44:28" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="8c210e78f33992e525fb72ef315c29301ab15417" CHECKSUMTYPE="SHA-1" SIZE="5034719">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-08-01T18:44:51" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="9ae1aed7010b8bc215237bdbb6e27dc135dc2a83" CHECKSUMTYPE="SHA-1" SIZE="4727828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-08-01T18:45:17" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="a0c14bed4bcb8ae67144994c7be1a1026f201794" CHECKSUMTYPE="SHA-1" SIZE="5016711">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-08-01T18:45:40" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="a7655831f901278659055deecf22379a3d927ec1" CHECKSUMTYPE="SHA-1" SIZE="4678324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-08-01T18:46:01" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="b5d77d756f7d2c88f892be4bd3d355ffec1ff1ee" CHECKSUMTYPE="SHA-1" SIZE="5035626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-08-01T18:46:27" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="0298de3d297ddf37996af52d40360d7bd2b45e62" CHECKSUMTYPE="SHA-1" SIZE="4757511">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-08-01T18:46:54" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="c31608d2a1fa70f0685574aa962e057b0a632075" CHECKSUMTYPE="SHA-1" SIZE="5021227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-08-01T18:47:20" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="ece4e102c32848f31af926784eca6e4349a810c9" CHECKSUMTYPE="SHA-1" SIZE="4696328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-08-01T18:47:46" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="1ad8a6c47a9e35f0afe497b80945cd8e35a17f63" CHECKSUMTYPE="SHA-1" SIZE="5029327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-08-01T18:48:14" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="0b72b07afdfba109118219d14b7bc8ecf50ba272" CHECKSUMTYPE="SHA-1" SIZE="4765599">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-08-01T18:48:41" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="cf9f3eb8e4b704c2236a4f53df1312cbf84ece4c" CHECKSUMTYPE="SHA-1" SIZE="5027528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-08-01T18:49:07" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="c05b37d1449011eca93e3b82b61dbdbc1fdb8d78" CHECKSUMTYPE="SHA-1" SIZE="4724111">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-08-01T18:49:33" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="56c0649b9a4373c14afca5f77a273ccf0c9523cf" CHECKSUMTYPE="SHA-1" SIZE="5083329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-08-01T18:49:59" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="60d8d2055b6809704775e6333ee17c06671957bd" CHECKSUMTYPE="SHA-1" SIZE="4765627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-08-01T18:50:25" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="25936bbd1a9a355a719922e49248a13eee542efc" CHECKSUMTYPE="SHA-1" SIZE="5031129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-08-01T18:50:50" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="6cd0673fd3585a566c55bf8a0d15294403906472" CHECKSUMTYPE="SHA-1" SIZE="4814224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-08-01T18:51:17" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="e510e97268aba80ebec19674707ca2780af0744a" CHECKSUMTYPE="SHA-1" SIZE="5083327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-08-01T18:51:43" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="dd196db835203a8adbf24733155da89c18a50f61" CHECKSUMTYPE="SHA-1" SIZE="4779127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-08-01T18:52:08" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="7dba7b3c785a519ea17b74ced2e36387e0528a15" CHECKSUMTYPE="SHA-1" SIZE="5060829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-08-01T18:52:33" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="30d2bc33ccf6f8d2519335c6ff7e2326700db7d7" CHECKSUMTYPE="SHA-1" SIZE="4779129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-08-01T18:53:01" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="fd198161b288bfd4fb0d3ccb7891f7eebfe7c2e7" CHECKSUMTYPE="SHA-1" SIZE="5069819">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-08-01T18:53:28" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="0e7f7c5965f39eeb86a78f460f2d8eb0edbc3338" CHECKSUMTYPE="SHA-1" SIZE="4781829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-08-01T18:53:56" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="19fc33cc1601ff84e0619f719d8d4557066bcd23" CHECKSUMTYPE="SHA-1" SIZE="5073425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-08-01T18:54:25" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="892b6f8032f02f1deb03fb1abb1481bed7584a48" CHECKSUMTYPE="SHA-1" SIZE="4753923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-08-01T18:54:55" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="b391059bb227201e2ac7c166ec61997fc7b1c027" CHECKSUMTYPE="SHA-1" SIZE="5076119">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-08-01T18:55:24" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="a78c4cea2abff7e15074b17a38e0095126e0ac56" CHECKSUMTYPE="SHA-1" SIZE="4754826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-08-01T18:55:53" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="2ca7da1f75e65d4612258309d75bf8f1945b7362" CHECKSUMTYPE="SHA-1" SIZE="5067118">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-08-01T18:56:21" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="dc43195147141477215f45271562444399c549a2" CHECKSUMTYPE="SHA-1" SIZE="4812427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-08-01T18:56:48" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="013ec31f0ccbed3388e960d040c209e4e38e00e2" CHECKSUMTYPE="SHA-1" SIZE="5094128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-08-01T18:57:17" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="23b3e97190be6f647417c9dc97c3ac5a0fb17f47" CHECKSUMTYPE="SHA-1" SIZE="4851116">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-08-01T18:57:45" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="8475741f1ab6ac7417b71070ff605ec7d57e355a" CHECKSUMTYPE="SHA-1" SIZE="5088726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-08-01T18:58:14" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="a5ca36e094a935928e91a429869b266edacf4e1d" CHECKSUMTYPE="SHA-1" SIZE="4864629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-08-01T18:58:42" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="bb2228862a70e6deecbe1a8e43d0d4e62e3c3e52" CHECKSUMTYPE="SHA-1" SIZE="5131926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-08-01T18:59:11" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="ea55bcfc7aa39d9a830c1dbf36d6989e01ecb72f" CHECKSUMTYPE="SHA-1" SIZE="4917728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-08-01T18:59:39" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="85d0f31e7743a2759d0df4b6747084355cf0e4b0" CHECKSUMTYPE="SHA-1" SIZE="5097729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-08-01T19:00:08" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="cbd8813ced86d22960e74b5ad91d882b3ab82d4c" CHECKSUMTYPE="SHA-1" SIZE="4924929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-08-01T19:00:37" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="e28befe7a54302b32a0424729be941771dc8f2c6" CHECKSUMTYPE="SHA-1" SIZE="5109427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-08-01T19:01:07" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="2c9e4c4457060a05bd796011646a13cd8fd60ec0" CHECKSUMTYPE="SHA-1" SIZE="4928523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-08-01T19:01:36" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="4e5d3d23787cd7b097713cb58051904a7b4737bc" CHECKSUMTYPE="SHA-1" SIZE="5137328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-08-01T19:02:06" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="0adc122679e488b9ba4aa99d8e7a4526e35dda76" CHECKSUMTYPE="SHA-1" SIZE="4913212">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-08-01T19:02:38" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="e7ca976f0ccd27d7f1a6427dc3057a4176758e82" CHECKSUMTYPE="SHA-1" SIZE="5115724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-08-01T19:03:05" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="4aca5abe3d7712ee4dcff9245eab072553f7948d" CHECKSUMTYPE="SHA-1" SIZE="4922222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-08-01T19:03:34" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="822a9abe9ec5d10e56c954bc37191789c8f46abf" CHECKSUMTYPE="SHA-1" SIZE="5105806">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-08-01T19:04:03" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="5cfcbcbdfce6a90d8a11c179406ea3e55f2897ce" CHECKSUMTYPE="SHA-1" SIZE="4956412">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-08-01T19:04:32" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="6cee5a464cad329a2807f33ca9db071ac0bc2298" CHECKSUMTYPE="SHA-1" SIZE="5136425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-08-01T19:05:00" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="6d4abd6ed9c2830a9082d41db2da7baf5107942f" CHECKSUMTYPE="SHA-1" SIZE="4938385">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-08-01T19:05:28" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="71d09b86a9e6e0ed6f2411c8c6c9961a45b383b0" CHECKSUMTYPE="SHA-1" SIZE="5143625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-08-01T19:05:56" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="902530603666a5f23f87959656a6b68af135258a" CHECKSUMTYPE="SHA-1" SIZE="4930328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-08-01T19:06:27" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="170fd4baf47da4bbc82684d8b238f7bf5ca79599" CHECKSUMTYPE="SHA-1" SIZE="5122929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-08-01T19:06:56" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="de5763a55d736fa279c5e98bdfc8615c01a8b72f" CHECKSUMTYPE="SHA-1" SIZE="4908577">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-08-01T19:07:24" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="24d80ee8e188053f16e1ca64bb49ea83d0befaa0" CHECKSUMTYPE="SHA-1" SIZE="5152624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-08-01T19:07:54" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="ac273c1efaf3744075b8e6b38e0f48fa80c3db57" CHECKSUMTYPE="SHA-1" SIZE="4969929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-08-01T19:08:23" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="96f14ecc617d76ad80748e804356bc7bc4492bc7" CHECKSUMTYPE="SHA-1" SIZE="5199429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-08-01T19:08:53" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="4a89abcf12e0fc97e74a0a351e45557c68c1b2fc" CHECKSUMTYPE="SHA-1" SIZE="5065316">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-08-01T19:09:22" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="53bb8634fc541303f1c8d1c82e2643f0cea9bce5" CHECKSUMTYPE="SHA-1" SIZE="5164329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-08-01T19:09:52" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="1abaa3b38d6360d9d5036f6fcb1a577525a194da" CHECKSUMTYPE="SHA-1" SIZE="4989719">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-08-01T19:10:23" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="54d7273dd8fe40c4c809a315405f89009997be76" CHECKSUMTYPE="SHA-1" SIZE="5186827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-08-01T19:10:53" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="950575504ba57b4787a78758d0b6925485f1cc81" CHECKSUMTYPE="SHA-1" SIZE="4973529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-08-01T19:11:21" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="4f38033061a627cad17cb5c3bdc88e18498807be" CHECKSUMTYPE="SHA-1" SIZE="5222829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-08-01T19:11:48" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="6aa817e0dccb5ce35bd010d05bbde041b54ca162" CHECKSUMTYPE="SHA-1" SIZE="4968127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-08-01T19:12:16" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="61a37ad82a0fdbd7843746998984402718087040" CHECKSUMTYPE="SHA-1" SIZE="5158925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-08-01T19:12:45" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="7aceabd851d25d0eb442448e7a099b160e53ac86" CHECKSUMTYPE="SHA-1" SIZE="4961827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-08-01T19:13:14" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="258b0d872377f795570d50f068fd8613d2d2e85e" CHECKSUMTYPE="SHA-1" SIZE="5203929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-08-01T19:13:43" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="f32cf2ce686e6f918b3ee2acc142174110077b22" CHECKSUMTYPE="SHA-1" SIZE="4933927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-08-01T19:14:09" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="de038dd9a310d7f71efaf36c5252c95566aa6bbc" CHECKSUMTYPE="SHA-1" SIZE="5156229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-08-01T19:14:35" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="fc76d74f3e649faf9e5f4a1becb292f9f67d99c5" CHECKSUMTYPE="SHA-1" SIZE="4925823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-08-01T19:15:02" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="ef1d9aff3fa26566d09d4170e215b5d2b6aee76b" CHECKSUMTYPE="SHA-1" SIZE="5167917">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0094.jp2"/>
-			</file>
-			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-08-01T19:15:29" MIMETYPE="image/jp2" SEQ="95"
-				CHECKSUM="85f2e2ea1ffd094caa5c0126aee7f1e605dd25dc" CHECKSUMTYPE="SHA-1" SIZE="5015829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0095.jp2"/>
-			</file>
-			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-08-01T19:16:01" MIMETYPE="image/jp2" SEQ="96"
-				CHECKSUM="b48dd8989bda1691a1ae3a2ea10f9d58104193a3" CHECKSUMTYPE="SHA-1" SIZE="5214684">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0096.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-08-01T18:33:32" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="93cd13b3c2dc82b6fbd5647ec215574c92326fda" CHECKSUMTYPE="SHA-1" SIZE="4842125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-08-01T18:34:01" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="f1123329268b35369449abbff92bdc5d099c4786" CHECKSUMTYPE="SHA-1" SIZE="4993326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-08-01T18:34:31" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="b930447e4cef2463d067ef168113ddba29e2eda3" CHECKSUMTYPE="SHA-1" SIZE="4830336">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-08-01T18:34:54" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="f64288e75ec38d4ed051f7a7190f555b11483c33" CHECKSUMTYPE="SHA-1" SIZE="4973443">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-08-01T18:35:16" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="21959f92ccc438a53f070e67398d10cd5289ea21" CHECKSUMTYPE="SHA-1" SIZE="4816925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-08-01T18:35:39" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="60d0d60efa53bcf10ce7ce32ea55d7df3d6dfeec" CHECKSUMTYPE="SHA-1" SIZE="4979827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-08-01T18:36:02" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="6213821c4e005ef3dd416a8a67be83744922628d" CHECKSUMTYPE="SHA-1" SIZE="4806968">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-08-01T18:36:24" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="eee72627cdbc602b261308b4fe760f4b72c145ad" CHECKSUMTYPE="SHA-1" SIZE="4980721">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-08-01T18:36:47" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="ced75ea40729da8af7e141f11cb08bad6864460b" CHECKSUMTYPE="SHA-1" SIZE="4780929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-08-01T18:37:12" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="85cabddf733a4842b14ec2d4fbbd4bc7c533be7e" CHECKSUMTYPE="SHA-1" SIZE="4985225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-08-01T18:37:35" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="941246cc7b72e39558883904888baba0537eaa09" CHECKSUMTYPE="SHA-1" SIZE="4761991">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-08-01T18:37:58" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="57a218204e5b9beb6114732eda4d6b6963bd38e2" CHECKSUMTYPE="SHA-1" SIZE="4986111">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-08-01T18:38:25" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="994fab74f670ab439da26ff5a548bdb2e4544b60" CHECKSUMTYPE="SHA-1" SIZE="4765628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-08-01T18:38:50" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="4c2ac8fc1320d6f3a2d471f42ef8112c39357e5d" CHECKSUMTYPE="SHA-1" SIZE="4946513">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-08-01T18:39:15" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="343988099cbdc1bbdba09d90211249cb7ad0817a" CHECKSUMTYPE="SHA-1" SIZE="4700829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-08-01T18:39:38" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="4fd316494a2218a90a268146e7e81cfdd624db0d" CHECKSUMTYPE="SHA-1" SIZE="4990629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-08-01T18:40:00" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="2f03dad3ff12408671e888c0b7da599e4152184e" CHECKSUMTYPE="SHA-1" SIZE="4724226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-08-01T18:40:26" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="96e62d5c3569b05c21b3eac1cd9db20bbda94bd5" CHECKSUMTYPE="SHA-1" SIZE="5022128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-08-01T18:40:52" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="6c21bb8c67d0d880bdbbb817f109f7358b97df10" CHECKSUMTYPE="SHA-1" SIZE="4762929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-08-01T18:41:14" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="662d70e3309eefa3fa9a9925107f9f1880953261" CHECKSUMTYPE="SHA-1" SIZE="4969900">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-08-01T18:41:38" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="8a9ff59438a95f297b750ec586f2ded63704cb96" CHECKSUMTYPE="SHA-1" SIZE="4702431">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-08-01T18:42:02" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="9b724c1d9e482f57d25f06de18f28d22de2a4d06" CHECKSUMTYPE="SHA-1" SIZE="4975329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-08-01T18:42:27" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="e809fd220511f3916cfb1d11b07eca0981bc9f3c" CHECKSUMTYPE="SHA-1" SIZE="4710729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-08-01T18:42:52" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="5d817d5c574e2280b13d56036a212b521e85be35" CHECKSUMTYPE="SHA-1" SIZE="5016729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-08-01T18:43:17" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="31f4db5a795c7f2bc0680840ac82333ea160c486" CHECKSUMTYPE="SHA-1" SIZE="4738628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-08-01T18:43:41" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="3561feb37447910ce8c29586db0633bba0f9f064" CHECKSUMTYPE="SHA-1" SIZE="5046428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-08-01T18:44:05" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="e20b6cc4f0406d15f9943386582067daab296523" CHECKSUMTYPE="SHA-1" SIZE="4715229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-08-01T18:44:28" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="8c210e78f33992e525fb72ef315c29301ab15417" CHECKSUMTYPE="SHA-1" SIZE="5034719">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-08-01T18:44:51" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="9ae1aed7010b8bc215237bdbb6e27dc135dc2a83" CHECKSUMTYPE="SHA-1" SIZE="4727828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-08-01T18:45:17" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="a0c14bed4bcb8ae67144994c7be1a1026f201794" CHECKSUMTYPE="SHA-1" SIZE="5016711">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-08-01T18:45:40" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="a7655831f901278659055deecf22379a3d927ec1" CHECKSUMTYPE="SHA-1" SIZE="4678324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-08-01T18:46:01" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="b5d77d756f7d2c88f892be4bd3d355ffec1ff1ee" CHECKSUMTYPE="SHA-1" SIZE="5035626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-08-01T18:46:27" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="0298de3d297ddf37996af52d40360d7bd2b45e62" CHECKSUMTYPE="SHA-1" SIZE="4757511">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-08-01T18:46:54" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="c31608d2a1fa70f0685574aa962e057b0a632075" CHECKSUMTYPE="SHA-1" SIZE="5021227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-08-01T18:47:20" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="ece4e102c32848f31af926784eca6e4349a810c9" CHECKSUMTYPE="SHA-1" SIZE="4696328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-08-01T18:47:46" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="1ad8a6c47a9e35f0afe497b80945cd8e35a17f63" CHECKSUMTYPE="SHA-1" SIZE="5029327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-08-01T18:48:14" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="0b72b07afdfba109118219d14b7bc8ecf50ba272" CHECKSUMTYPE="SHA-1" SIZE="4765599">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-08-01T18:48:41" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="cf9f3eb8e4b704c2236a4f53df1312cbf84ece4c" CHECKSUMTYPE="SHA-1" SIZE="5027528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-08-01T18:49:07" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="c05b37d1449011eca93e3b82b61dbdbc1fdb8d78" CHECKSUMTYPE="SHA-1" SIZE="4724111">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-08-01T18:49:33" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="56c0649b9a4373c14afca5f77a273ccf0c9523cf" CHECKSUMTYPE="SHA-1" SIZE="5083329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-08-01T18:49:59" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="60d8d2055b6809704775e6333ee17c06671957bd" CHECKSUMTYPE="SHA-1" SIZE="4765627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-08-01T18:50:25" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="25936bbd1a9a355a719922e49248a13eee542efc" CHECKSUMTYPE="SHA-1" SIZE="5031129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-08-01T18:50:50" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="6cd0673fd3585a566c55bf8a0d15294403906472" CHECKSUMTYPE="SHA-1" SIZE="4814224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-08-01T18:51:17" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="e510e97268aba80ebec19674707ca2780af0744a" CHECKSUMTYPE="SHA-1" SIZE="5083327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-08-01T18:51:43" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="dd196db835203a8adbf24733155da89c18a50f61" CHECKSUMTYPE="SHA-1" SIZE="4779127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-08-01T18:52:08" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="7dba7b3c785a519ea17b74ced2e36387e0528a15" CHECKSUMTYPE="SHA-1" SIZE="5060829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-08-01T18:52:33" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="30d2bc33ccf6f8d2519335c6ff7e2326700db7d7" CHECKSUMTYPE="SHA-1" SIZE="4779129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-08-01T18:53:01" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="fd198161b288bfd4fb0d3ccb7891f7eebfe7c2e7" CHECKSUMTYPE="SHA-1" SIZE="5069819">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-08-01T18:53:28" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="0e7f7c5965f39eeb86a78f460f2d8eb0edbc3338" CHECKSUMTYPE="SHA-1" SIZE="4781829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-08-01T18:53:56" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="19fc33cc1601ff84e0619f719d8d4557066bcd23" CHECKSUMTYPE="SHA-1" SIZE="5073425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-08-01T18:54:25" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="892b6f8032f02f1deb03fb1abb1481bed7584a48" CHECKSUMTYPE="SHA-1" SIZE="4753923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-08-01T18:54:55" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="b391059bb227201e2ac7c166ec61997fc7b1c027" CHECKSUMTYPE="SHA-1" SIZE="5076119">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-08-01T18:55:24" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="a78c4cea2abff7e15074b17a38e0095126e0ac56" CHECKSUMTYPE="SHA-1" SIZE="4754826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-08-01T18:55:53" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="2ca7da1f75e65d4612258309d75bf8f1945b7362" CHECKSUMTYPE="SHA-1" SIZE="5067118">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-08-01T18:56:21" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="dc43195147141477215f45271562444399c549a2" CHECKSUMTYPE="SHA-1" SIZE="4812427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-08-01T18:56:48" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="013ec31f0ccbed3388e960d040c209e4e38e00e2" CHECKSUMTYPE="SHA-1" SIZE="5094128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-08-01T18:57:17" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="23b3e97190be6f647417c9dc97c3ac5a0fb17f47" CHECKSUMTYPE="SHA-1" SIZE="4851116">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-08-01T18:57:45" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="8475741f1ab6ac7417b71070ff605ec7d57e355a" CHECKSUMTYPE="SHA-1" SIZE="5088726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-08-01T18:58:14" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="a5ca36e094a935928e91a429869b266edacf4e1d" CHECKSUMTYPE="SHA-1" SIZE="4864629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-08-01T18:58:42" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="bb2228862a70e6deecbe1a8e43d0d4e62e3c3e52" CHECKSUMTYPE="SHA-1" SIZE="5131926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-08-01T18:59:11" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="ea55bcfc7aa39d9a830c1dbf36d6989e01ecb72f" CHECKSUMTYPE="SHA-1" SIZE="4917728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-08-01T18:59:39" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="85d0f31e7743a2759d0df4b6747084355cf0e4b0" CHECKSUMTYPE="SHA-1" SIZE="5097729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-08-01T19:00:08" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="cbd8813ced86d22960e74b5ad91d882b3ab82d4c" CHECKSUMTYPE="SHA-1" SIZE="4924929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-08-01T19:00:37" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="e28befe7a54302b32a0424729be941771dc8f2c6" CHECKSUMTYPE="SHA-1" SIZE="5109427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-08-01T19:01:07" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="2c9e4c4457060a05bd796011646a13cd8fd60ec0" CHECKSUMTYPE="SHA-1" SIZE="4928523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-08-01T19:01:36" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="4e5d3d23787cd7b097713cb58051904a7b4737bc" CHECKSUMTYPE="SHA-1" SIZE="5137328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-08-01T19:02:06" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="0adc122679e488b9ba4aa99d8e7a4526e35dda76" CHECKSUMTYPE="SHA-1" SIZE="4913212">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-08-01T19:02:38" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="e7ca976f0ccd27d7f1a6427dc3057a4176758e82" CHECKSUMTYPE="SHA-1" SIZE="5115724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-08-01T19:03:05" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="4aca5abe3d7712ee4dcff9245eab072553f7948d" CHECKSUMTYPE="SHA-1" SIZE="4922222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-08-01T19:03:34" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="822a9abe9ec5d10e56c954bc37191789c8f46abf" CHECKSUMTYPE="SHA-1" SIZE="5105806">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-08-01T19:04:03" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="5cfcbcbdfce6a90d8a11c179406ea3e55f2897ce" CHECKSUMTYPE="SHA-1" SIZE="4956412">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-08-01T19:04:32" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="6cee5a464cad329a2807f33ca9db071ac0bc2298" CHECKSUMTYPE="SHA-1" SIZE="5136425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-08-01T19:05:00" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="6d4abd6ed9c2830a9082d41db2da7baf5107942f" CHECKSUMTYPE="SHA-1" SIZE="4938385">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-08-01T19:05:28" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="71d09b86a9e6e0ed6f2411c8c6c9961a45b383b0" CHECKSUMTYPE="SHA-1" SIZE="5143625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-08-01T19:05:56" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="902530603666a5f23f87959656a6b68af135258a" CHECKSUMTYPE="SHA-1" SIZE="4930328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-08-01T19:06:27" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="170fd4baf47da4bbc82684d8b238f7bf5ca79599" CHECKSUMTYPE="SHA-1" SIZE="5122929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-08-01T19:06:56" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="de5763a55d736fa279c5e98bdfc8615c01a8b72f" CHECKSUMTYPE="SHA-1" SIZE="4908577">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-08-01T19:07:24" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="24d80ee8e188053f16e1ca64bb49ea83d0befaa0" CHECKSUMTYPE="SHA-1" SIZE="5152624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-08-01T19:07:54" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="ac273c1efaf3744075b8e6b38e0f48fa80c3db57" CHECKSUMTYPE="SHA-1" SIZE="4969929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-08-01T19:08:23" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="96f14ecc617d76ad80748e804356bc7bc4492bc7" CHECKSUMTYPE="SHA-1" SIZE="5199429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-08-01T19:08:53" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="4a89abcf12e0fc97e74a0a351e45557c68c1b2fc" CHECKSUMTYPE="SHA-1" SIZE="5065316">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-08-01T19:09:22" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="53bb8634fc541303f1c8d1c82e2643f0cea9bce5" CHECKSUMTYPE="SHA-1" SIZE="5164329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-08-01T19:09:52" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="1abaa3b38d6360d9d5036f6fcb1a577525a194da" CHECKSUMTYPE="SHA-1" SIZE="4989719">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-08-01T19:10:23" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="54d7273dd8fe40c4c809a315405f89009997be76" CHECKSUMTYPE="SHA-1" SIZE="5186827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-08-01T19:10:53" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="950575504ba57b4787a78758d0b6925485f1cc81" CHECKSUMTYPE="SHA-1" SIZE="4973529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-08-01T19:11:21" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="4f38033061a627cad17cb5c3bdc88e18498807be" CHECKSUMTYPE="SHA-1" SIZE="5222829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-08-01T19:11:48" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="6aa817e0dccb5ce35bd010d05bbde041b54ca162" CHECKSUMTYPE="SHA-1" SIZE="4968127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-08-01T19:12:16" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="61a37ad82a0fdbd7843746998984402718087040" CHECKSUMTYPE="SHA-1" SIZE="5158925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-08-01T19:12:45" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="7aceabd851d25d0eb442448e7a099b160e53ac86" CHECKSUMTYPE="SHA-1" SIZE="4961827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-08-01T19:13:14" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="258b0d872377f795570d50f068fd8613d2d2e85e" CHECKSUMTYPE="SHA-1" SIZE="5203929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-08-01T19:13:43" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="f32cf2ce686e6f918b3ee2acc142174110077b22" CHECKSUMTYPE="SHA-1" SIZE="4933927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-08-01T19:14:09" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="de038dd9a310d7f71efaf36c5252c95566aa6bbc" CHECKSUMTYPE="SHA-1" SIZE="5156229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-08-01T19:14:35" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="fc76d74f3e649faf9e5f4a1becb292f9f67d99c5" CHECKSUMTYPE="SHA-1" SIZE="4925823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-08-01T19:15:02" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="ef1d9aff3fa26566d09d4170e215b5d2b6aee76b" CHECKSUMTYPE="SHA-1" SIZE="5167917">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0094.jp2"/>
+			</file>
+			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-08-01T19:15:29" MIMETYPE="image/jp2" SEQ="95" CHECKSUM="85f2e2ea1ffd094caa5c0126aee7f1e605dd25dc" CHECKSUMTYPE="SHA-1" SIZE="5015829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0095.jp2"/>
+			</file>
+			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-08-01T19:16:01" MIMETYPE="image/jp2" SEQ="96" CHECKSUM="b48dd8989bda1691a1ae3a2ea10f9d58104193a3" CHECKSUMTYPE="SHA-1" SIZE="5214684">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/delivery/bmtnabe_1898-05_01_0096.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-08-01T19:16:21" MIMETYPE="text/xml" CHECKSUM="90e72ba85234a25fe1850db8890ef8cb2f960005"
-				CHECKSUMTYPE="SHA-1" SIZE="2112">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-08-01T19:16:21" MIMETYPE="text/xml" CHECKSUM="90e72ba85234a25fe1850db8890ef8cb2f960005" CHECKSUMTYPE="SHA-1" SIZE="2112">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-08-01T19:16:21" MIMETYPE="text/xml" CHECKSUM="6dd9d8fbcae56ea7c5ec1ac90a277643758019ab"
-				CHECKSUMTYPE="SHA-1" SIZE="1720">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-08-01T19:16:21" MIMETYPE="text/xml" CHECKSUM="6dd9d8fbcae56ea7c5ec1ac90a277643758019ab" CHECKSUMTYPE="SHA-1" SIZE="1720">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-08-01T19:16:21" MIMETYPE="text/xml" CHECKSUM="3fd2a23aecc8f9112b91a168d8fb718c36393eb5"
-				CHECKSUMTYPE="SHA-1" SIZE="1716">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-08-01T19:16:21" MIMETYPE="text/xml" CHECKSUM="3fd2a23aecc8f9112b91a168d8fb718c36393eb5" CHECKSUMTYPE="SHA-1" SIZE="1716">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-08-01T19:16:22" MIMETYPE="text/xml" CHECKSUM="ed59079f94db319571f3bcaefd8bc075e133f39e"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-08-01T19:16:22" MIMETYPE="text/xml" CHECKSUM="ed59079f94db319571f3bcaefd8bc075e133f39e" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-08-01T19:16:22" MIMETYPE="text/xml" CHECKSUM="df167c526dfa9fb4726250e9efdde097c9647ba3"
-				CHECKSUMTYPE="SHA-1" SIZE="8035">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-08-01T19:16:22" MIMETYPE="text/xml" CHECKSUM="df167c526dfa9fb4726250e9efdde097c9647ba3" CHECKSUMTYPE="SHA-1" SIZE="8035">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-08-01T19:16:22" MIMETYPE="text/xml" CHECKSUM="ce0beaceac92bebff44e1c83955fae153b73802f"
-				CHECKSUMTYPE="SHA-1" SIZE="1716">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-08-01T19:16:22" MIMETYPE="text/xml" CHECKSUM="ce0beaceac92bebff44e1c83955fae153b73802f" CHECKSUMTYPE="SHA-1" SIZE="1716">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-08-01T19:16:22" MIMETYPE="text/xml" CHECKSUM="33bb29ff5c16a8646223f9f61862800dc4d4fefd"
-				CHECKSUMTYPE="SHA-1" SIZE="1716">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-08-01T19:16:22" MIMETYPE="text/xml" CHECKSUM="33bb29ff5c16a8646223f9f61862800dc4d4fefd" CHECKSUMTYPE="SHA-1" SIZE="1716">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-08-01T19:16:23" MIMETYPE="text/xml" CHECKSUM="1f1e17d1a1f58f05bbcece751f5c4b696e979c3b"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-08-01T19:16:23" MIMETYPE="text/xml" CHECKSUM="1f1e17d1a1f58f05bbcece751f5c4b696e979c3b" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-08-01T19:16:23" MIMETYPE="text/xml" CHECKSUM="f0b3a60bac40e9dd667e1e973ec57dc6b16f57aa"
-				CHECKSUMTYPE="SHA-1" SIZE="13710">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-08-01T19:16:23" MIMETYPE="text/xml" CHECKSUM="f0b3a60bac40e9dd667e1e973ec57dc6b16f57aa" CHECKSUMTYPE="SHA-1" SIZE="13710">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-08-01T19:16:23" MIMETYPE="text/xml"
-				CHECKSUM="4494bd3f49a43df93902665a6d048f9b276a4635" CHECKSUMTYPE="SHA-1" SIZE="3412">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-08-01T19:16:23" MIMETYPE="text/xml" CHECKSUM="4494bd3f49a43df93902665a6d048f9b276a4635" CHECKSUMTYPE="SHA-1" SIZE="3412">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-08-01T19:16:23" MIMETYPE="text/xml"
-				CHECKSUM="e7c50891988e2292f3a3a1b4f3f48c4bd1001784" CHECKSUMTYPE="SHA-1" SIZE="1719">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-08-01T19:16:23" MIMETYPE="text/xml" CHECKSUM="e7c50891988e2292f3a3a1b4f3f48c4bd1001784" CHECKSUMTYPE="SHA-1" SIZE="1719">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-08-01T19:16:24" MIMETYPE="text/xml"
-				CHECKSUM="897429be60282c2fd5521dd5516dc1912488b7d7" CHECKSUMTYPE="SHA-1" SIZE="4993">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-08-01T19:16:24" MIMETYPE="text/xml" CHECKSUM="897429be60282c2fd5521dd5516dc1912488b7d7" CHECKSUMTYPE="SHA-1" SIZE="4993">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-08-01T19:16:24" MIMETYPE="text/xml"
-				CHECKSUM="30d5fe87c7a34909586929738e499d2d7b105dc1" CHECKSUMTYPE="SHA-1" SIZE="19751">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-08-01T19:16:24" MIMETYPE="text/xml" CHECKSUM="30d5fe87c7a34909586929738e499d2d7b105dc1" CHECKSUMTYPE="SHA-1" SIZE="19751">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-08-01T19:16:24" MIMETYPE="text/xml"
-				CHECKSUM="b17924cbb3469cf27ae217ffbc5315fa99a5ac24" CHECKSUMTYPE="SHA-1" SIZE="37466">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-08-01T19:16:24" MIMETYPE="text/xml" CHECKSUM="b17924cbb3469cf27ae217ffbc5315fa99a5ac24" CHECKSUMTYPE="SHA-1" SIZE="37466">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-08-01T19:16:25" MIMETYPE="text/xml"
-				CHECKSUM="5ef5b5dbb7dfae47c5db2a8f401d85bd544a2797" CHECKSUMTYPE="SHA-1" SIZE="21576">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-08-01T19:16:25" MIMETYPE="text/xml" CHECKSUM="5ef5b5dbb7dfae47c5db2a8f401d85bd544a2797" CHECKSUMTYPE="SHA-1" SIZE="21576">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-08-01T19:16:25" MIMETYPE="text/xml"
-				CHECKSUM="aebf4783f3d32632e6db8deb1330c4cacf054dc1" CHECKSUMTYPE="SHA-1" SIZE="40712">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-08-01T19:16:25" MIMETYPE="text/xml" CHECKSUM="aebf4783f3d32632e6db8deb1330c4cacf054dc1" CHECKSUMTYPE="SHA-1" SIZE="40712">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-08-01T19:16:25" MIMETYPE="text/xml"
-				CHECKSUM="d7526763c125250f306b61a6f79d8b9ad5ef8adb" CHECKSUMTYPE="SHA-1" SIZE="5042">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-08-01T19:16:25" MIMETYPE="text/xml" CHECKSUM="d7526763c125250f306b61a6f79d8b9ad5ef8adb" CHECKSUMTYPE="SHA-1" SIZE="5042">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-08-01T19:16:25" MIMETYPE="text/xml"
-				CHECKSUM="ac8a1709f7dcdc702ae3c8af04152ec8956c1300" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-08-01T19:16:25" MIMETYPE="text/xml" CHECKSUM="ac8a1709f7dcdc702ae3c8af04152ec8956c1300" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-08-01T19:16:26" MIMETYPE="text/xml"
-				CHECKSUM="f7221e78e613373862d66e58bb8137757c4a394d" CHECKSUMTYPE="SHA-1" SIZE="70415">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-08-01T19:16:26" MIMETYPE="text/xml" CHECKSUM="f7221e78e613373862d66e58bb8137757c4a394d" CHECKSUMTYPE="SHA-1" SIZE="70415">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-08-01T19:16:26" MIMETYPE="text/xml"
-				CHECKSUM="7418d5fecae6afd708a59587e2150446f8aea176" CHECKSUMTYPE="SHA-1" SIZE="93618">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-08-01T19:16:26" MIMETYPE="text/xml" CHECKSUM="7418d5fecae6afd708a59587e2150446f8aea176" CHECKSUMTYPE="SHA-1" SIZE="93618">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-08-01T19:16:26" MIMETYPE="text/xml"
-				CHECKSUM="55bba5894c4a271ef150f97acad6db9dc53ad4ab" CHECKSUMTYPE="SHA-1" SIZE="79220">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-08-01T19:16:26" MIMETYPE="text/xml" CHECKSUM="55bba5894c4a271ef150f97acad6db9dc53ad4ab" CHECKSUMTYPE="SHA-1" SIZE="79220">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-08-01T19:16:27" MIMETYPE="text/xml"
-				CHECKSUM="45c1573dbed225f0115bc94039569dd65df2f5ca" CHECKSUMTYPE="SHA-1" SIZE="84159">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-08-01T19:16:27" MIMETYPE="text/xml" CHECKSUM="45c1573dbed225f0115bc94039569dd65df2f5ca" CHECKSUMTYPE="SHA-1" SIZE="84159">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-08-01T19:16:27" MIMETYPE="text/xml"
-				CHECKSUM="5fa7e742756ff71b74a60708daf43d925c531d91" CHECKSUMTYPE="SHA-1" SIZE="5118">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-08-01T19:16:27" MIMETYPE="text/xml" CHECKSUM="5fa7e742756ff71b74a60708daf43d925c531d91" CHECKSUMTYPE="SHA-1" SIZE="5118">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-08-01T19:16:27" MIMETYPE="text/xml"
-				CHECKSUM="ab3f3d50f2619429ca7cb1590ca73546baad282c" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-08-01T19:16:27" MIMETYPE="text/xml" CHECKSUM="ab3f3d50f2619429ca7cb1590ca73546baad282c" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-08-01T19:16:28" MIMETYPE="text/xml"
-				CHECKSUM="45d1a77bf425699a40f3cd7b8f57eb4d09bbd001" CHECKSUMTYPE="SHA-1" SIZE="81638">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-08-01T19:16:28" MIMETYPE="text/xml" CHECKSUM="45d1a77bf425699a40f3cd7b8f57eb4d09bbd001" CHECKSUMTYPE="SHA-1" SIZE="81638">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-08-01T19:16:28" MIMETYPE="text/xml"
-				CHECKSUM="bbce88900175ef1be8e18cf8f53d312fac6cd4a6" CHECKSUMTYPE="SHA-1" SIZE="27876">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-08-01T19:16:28" MIMETYPE="text/xml" CHECKSUM="bbce88900175ef1be8e18cf8f53d312fac6cd4a6" CHECKSUMTYPE="SHA-1" SIZE="27876">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-08-01T19:16:28" MIMETYPE="text/xml"
-				CHECKSUM="34e16a23c6f94a47c41e3525d8bad83185b9def3" CHECKSUMTYPE="SHA-1" SIZE="43702">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-08-01T19:16:28" MIMETYPE="text/xml" CHECKSUM="34e16a23c6f94a47c41e3525d8bad83185b9def3" CHECKSUMTYPE="SHA-1" SIZE="43702">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-08-01T19:16:29" MIMETYPE="text/xml"
-				CHECKSUM="10382c729e44749aee1b95deebe2b4ea3cd43495" CHECKSUMTYPE="SHA-1" SIZE="41582">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-08-01T19:16:29" MIMETYPE="text/xml" CHECKSUM="10382c729e44749aee1b95deebe2b4ea3cd43495" CHECKSUMTYPE="SHA-1" SIZE="41582">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-08-01T19:16:29" MIMETYPE="text/xml"
-				CHECKSUM="12b5d8b1002ce1182143fb50b30409c69aa5abc5" CHECKSUMTYPE="SHA-1" SIZE="32290">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-08-01T19:16:29" MIMETYPE="text/xml" CHECKSUM="12b5d8b1002ce1182143fb50b30409c69aa5abc5" CHECKSUMTYPE="SHA-1" SIZE="32290">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-08-01T19:16:29" MIMETYPE="text/xml"
-				CHECKSUM="ea93aec45891d2a4a9ac5f809a06c2be9fae8e50" CHECKSUMTYPE="SHA-1" SIZE="47613">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-08-01T19:16:29" MIMETYPE="text/xml" CHECKSUM="ea93aec45891d2a4a9ac5f809a06c2be9fae8e50" CHECKSUMTYPE="SHA-1" SIZE="47613">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-08-01T19:16:29" MIMETYPE="text/xml"
-				CHECKSUM="0e7d043290030f425680b9ff54448127cd404bc5" CHECKSUMTYPE="SHA-1" SIZE="41490">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-08-01T19:16:29" MIMETYPE="text/xml" CHECKSUM="0e7d043290030f425680b9ff54448127cd404bc5" CHECKSUMTYPE="SHA-1" SIZE="41490">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-08-01T19:16:30" MIMETYPE="text/xml"
-				CHECKSUM="c21b0a7bd15e88b877d58469a278c0ed7747e566" CHECKSUMTYPE="SHA-1" SIZE="39934">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-08-01T19:16:30" MIMETYPE="text/xml" CHECKSUM="c21b0a7bd15e88b877d58469a278c0ed7747e566" CHECKSUMTYPE="SHA-1" SIZE="39934">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-08-01T19:16:30" MIMETYPE="text/xml"
-				CHECKSUM="a063defb8b328a43b071a01493e30dfc54b83591" CHECKSUMTYPE="SHA-1" SIZE="4921">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-08-01T19:16:30" MIMETYPE="text/xml" CHECKSUM="a063defb8b328a43b071a01493e30dfc54b83591" CHECKSUMTYPE="SHA-1" SIZE="4921">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-08-01T19:16:30" MIMETYPE="text/xml"
-				CHECKSUM="964320d63a0232caf1862a0d3305cf2de070b410" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-08-01T19:16:30" MIMETYPE="text/xml" CHECKSUM="964320d63a0232caf1862a0d3305cf2de070b410" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-08-01T19:16:31" MIMETYPE="text/xml"
-				CHECKSUM="b23e1113b83a7758fe081a47c232fecb7963b73c" CHECKSUMTYPE="SHA-1" SIZE="91961">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-08-01T19:16:31" MIMETYPE="text/xml" CHECKSUM="b23e1113b83a7758fe081a47c232fecb7963b73c" CHECKSUMTYPE="SHA-1" SIZE="91961">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-08-01T19:16:31" MIMETYPE="text/xml"
-				CHECKSUM="24c32f7f99a6213a6732e4a607a535aa010c5c33" CHECKSUMTYPE="SHA-1" SIZE="136691">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-08-01T19:16:31" MIMETYPE="text/xml" CHECKSUM="24c32f7f99a6213a6732e4a607a535aa010c5c33" CHECKSUMTYPE="SHA-1" SIZE="136691">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-08-01T19:16:31" MIMETYPE="text/xml"
-				CHECKSUM="4b1e83c23394fd2f4cc42af0b480d90e5ea39dcd" CHECKSUMTYPE="SHA-1" SIZE="144958">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-08-01T19:16:31" MIMETYPE="text/xml" CHECKSUM="4b1e83c23394fd2f4cc42af0b480d90e5ea39dcd" CHECKSUMTYPE="SHA-1" SIZE="144958">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-08-01T19:16:32" MIMETYPE="text/xml"
-				CHECKSUM="ab1a2bbc777a88cf2276888c088298e3403631af" CHECKSUMTYPE="SHA-1" SIZE="93855">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-08-01T19:16:32" MIMETYPE="text/xml" CHECKSUM="ab1a2bbc777a88cf2276888c088298e3403631af" CHECKSUMTYPE="SHA-1" SIZE="93855">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-08-01T19:16:32" MIMETYPE="text/xml"
-				CHECKSUM="038161db955e05f63b0f43096013664c2a06a112" CHECKSUMTYPE="SHA-1" SIZE="5328">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-08-01T19:16:32" MIMETYPE="text/xml" CHECKSUM="038161db955e05f63b0f43096013664c2a06a112" CHECKSUMTYPE="SHA-1" SIZE="5328">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-08-01T19:16:32" MIMETYPE="text/xml"
-				CHECKSUM="0b7e5d2641bc27934e820fc349fd1e43358f910b" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-08-01T19:16:32" MIMETYPE="text/xml" CHECKSUM="0b7e5d2641bc27934e820fc349fd1e43358f910b" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-08-01T19:16:33" MIMETYPE="text/xml"
-				CHECKSUM="a2c09a03b99c04165ba85593dadf6a566a11c989" CHECKSUMTYPE="SHA-1" SIZE="46033">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-08-01T19:16:33" MIMETYPE="text/xml" CHECKSUM="a2c09a03b99c04165ba85593dadf6a566a11c989" CHECKSUMTYPE="SHA-1" SIZE="46033">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-08-01T19:16:33" MIMETYPE="text/xml"
-				CHECKSUM="6eee5d59b3e23c16792a64e63d481c89edf1a4cd" CHECKSUMTYPE="SHA-1" SIZE="73000">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-08-01T19:16:33" MIMETYPE="text/xml" CHECKSUM="6eee5d59b3e23c16792a64e63d481c89edf1a4cd" CHECKSUMTYPE="SHA-1" SIZE="73000">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-08-01T19:16:33" MIMETYPE="text/xml"
-				CHECKSUM="3c58151317dd2b3ea7cd915492e367f7c8d016bc" CHECKSUMTYPE="SHA-1" SIZE="48188">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-08-01T19:16:33" MIMETYPE="text/xml" CHECKSUM="3c58151317dd2b3ea7cd915492e367f7c8d016bc" CHECKSUMTYPE="SHA-1" SIZE="48188">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-08-01T19:16:34" MIMETYPE="text/xml"
-				CHECKSUM="0078f8223fc74f71ddbe0ce56f1bd0b579feb3e9" CHECKSUMTYPE="SHA-1" SIZE="34169">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-08-01T19:16:34" MIMETYPE="text/xml" CHECKSUM="0078f8223fc74f71ddbe0ce56f1bd0b579feb3e9" CHECKSUMTYPE="SHA-1" SIZE="34169">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-08-01T19:16:34" MIMETYPE="text/xml"
-				CHECKSUM="6be78a9e2690998ba61f61b66fb84e38c962b659" CHECKSUMTYPE="SHA-1" SIZE="5018">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-08-01T19:16:34" MIMETYPE="text/xml" CHECKSUM="6be78a9e2690998ba61f61b66fb84e38c962b659" CHECKSUMTYPE="SHA-1" SIZE="5018">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-08-01T19:16:34" MIMETYPE="text/xml"
-				CHECKSUM="8e0eae99a776b55cf3680d1424b4c2b5a38386a6" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-08-01T19:16:34" MIMETYPE="text/xml" CHECKSUM="8e0eae99a776b55cf3680d1424b4c2b5a38386a6" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-08-01T19:16:34" MIMETYPE="text/xml"
-				CHECKSUM="47f96f4859cc02f30e755ac102887d5232875b58" CHECKSUMTYPE="SHA-1" SIZE="10350">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-08-01T19:16:34" MIMETYPE="text/xml" CHECKSUM="47f96f4859cc02f30e755ac102887d5232875b58" CHECKSUMTYPE="SHA-1" SIZE="10350">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-08-01T19:16:35" MIMETYPE="text/xml"
-				CHECKSUM="0b34f8a9a2bad97fb8f55767a2773eb514461828" CHECKSUMTYPE="SHA-1" SIZE="72098">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-08-01T19:16:35" MIMETYPE="text/xml" CHECKSUM="0b34f8a9a2bad97fb8f55767a2773eb514461828" CHECKSUMTYPE="SHA-1" SIZE="72098">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-08-01T19:16:35" MIMETYPE="text/xml"
-				CHECKSUM="9b1a84a3f5a1e5b30ac09e9c559d0a624c58657c" CHECKSUMTYPE="SHA-1" SIZE="143698">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-08-01T19:16:35" MIMETYPE="text/xml" CHECKSUM="9b1a84a3f5a1e5b30ac09e9c559d0a624c58657c" CHECKSUMTYPE="SHA-1" SIZE="143698">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-08-01T19:16:35" MIMETYPE="text/xml"
-				CHECKSUM="51adfecf771524bd99640312125800d2bbc0f0bb" CHECKSUMTYPE="SHA-1" SIZE="109942">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-08-01T19:16:35" MIMETYPE="text/xml" CHECKSUM="51adfecf771524bd99640312125800d2bbc0f0bb" CHECKSUMTYPE="SHA-1" SIZE="109942">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-08-01T19:16:36" MIMETYPE="text/xml"
-				CHECKSUM="7c2ed89092142c88bfbc7f3dd1b44d9d1705dca4" CHECKSUMTYPE="SHA-1" SIZE="75233">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-08-01T19:16:36" MIMETYPE="text/xml" CHECKSUM="7c2ed89092142c88bfbc7f3dd1b44d9d1705dca4" CHECKSUMTYPE="SHA-1" SIZE="75233">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-08-01T19:16:36" MIMETYPE="text/xml"
-				CHECKSUM="b9374dc6077a3941a6406ac0936210c734b3c275" CHECKSUMTYPE="SHA-1" SIZE="186197">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-08-01T19:16:36" MIMETYPE="text/xml" CHECKSUM="b9374dc6077a3941a6406ac0936210c734b3c275" CHECKSUMTYPE="SHA-1" SIZE="186197">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-08-01T19:16:37" MIMETYPE="text/xml"
-				CHECKSUM="afd0329999d3ee6c12bcbbeedfd4fb73dcbda14a" CHECKSUMTYPE="SHA-1" SIZE="177287">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-08-01T19:16:37" MIMETYPE="text/xml" CHECKSUM="afd0329999d3ee6c12bcbbeedfd4fb73dcbda14a" CHECKSUMTYPE="SHA-1" SIZE="177287">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-08-01T19:16:37" MIMETYPE="text/xml"
-				CHECKSUM="f5e36c3b317cc34fc7d19962cdf278909cc233a1" CHECKSUMTYPE="SHA-1" SIZE="162047">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-08-01T19:16:37" MIMETYPE="text/xml" CHECKSUM="f5e36c3b317cc34fc7d19962cdf278909cc233a1" CHECKSUMTYPE="SHA-1" SIZE="162047">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-08-01T19:16:38" MIMETYPE="text/xml"
-				CHECKSUM="88cef41d6fa14d03eda71a0ec32d73f61ae44263" CHECKSUMTYPE="SHA-1" SIZE="186100">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-08-01T19:16:38" MIMETYPE="text/xml" CHECKSUM="88cef41d6fa14d03eda71a0ec32d73f61ae44263" CHECKSUMTYPE="SHA-1" SIZE="186100">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-08-01T19:16:38" MIMETYPE="text/xml"
-				CHECKSUM="6c6b14625ea152db79f0b7806178242910cb1553" CHECKSUMTYPE="SHA-1" SIZE="143348">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-08-01T19:16:38" MIMETYPE="text/xml" CHECKSUM="6c6b14625ea152db79f0b7806178242910cb1553" CHECKSUMTYPE="SHA-1" SIZE="143348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-08-01T19:16:38" MIMETYPE="text/xml"
-				CHECKSUM="c95773da27c1a3962334d6e847ed64b4cfc26ac0" CHECKSUMTYPE="SHA-1" SIZE="159273">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-08-01T19:16:38" MIMETYPE="text/xml" CHECKSUM="c95773da27c1a3962334d6e847ed64b4cfc26ac0" CHECKSUMTYPE="SHA-1" SIZE="159273">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-08-01T19:16:39" MIMETYPE="text/xml"
-				CHECKSUM="c34508e6494e4c1450a58c87f402aa0440bc55e6" CHECKSUMTYPE="SHA-1" SIZE="135935">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-08-01T19:16:39" MIMETYPE="text/xml" CHECKSUM="c34508e6494e4c1450a58c87f402aa0440bc55e6" CHECKSUMTYPE="SHA-1" SIZE="135935">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-08-01T19:16:39" MIMETYPE="text/xml"
-				CHECKSUM="e47b47425e734f725474e1d6d0c82059df9222a5" CHECKSUMTYPE="SHA-1" SIZE="155251">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-08-01T19:16:39" MIMETYPE="text/xml" CHECKSUM="e47b47425e734f725474e1d6d0c82059df9222a5" CHECKSUMTYPE="SHA-1" SIZE="155251">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-08-01T19:16:40" MIMETYPE="text/xml"
-				CHECKSUM="a1a2184826d9db6de13439be467c722f503e8479" CHECKSUMTYPE="SHA-1" SIZE="163753">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-08-01T19:16:40" MIMETYPE="text/xml" CHECKSUM="a1a2184826d9db6de13439be467c722f503e8479" CHECKSUMTYPE="SHA-1" SIZE="163753">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-08-01T19:16:40" MIMETYPE="text/xml"
-				CHECKSUM="0db625a3f67af05c9f44be57eb895fd0aa805a7b" CHECKSUMTYPE="SHA-1" SIZE="172628">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-08-01T19:16:40" MIMETYPE="text/xml" CHECKSUM="0db625a3f67af05c9f44be57eb895fd0aa805a7b" CHECKSUMTYPE="SHA-1" SIZE="172628">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-08-01T19:16:40" MIMETYPE="text/xml"
-				CHECKSUM="668808e781ccf9dcd602d8f337d1c490c1088016" CHECKSUMTYPE="SHA-1" SIZE="168633">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-08-01T19:16:40" MIMETYPE="text/xml" CHECKSUM="668808e781ccf9dcd602d8f337d1c490c1088016" CHECKSUMTYPE="SHA-1" SIZE="168633">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-08-01T19:16:41" MIMETYPE="text/xml"
-				CHECKSUM="f32a7beb0f265f441771ad046286c0ae5a41e2ea" CHECKSUMTYPE="SHA-1" SIZE="163973">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-08-01T19:16:41" MIMETYPE="text/xml" CHECKSUM="f32a7beb0f265f441771ad046286c0ae5a41e2ea" CHECKSUMTYPE="SHA-1" SIZE="163973">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-08-01T19:16:41" MIMETYPE="text/xml"
-				CHECKSUM="89f1c51f843c98066320a6f27e3c45d3a7e635f6" CHECKSUMTYPE="SHA-1" SIZE="88868">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-08-01T19:16:41" MIMETYPE="text/xml" CHECKSUM="89f1c51f843c98066320a6f27e3c45d3a7e635f6" CHECKSUMTYPE="SHA-1" SIZE="88868">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-08-01T19:16:42" MIMETYPE="text/xml"
-				CHECKSUM="b42de52b36790a2ba902f4698f212c17ac865733" CHECKSUMTYPE="SHA-1" SIZE="146653">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-08-01T19:16:42" MIMETYPE="text/xml" CHECKSUM="b42de52b36790a2ba902f4698f212c17ac865733" CHECKSUMTYPE="SHA-1" SIZE="146653">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-08-01T19:16:42" MIMETYPE="text/xml"
-				CHECKSUM="47cb91b0020324121076a3f2c9f20df8cdcff111" CHECKSUMTYPE="SHA-1" SIZE="98634">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-08-01T19:16:42" MIMETYPE="text/xml" CHECKSUM="47cb91b0020324121076a3f2c9f20df8cdcff111" CHECKSUMTYPE="SHA-1" SIZE="98634">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-08-01T19:16:42" MIMETYPE="text/xml"
-				CHECKSUM="e1130107b79f4ae0fb904e471441ee5e607fccf9" CHECKSUMTYPE="SHA-1" SIZE="4889">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-08-01T19:16:42" MIMETYPE="text/xml" CHECKSUM="e1130107b79f4ae0fb904e471441ee5e607fccf9" CHECKSUMTYPE="SHA-1" SIZE="4889">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-08-01T19:16:43" MIMETYPE="text/xml"
-				CHECKSUM="adab777eb34855f2401662a1399d68d6034d7ee1" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-08-01T19:16:43" MIMETYPE="text/xml" CHECKSUM="adab777eb34855f2401662a1399d68d6034d7ee1" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-08-01T19:16:43" MIMETYPE="text/xml"
-				CHECKSUM="2f84103334ca7f5b3e1954c9457ecb57fdd67f4d" CHECKSUMTYPE="SHA-1" SIZE="67386">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-08-01T19:16:43" MIMETYPE="text/xml" CHECKSUM="2f84103334ca7f5b3e1954c9457ecb57fdd67f4d" CHECKSUMTYPE="SHA-1" SIZE="67386">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-08-01T19:16:43" MIMETYPE="text/xml"
-				CHECKSUM="32dc1a92cbe27048595e9fd7aa487cecde4b4509" CHECKSUMTYPE="SHA-1" SIZE="174332">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-08-01T19:16:43" MIMETYPE="text/xml" CHECKSUM="32dc1a92cbe27048595e9fd7aa487cecde4b4509" CHECKSUMTYPE="SHA-1" SIZE="174332">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-08-01T19:16:44" MIMETYPE="text/xml"
-				CHECKSUM="733ca72e538f41eeaa5e3cd71994cbab7e9c5ce3" CHECKSUMTYPE="SHA-1" SIZE="185319">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-08-01T19:16:44" MIMETYPE="text/xml" CHECKSUM="733ca72e538f41eeaa5e3cd71994cbab7e9c5ce3" CHECKSUMTYPE="SHA-1" SIZE="185319">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-08-01T19:16:44" MIMETYPE="text/xml"
-				CHECKSUM="e48523386a38b8719ab69bfcbdba7df731ea9f52" CHECKSUMTYPE="SHA-1" SIZE="176872">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-08-01T19:16:44" MIMETYPE="text/xml" CHECKSUM="e48523386a38b8719ab69bfcbdba7df731ea9f52" CHECKSUMTYPE="SHA-1" SIZE="176872">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-08-01T19:16:45" MIMETYPE="text/xml"
-				CHECKSUM="4dd69cb5882c8475bba0d46abc1e9597d3524fb3" CHECKSUMTYPE="SHA-1" SIZE="181666">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-08-01T19:16:45" MIMETYPE="text/xml" CHECKSUM="4dd69cb5882c8475bba0d46abc1e9597d3524fb3" CHECKSUMTYPE="SHA-1" SIZE="181666">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-08-01T19:16:45" MIMETYPE="text/xml"
-				CHECKSUM="c4987cc9c5f3d0b9d1c96903fc934fe2a00a0151" CHECKSUMTYPE="SHA-1" SIZE="42229">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-08-01T19:16:45" MIMETYPE="text/xml" CHECKSUM="c4987cc9c5f3d0b9d1c96903fc934fe2a00a0151" CHECKSUMTYPE="SHA-1" SIZE="42229">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-08-01T19:16:45" MIMETYPE="text/xml"
-				CHECKSUM="759b5e9bb3ef3c0d4885d88c43a2b56a1462233d" CHECKSUMTYPE="SHA-1" SIZE="4798">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-08-01T19:16:45" MIMETYPE="text/xml" CHECKSUM="759b5e9bb3ef3c0d4885d88c43a2b56a1462233d" CHECKSUMTYPE="SHA-1" SIZE="4798">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-08-01T19:16:46" MIMETYPE="text/xml"
-				CHECKSUM="6df50fdf03e412e2847ddfb8568d9522374b2817" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-08-01T19:16:46" MIMETYPE="text/xml" CHECKSUM="6df50fdf03e412e2847ddfb8568d9522374b2817" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-08-01T19:16:46" MIMETYPE="text/xml"
-				CHECKSUM="4bcb0e5c6fde215d4b67acb82cd9bf6dd3309f61" CHECKSUMTYPE="SHA-1" SIZE="120209">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-08-01T19:16:46" MIMETYPE="text/xml" CHECKSUM="4bcb0e5c6fde215d4b67acb82cd9bf6dd3309f61" CHECKSUMTYPE="SHA-1" SIZE="120209">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-08-01T19:16:46" MIMETYPE="text/xml"
-				CHECKSUM="8b7689b47fbefa0a98a9a7a4ad117599cc70150c" CHECKSUMTYPE="SHA-1" SIZE="187641">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-08-01T19:16:46" MIMETYPE="text/xml" CHECKSUM="8b7689b47fbefa0a98a9a7a4ad117599cc70150c" CHECKSUMTYPE="SHA-1" SIZE="187641">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-08-01T19:16:47" MIMETYPE="text/xml"
-				CHECKSUM="01c7f7c29ff7d9b0af3b0ed36424344b9d99882a" CHECKSUMTYPE="SHA-1" SIZE="5131">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-08-01T19:16:47" MIMETYPE="text/xml" CHECKSUM="01c7f7c29ff7d9b0af3b0ed36424344b9d99882a" CHECKSUMTYPE="SHA-1" SIZE="5131">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-08-01T19:16:47" MIMETYPE="text/xml"
-				CHECKSUM="238e2e341dcbd7eaa13ddcd6639794cf0a88c0fc" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-08-01T19:16:47" MIMETYPE="text/xml" CHECKSUM="238e2e341dcbd7eaa13ddcd6639794cf0a88c0fc" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-08-01T19:16:47" MIMETYPE="text/xml"
-				CHECKSUM="75fa0c454685e9d7fbae84ae0faa734c82394b3a" CHECKSUMTYPE="SHA-1" SIZE="186741">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-08-01T19:16:47" MIMETYPE="text/xml" CHECKSUM="75fa0c454685e9d7fbae84ae0faa734c82394b3a" CHECKSUMTYPE="SHA-1" SIZE="186741">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-08-01T19:16:48" MIMETYPE="text/xml"
-				CHECKSUM="93653cd1c7880a61113521e6e8145ef1b4b483e5" CHECKSUMTYPE="SHA-1" SIZE="179883">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-08-01T19:16:48" MIMETYPE="text/xml" CHECKSUM="93653cd1c7880a61113521e6e8145ef1b4b483e5" CHECKSUMTYPE="SHA-1" SIZE="179883">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-08-01T19:16:48" MIMETYPE="text/xml"
-				CHECKSUM="31248b08ac4f4aefe49bccdca2a345f51716a02f" CHECKSUMTYPE="SHA-1" SIZE="3884">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-08-01T19:16:48" MIMETYPE="text/xml" CHECKSUM="31248b08ac4f4aefe49bccdca2a345f51716a02f" CHECKSUMTYPE="SHA-1" SIZE="3884">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-08-01T19:16:48" MIMETYPE="text/xml"
-				CHECKSUM="e98b6d2760a27f91a4648ac08e35d661da688153" CHECKSUMTYPE="SHA-1" SIZE="189323">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-08-01T19:16:48" MIMETYPE="text/xml" CHECKSUM="e98b6d2760a27f91a4648ac08e35d661da688153" CHECKSUMTYPE="SHA-1" SIZE="189323">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-08-01T19:16:49" MIMETYPE="text/xml"
-				CHECKSUM="8e903e9d8fb3d99575f56711ce441ee9a07952bd" CHECKSUMTYPE="SHA-1" SIZE="5554">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-08-01T19:16:49" MIMETYPE="text/xml" CHECKSUM="8e903e9d8fb3d99575f56711ce441ee9a07952bd" CHECKSUMTYPE="SHA-1" SIZE="5554">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-08-01T19:16:49" MIMETYPE="text/xml"
-				CHECKSUM="356b40d0c395f35fd4582faca3c1b1f826851c71" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-08-01T19:16:49" MIMETYPE="text/xml" CHECKSUM="356b40d0c395f35fd4582faca3c1b1f826851c71" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-08-01T19:16:49" MIMETYPE="text/xml"
-				CHECKSUM="1e7447ccae85640608e8559119318a17dd4f5e39" CHECKSUMTYPE="SHA-1" SIZE="182767">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-08-01T19:16:49" MIMETYPE="text/xml" CHECKSUM="1e7447ccae85640608e8559119318a17dd4f5e39" CHECKSUMTYPE="SHA-1" SIZE="182767">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-08-01T19:16:50" MIMETYPE="text/xml"
-				CHECKSUM="4b4b6764dc24af15266de5d5c78722943ed286d6" CHECKSUMTYPE="SHA-1" SIZE="89576">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-08-01T19:16:50" MIMETYPE="text/xml" CHECKSUM="4b4b6764dc24af15266de5d5c78722943ed286d6" CHECKSUMTYPE="SHA-1" SIZE="89576">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-08-01T19:16:50" MIMETYPE="text/xml"
-				CHECKSUM="6d14eea76a53b309ea8f4ad29c261250eaf4b328" CHECKSUMTYPE="SHA-1" SIZE="5664">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-08-01T19:16:50" MIMETYPE="text/xml" CHECKSUM="6d14eea76a53b309ea8f4ad29c261250eaf4b328" CHECKSUMTYPE="SHA-1" SIZE="5664">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-08-01T19:16:50" MIMETYPE="text/xml"
-				CHECKSUM="111c56898fb0967e2860892a301a78bc8ae61b22" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-08-01T19:16:50" MIMETYPE="text/xml" CHECKSUM="111c56898fb0967e2860892a301a78bc8ae61b22" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-08-01T19:16:51" MIMETYPE="text/xml"
-				CHECKSUM="bcffa5742d9ac2148feea9eb371a8993ee7ceed1" CHECKSUMTYPE="SHA-1" SIZE="51421">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-08-01T19:16:51" MIMETYPE="text/xml" CHECKSUM="bcffa5742d9ac2148feea9eb371a8993ee7ceed1" CHECKSUMTYPE="SHA-1" SIZE="51421">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-08-01T19:16:51" MIMETYPE="text/xml"
-				CHECKSUM="c97f92b6fa560d84a1c907be8d16006c4ae7f1bf" CHECKSUMTYPE="SHA-1" SIZE="26296">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-08-01T19:16:51" MIMETYPE="text/xml" CHECKSUM="c97f92b6fa560d84a1c907be8d16006c4ae7f1bf" CHECKSUMTYPE="SHA-1" SIZE="26296">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-08-01T19:16:51" MIMETYPE="text/xml"
-				CHECKSUM="ab80d0fb180d1251abd8c44dd2db9467b8f701a3" CHECKSUMTYPE="SHA-1" SIZE="25520">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-08-01T19:16:51" MIMETYPE="text/xml" CHECKSUM="ab80d0fb180d1251abd8c44dd2db9467b8f701a3" CHECKSUMTYPE="SHA-1" SIZE="25520">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-08-01T19:16:51" MIMETYPE="text/xml"
-				CHECKSUM="e94b31c0b4995aa5dc62917aee380568baaa694a" CHECKSUMTYPE="SHA-1" SIZE="39649">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-08-01T19:16:51" MIMETYPE="text/xml" CHECKSUM="e94b31c0b4995aa5dc62917aee380568baaa694a" CHECKSUMTYPE="SHA-1" SIZE="39649">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0094.alto.xml"/>
 			</file>
-			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-08-01T19:16:52" MIMETYPE="text/xml"
-				CHECKSUM="06c9e80ff2e02f5e203070ae87c11f97c1579022" CHECKSUMTYPE="SHA-1" SIZE="2018">
+			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-08-01T19:16:52" MIMETYPE="text/xml" CHECKSUM="06c9e80ff2e02f5e203070ae87c11f97c1579022" CHECKSUMTYPE="SHA-1" SIZE="2018">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0095.alto.xml"/>
 			</file>
-			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-08-01T19:16:52" MIMETYPE="text/xml"
-				CHECKSUM="e8c8b48052c7f155c4c6fd288b7240f5963d247d" CHECKSUMTYPE="SHA-1" SIZE="7654">
+			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-08-01T19:16:52" MIMETYPE="text/xml" CHECKSUM="e8c8b48052c7f155c4c6fd288b7240f5963d247d" CHECKSUMTYPE="SHA-1" SIZE="7654">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-05_01_0096.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-08-01T19:20:41" MIMETYPE="application/pdf" CHECKSUM="c9d48b17513d97afed2f1748fb20453360160c93"
-				CHECKSUMTYPE="SHA-1" SIZE="44600693">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/bmtnabe_1898-05_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-08-01T19:20:41" MIMETYPE="application/pdf" CHECKSUM="c9d48b17513d97afed2f1748fb20453360160c93" CHECKSUMTYPE="SHA-1" SIZE="44600693">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/05_01/bmtnabe_1898-05_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -11113,8 +10819,7 @@
 					</div>
 
 				</div>
-				<div ID="L.1.1.20" TYPE="TextContent" ORDER="20" DMDID="c040"
-					LABEL="AUS &#34;GEIST DER FINSTERNIS UND DES ABGRUNDS&#34; “ EINOEDENGOTT – FEUERWEIBCHEN">
+				<div ID="L.1.1.20" TYPE="TextContent" ORDER="20" DMDID="c040" LABEL="AUS &#34;GEIST DER FINSTERNIS UND DES ABGRUNDS&#34; “ EINOEDENGOTT – FEUERWEIBCHEN">
 					<div ID="L.1.1.20.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00041" BEGIN="P41_TB00002"/>

--- a/metadata/periodicals/bmtnabe/issues/1898/10_01/bmtnabe_1898-10_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1898/10_01/bmtnabe_1898-10_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1898-10_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1898-10_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-10_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-10_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1898-10_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1898-10_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-10_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -8365,860 +8361,576 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:34:37" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="6f001fd19c6014ef1f06e3ccb96ed8e9287e2ef4" CHECKSUMTYPE="SHA-1" SIZE="4991518">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:35:04" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="fc20b63ee00cd2c11d07f90d0cf13df235990cd4" CHECKSUMTYPE="SHA-1" SIZE="5180522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:35:32" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="85ec8dfc5302e92da217b7eb23a5cd23d04e8d6f" CHECKSUMTYPE="SHA-1" SIZE="4974429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:35:54" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="1722b93f5fec695193f4d6d3cca9c8b4b8e35bed" CHECKSUMTYPE="SHA-1" SIZE="5126529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:36:19" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="91e81a720435fe8634fbd6170f9cdce73064aaf9" CHECKSUMTYPE="SHA-1" SIZE="4991529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:36:43" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="62ca2bd371c41b2a8a6606b2c1be057bca79ed86" CHECKSUMTYPE="SHA-1" SIZE="5182329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:37:08" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="1eea742253bdbcc994381b7a3c444f05d0d83c26" CHECKSUMTYPE="SHA-1" SIZE="4999628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:37:33" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="cc901c4ca92df68ab66da7d64750d4e7288c079b" CHECKSUMTYPE="SHA-1" SIZE="5213828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:38:00" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="d12ef5809c607ae407da94267838d21a0a99f095" CHECKSUMTYPE="SHA-1" SIZE="4933029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:38:24" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="4a54066f99efa79d1fcc2a0895ffd21c4167a83b" CHECKSUMTYPE="SHA-1" SIZE="5244429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:38:48" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="e781df9af7baaff37c22b62d9fd25ed5b74b2d8a" CHECKSUMTYPE="SHA-1" SIZE="4905127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:39:15" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="60c6c5eca40926cf0122ade4efe216b144309f3d" CHECKSUMTYPE="SHA-1" SIZE="5244425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:39:43" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="1bf019850cf18470743e82961dc4d624bf4b4590" CHECKSUMTYPE="SHA-1" SIZE="4950125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:40:07" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="6b06b140f2736a30568ea469933b09a30cc87f81" CHECKSUMTYPE="SHA-1" SIZE="5219223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:40:33" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="86977725d9c9683b9f1cd8c8b4370593436d7a3f" CHECKSUMTYPE="SHA-1" SIZE="4932124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:40:57" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="58552a88112bb81104acb6e982cb4b77a3d236c8" CHECKSUMTYPE="SHA-1" SIZE="5244422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:41:20" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="8fc25c8cc51d589fd5c10023aafece58f2eb0b0a" CHECKSUMTYPE="SHA-1" SIZE="4915841">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:41:46" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="396833186f77f9ca8cde6d29aa13a82a44245b00" CHECKSUMTYPE="SHA-1" SIZE="5163428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:42:11" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="3fa0bcc15ffbc3e0141ce0f0ab088fe172a197dc" CHECKSUMTYPE="SHA-1" SIZE="4932937">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:42:36" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="64ff5f497c868bf855ddcd2245fc73d0b91321c3" CHECKSUMTYPE="SHA-1" SIZE="5230027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:43:04" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="f31f8ede16af418be5ea7dca1dff9a2b26e7f145" CHECKSUMTYPE="SHA-1" SIZE="4974427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:43:29" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="8aea3cf212bc6ed18ad19bf537b4b77efb6040ed" CHECKSUMTYPE="SHA-1" SIZE="5244429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:43:54" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="3efb8c7d3c2102804337e57b655d8712291b68c7" CHECKSUMTYPE="SHA-1" SIZE="4983429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:44:18" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="3e84736297a4b11453ef88cbdf60b3f6be4dbe03" CHECKSUMTYPE="SHA-1" SIZE="5233628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:44:41" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="a4963bdd8ee01630222c3d50e7bf85b0f80825c4" CHECKSUMTYPE="SHA-1" SIZE="4970829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:45:05" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="ee4c19a08109aa0fdb498996962e8de789c538b3" CHECKSUMTYPE="SHA-1" SIZE="5234527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:45:31" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="d471b2ec330facf618fa1c46415eaefed7a522b9" CHECKSUMTYPE="SHA-1" SIZE="4987928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:45:57" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="190f676d8136e0910652ddd8e0de521fd3553b07" CHECKSUMTYPE="SHA-1" SIZE="5228229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:46:22" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="a112d669812edb31c114b2320c96e4507ec11b79" CHECKSUMTYPE="SHA-1" SIZE="4940228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:46:47" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="8a3918806e215865da5b1c902864ea3bad3780a6" CHECKSUMTYPE="SHA-1" SIZE="5257020">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:47:25" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="3c42238b362df5ee24038e0a315af0bbe7218822" CHECKSUMTYPE="SHA-1" SIZE="4974428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:47:51" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="e9a472404d828796ac6d0fddcaa66d728c9176be" CHECKSUMTYPE="SHA-1" SIZE="5215614">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:48:17" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="671b32e5d667a0154b2f59b825d66821f2583301" CHECKSUMTYPE="SHA-1" SIZE="4982526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:48:42" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="6e965c2dcf8ae41bf1726e221ac180e05080a48e" CHECKSUMTYPE="SHA-1" SIZE="5266027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:49:08" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="04ab9fdb09269c7ebf7a25562dd6a94fde7fd4c9" CHECKSUMTYPE="SHA-1" SIZE="5034722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:49:33" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="6c526060fccf46e4ef1d1ab9d99f5f7a12c33fef" CHECKSUMTYPE="SHA-1" SIZE="5244422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:50:01" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="8e0ec43337df1ba4327213d5a5b60d4d805469ba" CHECKSUMTYPE="SHA-1" SIZE="5059926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:50:28" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="914ce77c424848be7ae67ca06f22083466193a66" CHECKSUMTYPE="SHA-1" SIZE="5244429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:50:56" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="6db056a9668bbfdb45f12a284fbe940aca84853c" CHECKSUMTYPE="SHA-1" SIZE="5032028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:51:26" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="1f60e0eece2239b45acf52c2b333ee7a4f7a17ed" CHECKSUMTYPE="SHA-1" SIZE="5233629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:51:55" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="3985f074670576958d9fea8955e7c67f38c1db46" CHECKSUMTYPE="SHA-1" SIZE="5095022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:52:22" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="10c47e0e22b0cb0a7c4f2f2bbd2faf8bc7a37551" CHECKSUMTYPE="SHA-1" SIZE="5244412">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:52:49" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="38b3114b5b43aaa748c62c20fa74fa3401c79ce0" CHECKSUMTYPE="SHA-1" SIZE="5085128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:53:14" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="e353daafd1b76d36a9de2643d1bc51873fa701ca" CHECKSUMTYPE="SHA-1" SIZE="5216527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:53:39" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="c117b9cb207ab844c686fc77921f493759ee6d96" CHECKSUMTYPE="SHA-1" SIZE="5028429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:54:03" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="bcce8298f738db79f8ce66a8a3b123c865941384" CHECKSUMTYPE="SHA-1" SIZE="5264201">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:54:28" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="4731f55abc06997fef0ad2cff4e3b1fc25bbf0d9" CHECKSUMTYPE="SHA-1" SIZE="5117523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:54:52" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="de97268e8b23f9d41390ce9f7e84ff379eb220f9" CHECKSUMTYPE="SHA-1" SIZE="5255227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:55:17" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="b08a0473ecb987a7c895303d9f4ef034df182d25" CHECKSUMTYPE="SHA-1" SIZE="5111229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:55:43" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="a1acd65777063bdd701180099957a0388218b585" CHECKSUMTYPE="SHA-1" SIZE="5244422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:56:09" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="8a4cb25d67f6552ba6c5b99a02b082351f5d3a6a" CHECKSUMTYPE="SHA-1" SIZE="5116629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:56:34" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="d7d1f6bb123109f2c89d1be56244b0393926751a" CHECKSUMTYPE="SHA-1" SIZE="5255227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:57:01" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="31d7abe8294f01320b0d03ff6c52dc3ab5015206" CHECKSUMTYPE="SHA-1" SIZE="5130966">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:57:27" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="3cda8e3b2569a5c46da9dd2ce749b57d228f392c" CHECKSUMTYPE="SHA-1" SIZE="5244429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:57:53" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="d6dc37dc9a92ca751477021bfd255f99640a8f5b" CHECKSUMTYPE="SHA-1" SIZE="5120227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:58:21" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="57aca039ccbdd5e26f358af345c3bde78c3759b0" CHECKSUMTYPE="SHA-1" SIZE="5244425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:58:47" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="1bf4463b0ddb75408902551300608de239e87d07" CHECKSUMTYPE="SHA-1" SIZE="5164328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:59:14" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="e9b74599e48f91030a7930aebbcd9a7ab47b88fc" CHECKSUMTYPE="SHA-1" SIZE="5192228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T17:59:43" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="b0285f008d695b6221fb9ab470fce44b3ede62ad" CHECKSUMTYPE="SHA-1" SIZE="5105829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:00:08" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="6f2fee4eb600306ba11b60af936d8db1766f3235" CHECKSUMTYPE="SHA-1" SIZE="5201228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:00:33" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="297b4d65b2d1b2cfeaa9e23c525b239cce4da724" CHECKSUMTYPE="SHA-1" SIZE="5097728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:00:58" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="986811c0a01bfe24c8268fe58d4f66b8751ef5ce" CHECKSUMTYPE="SHA-1" SIZE="5276819">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:01:24" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="5434ed19b6b51345cb809e8ea4be4b9cb3979342" CHECKSUMTYPE="SHA-1" SIZE="5122929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:01:52" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="83a8e24aa28fab19091b129ccfd3579987a3eda6" CHECKSUMTYPE="SHA-1" SIZE="5266029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:02:17" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="fd8c1e052c4c1dab35ef88a0644cb8e8316e92bd" CHECKSUMTYPE="SHA-1" SIZE="5110317">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:02:45" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="02191658c3e0b74766dfc4c4c676e1f493ef6165" CHECKSUMTYPE="SHA-1" SIZE="5328105">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:03:11" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="4f54ed52a4b4c40ed73f235a2cd1942aaaa07f51" CHECKSUMTYPE="SHA-1" SIZE="5074322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:03:40" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="f9a855e35e1eac39f92ecc3cf6575df9a7bd8c6f" CHECKSUMTYPE="SHA-1" SIZE="5255228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:04:06" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="a6fcf200e7eadfbd959554f67f5abaf968ef6ba2" CHECKSUMTYPE="SHA-1" SIZE="5096828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:04:33" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="d4d50865b58e32e159202e56efffd7299bcb83ba" CHECKSUMTYPE="SHA-1" SIZE="5259648">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:05:00" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="2c6deb3e20af24e024e8db3388707f39309b71e2" CHECKSUMTYPE="SHA-1" SIZE="5109427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:05:27" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="a7c94f6bcb24eddefcc4e8253efdef7d50db78a2" CHECKSUMTYPE="SHA-1" SIZE="5280428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:05:52" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="8b7dccbbdaac53c1dcd270ffbd111a177942960b" CHECKSUMTYPE="SHA-1" SIZE="5095927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:06:18" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="fd7662d178016d1d12d6cb42c250cbd347f519e5" CHECKSUMTYPE="SHA-1" SIZE="5183131">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:06:43" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="040754b26841f3e41bd3a3e7a340dd37d902ed67" CHECKSUMTYPE="SHA-1" SIZE="5117529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:07:07" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="f01c0f99227357ffef1ebf1ad0fa9e0ca69290b5" CHECKSUMTYPE="SHA-1" SIZE="5232726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:07:34" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="ebabc240c9fc117ddb3b17d9eedd69d8f925985a" CHECKSUMTYPE="SHA-1" SIZE="5108524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:08:02" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="ee8267f112872ffaf32ed39cfa26610ab9ad1e3e" CHECKSUMTYPE="SHA-1" SIZE="5302024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:08:29" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="55b0f366203513a6cf80354e9ffdf6e54f17ad12" CHECKSUMTYPE="SHA-1" SIZE="5101328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:08:57" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="0cabf290c8901826d86b90b975bdfd47b70f4971" CHECKSUMTYPE="SHA-1" SIZE="5276823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:09:26" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="9f98a4de7367b3b71c8cff7808880ca04415e30a" CHECKSUMTYPE="SHA-1" SIZE="5118429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:09:52" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="9437e34522ad86b110ad85d5f080aa61f4a3465e" CHECKSUMTYPE="SHA-1" SIZE="5275921">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:10:19" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="bf4a2c0d422d6ce9678a70d1b5efbf287a173ab4" CHECKSUMTYPE="SHA-1" SIZE="5084229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:10:48" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="a943cf23fa4e16ea697f72ecd10ac217ee68699a" CHECKSUMTYPE="SHA-1" SIZE="5275922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:11:17" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="b84809856374630ec4630b0a250408c0b456e38b" CHECKSUMTYPE="SHA-1" SIZE="5095027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:11:47" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="a3b069e2bcefac20bdbcbf658d98fcc091da277d" CHECKSUMTYPE="SHA-1" SIZE="5305629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T18:12:14" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="203892491bda79428bc7c8c57524459abf47d862" CHECKSUMTYPE="SHA-1" SIZE="5129225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T18:12:42" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="5598d120e72fe6823a005e8a2bfeb2f9d85f7f88" CHECKSUMTYPE="SHA-1" SIZE="5285824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T18:13:07" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="ac022d50a6603d16e1a0f07853ddc60a0994581c" CHECKSUMTYPE="SHA-1" SIZE="5101329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T18:13:34" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="305e7b2f3b1dec6e0daff3ef01b2f16ea20d7de2" CHECKSUMTYPE="SHA-1" SIZE="5324528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T18:13:58" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="def75c49cc4cf9efd5cc9fb28de8ce9ac0475c75" CHECKSUMTYPE="SHA-1" SIZE="5118429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T18:14:24" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="35f6abf5b5877b9ccd01807513450f37d37f5d38" CHECKSUMTYPE="SHA-1" SIZE="5281328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T18:14:49" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="33f651fcb2923560a52328a9bc2db741d1079e70" CHECKSUMTYPE="SHA-1" SIZE="5131027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T18:15:18" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="7542b8179c81721ebfdec94de67e4e3f54e30810" CHECKSUMTYPE="SHA-1" SIZE="5296625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0094.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:34:37" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="6f001fd19c6014ef1f06e3ccb96ed8e9287e2ef4" CHECKSUMTYPE="SHA-1" SIZE="4991518">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:35:04" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="fc20b63ee00cd2c11d07f90d0cf13df235990cd4" CHECKSUMTYPE="SHA-1" SIZE="5180522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:35:32" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="85ec8dfc5302e92da217b7eb23a5cd23d04e8d6f" CHECKSUMTYPE="SHA-1" SIZE="4974429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:35:54" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="1722b93f5fec695193f4d6d3cca9c8b4b8e35bed" CHECKSUMTYPE="SHA-1" SIZE="5126529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:36:19" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="91e81a720435fe8634fbd6170f9cdce73064aaf9" CHECKSUMTYPE="SHA-1" SIZE="4991529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:36:43" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="62ca2bd371c41b2a8a6606b2c1be057bca79ed86" CHECKSUMTYPE="SHA-1" SIZE="5182329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:37:08" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="1eea742253bdbcc994381b7a3c444f05d0d83c26" CHECKSUMTYPE="SHA-1" SIZE="4999628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:37:33" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="cc901c4ca92df68ab66da7d64750d4e7288c079b" CHECKSUMTYPE="SHA-1" SIZE="5213828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:38:00" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="d12ef5809c607ae407da94267838d21a0a99f095" CHECKSUMTYPE="SHA-1" SIZE="4933029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:38:24" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="4a54066f99efa79d1fcc2a0895ffd21c4167a83b" CHECKSUMTYPE="SHA-1" SIZE="5244429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:38:48" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="e781df9af7baaff37c22b62d9fd25ed5b74b2d8a" CHECKSUMTYPE="SHA-1" SIZE="4905127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:39:15" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="60c6c5eca40926cf0122ade4efe216b144309f3d" CHECKSUMTYPE="SHA-1" SIZE="5244425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:39:43" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="1bf019850cf18470743e82961dc4d624bf4b4590" CHECKSUMTYPE="SHA-1" SIZE="4950125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:40:07" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="6b06b140f2736a30568ea469933b09a30cc87f81" CHECKSUMTYPE="SHA-1" SIZE="5219223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:40:33" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="86977725d9c9683b9f1cd8c8b4370593436d7a3f" CHECKSUMTYPE="SHA-1" SIZE="4932124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:40:57" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="58552a88112bb81104acb6e982cb4b77a3d236c8" CHECKSUMTYPE="SHA-1" SIZE="5244422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:41:20" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="8fc25c8cc51d589fd5c10023aafece58f2eb0b0a" CHECKSUMTYPE="SHA-1" SIZE="4915841">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:41:46" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="396833186f77f9ca8cde6d29aa13a82a44245b00" CHECKSUMTYPE="SHA-1" SIZE="5163428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:42:11" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="3fa0bcc15ffbc3e0141ce0f0ab088fe172a197dc" CHECKSUMTYPE="SHA-1" SIZE="4932937">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:42:36" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="64ff5f497c868bf855ddcd2245fc73d0b91321c3" CHECKSUMTYPE="SHA-1" SIZE="5230027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:43:04" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="f31f8ede16af418be5ea7dca1dff9a2b26e7f145" CHECKSUMTYPE="SHA-1" SIZE="4974427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:43:29" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="8aea3cf212bc6ed18ad19bf537b4b77efb6040ed" CHECKSUMTYPE="SHA-1" SIZE="5244429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:43:54" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="3efb8c7d3c2102804337e57b655d8712291b68c7" CHECKSUMTYPE="SHA-1" SIZE="4983429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:44:18" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="3e84736297a4b11453ef88cbdf60b3f6be4dbe03" CHECKSUMTYPE="SHA-1" SIZE="5233628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:44:41" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="a4963bdd8ee01630222c3d50e7bf85b0f80825c4" CHECKSUMTYPE="SHA-1" SIZE="4970829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:45:05" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ee4c19a08109aa0fdb498996962e8de789c538b3" CHECKSUMTYPE="SHA-1" SIZE="5234527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:45:31" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="d471b2ec330facf618fa1c46415eaefed7a522b9" CHECKSUMTYPE="SHA-1" SIZE="4987928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:45:57" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="190f676d8136e0910652ddd8e0de521fd3553b07" CHECKSUMTYPE="SHA-1" SIZE="5228229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:46:22" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="a112d669812edb31c114b2320c96e4507ec11b79" CHECKSUMTYPE="SHA-1" SIZE="4940228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:46:47" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="8a3918806e215865da5b1c902864ea3bad3780a6" CHECKSUMTYPE="SHA-1" SIZE="5257020">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:47:25" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="3c42238b362df5ee24038e0a315af0bbe7218822" CHECKSUMTYPE="SHA-1" SIZE="4974428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:47:51" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="e9a472404d828796ac6d0fddcaa66d728c9176be" CHECKSUMTYPE="SHA-1" SIZE="5215614">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:48:17" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="671b32e5d667a0154b2f59b825d66821f2583301" CHECKSUMTYPE="SHA-1" SIZE="4982526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:48:42" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="6e965c2dcf8ae41bf1726e221ac180e05080a48e" CHECKSUMTYPE="SHA-1" SIZE="5266027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:49:08" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="04ab9fdb09269c7ebf7a25562dd6a94fde7fd4c9" CHECKSUMTYPE="SHA-1" SIZE="5034722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:49:33" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="6c526060fccf46e4ef1d1ab9d99f5f7a12c33fef" CHECKSUMTYPE="SHA-1" SIZE="5244422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:50:01" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="8e0ec43337df1ba4327213d5a5b60d4d805469ba" CHECKSUMTYPE="SHA-1" SIZE="5059926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:50:28" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="914ce77c424848be7ae67ca06f22083466193a66" CHECKSUMTYPE="SHA-1" SIZE="5244429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:50:56" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="6db056a9668bbfdb45f12a284fbe940aca84853c" CHECKSUMTYPE="SHA-1" SIZE="5032028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:51:26" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="1f60e0eece2239b45acf52c2b333ee7a4f7a17ed" CHECKSUMTYPE="SHA-1" SIZE="5233629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:51:55" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="3985f074670576958d9fea8955e7c67f38c1db46" CHECKSUMTYPE="SHA-1" SIZE="5095022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:52:22" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="10c47e0e22b0cb0a7c4f2f2bbd2faf8bc7a37551" CHECKSUMTYPE="SHA-1" SIZE="5244412">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:52:49" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="38b3114b5b43aaa748c62c20fa74fa3401c79ce0" CHECKSUMTYPE="SHA-1" SIZE="5085128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:53:14" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="e353daafd1b76d36a9de2643d1bc51873fa701ca" CHECKSUMTYPE="SHA-1" SIZE="5216527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:53:39" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="c117b9cb207ab844c686fc77921f493759ee6d96" CHECKSUMTYPE="SHA-1" SIZE="5028429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:54:03" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="bcce8298f738db79f8ce66a8a3b123c865941384" CHECKSUMTYPE="SHA-1" SIZE="5264201">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:54:28" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="4731f55abc06997fef0ad2cff4e3b1fc25bbf0d9" CHECKSUMTYPE="SHA-1" SIZE="5117523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:54:52" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="de97268e8b23f9d41390ce9f7e84ff379eb220f9" CHECKSUMTYPE="SHA-1" SIZE="5255227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:55:17" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="b08a0473ecb987a7c895303d9f4ef034df182d25" CHECKSUMTYPE="SHA-1" SIZE="5111229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:55:43" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="a1acd65777063bdd701180099957a0388218b585" CHECKSUMTYPE="SHA-1" SIZE="5244422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:56:09" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="8a4cb25d67f6552ba6c5b99a02b082351f5d3a6a" CHECKSUMTYPE="SHA-1" SIZE="5116629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:56:34" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="d7d1f6bb123109f2c89d1be56244b0393926751a" CHECKSUMTYPE="SHA-1" SIZE="5255227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:57:01" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="31d7abe8294f01320b0d03ff6c52dc3ab5015206" CHECKSUMTYPE="SHA-1" SIZE="5130966">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:57:27" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="3cda8e3b2569a5c46da9dd2ce749b57d228f392c" CHECKSUMTYPE="SHA-1" SIZE="5244429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:57:53" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="d6dc37dc9a92ca751477021bfd255f99640a8f5b" CHECKSUMTYPE="SHA-1" SIZE="5120227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:58:21" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="57aca039ccbdd5e26f358af345c3bde78c3759b0" CHECKSUMTYPE="SHA-1" SIZE="5244425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:58:47" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="1bf4463b0ddb75408902551300608de239e87d07" CHECKSUMTYPE="SHA-1" SIZE="5164328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:59:14" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="e9b74599e48f91030a7930aebbcd9a7ab47b88fc" CHECKSUMTYPE="SHA-1" SIZE="5192228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T17:59:43" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="b0285f008d695b6221fb9ab470fce44b3ede62ad" CHECKSUMTYPE="SHA-1" SIZE="5105829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:00:08" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="6f2fee4eb600306ba11b60af936d8db1766f3235" CHECKSUMTYPE="SHA-1" SIZE="5201228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:00:33" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="297b4d65b2d1b2cfeaa9e23c525b239cce4da724" CHECKSUMTYPE="SHA-1" SIZE="5097728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:00:58" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="986811c0a01bfe24c8268fe58d4f66b8751ef5ce" CHECKSUMTYPE="SHA-1" SIZE="5276819">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:01:24" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="5434ed19b6b51345cb809e8ea4be4b9cb3979342" CHECKSUMTYPE="SHA-1" SIZE="5122929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:01:52" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="83a8e24aa28fab19091b129ccfd3579987a3eda6" CHECKSUMTYPE="SHA-1" SIZE="5266029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:02:17" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="fd8c1e052c4c1dab35ef88a0644cb8e8316e92bd" CHECKSUMTYPE="SHA-1" SIZE="5110317">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:02:45" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="02191658c3e0b74766dfc4c4c676e1f493ef6165" CHECKSUMTYPE="SHA-1" SIZE="5328105">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:03:11" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="4f54ed52a4b4c40ed73f235a2cd1942aaaa07f51" CHECKSUMTYPE="SHA-1" SIZE="5074322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:03:40" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="f9a855e35e1eac39f92ecc3cf6575df9a7bd8c6f" CHECKSUMTYPE="SHA-1" SIZE="5255228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:04:06" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="a6fcf200e7eadfbd959554f67f5abaf968ef6ba2" CHECKSUMTYPE="SHA-1" SIZE="5096828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:04:33" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="d4d50865b58e32e159202e56efffd7299bcb83ba" CHECKSUMTYPE="SHA-1" SIZE="5259648">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:05:00" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="2c6deb3e20af24e024e8db3388707f39309b71e2" CHECKSUMTYPE="SHA-1" SIZE="5109427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:05:27" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="a7c94f6bcb24eddefcc4e8253efdef7d50db78a2" CHECKSUMTYPE="SHA-1" SIZE="5280428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:05:52" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="8b7dccbbdaac53c1dcd270ffbd111a177942960b" CHECKSUMTYPE="SHA-1" SIZE="5095927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:06:18" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="fd7662d178016d1d12d6cb42c250cbd347f519e5" CHECKSUMTYPE="SHA-1" SIZE="5183131">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:06:43" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="040754b26841f3e41bd3a3e7a340dd37d902ed67" CHECKSUMTYPE="SHA-1" SIZE="5117529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:07:07" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="f01c0f99227357ffef1ebf1ad0fa9e0ca69290b5" CHECKSUMTYPE="SHA-1" SIZE="5232726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:07:34" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="ebabc240c9fc117ddb3b17d9eedd69d8f925985a" CHECKSUMTYPE="SHA-1" SIZE="5108524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:08:02" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="ee8267f112872ffaf32ed39cfa26610ab9ad1e3e" CHECKSUMTYPE="SHA-1" SIZE="5302024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:08:29" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="55b0f366203513a6cf80354e9ffdf6e54f17ad12" CHECKSUMTYPE="SHA-1" SIZE="5101328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:08:57" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="0cabf290c8901826d86b90b975bdfd47b70f4971" CHECKSUMTYPE="SHA-1" SIZE="5276823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:09:26" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="9f98a4de7367b3b71c8cff7808880ca04415e30a" CHECKSUMTYPE="SHA-1" SIZE="5118429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:09:52" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="9437e34522ad86b110ad85d5f080aa61f4a3465e" CHECKSUMTYPE="SHA-1" SIZE="5275921">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:10:19" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="bf4a2c0d422d6ce9678a70d1b5efbf287a173ab4" CHECKSUMTYPE="SHA-1" SIZE="5084229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:10:48" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="a943cf23fa4e16ea697f72ecd10ac217ee68699a" CHECKSUMTYPE="SHA-1" SIZE="5275922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:11:17" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="b84809856374630ec4630b0a250408c0b456e38b" CHECKSUMTYPE="SHA-1" SIZE="5095027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:11:47" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="a3b069e2bcefac20bdbcbf658d98fcc091da277d" CHECKSUMTYPE="SHA-1" SIZE="5305629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T18:12:14" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="203892491bda79428bc7c8c57524459abf47d862" CHECKSUMTYPE="SHA-1" SIZE="5129225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T18:12:42" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="5598d120e72fe6823a005e8a2bfeb2f9d85f7f88" CHECKSUMTYPE="SHA-1" SIZE="5285824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T18:13:07" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="ac022d50a6603d16e1a0f07853ddc60a0994581c" CHECKSUMTYPE="SHA-1" SIZE="5101329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T18:13:34" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="305e7b2f3b1dec6e0daff3ef01b2f16ea20d7de2" CHECKSUMTYPE="SHA-1" SIZE="5324528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T18:13:58" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="def75c49cc4cf9efd5cc9fb28de8ce9ac0475c75" CHECKSUMTYPE="SHA-1" SIZE="5118429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T18:14:24" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="35f6abf5b5877b9ccd01807513450f37d37f5d38" CHECKSUMTYPE="SHA-1" SIZE="5281328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T18:14:49" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="33f651fcb2923560a52328a9bc2db741d1079e70" CHECKSUMTYPE="SHA-1" SIZE="5131027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T18:15:18" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="7542b8179c81721ebfdec94de67e4e3f54e30810" CHECKSUMTYPE="SHA-1" SIZE="5296625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/delivery/bmtnabe_1898-10_01_0094.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml" CHECKSUM="073feb00637ec609aab8e655f8366f4a0632be39"
-				CHECKSUMTYPE="SHA-1" SIZE="2116">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml" CHECKSUM="073feb00637ec609aab8e655f8366f4a0632be39" CHECKSUMTYPE="SHA-1" SIZE="2116">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml" CHECKSUM="3828852a7986fa910689f9974bb85fb5cf0798cc"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml" CHECKSUM="3828852a7986fa910689f9974bb85fb5cf0798cc" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml" CHECKSUM="f5e3085243f8f6acca732ca06bf9bdcbd2c31735"
-				CHECKSUMTYPE="SHA-1" SIZE="1713">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml" CHECKSUM="f5e3085243f8f6acca732ca06bf9bdcbd2c31735" CHECKSUMTYPE="SHA-1" SIZE="1713">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml" CHECKSUM="13079d64c7c027c6023c313dc76103dbede878f2"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:15:36" MIMETYPE="text/xml" CHECKSUM="13079d64c7c027c6023c313dc76103dbede878f2" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="dfb4c774d55f3f0d931cb8403a3a48490f373757"
-				CHECKSUMTYPE="SHA-1" SIZE="14225">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="dfb4c774d55f3f0d931cb8403a3a48490f373757" CHECKSUMTYPE="SHA-1" SIZE="14225">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="09e0e4938488e961bdeb9ebf9ecc7f26567028a0"
-				CHECKSUMTYPE="SHA-1" SIZE="3380">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="09e0e4938488e961bdeb9ebf9ecc7f26567028a0" CHECKSUMTYPE="SHA-1" SIZE="3380">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="be9280671754deea3875991bde2d343b97d367f1"
-				CHECKSUMTYPE="SHA-1" SIZE="1713">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="be9280671754deea3875991bde2d343b97d367f1" CHECKSUMTYPE="SHA-1" SIZE="1713">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="19988c0db2007a4268d3f28a704f9f8a491cbdc7"
-				CHECKSUMTYPE="SHA-1" SIZE="5474">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:15:37" MIMETYPE="text/xml" CHECKSUM="19988c0db2007a4268d3f28a704f9f8a491cbdc7" CHECKSUMTYPE="SHA-1" SIZE="5474">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml" CHECKSUM="d0970545d4a301a2fefaa84e6d912d5797d47902"
-				CHECKSUMTYPE="SHA-1" SIZE="7558">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml" CHECKSUM="d0970545d4a301a2fefaa84e6d912d5797d47902" CHECKSUMTYPE="SHA-1" SIZE="7558">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml"
-				CHECKSUM="95029f33017615d505c0e34c6c64a98d64cac39a" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml" CHECKSUM="95029f33017615d505c0e34c6c64a98d64cac39a" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml"
-				CHECKSUM="ff968a6bd920b9113be9cf8fc45064cf8adb2e6a" CHECKSUMTYPE="SHA-1" SIZE="26204">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml" CHECKSUM="ff968a6bd920b9113be9cf8fc45064cf8adb2e6a" CHECKSUMTYPE="SHA-1" SIZE="26204">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml"
-				CHECKSUM="3a1e3b73be0a4442ad1c1273fdc7cc731abb9943" CHECKSUMTYPE="SHA-1" SIZE="106666">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:15:38" MIMETYPE="text/xml" CHECKSUM="3a1e3b73be0a4442ad1c1273fdc7cc731abb9943" CHECKSUMTYPE="SHA-1" SIZE="106666">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml"
-				CHECKSUM="39c8f7287bfcd02e215b17105b5c7eb103b83258" CHECKSUMTYPE="SHA-1" SIZE="104962">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml" CHECKSUM="39c8f7287bfcd02e215b17105b5c7eb103b83258" CHECKSUMTYPE="SHA-1" SIZE="104962">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml"
-				CHECKSUM="3084f1bc37114d00cd49303e48f26903bcaa2822" CHECKSUMTYPE="SHA-1" SIZE="85773">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml" CHECKSUM="3084f1bc37114d00cd49303e48f26903bcaa2822" CHECKSUMTYPE="SHA-1" SIZE="85773">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml"
-				CHECKSUM="535c8e954651afde9f96023144b83f16ce694fd6" CHECKSUMTYPE="SHA-1" SIZE="5140">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml" CHECKSUM="535c8e954651afde9f96023144b83f16ce694fd6" CHECKSUMTYPE="SHA-1" SIZE="5140">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml"
-				CHECKSUM="a49f4dd2c7ebb25e1fa8b2b43ecd3bb0616f9581" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:15:39" MIMETYPE="text/xml" CHECKSUM="a49f4dd2c7ebb25e1fa8b2b43ecd3bb0616f9581" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml"
-				CHECKSUM="063429424cf3dd1fcd4112df5f00b6d6f9c2f7a8" CHECKSUMTYPE="SHA-1" SIZE="36265">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml" CHECKSUM="063429424cf3dd1fcd4112df5f00b6d6f9c2f7a8" CHECKSUMTYPE="SHA-1" SIZE="36265">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml"
-				CHECKSUM="554ee4ebb9aa51abe3a5d183ffce13cd90c91065" CHECKSUMTYPE="SHA-1" SIZE="37147">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml" CHECKSUM="554ee4ebb9aa51abe3a5d183ffce13cd90c91065" CHECKSUMTYPE="SHA-1" SIZE="37147">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml"
-				CHECKSUM="fbc5de88dcd49c16ec5a0f53820a38f2f750113a" CHECKSUMTYPE="SHA-1" SIZE="49300">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:15:40" MIMETYPE="text/xml" CHECKSUM="fbc5de88dcd49c16ec5a0f53820a38f2f750113a" CHECKSUMTYPE="SHA-1" SIZE="49300">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml"
-				CHECKSUM="08935dfbb1c6ee1e46f3e4264561a68e83d13f6f" CHECKSUMTYPE="SHA-1" SIZE="138489">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml" CHECKSUM="08935dfbb1c6ee1e46f3e4264561a68e83d13f6f" CHECKSUMTYPE="SHA-1" SIZE="138489">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml"
-				CHECKSUM="71008d23e87122d66b6af74f391b610aa6886b20" CHECKSUMTYPE="SHA-1" SIZE="120919">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml" CHECKSUM="71008d23e87122d66b6af74f391b610aa6886b20" CHECKSUMTYPE="SHA-1" SIZE="120919">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml"
-				CHECKSUM="213999819599423232daf4a8ec8bf8d1e7fe02e8" CHECKSUMTYPE="SHA-1" SIZE="86639">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml" CHECKSUM="213999819599423232daf4a8ec8bf8d1e7fe02e8" CHECKSUMTYPE="SHA-1" SIZE="86639">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml"
-				CHECKSUM="4af77a3edb06c84f496fc13c9d25669eac3ca53d" CHECKSUMTYPE="SHA-1" SIZE="122040">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:15:41" MIMETYPE="text/xml" CHECKSUM="4af77a3edb06c84f496fc13c9d25669eac3ca53d" CHECKSUMTYPE="SHA-1" SIZE="122040">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:15:42" MIMETYPE="text/xml"
-				CHECKSUM="2766f873e0538c8a62986f4b137e27e78e360d1b" CHECKSUMTYPE="SHA-1" SIZE="115716">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:15:42" MIMETYPE="text/xml" CHECKSUM="2766f873e0538c8a62986f4b137e27e78e360d1b" CHECKSUMTYPE="SHA-1" SIZE="115716">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:15:42" MIMETYPE="text/xml"
-				CHECKSUM="0fe3fc2b152f38b40a7bd7c98986ff3aeb995a8a" CHECKSUMTYPE="SHA-1" SIZE="139210">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:15:42" MIMETYPE="text/xml" CHECKSUM="0fe3fc2b152f38b40a7bd7c98986ff3aeb995a8a" CHECKSUMTYPE="SHA-1" SIZE="139210">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml"
-				CHECKSUM="7fda49d36e56477d344e53600cf128f771c54c2a" CHECKSUMTYPE="SHA-1" SIZE="130026">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml" CHECKSUM="7fda49d36e56477d344e53600cf128f771c54c2a" CHECKSUMTYPE="SHA-1" SIZE="130026">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml"
-				CHECKSUM="a51bac9f0f2889c6076167a526473dad26befd22" CHECKSUMTYPE="SHA-1" SIZE="82350">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml" CHECKSUM="a51bac9f0f2889c6076167a526473dad26befd22" CHECKSUMTYPE="SHA-1" SIZE="82350">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml"
-				CHECKSUM="0e3ed9d2a548ffe46289c9b64144bbccbfb5df94" CHECKSUMTYPE="SHA-1" SIZE="42918">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:15:43" MIMETYPE="text/xml" CHECKSUM="0e3ed9d2a548ffe46289c9b64144bbccbfb5df94" CHECKSUMTYPE="SHA-1" SIZE="42918">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:15:44" MIMETYPE="text/xml"
-				CHECKSUM="ba8ec87833fc10c6c94874b095044a68ad22dfac" CHECKSUMTYPE="SHA-1" SIZE="5163">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:15:44" MIMETYPE="text/xml" CHECKSUM="ba8ec87833fc10c6c94874b095044a68ad22dfac" CHECKSUMTYPE="SHA-1" SIZE="5163">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:15:44" MIMETYPE="text/xml"
-				CHECKSUM="3d6883fb75b951515eae39e0acb9c277827e477a" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:15:44" MIMETYPE="text/xml" CHECKSUM="3d6883fb75b951515eae39e0acb9c277827e477a" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:15:44" MIMETYPE="text/xml"
-				CHECKSUM="898f63de3f4b270f8359b279a2e431491cb00b37" CHECKSUMTYPE="SHA-1" SIZE="69464">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:15:44" MIMETYPE="text/xml" CHECKSUM="898f63de3f4b270f8359b279a2e431491cb00b37" CHECKSUMTYPE="SHA-1" SIZE="69464">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml"
-				CHECKSUM="61262ff95b3f2e00451e9fb0a69de5626d19db87" CHECKSUMTYPE="SHA-1" SIZE="100670">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml" CHECKSUM="61262ff95b3f2e00451e9fb0a69de5626d19db87" CHECKSUMTYPE="SHA-1" SIZE="100670">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml"
-				CHECKSUM="f40e763837a314bc3541157ca5e1d735dd8b957c" CHECKSUMTYPE="SHA-1" SIZE="100075">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml" CHECKSUM="f40e763837a314bc3541157ca5e1d735dd8b957c" CHECKSUMTYPE="SHA-1" SIZE="100075">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml"
-				CHECKSUM="a24ab93818e631b3701cce2018836f78240b5334" CHECKSUMTYPE="SHA-1" SIZE="73252">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml" CHECKSUM="a24ab93818e631b3701cce2018836f78240b5334" CHECKSUMTYPE="SHA-1" SIZE="73252">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml"
-				CHECKSUM="60afe2a71ba3e984d2b99fd57c3098e5581a75c1" CHECKSUMTYPE="SHA-1" SIZE="118752">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:15:45" MIMETYPE="text/xml" CHECKSUM="60afe2a71ba3e984d2b99fd57c3098e5581a75c1" CHECKSUMTYPE="SHA-1" SIZE="118752">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:15:46" MIMETYPE="text/xml"
-				CHECKSUM="e55217334e20900a88b47627fcf53caeac6c0c3f" CHECKSUMTYPE="SHA-1" SIZE="202857">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:15:46" MIMETYPE="text/xml" CHECKSUM="e55217334e20900a88b47627fcf53caeac6c0c3f" CHECKSUMTYPE="SHA-1" SIZE="202857">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:15:46" MIMETYPE="text/xml"
-				CHECKSUM="63d34354fbf52f167f66aeb520f1d80807710c09" CHECKSUMTYPE="SHA-1" SIZE="178207">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:15:46" MIMETYPE="text/xml" CHECKSUM="63d34354fbf52f167f66aeb520f1d80807710c09" CHECKSUMTYPE="SHA-1" SIZE="178207">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:15:47" MIMETYPE="text/xml"
-				CHECKSUM="aac10141381787d06e7da467642612283da08fd0" CHECKSUMTYPE="SHA-1" SIZE="176298">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:15:47" MIMETYPE="text/xml" CHECKSUM="aac10141381787d06e7da467642612283da08fd0" CHECKSUMTYPE="SHA-1" SIZE="176298">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:15:47" MIMETYPE="text/xml"
-				CHECKSUM="db4fb44cb630087636c220c5b64ce455b2c8c175" CHECKSUMTYPE="SHA-1" SIZE="193870">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:15:47" MIMETYPE="text/xml" CHECKSUM="db4fb44cb630087636c220c5b64ce455b2c8c175" CHECKSUMTYPE="SHA-1" SIZE="193870">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml"
-				CHECKSUM="b717ce42da7a04116b588ededf372e0f163d44af" CHECKSUMTYPE="SHA-1" SIZE="198840">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml" CHECKSUM="b717ce42da7a04116b588ededf372e0f163d44af" CHECKSUMTYPE="SHA-1" SIZE="198840">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml"
-				CHECKSUM="2fb31e3c91141d9cb91b3e1bb56983995c268223" CHECKSUMTYPE="SHA-1" SIZE="204350">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml" CHECKSUM="2fb31e3c91141d9cb91b3e1bb56983995c268223" CHECKSUMTYPE="SHA-1" SIZE="204350">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml"
-				CHECKSUM="e922e1dd0c6ee311a234ab65c1b6860f79476eab" CHECKSUMTYPE="SHA-1" SIZE="63573">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:15:48" MIMETYPE="text/xml" CHECKSUM="e922e1dd0c6ee311a234ab65c1b6860f79476eab" CHECKSUMTYPE="SHA-1" SIZE="63573">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:15:49" MIMETYPE="text/xml"
-				CHECKSUM="6f27a0fa9d0f53a82174e255517359538164d0a4" CHECKSUMTYPE="SHA-1" SIZE="6063">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:15:49" MIMETYPE="text/xml" CHECKSUM="6f27a0fa9d0f53a82174e255517359538164d0a4" CHECKSUMTYPE="SHA-1" SIZE="6063">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:15:49" MIMETYPE="text/xml"
-				CHECKSUM="c1e2d3ccc03e69ba22e05917f8cacde839a3fd0a" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:15:49" MIMETYPE="text/xml" CHECKSUM="c1e2d3ccc03e69ba22e05917f8cacde839a3fd0a" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:15:49" MIMETYPE="text/xml"
-				CHECKSUM="8df35105e6574c4219b321f7c638d6e5b6c5fc45" CHECKSUMTYPE="SHA-1" SIZE="48143">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:15:49" MIMETYPE="text/xml" CHECKSUM="8df35105e6574c4219b321f7c638d6e5b6c5fc45" CHECKSUMTYPE="SHA-1" SIZE="48143">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml"
-				CHECKSUM="8e25c3004825b87f75f6cec6ac642b5bd308ba5b" CHECKSUMTYPE="SHA-1" SIZE="52982">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml" CHECKSUM="8e25c3004825b87f75f6cec6ac642b5bd308ba5b" CHECKSUMTYPE="SHA-1" SIZE="52982">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml"
-				CHECKSUM="33d3aae3d4e70dc4048e88137a6dccafd4475501" CHECKSUMTYPE="SHA-1" SIZE="78236">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml" CHECKSUM="33d3aae3d4e70dc4048e88137a6dccafd4475501" CHECKSUMTYPE="SHA-1" SIZE="78236">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml"
-				CHECKSUM="7b2dcf28c6ad2eb80777e21e4354adbce26bb16a" CHECKSUMTYPE="SHA-1" SIZE="55424">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:15:50" MIMETYPE="text/xml" CHECKSUM="7b2dcf28c6ad2eb80777e21e4354adbce26bb16a" CHECKSUMTYPE="SHA-1" SIZE="55424">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml"
-				CHECKSUM="494ce592097091323dfe496f631ba5995242a359" CHECKSUMTYPE="SHA-1" SIZE="5227">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml" CHECKSUM="494ce592097091323dfe496f631ba5995242a359" CHECKSUMTYPE="SHA-1" SIZE="5227">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml"
-				CHECKSUM="1b4b85339bb9d92136c2370004fc411f3265cae0" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml" CHECKSUM="1b4b85339bb9d92136c2370004fc411f3265cae0" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml"
-				CHECKSUM="48031a5d972456b954cf922dcdf40ee2cfbbf8c1" CHECKSUMTYPE="SHA-1" SIZE="103521">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml" CHECKSUM="48031a5d972456b954cf922dcdf40ee2cfbbf8c1" CHECKSUMTYPE="SHA-1" SIZE="103521">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml"
-				CHECKSUM="63d328d4a56e581681d1ffe29a48c2bff1bf993e" CHECKSUMTYPE="SHA-1" SIZE="196839">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:15:51" MIMETYPE="text/xml" CHECKSUM="63d328d4a56e581681d1ffe29a48c2bff1bf993e" CHECKSUMTYPE="SHA-1" SIZE="196839">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:15:52" MIMETYPE="text/xml"
-				CHECKSUM="4f1b6af5cb9082143db88d90bb73086773125832" CHECKSUMTYPE="SHA-1" SIZE="198221">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:15:52" MIMETYPE="text/xml" CHECKSUM="4f1b6af5cb9082143db88d90bb73086773125832" CHECKSUMTYPE="SHA-1" SIZE="198221">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:15:52" MIMETYPE="text/xml"
-				CHECKSUM="92ff5864805ed81a1a692b5c69c1c8c26b2f17d7" CHECKSUMTYPE="SHA-1" SIZE="78367">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:15:52" MIMETYPE="text/xml" CHECKSUM="92ff5864805ed81a1a692b5c69c1c8c26b2f17d7" CHECKSUMTYPE="SHA-1" SIZE="78367">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml"
-				CHECKSUM="82f304452dbc02c377ea850603c73a6094da58a6" CHECKSUMTYPE="SHA-1" SIZE="6725">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml" CHECKSUM="82f304452dbc02c377ea850603c73a6094da58a6" CHECKSUMTYPE="SHA-1" SIZE="6725">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml"
-				CHECKSUM="8f82c6b1987928970ca8fb478b950dad923d8510" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml" CHECKSUM="8f82c6b1987928970ca8fb478b950dad923d8510" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml"
-				CHECKSUM="00bce3fccced99d4de91aea5c23d206c7365086c" CHECKSUMTYPE="SHA-1" SIZE="80477">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml" CHECKSUM="00bce3fccced99d4de91aea5c23d206c7365086c" CHECKSUMTYPE="SHA-1" SIZE="80477">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml"
-				CHECKSUM="65d5e556592481e697a62f11bcab8498ad26745c" CHECKSUMTYPE="SHA-1" SIZE="151512">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:15:53" MIMETYPE="text/xml" CHECKSUM="65d5e556592481e697a62f11bcab8498ad26745c" CHECKSUMTYPE="SHA-1" SIZE="151512">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:15:54" MIMETYPE="text/xml"
-				CHECKSUM="3febb9b471f6e4d1f65cd1f9151111066fe44dd1" CHECKSUMTYPE="SHA-1" SIZE="183162">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:15:54" MIMETYPE="text/xml" CHECKSUM="3febb9b471f6e4d1f65cd1f9151111066fe44dd1" CHECKSUMTYPE="SHA-1" SIZE="183162">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:15:54" MIMETYPE="text/xml"
-				CHECKSUM="f84c66f400218e44ee9e076b8857865d585182aa" CHECKSUMTYPE="SHA-1" SIZE="175795">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:15:54" MIMETYPE="text/xml" CHECKSUM="f84c66f400218e44ee9e076b8857865d585182aa" CHECKSUMTYPE="SHA-1" SIZE="175795">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml"
-				CHECKSUM="9876280740a3b468324a0aac5af87c5fb984b412" CHECKSUMTYPE="SHA-1" SIZE="171310">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml" CHECKSUM="9876280740a3b468324a0aac5af87c5fb984b412" CHECKSUMTYPE="SHA-1" SIZE="171310">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml"
-				CHECKSUM="34257f5e6eb1cafa95d146892850a40eec8da97d" CHECKSUMTYPE="SHA-1" SIZE="177658">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml" CHECKSUM="34257f5e6eb1cafa95d146892850a40eec8da97d" CHECKSUMTYPE="SHA-1" SIZE="177658">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml"
-				CHECKSUM="4599d8bc7d753e343cb6c1819ee72c72008538cf" CHECKSUMTYPE="SHA-1" SIZE="186012">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:15:55" MIMETYPE="text/xml" CHECKSUM="4599d8bc7d753e343cb6c1819ee72c72008538cf" CHECKSUMTYPE="SHA-1" SIZE="186012">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml"
-				CHECKSUM="8ecc9431a79b285177922449eebab598be5afd7b" CHECKSUMTYPE="SHA-1" SIZE="132718">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml" CHECKSUM="8ecc9431a79b285177922449eebab598be5afd7b" CHECKSUMTYPE="SHA-1" SIZE="132718">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml"
-				CHECKSUM="f71bc89bf7b9d25f4fe0c62ff0b2425e37df96f7" CHECKSUMTYPE="SHA-1" SIZE="4358">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml" CHECKSUM="f71bc89bf7b9d25f4fe0c62ff0b2425e37df96f7" CHECKSUMTYPE="SHA-1" SIZE="4358">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml"
-				CHECKSUM="7cecbbb52a1cd2f96366701ec0bd896235ba2c2c" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml" CHECKSUM="7cecbbb52a1cd2f96366701ec0bd896235ba2c2c" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml"
-				CHECKSUM="836653e8527b6748996778981ac027a1ab5c2f24" CHECKSUMTYPE="SHA-1" SIZE="126048">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:15:56" MIMETYPE="text/xml" CHECKSUM="836653e8527b6748996778981ac027a1ab5c2f24" CHECKSUMTYPE="SHA-1" SIZE="126048">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml"
-				CHECKSUM="22ef0f41757c100c8133af62d1b9ede3e830dd1b" CHECKSUMTYPE="SHA-1" SIZE="193470">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml" CHECKSUM="22ef0f41757c100c8133af62d1b9ede3e830dd1b" CHECKSUMTYPE="SHA-1" SIZE="193470">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml"
-				CHECKSUM="8dfa9263f9562bdc4b78bfeb56fc4d8653815ad0" CHECKSUMTYPE="SHA-1" SIZE="194012">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml" CHECKSUM="8dfa9263f9562bdc4b78bfeb56fc4d8653815ad0" CHECKSUMTYPE="SHA-1" SIZE="194012">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml"
-				CHECKSUM="1e3360c663f442b966357c336d3d5dae4d356d0f" CHECKSUMTYPE="SHA-1" SIZE="143252">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:15:57" MIMETYPE="text/xml" CHECKSUM="1e3360c663f442b966357c336d3d5dae4d356d0f" CHECKSUMTYPE="SHA-1" SIZE="143252">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml"
-				CHECKSUM="2050059a2ff2fe1d734324747eb01ffa69b98d22" CHECKSUMTYPE="SHA-1" SIZE="5557">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml" CHECKSUM="2050059a2ff2fe1d734324747eb01ffa69b98d22" CHECKSUMTYPE="SHA-1" SIZE="5557">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml"
-				CHECKSUM="84c6bc68d882958450cbd6b0f060e25e3673885d" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml" CHECKSUM="84c6bc68d882958450cbd6b0f060e25e3673885d" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml"
-				CHECKSUM="632dea8f48a09806a135761a1a66f6b40dca7c51" CHECKSUMTYPE="SHA-1" SIZE="29546">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml" CHECKSUM="632dea8f48a09806a135761a1a66f6b40dca7c51" CHECKSUMTYPE="SHA-1" SIZE="29546">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml"
-				CHECKSUM="defe7d6188b1c6f11ee87872e40862e5beaf4b06" CHECKSUMTYPE="SHA-1" SIZE="83644">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:15:58" MIMETYPE="text/xml" CHECKSUM="defe7d6188b1c6f11ee87872e40862e5beaf4b06" CHECKSUMTYPE="SHA-1" SIZE="83644">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:15:59" MIMETYPE="text/xml"
-				CHECKSUM="ea53c35ed48f57618ddb3ee2485d4c1220307d50" CHECKSUMTYPE="SHA-1" SIZE="62638">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:15:59" MIMETYPE="text/xml" CHECKSUM="ea53c35ed48f57618ddb3ee2485d4c1220307d50" CHECKSUMTYPE="SHA-1" SIZE="62638">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:15:59" MIMETYPE="text/xml"
-				CHECKSUM="f5db7b0f3db72ab012ae69c7ab79c6f786f89422" CHECKSUMTYPE="SHA-1" SIZE="74785">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:15:59" MIMETYPE="text/xml" CHECKSUM="f5db7b0f3db72ab012ae69c7ab79c6f786f89422" CHECKSUMTYPE="SHA-1" SIZE="74785">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:15:59" MIMETYPE="text/xml"
-				CHECKSUM="a03ee0a2d2352d5bebfe1692b0ff3a2ad91a1b6a" CHECKSUMTYPE="SHA-1" SIZE="188402">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:15:59" MIMETYPE="text/xml" CHECKSUM="a03ee0a2d2352d5bebfe1692b0ff3a2ad91a1b6a" CHECKSUMTYPE="SHA-1" SIZE="188402">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:16:00" MIMETYPE="text/xml"
-				CHECKSUM="edda99692a8c22245ad252d286328b913b6978a8" CHECKSUMTYPE="SHA-1" SIZE="194615">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:16:00" MIMETYPE="text/xml" CHECKSUM="edda99692a8c22245ad252d286328b913b6978a8" CHECKSUMTYPE="SHA-1" SIZE="194615">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:16:00" MIMETYPE="text/xml"
-				CHECKSUM="022e88d4cf60894b8f3dd36ca30bee3e611d2230" CHECKSUMTYPE="SHA-1" SIZE="181182">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:16:00" MIMETYPE="text/xml" CHECKSUM="022e88d4cf60894b8f3dd36ca30bee3e611d2230" CHECKSUMTYPE="SHA-1" SIZE="181182">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:16:01" MIMETYPE="text/xml"
-				CHECKSUM="be3ebbc6778b78764f363ac47f96254ba01270b2" CHECKSUMTYPE="SHA-1" SIZE="74190">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:16:01" MIMETYPE="text/xml" CHECKSUM="be3ebbc6778b78764f363ac47f96254ba01270b2" CHECKSUMTYPE="SHA-1" SIZE="74190">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:16:01" MIMETYPE="text/xml"
-				CHECKSUM="32ea34e701ddab527430009e4a611779270436ed" CHECKSUMTYPE="SHA-1" SIZE="183402">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:16:01" MIMETYPE="text/xml" CHECKSUM="32ea34e701ddab527430009e4a611779270436ed" CHECKSUMTYPE="SHA-1" SIZE="183402">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:16:01" MIMETYPE="text/xml"
-				CHECKSUM="16dbc2590590e95989d4dfc6d593411f4020e685" CHECKSUMTYPE="SHA-1" SIZE="141499">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:16:01" MIMETYPE="text/xml" CHECKSUM="16dbc2590590e95989d4dfc6d593411f4020e685" CHECKSUMTYPE="SHA-1" SIZE="141499">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:16:02" MIMETYPE="text/xml"
-				CHECKSUM="f28f273f18173621ad78e9ebfe54b81b6bbcf307" CHECKSUMTYPE="SHA-1" SIZE="140678">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:16:02" MIMETYPE="text/xml" CHECKSUM="f28f273f18173621ad78e9ebfe54b81b6bbcf307" CHECKSUMTYPE="SHA-1" SIZE="140678">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:16:02" MIMETYPE="text/xml"
-				CHECKSUM="fb89582d4a244d9795fcd5b556fc2e67230b71d3" CHECKSUMTYPE="SHA-1" SIZE="185746">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:16:02" MIMETYPE="text/xml" CHECKSUM="fb89582d4a244d9795fcd5b556fc2e67230b71d3" CHECKSUMTYPE="SHA-1" SIZE="185746">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:16:02" MIMETYPE="text/xml"
-				CHECKSUM="8752fae469cf0e750a8d886e3067f9020f145545" CHECKSUMTYPE="SHA-1" SIZE="5031">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:16:02" MIMETYPE="text/xml" CHECKSUM="8752fae469cf0e750a8d886e3067f9020f145545" CHECKSUMTYPE="SHA-1" SIZE="5031">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:16:03" MIMETYPE="text/xml"
-				CHECKSUM="1738d742e05d740668dec2769b39066a3ee06e4d" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:16:03" MIMETYPE="text/xml" CHECKSUM="1738d742e05d740668dec2769b39066a3ee06e4d" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:16:03" MIMETYPE="text/xml"
-				CHECKSUM="240accd6d4db6d4edab5339522a0b9658674a486" CHECKSUMTYPE="SHA-1" SIZE="137465">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:16:03" MIMETYPE="text/xml" CHECKSUM="240accd6d4db6d4edab5339522a0b9658674a486" CHECKSUMTYPE="SHA-1" SIZE="137465">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:16:03" MIMETYPE="text/xml"
-				CHECKSUM="18b42cc1879baf8419dd35852503e78aacaea784" CHECKSUMTYPE="SHA-1" SIZE="157793">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:16:03" MIMETYPE="text/xml" CHECKSUM="18b42cc1879baf8419dd35852503e78aacaea784" CHECKSUMTYPE="SHA-1" SIZE="157793">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:16:04" MIMETYPE="text/xml"
-				CHECKSUM="154198af0c44c3113c770bb8e18f3acfeccdbfb4" CHECKSUMTYPE="SHA-1" SIZE="48811">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:16:04" MIMETYPE="text/xml" CHECKSUM="154198af0c44c3113c770bb8e18f3acfeccdbfb4" CHECKSUMTYPE="SHA-1" SIZE="48811">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:16:04" MIMETYPE="text/xml"
-				CHECKSUM="1d2a4f5e6a0e00c6f07d385154189a8fd859d16c" CHECKSUMTYPE="SHA-1" SIZE="43847">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:16:04" MIMETYPE="text/xml" CHECKSUM="1d2a4f5e6a0e00c6f07d385154189a8fd859d16c" CHECKSUMTYPE="SHA-1" SIZE="43847">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:16:04" MIMETYPE="text/xml"
-				CHECKSUM="bf548261b4429be3fa040cc572b043f35944774d" CHECKSUMTYPE="SHA-1" SIZE="18047">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:16:04" MIMETYPE="text/xml" CHECKSUM="bf548261b4429be3fa040cc572b043f35944774d" CHECKSUMTYPE="SHA-1" SIZE="18047">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:16:04" MIMETYPE="text/xml"
-				CHECKSUM="92f62a3e7786b5628ee17ecf321d14c6ec9178ba" CHECKSUMTYPE="SHA-1" SIZE="43802">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:16:04" MIMETYPE="text/xml" CHECKSUM="92f62a3e7786b5628ee17ecf321d14c6ec9178ba" CHECKSUMTYPE="SHA-1" SIZE="43802">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T18:16:05" MIMETYPE="text/xml"
-				CHECKSUM="2dd33fb69b99c001643a6bd5430faaf3c89c95e7" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T18:16:05" MIMETYPE="text/xml" CHECKSUM="2dd33fb69b99c001643a6bd5430faaf3c89c95e7" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T18:16:05" MIMETYPE="text/xml"
-				CHECKSUM="7a21c72564d7e6c97aa9eec70e3631c4529c8576" CHECKSUMTYPE="SHA-1" SIZE="5753">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T18:16:05" MIMETYPE="text/xml" CHECKSUM="7a21c72564d7e6c97aa9eec70e3631c4529c8576" CHECKSUMTYPE="SHA-1" SIZE="5753">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-10_01_0094.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:20:03" MIMETYPE="application/pdf" CHECKSUM="bb929c26a9aa94ad48575081f1332172975406a3"
-				CHECKSUMTYPE="SHA-1" SIZE="47837941">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/bmtnabe_1898-10_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:20:03" MIMETYPE="application/pdf" CHECKSUM="bb929c26a9aa94ad48575081f1332172975406a3" CHECKSUMTYPE="SHA-1" SIZE="47837941">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/10_01/bmtnabe_1898-10_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -11225,8 +10937,7 @@
 					</div>
 
 				</div>
-				<div ID="L.1.1.20" TYPE="TextContent" ORDER="20" DMDID="c057"
-					LABEL="TAGEBUCH-AUFZEICHNUNGEN UEBER ARNOLD BOECKLIN VON RUD. SCHICK AUS DEN JAHREN 1866, 1868, 1869">
+				<div ID="L.1.1.20" TYPE="TextContent" ORDER="20" DMDID="c057" LABEL="TAGEBUCH-AUFZEICHNUNGEN UEBER ARNOLD BOECKLIN VON RUD. SCHICK AUS DEN JAHREN 1866, 1868, 1869">
 					<div ID="L.1.1.20.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00057" BEGIN="P57_TB00002"/>
@@ -11715,8 +11426,7 @@
 					</div>
 
 				</div>
-				<div ID="L.1.1.24" TYPE="TextContent" ORDER="24" DMDID="c079"
-					LABEL="AUS KUNST UND DICHTUNG DES SKANDINAVISCHEN NORDENS WELLE EIN MAERCHEN">
+				<div ID="L.1.1.24" TYPE="TextContent" ORDER="24" DMDID="c079" LABEL="AUS KUNST UND DICHTUNG DES SKANDINAVISCHEN NORDENS WELLE EIN MAERCHEN">
 					<div ID="L.1.1.24.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00073" BEGIN="P73_TB00002"/>

--- a/metadata/periodicals/bmtnabe/issues/1898/11_01/bmtnabe_1898-11_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1898/11_01/bmtnabe_1898-11_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1898-11_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1898-11_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-11_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-11_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1898-11_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1898-11_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1898-11_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -8112,842 +8108,564 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:35:59" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="93a55577f00379c289046fb3f9edb7d27e5884fc" CHECKSUMTYPE="SHA-1" SIZE="5051777">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:36:27" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="7d2d53de85866975e4b3083818c37d64d92a0422" CHECKSUMTYPE="SHA-1" SIZE="5281295">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:36:52" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="41c0bf77070b3665764e6c041399cc632f14fbc5" CHECKSUMTYPE="SHA-1" SIZE="5084229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:37:14" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="2f1f0386c208610917f580b3c3ec23a890be75e6" CHECKSUMTYPE="SHA-1" SIZE="5277728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:37:38" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="7024d9eacefb2ec160a0289ddc41143ee2865072" CHECKSUMTYPE="SHA-1" SIZE="5068929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:38:01" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="bd1e16b9fc52fe4f978c078666ef794d4f1c1812" CHECKSUMTYPE="SHA-1" SIZE="5291102">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:38:24" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="aa1c772fa4f84b7677f68916284468349b6eb9d1" CHECKSUMTYPE="SHA-1" SIZE="5110304">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:38:47" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="9c5ec3194b0037fd37f2e889cd6d704ec8d97767" CHECKSUMTYPE="SHA-1" SIZE="5239929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:39:10" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="85a5d9c9aa6cc28b71e7bd7e9faa19e2edab6a47" CHECKSUMTYPE="SHA-1" SIZE="5091429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:39:35" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="8b61acc3aad95070474ef4e76c2070d9e5922982" CHECKSUMTYPE="SHA-1" SIZE="5290329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:39:59" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="99f13b81bb2c65e5a99aed705bcc5b1207725421" CHECKSUMTYPE="SHA-1" SIZE="5133728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:40:24" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="2e09c8554070f5279830dce42d3cb6fd85423019" CHECKSUMTYPE="SHA-1" SIZE="5279520">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:40:49" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="be6e1cd102b0c082a75074b92e992175660a3345" CHECKSUMTYPE="SHA-1" SIZE="5177823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:41:13" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="be1803a394b8a4f95165c9557cd7882fa8fe9033" CHECKSUMTYPE="SHA-1" SIZE="5292125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:41:37" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="42e8ff2ce19d47b4a35c61ed3a98330612d49c14" CHECKSUMTYPE="SHA-1" SIZE="5148129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:42:03" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="8a22944888ef8bb00fdaeceb089bae149b98408c" CHECKSUMTYPE="SHA-1" SIZE="5316417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:42:27" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="66e051044759f9343d134fc40f0af4f4972b0b1f" CHECKSUMTYPE="SHA-1" SIZE="5152626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:42:51" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="bf7428b4fc3c677c76f5147427d9a4a0a0f7ef82" CHECKSUMTYPE="SHA-1" SIZE="5331726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:43:17" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="a97e293d513a8e4fc8929c6c1c5305acd2e1b61f" CHECKSUMTYPE="SHA-1" SIZE="5157018">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:43:44" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="3173b5c69dac9076ebdc1c9690c7eb3185e02b5a" CHECKSUMTYPE="SHA-1" SIZE="5267829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:44:08" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="14fb4582d39340f9d8cfc26ecf5bc796e718e598" CHECKSUMTYPE="SHA-1" SIZE="5149916">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:44:34" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="60fa124fa72cdae8751338c12bd4aa394ceebf57" CHECKSUMTYPE="SHA-1" SIZE="5262429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:44:58" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="e70f93dc56e85f57ffe09bb388766294754cd670" CHECKSUMTYPE="SHA-1" SIZE="5126529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:45:22" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="2b1e0efdf9499103702ecfb3d1be5ad4117975e5" CHECKSUMTYPE="SHA-1" SIZE="5321812">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:45:49" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="33c813a8986b976ffcc6be6b14d85f0e549d55cb" CHECKSUMTYPE="SHA-1" SIZE="5158928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:46:17" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="622309eaca9520c35b839434d0e11d975fcb8f40" CHECKSUMTYPE="SHA-1" SIZE="5316422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:46:44" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="a08bd6e74d50efb1b645275074c8aa1cea680091" CHECKSUMTYPE="SHA-1" SIZE="5175127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:47:09" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="61d66336957407fbd1bac3bcffcdb5bb33e7bbd2" CHECKSUMTYPE="SHA-1" SIZE="5294825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:47:35" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="be7914a06beec334b4c6554611f905bb094081dc" CHECKSUMTYPE="SHA-1" SIZE="5162519">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:47:59" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="ff315718283b2ad3a3623a4e94a18af2199a0bdc" CHECKSUMTYPE="SHA-1" SIZE="5293928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:48:23" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="bf135f77c721a53f4426d46a473e2c936ad54005" CHECKSUMTYPE="SHA-1" SIZE="5142729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:48:49" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="3377a8a3df76a5d353803fe2850d7e116f5e8cec" CHECKSUMTYPE="SHA-1" SIZE="5306529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:49:12" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="f571bb8fadaaa84dec7ed31905c2377724ad651b" CHECKSUMTYPE="SHA-1" SIZE="5157116">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:49:37" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="b1b830133d8b4efaf70346abe2324e25c523884e" CHECKSUMTYPE="SHA-1" SIZE="5258826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:50:01" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="a345088bdc35553ca3aa08b7934b86d3b152e0d0" CHECKSUMTYPE="SHA-1" SIZE="5193129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:50:29" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="1e0b96d4ce8246d022ff9ae0862f99b1e7ff5afc" CHECKSUMTYPE="SHA-1" SIZE="5254327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:50:53" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="17c5d342c221f68335d9c4e285e6b8e1e5e2d2d8" CHECKSUMTYPE="SHA-1" SIZE="5188618">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:51:23" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="834d060589c98a3372c0dabc69ab24490265f861" CHECKSUMTYPE="SHA-1" SIZE="5279523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:51:47" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="703b57a1cb1c04ecc07e538907bc2e2ac243cfda" CHECKSUMTYPE="SHA-1" SIZE="5223727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:52:11" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="c7967ae29075939edaee9f4a3e03d7035370e81d" CHECKSUMTYPE="SHA-1" SIZE="5286728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:52:36" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="7ddaa4352925e046d3615d972e1a7c82c06d7872" CHECKSUMTYPE="SHA-1" SIZE="5209327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:53:01" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="875e14963c150787167a62936021dc684be361de" CHECKSUMTYPE="SHA-1" SIZE="5285829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:53:26" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="76137bb2ab5d4ebf215ca2894de1545f563687c1" CHECKSUMTYPE="SHA-1" SIZE="5190425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:53:57" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="c044d3da6564b98ce838da3ab004dbea4e64c94a" CHECKSUMTYPE="SHA-1" SIZE="5270528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:54:21" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="cf772ea7965ca4437dcf70cf85c6a80d96de8437" CHECKSUMTYPE="SHA-1" SIZE="5227326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:54:47" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="7015091fc7ea4ad04091aac80d5c914f4c27879b" CHECKSUMTYPE="SHA-1" SIZE="5252513">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:55:11" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="9f297d75811641b98ea5b9ba414235ddd246f239" CHECKSUMTYPE="SHA-1" SIZE="5219227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:55:37" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="487aa4c2551643da9451c96deb6192f36a50e0f8" CHECKSUMTYPE="SHA-1" SIZE="5277710">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:56:04" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="58ef0570b999ba6379330f2b91ea4d83e1155ffa" CHECKSUMTYPE="SHA-1" SIZE="5157128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:56:29" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="4715eea3d3ab80c761476a52375c66fbda96b128" CHECKSUMTYPE="SHA-1" SIZE="5293023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:56:54" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="585f3513d9e2cb4afa26d15fa4a30e988a4e22d8" CHECKSUMTYPE="SHA-1" SIZE="5201225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:57:20" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="6ca49f594da5685ac42638c593a3bd2913d44694" CHECKSUMTYPE="SHA-1" SIZE="5239029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:57:44" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="75dd14ff7fd47d2a940ba4fa1b50887edea15710" CHECKSUMTYPE="SHA-1" SIZE="5210199">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:58:11" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="4df5f15d686c88acb25eb6479961520dd1fcf664" CHECKSUMTYPE="SHA-1" SIZE="5300228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:58:37" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="fd83cc320aee229506677347d597e81590685fa6" CHECKSUMTYPE="SHA-1" SIZE="5179629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:59:02" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="a18ff004f201a7b302b9a995a3f8d155913d6a8b" CHECKSUMTYPE="SHA-1" SIZE="5302925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:59:29" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="ae45d507ff769c84d34b437de5b1687f570ee863" CHECKSUMTYPE="SHA-1" SIZE="5210226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:59:54" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="4ffb40a154649d59ee519461b91fb20c35ba0437" CHECKSUMTYPE="SHA-1" SIZE="5284925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:00:21" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="c969584496b5b8c7b5ac8f42a069b51535bc1fc1" CHECKSUMTYPE="SHA-1" SIZE="5229118">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:00:47" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="d422f47f2fb116322a53d5c8c862aefbdd6a2569" CHECKSUMTYPE="SHA-1" SIZE="5262422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:01:13" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="95c24d8c576aa5d90befee1ff08978f3520bb3e7" CHECKSUMTYPE="SHA-1" SIZE="5170594">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:01:41" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="f0bb2b29e3b65a7c560468695bb192525b8ec383" CHECKSUMTYPE="SHA-1" SIZE="5273229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:02:06" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="950033636f289e08f4f30bbe619c04cef900e57b" CHECKSUMTYPE="SHA-1" SIZE="5187725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:02:32" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="2c57cee16457c807e31da7bf9dd0c327992dcd45" CHECKSUMTYPE="SHA-1" SIZE="5244422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:02:58" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="95329a9de9f9ae794a23b1305493a15b71c33727" CHECKSUMTYPE="SHA-1" SIZE="5225513">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:03:23" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="9240cd1e7dd896b60e2c532179288f63b734224c" CHECKSUMTYPE="SHA-1" SIZE="5227313">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:03:48" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="ee787d23f3114afc6888e94e2554c3f6bab61e18" CHECKSUMTYPE="SHA-1" SIZE="5225529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:04:12" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="97ed4d6a36d7ff899a13e2e02f51c52fdb1dad02" CHECKSUMTYPE="SHA-1" SIZE="5268714">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:04:38" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="d5b8f494853006b032dc0ad2b5ddabd98d06b9ec" CHECKSUMTYPE="SHA-1" SIZE="5210226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:05:04" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="c24a3938fa57f1d3233fed26e747ee567c18cba6" CHECKSUMTYPE="SHA-1" SIZE="5248029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:05:31" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="08b46dbbebf8201b1d61bd752c65fc2170183dea" CHECKSUMTYPE="SHA-1" SIZE="5220123">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:05:57" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="cc5c08eca25522dde1ce31c7306b7c276ca4bbfa" CHECKSUMTYPE="SHA-1" SIZE="5261526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:06:22" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="5abf47270decd31a94dbf64eaa21690b7a6fea06" CHECKSUMTYPE="SHA-1" SIZE="5253427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:06:46" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="597f770f83b0684dcfb2bd154c819ae1b145be6a" CHECKSUMTYPE="SHA-1" SIZE="5241729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:07:10" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="885f4de29857d2bf84418854a21285f0ddc94d02" CHECKSUMTYPE="SHA-1" SIZE="5191306">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:07:32" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="f2e6127cd995cba09455860ad342008966fb802c" CHECKSUMTYPE="SHA-1" SIZE="5227329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:07:56" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="f492ce411a73d3b6bed2d03074e2aaec067bdcc6" CHECKSUMTYPE="SHA-1" SIZE="5202124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:08:21" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="f4d38956360114f69e864a4e700bc9a55a4cb70c" CHECKSUMTYPE="SHA-1" SIZE="5221027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:08:49" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="8450fd1c27049dee4f7f87e84489517525f3acc6" CHECKSUMTYPE="SHA-1" SIZE="5261529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:09:15" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="f5523d75b7f3a7f584d48afbfd4619e8ea6904ad" CHECKSUMTYPE="SHA-1" SIZE="5188629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:09:38" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="493721bb43a749c3fe2d3522f8b3ea6bb6f4fbad" CHECKSUMTYPE="SHA-1" SIZE="5257925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:10:04" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="08ca303d720aced456795c10d55eb76a6da2b23d" CHECKSUMTYPE="SHA-1" SIZE="5230927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:10:27" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="931a5faacc00db1c6bc2e17d76ba201ae4da68de" CHECKSUMTYPE="SHA-1" SIZE="5167929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:10:53" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="bdc3015f9f9d27cd8341770606eaf4e7dd1400c5" CHECKSUMTYPE="SHA-1" SIZE="5249824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:11:18" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="c600bb763085af6b83f65eb89e48c8983b51dc6c" CHECKSUMTYPE="SHA-1" SIZE="5178718">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:11:46" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="c45a37eefedae393ddb1a425176c8a293f3248ee" CHECKSUMTYPE="SHA-1" SIZE="5230920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T18:12:12" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="b27c25af954d5c7281a3bdb7d8626d900cbd0e31" CHECKSUMTYPE="SHA-1" SIZE="5170629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T18:12:35" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="1d7220d4aecea394b5f0141dfc6bd97ba38597f4" CHECKSUMTYPE="SHA-1" SIZE="5230029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T18:12:57" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="a5449a8e64f9672190304cb67411770a0639fce9" CHECKSUMTYPE="SHA-1" SIZE="5147225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T18:13:20" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="f0ed38b2775e94fabf03a7b3c544f2b0dda895ca" CHECKSUMTYPE="SHA-1" SIZE="5252432">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T18:13:45" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="09aad9cffbc134cbadd5572a9b3e619f64b220a7" CHECKSUMTYPE="SHA-1" SIZE="5138225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T18:14:10" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="9f1b8085fb09d35a92620684a954f7bd2faacc2a" CHECKSUMTYPE="SHA-1" SIZE="5229126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0092.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:35:59" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="93a55577f00379c289046fb3f9edb7d27e5884fc" CHECKSUMTYPE="SHA-1" SIZE="5051777">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:36:27" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="7d2d53de85866975e4b3083818c37d64d92a0422" CHECKSUMTYPE="SHA-1" SIZE="5281295">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:36:52" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="41c0bf77070b3665764e6c041399cc632f14fbc5" CHECKSUMTYPE="SHA-1" SIZE="5084229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:37:14" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="2f1f0386c208610917f580b3c3ec23a890be75e6" CHECKSUMTYPE="SHA-1" SIZE="5277728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:37:38" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="7024d9eacefb2ec160a0289ddc41143ee2865072" CHECKSUMTYPE="SHA-1" SIZE="5068929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:38:01" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="bd1e16b9fc52fe4f978c078666ef794d4f1c1812" CHECKSUMTYPE="SHA-1" SIZE="5291102">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:38:24" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="aa1c772fa4f84b7677f68916284468349b6eb9d1" CHECKSUMTYPE="SHA-1" SIZE="5110304">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:38:47" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="9c5ec3194b0037fd37f2e889cd6d704ec8d97767" CHECKSUMTYPE="SHA-1" SIZE="5239929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:39:10" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="85a5d9c9aa6cc28b71e7bd7e9faa19e2edab6a47" CHECKSUMTYPE="SHA-1" SIZE="5091429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:39:35" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="8b61acc3aad95070474ef4e76c2070d9e5922982" CHECKSUMTYPE="SHA-1" SIZE="5290329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:39:59" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="99f13b81bb2c65e5a99aed705bcc5b1207725421" CHECKSUMTYPE="SHA-1" SIZE="5133728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:40:24" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="2e09c8554070f5279830dce42d3cb6fd85423019" CHECKSUMTYPE="SHA-1" SIZE="5279520">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T17:40:49" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="be6e1cd102b0c082a75074b92e992175660a3345" CHECKSUMTYPE="SHA-1" SIZE="5177823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T17:41:13" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="be1803a394b8a4f95165c9557cd7882fa8fe9033" CHECKSUMTYPE="SHA-1" SIZE="5292125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T17:41:37" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="42e8ff2ce19d47b4a35c61ed3a98330612d49c14" CHECKSUMTYPE="SHA-1" SIZE="5148129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T17:42:03" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="8a22944888ef8bb00fdaeceb089bae149b98408c" CHECKSUMTYPE="SHA-1" SIZE="5316417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T17:42:27" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="66e051044759f9343d134fc40f0af4f4972b0b1f" CHECKSUMTYPE="SHA-1" SIZE="5152626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T17:42:51" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="bf7428b4fc3c677c76f5147427d9a4a0a0f7ef82" CHECKSUMTYPE="SHA-1" SIZE="5331726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T17:43:17" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="a97e293d513a8e4fc8929c6c1c5305acd2e1b61f" CHECKSUMTYPE="SHA-1" SIZE="5157018">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T17:43:44" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="3173b5c69dac9076ebdc1c9690c7eb3185e02b5a" CHECKSUMTYPE="SHA-1" SIZE="5267829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T17:44:08" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="14fb4582d39340f9d8cfc26ecf5bc796e718e598" CHECKSUMTYPE="SHA-1" SIZE="5149916">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T17:44:34" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="60fa124fa72cdae8751338c12bd4aa394ceebf57" CHECKSUMTYPE="SHA-1" SIZE="5262429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T17:44:58" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="e70f93dc56e85f57ffe09bb388766294754cd670" CHECKSUMTYPE="SHA-1" SIZE="5126529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T17:45:22" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="2b1e0efdf9499103702ecfb3d1be5ad4117975e5" CHECKSUMTYPE="SHA-1" SIZE="5321812">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T17:45:49" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="33c813a8986b976ffcc6be6b14d85f0e549d55cb" CHECKSUMTYPE="SHA-1" SIZE="5158928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T17:46:17" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="622309eaca9520c35b839434d0e11d975fcb8f40" CHECKSUMTYPE="SHA-1" SIZE="5316422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T17:46:44" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="a08bd6e74d50efb1b645275074c8aa1cea680091" CHECKSUMTYPE="SHA-1" SIZE="5175127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T17:47:09" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="61d66336957407fbd1bac3bcffcdb5bb33e7bbd2" CHECKSUMTYPE="SHA-1" SIZE="5294825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T17:47:35" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="be7914a06beec334b4c6554611f905bb094081dc" CHECKSUMTYPE="SHA-1" SIZE="5162519">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T17:47:59" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="ff315718283b2ad3a3623a4e94a18af2199a0bdc" CHECKSUMTYPE="SHA-1" SIZE="5293928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T17:48:23" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="bf135f77c721a53f4426d46a473e2c936ad54005" CHECKSUMTYPE="SHA-1" SIZE="5142729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T17:48:49" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="3377a8a3df76a5d353803fe2850d7e116f5e8cec" CHECKSUMTYPE="SHA-1" SIZE="5306529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T17:49:12" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="f571bb8fadaaa84dec7ed31905c2377724ad651b" CHECKSUMTYPE="SHA-1" SIZE="5157116">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T17:49:37" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="b1b830133d8b4efaf70346abe2324e25c523884e" CHECKSUMTYPE="SHA-1" SIZE="5258826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T17:50:01" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="a345088bdc35553ca3aa08b7934b86d3b152e0d0" CHECKSUMTYPE="SHA-1" SIZE="5193129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T17:50:29" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="1e0b96d4ce8246d022ff9ae0862f99b1e7ff5afc" CHECKSUMTYPE="SHA-1" SIZE="5254327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T17:50:53" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="17c5d342c221f68335d9c4e285e6b8e1e5e2d2d8" CHECKSUMTYPE="SHA-1" SIZE="5188618">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T17:51:23" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="834d060589c98a3372c0dabc69ab24490265f861" CHECKSUMTYPE="SHA-1" SIZE="5279523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T17:51:47" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="703b57a1cb1c04ecc07e538907bc2e2ac243cfda" CHECKSUMTYPE="SHA-1" SIZE="5223727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T17:52:11" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="c7967ae29075939edaee9f4a3e03d7035370e81d" CHECKSUMTYPE="SHA-1" SIZE="5286728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T17:52:36" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="7ddaa4352925e046d3615d972e1a7c82c06d7872" CHECKSUMTYPE="SHA-1" SIZE="5209327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T17:53:01" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="875e14963c150787167a62936021dc684be361de" CHECKSUMTYPE="SHA-1" SIZE="5285829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T17:53:26" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="76137bb2ab5d4ebf215ca2894de1545f563687c1" CHECKSUMTYPE="SHA-1" SIZE="5190425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T17:53:57" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="c044d3da6564b98ce838da3ab004dbea4e64c94a" CHECKSUMTYPE="SHA-1" SIZE="5270528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T17:54:21" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="cf772ea7965ca4437dcf70cf85c6a80d96de8437" CHECKSUMTYPE="SHA-1" SIZE="5227326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T17:54:47" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="7015091fc7ea4ad04091aac80d5c914f4c27879b" CHECKSUMTYPE="SHA-1" SIZE="5252513">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T17:55:11" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="9f297d75811641b98ea5b9ba414235ddd246f239" CHECKSUMTYPE="SHA-1" SIZE="5219227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T17:55:37" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="487aa4c2551643da9451c96deb6192f36a50e0f8" CHECKSUMTYPE="SHA-1" SIZE="5277710">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T17:56:04" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="58ef0570b999ba6379330f2b91ea4d83e1155ffa" CHECKSUMTYPE="SHA-1" SIZE="5157128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T17:56:29" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="4715eea3d3ab80c761476a52375c66fbda96b128" CHECKSUMTYPE="SHA-1" SIZE="5293023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T17:56:54" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="585f3513d9e2cb4afa26d15fa4a30e988a4e22d8" CHECKSUMTYPE="SHA-1" SIZE="5201225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T17:57:20" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="6ca49f594da5685ac42638c593a3bd2913d44694" CHECKSUMTYPE="SHA-1" SIZE="5239029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T17:57:44" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="75dd14ff7fd47d2a940ba4fa1b50887edea15710" CHECKSUMTYPE="SHA-1" SIZE="5210199">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T17:58:11" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="4df5f15d686c88acb25eb6479961520dd1fcf664" CHECKSUMTYPE="SHA-1" SIZE="5300228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T17:58:37" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="fd83cc320aee229506677347d597e81590685fa6" CHECKSUMTYPE="SHA-1" SIZE="5179629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T17:59:02" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="a18ff004f201a7b302b9a995a3f8d155913d6a8b" CHECKSUMTYPE="SHA-1" SIZE="5302925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T17:59:29" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="ae45d507ff769c84d34b437de5b1687f570ee863" CHECKSUMTYPE="SHA-1" SIZE="5210226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T17:59:54" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="4ffb40a154649d59ee519461b91fb20c35ba0437" CHECKSUMTYPE="SHA-1" SIZE="5284925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:00:21" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="c969584496b5b8c7b5ac8f42a069b51535bc1fc1" CHECKSUMTYPE="SHA-1" SIZE="5229118">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:00:47" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="d422f47f2fb116322a53d5c8c862aefbdd6a2569" CHECKSUMTYPE="SHA-1" SIZE="5262422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:01:13" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="95c24d8c576aa5d90befee1ff08978f3520bb3e7" CHECKSUMTYPE="SHA-1" SIZE="5170594">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:01:41" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="f0bb2b29e3b65a7c560468695bb192525b8ec383" CHECKSUMTYPE="SHA-1" SIZE="5273229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:02:06" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="950033636f289e08f4f30bbe619c04cef900e57b" CHECKSUMTYPE="SHA-1" SIZE="5187725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:02:32" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="2c57cee16457c807e31da7bf9dd0c327992dcd45" CHECKSUMTYPE="SHA-1" SIZE="5244422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:02:58" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="95329a9de9f9ae794a23b1305493a15b71c33727" CHECKSUMTYPE="SHA-1" SIZE="5225513">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:03:23" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="9240cd1e7dd896b60e2c532179288f63b734224c" CHECKSUMTYPE="SHA-1" SIZE="5227313">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:03:48" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="ee787d23f3114afc6888e94e2554c3f6bab61e18" CHECKSUMTYPE="SHA-1" SIZE="5225529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:04:12" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="97ed4d6a36d7ff899a13e2e02f51c52fdb1dad02" CHECKSUMTYPE="SHA-1" SIZE="5268714">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:04:38" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="d5b8f494853006b032dc0ad2b5ddabd98d06b9ec" CHECKSUMTYPE="SHA-1" SIZE="5210226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:05:04" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="c24a3938fa57f1d3233fed26e747ee567c18cba6" CHECKSUMTYPE="SHA-1" SIZE="5248029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:05:31" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="08b46dbbebf8201b1d61bd752c65fc2170183dea" CHECKSUMTYPE="SHA-1" SIZE="5220123">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:05:57" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="cc5c08eca25522dde1ce31c7306b7c276ca4bbfa" CHECKSUMTYPE="SHA-1" SIZE="5261526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:06:22" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="5abf47270decd31a94dbf64eaa21690b7a6fea06" CHECKSUMTYPE="SHA-1" SIZE="5253427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:06:46" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="597f770f83b0684dcfb2bd154c819ae1b145be6a" CHECKSUMTYPE="SHA-1" SIZE="5241729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:07:10" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="885f4de29857d2bf84418854a21285f0ddc94d02" CHECKSUMTYPE="SHA-1" SIZE="5191306">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:07:32" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="f2e6127cd995cba09455860ad342008966fb802c" CHECKSUMTYPE="SHA-1" SIZE="5227329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:07:56" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="f492ce411a73d3b6bed2d03074e2aaec067bdcc6" CHECKSUMTYPE="SHA-1" SIZE="5202124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:08:21" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="f4d38956360114f69e864a4e700bc9a55a4cb70c" CHECKSUMTYPE="SHA-1" SIZE="5221027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:08:49" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="8450fd1c27049dee4f7f87e84489517525f3acc6" CHECKSUMTYPE="SHA-1" SIZE="5261529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:09:15" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="f5523d75b7f3a7f584d48afbfd4619e8ea6904ad" CHECKSUMTYPE="SHA-1" SIZE="5188629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:09:38" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="493721bb43a749c3fe2d3522f8b3ea6bb6f4fbad" CHECKSUMTYPE="SHA-1" SIZE="5257925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:10:04" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="08ca303d720aced456795c10d55eb76a6da2b23d" CHECKSUMTYPE="SHA-1" SIZE="5230927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:10:27" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="931a5faacc00db1c6bc2e17d76ba201ae4da68de" CHECKSUMTYPE="SHA-1" SIZE="5167929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:10:53" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="bdc3015f9f9d27cd8341770606eaf4e7dd1400c5" CHECKSUMTYPE="SHA-1" SIZE="5249824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:11:18" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="c600bb763085af6b83f65eb89e48c8983b51dc6c" CHECKSUMTYPE="SHA-1" SIZE="5178718">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:11:46" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="c45a37eefedae393ddb1a425176c8a293f3248ee" CHECKSUMTYPE="SHA-1" SIZE="5230920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T18:12:12" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="b27c25af954d5c7281a3bdb7d8626d900cbd0e31" CHECKSUMTYPE="SHA-1" SIZE="5170629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T18:12:35" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="1d7220d4aecea394b5f0141dfc6bd97ba38597f4" CHECKSUMTYPE="SHA-1" SIZE="5230029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T18:12:57" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="a5449a8e64f9672190304cb67411770a0639fce9" CHECKSUMTYPE="SHA-1" SIZE="5147225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T18:13:20" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="f0ed38b2775e94fabf03a7b3c544f2b0dda895ca" CHECKSUMTYPE="SHA-1" SIZE="5252432">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T18:13:45" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="09aad9cffbc134cbadd5572a9b3e619f64b220a7" CHECKSUMTYPE="SHA-1" SIZE="5138225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T18:14:10" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="9f1b8085fb09d35a92620684a954f7bd2faacc2a" CHECKSUMTYPE="SHA-1" SIZE="5229126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/delivery/bmtnabe_1898-11_01_0092.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:14:24" MIMETYPE="text/xml" CHECKSUM="9a85cba59d8d311db07bcc180851b60c7123d57b"
-				CHECKSUMTYPE="SHA-1" SIZE="2108">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:14:24" MIMETYPE="text/xml" CHECKSUM="9a85cba59d8d311db07bcc180851b60c7123d57b" CHECKSUMTYPE="SHA-1" SIZE="2108">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:14:24" MIMETYPE="text/xml" CHECKSUM="7974c4de9d3f7165e4f67dbeb5458f6ac3fdcc86"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:14:24" MIMETYPE="text/xml" CHECKSUM="7974c4de9d3f7165e4f67dbeb5458f6ac3fdcc86" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:14:25" MIMETYPE="text/xml" CHECKSUM="4bd050aa65812433de85525afab2a20963d86f9d"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:14:25" MIMETYPE="text/xml" CHECKSUM="4bd050aa65812433de85525afab2a20963d86f9d" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:14:25" MIMETYPE="text/xml" CHECKSUM="1206b0274b1a7c97280a363f97c4aff657e08f26"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:14:25" MIMETYPE="text/xml" CHECKSUM="1206b0274b1a7c97280a363f97c4aff657e08f26" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:14:25" MIMETYPE="text/xml" CHECKSUM="5b93591b9fca645ea3071c487a5e315109e5883f"
-				CHECKSUMTYPE="SHA-1" SIZE="7967">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:14:25" MIMETYPE="text/xml" CHECKSUM="5b93591b9fca645ea3071c487a5e315109e5883f" CHECKSUMTYPE="SHA-1" SIZE="7967">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:14:25" MIMETYPE="text/xml" CHECKSUM="c369737d96ef6265a00799133effc3d3fd4f8b35"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:14:25" MIMETYPE="text/xml" CHECKSUM="c369737d96ef6265a00799133effc3d3fd4f8b35" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:14:26" MIMETYPE="text/xml" CHECKSUM="fb4a9d65f5513e04798db6c4eefb13730b5c9bb6"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:14:26" MIMETYPE="text/xml" CHECKSUM="fb4a9d65f5513e04798db6c4eefb13730b5c9bb6" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:14:26" MIMETYPE="text/xml" CHECKSUM="7e067f79ec733c644dc4ec78498d8eddf444fd65"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:14:26" MIMETYPE="text/xml" CHECKSUM="7e067f79ec733c644dc4ec78498d8eddf444fd65" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:14:26" MIMETYPE="text/xml" CHECKSUM="be1a6176527ccba59ba83956c6c2944e1dfd412d"
-				CHECKSUMTYPE="SHA-1" SIZE="13858">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:14:26" MIMETYPE="text/xml" CHECKSUM="be1a6176527ccba59ba83956c6c2944e1dfd412d" CHECKSUMTYPE="SHA-1" SIZE="13858">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:14:27" MIMETYPE="text/xml"
-				CHECKSUM="847ec843eef8ed66e3526d7fdd6c3954139db8cc" CHECKSUMTYPE="SHA-1" SIZE="3402">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:14:27" MIMETYPE="text/xml" CHECKSUM="847ec843eef8ed66e3526d7fdd6c3954139db8cc" CHECKSUMTYPE="SHA-1" SIZE="3402">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:14:27" MIMETYPE="text/xml"
-				CHECKSUM="0fd941dee09a89761131d42e7cfe660c6aab9fdc" CHECKSUMTYPE="SHA-1" SIZE="1713">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:14:27" MIMETYPE="text/xml" CHECKSUM="0fd941dee09a89761131d42e7cfe660c6aab9fdc" CHECKSUMTYPE="SHA-1" SIZE="1713">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:14:27" MIMETYPE="text/xml"
-				CHECKSUM="51c5827034165185ab10141ebbe8ce83e47d0118" CHECKSUMTYPE="SHA-1" SIZE="5440">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:14:27" MIMETYPE="text/xml" CHECKSUM="51c5827034165185ab10141ebbe8ce83e47d0118" CHECKSUMTYPE="SHA-1" SIZE="5440">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:14:27" MIMETYPE="text/xml"
-				CHECKSUM="e627a1d25f7d1a1a847650970aeae724c03be940" CHECKSUMTYPE="SHA-1" SIZE="19154">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:14:27" MIMETYPE="text/xml" CHECKSUM="e627a1d25f7d1a1a847650970aeae724c03be940" CHECKSUMTYPE="SHA-1" SIZE="19154">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:14:28" MIMETYPE="text/xml"
-				CHECKSUM="7407364be36f97fddacc7b9424ee15c9512b4983" CHECKSUMTYPE="SHA-1" SIZE="33255">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:14:28" MIMETYPE="text/xml" CHECKSUM="7407364be36f97fddacc7b9424ee15c9512b4983" CHECKSUMTYPE="SHA-1" SIZE="33255">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:14:28" MIMETYPE="text/xml"
-				CHECKSUM="27d58321e9b458d8be1f351c5271ae46a9a743e5" CHECKSUMTYPE="SHA-1" SIZE="18103">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:14:28" MIMETYPE="text/xml" CHECKSUM="27d58321e9b458d8be1f351c5271ae46a9a743e5" CHECKSUMTYPE="SHA-1" SIZE="18103">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:14:28" MIMETYPE="text/xml"
-				CHECKSUM="140f0b4fa09c4e8d410543108561791a94ee0a3a" CHECKSUMTYPE="SHA-1" SIZE="36962">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:14:28" MIMETYPE="text/xml" CHECKSUM="140f0b4fa09c4e8d410543108561791a94ee0a3a" CHECKSUMTYPE="SHA-1" SIZE="36962">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:14:28" MIMETYPE="text/xml"
-				CHECKSUM="36fbcfbbf3a00b50d55376fb423b2e99447c9f33" CHECKSUMTYPE="SHA-1" SIZE="51962">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:14:28" MIMETYPE="text/xml" CHECKSUM="36fbcfbbf3a00b50d55376fb423b2e99447c9f33" CHECKSUMTYPE="SHA-1" SIZE="51962">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:14:29" MIMETYPE="text/xml"
-				CHECKSUM="11fb213ba763046e09e5dd83192d7893be85cadd" CHECKSUMTYPE="SHA-1" SIZE="20253">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:14:29" MIMETYPE="text/xml" CHECKSUM="11fb213ba763046e09e5dd83192d7893be85cadd" CHECKSUMTYPE="SHA-1" SIZE="20253">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:14:29" MIMETYPE="text/xml"
-				CHECKSUM="ae68e63c4c0877346e0d9b625f5f53ed24572f69" CHECKSUMTYPE="SHA-1" SIZE="31962">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:14:29" MIMETYPE="text/xml" CHECKSUM="ae68e63c4c0877346e0d9b625f5f53ed24572f69" CHECKSUMTYPE="SHA-1" SIZE="31962">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:14:29" MIMETYPE="text/xml"
-				CHECKSUM="c8b40d08ed174771188512a759259f6121a31813" CHECKSUMTYPE="SHA-1" SIZE="36147">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:14:29" MIMETYPE="text/xml" CHECKSUM="c8b40d08ed174771188512a759259f6121a31813" CHECKSUMTYPE="SHA-1" SIZE="36147">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:14:29" MIMETYPE="text/xml"
-				CHECKSUM="994b882b1ce5acb1b62e6dea70ee4ed3d799246f" CHECKSUMTYPE="SHA-1" SIZE="5449">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:14:29" MIMETYPE="text/xml" CHECKSUM="994b882b1ce5acb1b62e6dea70ee4ed3d799246f" CHECKSUMTYPE="SHA-1" SIZE="5449">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:14:30" MIMETYPE="text/xml"
-				CHECKSUM="b11df6dac827d232a4cd7b4dc44ad1d5b6a9be35" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:14:30" MIMETYPE="text/xml" CHECKSUM="b11df6dac827d232a4cd7b4dc44ad1d5b6a9be35" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:14:30" MIMETYPE="text/xml"
-				CHECKSUM="9adf6f91c07680674a5b4e57b26cd0d72a21a7cc" CHECKSUMTYPE="SHA-1" SIZE="52957">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:14:30" MIMETYPE="text/xml" CHECKSUM="9adf6f91c07680674a5b4e57b26cd0d72a21a7cc" CHECKSUMTYPE="SHA-1" SIZE="52957">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:14:30" MIMETYPE="text/xml"
-				CHECKSUM="02d1a004f50cc9d8b0cf3f4fa2651e2dc0138972" CHECKSUMTYPE="SHA-1" SIZE="95686">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:14:30" MIMETYPE="text/xml" CHECKSUM="02d1a004f50cc9d8b0cf3f4fa2651e2dc0138972" CHECKSUMTYPE="SHA-1" SIZE="95686">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:14:30" MIMETYPE="text/xml"
-				CHECKSUM="28713fb23bdf9e00c75079a0ada8e965f435f7a5" CHECKSUMTYPE="SHA-1" SIZE="115398">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:14:30" MIMETYPE="text/xml" CHECKSUM="28713fb23bdf9e00c75079a0ada8e965f435f7a5" CHECKSUMTYPE="SHA-1" SIZE="115398">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:14:31" MIMETYPE="text/xml"
-				CHECKSUM="8aeddc59db279e75ca60ba829784b4cb1ab5a979" CHECKSUMTYPE="SHA-1" SIZE="98815">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:14:31" MIMETYPE="text/xml" CHECKSUM="8aeddc59db279e75ca60ba829784b4cb1ab5a979" CHECKSUMTYPE="SHA-1" SIZE="98815">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:14:31" MIMETYPE="text/xml"
-				CHECKSUM="cc51fd814179c230fc58e34fde57f7359f4a85e8" CHECKSUMTYPE="SHA-1" SIZE="95077">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:14:31" MIMETYPE="text/xml" CHECKSUM="cc51fd814179c230fc58e34fde57f7359f4a85e8" CHECKSUMTYPE="SHA-1" SIZE="95077">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:14:31" MIMETYPE="text/xml"
-				CHECKSUM="09a020ab7afc768ea9e8fc1ae9a8e0334e8514c8" CHECKSUMTYPE="SHA-1" SIZE="101609">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:14:31" MIMETYPE="text/xml" CHECKSUM="09a020ab7afc768ea9e8fc1ae9a8e0334e8514c8" CHECKSUMTYPE="SHA-1" SIZE="101609">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:14:32" MIMETYPE="text/xml"
-				CHECKSUM="2ff7df213d9fe323f4c7705b2543a321a7817118" CHECKSUMTYPE="SHA-1" SIZE="83055">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:14:32" MIMETYPE="text/xml" CHECKSUM="2ff7df213d9fe323f4c7705b2543a321a7817118" CHECKSUMTYPE="SHA-1" SIZE="83055">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:14:32" MIMETYPE="text/xml"
-				CHECKSUM="59b61d8fa88f2e311bfd042894e972c1d8cddad6" CHECKSUMTYPE="SHA-1" SIZE="90354">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:14:32" MIMETYPE="text/xml" CHECKSUM="59b61d8fa88f2e311bfd042894e972c1d8cddad6" CHECKSUMTYPE="SHA-1" SIZE="90354">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:14:32" MIMETYPE="text/xml"
-				CHECKSUM="a9f23570728eb2496c99cf51c62dd9a546fc8c77" CHECKSUMTYPE="SHA-1" SIZE="71349">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:14:32" MIMETYPE="text/xml" CHECKSUM="a9f23570728eb2496c99cf51c62dd9a546fc8c77" CHECKSUMTYPE="SHA-1" SIZE="71349">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:14:32" MIMETYPE="text/xml"
-				CHECKSUM="4dbddd346165e86534236893e8b6a4b220ba1798" CHECKSUMTYPE="SHA-1" SIZE="30420">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:14:32" MIMETYPE="text/xml" CHECKSUM="4dbddd346165e86534236893e8b6a4b220ba1798" CHECKSUMTYPE="SHA-1" SIZE="30420">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:14:33" MIMETYPE="text/xml"
-				CHECKSUM="1a2d1245ae84416b3b2c38255eb4f0f35cb11a2b" CHECKSUMTYPE="SHA-1" SIZE="49996">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:14:33" MIMETYPE="text/xml" CHECKSUM="1a2d1245ae84416b3b2c38255eb4f0f35cb11a2b" CHECKSUMTYPE="SHA-1" SIZE="49996">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:14:33" MIMETYPE="text/xml"
-				CHECKSUM="62282ea89c0bc937963776204a679cd68702d336" CHECKSUMTYPE="SHA-1" SIZE="38232">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:14:33" MIMETYPE="text/xml" CHECKSUM="62282ea89c0bc937963776204a679cd68702d336" CHECKSUMTYPE="SHA-1" SIZE="38232">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:14:33" MIMETYPE="text/xml"
-				CHECKSUM="fe277ed6748b9156c43a28215075c6cb973abea4" CHECKSUMTYPE="SHA-1" SIZE="4758">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:14:33" MIMETYPE="text/xml" CHECKSUM="fe277ed6748b9156c43a28215075c6cb973abea4" CHECKSUMTYPE="SHA-1" SIZE="4758">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:14:33" MIMETYPE="text/xml"
-				CHECKSUM="8cb4cd7293f1114055f8766644e3d3d1e75773c2" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:14:33" MIMETYPE="text/xml" CHECKSUM="8cb4cd7293f1114055f8766644e3d3d1e75773c2" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:14:34" MIMETYPE="text/xml"
-				CHECKSUM="93fbe991fe053c8d0be56c1f9b91a11bf5545168" CHECKSUMTYPE="SHA-1" SIZE="22957">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:14:34" MIMETYPE="text/xml" CHECKSUM="93fbe991fe053c8d0be56c1f9b91a11bf5545168" CHECKSUMTYPE="SHA-1" SIZE="22957">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:14:34" MIMETYPE="text/xml"
-				CHECKSUM="00b357cccdeb3f4ac83cfb71f3e8c02354a39a5b" CHECKSUMTYPE="SHA-1" SIZE="40036">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:14:34" MIMETYPE="text/xml" CHECKSUM="00b357cccdeb3f4ac83cfb71f3e8c02354a39a5b" CHECKSUMTYPE="SHA-1" SIZE="40036">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:14:34" MIMETYPE="text/xml"
-				CHECKSUM="69e25c9b2a4dcab6e6ffb2d0f672c508ae8469c6" CHECKSUMTYPE="SHA-1" SIZE="46276">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:14:34" MIMETYPE="text/xml" CHECKSUM="69e25c9b2a4dcab6e6ffb2d0f672c508ae8469c6" CHECKSUMTYPE="SHA-1" SIZE="46276">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:14:35" MIMETYPE="text/xml"
-				CHECKSUM="d404794e0fe61368abac198398fa179a1e89609e" CHECKSUMTYPE="SHA-1" SIZE="27191">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:14:35" MIMETYPE="text/xml" CHECKSUM="d404794e0fe61368abac198398fa179a1e89609e" CHECKSUMTYPE="SHA-1" SIZE="27191">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:14:36" MIMETYPE="text/xml"
-				CHECKSUM="b357796506618cc7dc3042a2c1d3f1de79d5fc88" CHECKSUMTYPE="SHA-1" SIZE="47677">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:14:36" MIMETYPE="text/xml" CHECKSUM="b357796506618cc7dc3042a2c1d3f1de79d5fc88" CHECKSUMTYPE="SHA-1" SIZE="47677">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:14:37" MIMETYPE="text/xml"
-				CHECKSUM="103b073fe1100e0b55a3d1fc714dfff23e97dde6" CHECKSUMTYPE="SHA-1" SIZE="133414">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:14:37" MIMETYPE="text/xml" CHECKSUM="103b073fe1100e0b55a3d1fc714dfff23e97dde6" CHECKSUMTYPE="SHA-1" SIZE="133414">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:14:37" MIMETYPE="text/xml"
-				CHECKSUM="1779e64318cf9acb517972feb06811381469feda" CHECKSUMTYPE="SHA-1" SIZE="123850">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:14:37" MIMETYPE="text/xml" CHECKSUM="1779e64318cf9acb517972feb06811381469feda" CHECKSUMTYPE="SHA-1" SIZE="123850">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:14:37" MIMETYPE="text/xml"
-				CHECKSUM="17a6211a801dac3e11e45923c7f8758ea9f83f1e" CHECKSUMTYPE="SHA-1" SIZE="92136">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:14:37" MIMETYPE="text/xml" CHECKSUM="17a6211a801dac3e11e45923c7f8758ea9f83f1e" CHECKSUMTYPE="SHA-1" SIZE="92136">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:14:38" MIMETYPE="text/xml"
-				CHECKSUM="097b746679de8948b068f7949106da2660222500" CHECKSUMTYPE="SHA-1" SIZE="7063">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:14:38" MIMETYPE="text/xml" CHECKSUM="097b746679de8948b068f7949106da2660222500" CHECKSUMTYPE="SHA-1" SIZE="7063">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:14:38" MIMETYPE="text/xml"
-				CHECKSUM="ece9b16365ea91eddfd147f610fcf5ad61cb7461" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:14:38" MIMETYPE="text/xml" CHECKSUM="ece9b16365ea91eddfd147f610fcf5ad61cb7461" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:14:38" MIMETYPE="text/xml"
-				CHECKSUM="a03ae079e4c752ea8961f2fa4ef8d08729374053" CHECKSUMTYPE="SHA-1" SIZE="9849">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:14:38" MIMETYPE="text/xml" CHECKSUM="a03ae079e4c752ea8961f2fa4ef8d08729374053" CHECKSUMTYPE="SHA-1" SIZE="9849">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:14:39" MIMETYPE="text/xml"
-				CHECKSUM="a221d5bc2a91218e6d5c53a7d3ebdc2f0d7b9a4d" CHECKSUMTYPE="SHA-1" SIZE="168610">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:14:39" MIMETYPE="text/xml" CHECKSUM="a221d5bc2a91218e6d5c53a7d3ebdc2f0d7b9a4d" CHECKSUMTYPE="SHA-1" SIZE="168610">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:14:39" MIMETYPE="text/xml"
-				CHECKSUM="509dbaaaebec55e8714646cba1a74394253c8191" CHECKSUMTYPE="SHA-1" SIZE="153424">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:14:39" MIMETYPE="text/xml" CHECKSUM="509dbaaaebec55e8714646cba1a74394253c8191" CHECKSUMTYPE="SHA-1" SIZE="153424">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:14:39" MIMETYPE="text/xml"
-				CHECKSUM="1bc10ce585cd6de9506255b613ad3dbd4640e35e" CHECKSUMTYPE="SHA-1" SIZE="174038">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:14:39" MIMETYPE="text/xml" CHECKSUM="1bc10ce585cd6de9506255b613ad3dbd4640e35e" CHECKSUMTYPE="SHA-1" SIZE="174038">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:14:40" MIMETYPE="text/xml"
-				CHECKSUM="86e15a2e3ddbb37902e15ad7004685f679ea76b9" CHECKSUMTYPE="SHA-1" SIZE="159433">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:14:40" MIMETYPE="text/xml" CHECKSUM="86e15a2e3ddbb37902e15ad7004685f679ea76b9" CHECKSUMTYPE="SHA-1" SIZE="159433">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:14:40" MIMETYPE="text/xml"
-				CHECKSUM="819c2d3cf35919360b4998bf80206b21f86ed58a" CHECKSUMTYPE="SHA-1" SIZE="139879">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:14:40" MIMETYPE="text/xml" CHECKSUM="819c2d3cf35919360b4998bf80206b21f86ed58a" CHECKSUMTYPE="SHA-1" SIZE="139879">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:14:40" MIMETYPE="text/xml"
-				CHECKSUM="f37dd5a3c45bf31b7e442dfa21d3a7ae0f2ef627" CHECKSUMTYPE="SHA-1" SIZE="5361">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:14:40" MIMETYPE="text/xml" CHECKSUM="f37dd5a3c45bf31b7e442dfa21d3a7ae0f2ef627" CHECKSUMTYPE="SHA-1" SIZE="5361">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:14:41" MIMETYPE="text/xml"
-				CHECKSUM="b0ce0f2f81f098746629b6f17e75e60f2a54622e" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:14:41" MIMETYPE="text/xml" CHECKSUM="b0ce0f2f81f098746629b6f17e75e60f2a54622e" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:14:41" MIMETYPE="text/xml"
-				CHECKSUM="9b19445af431c2cbf001751f497c59b0ab6cdaa5" CHECKSUMTYPE="SHA-1" SIZE="88265">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:14:41" MIMETYPE="text/xml" CHECKSUM="9b19445af431c2cbf001751f497c59b0ab6cdaa5" CHECKSUMTYPE="SHA-1" SIZE="88265">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:14:41" MIMETYPE="text/xml"
-				CHECKSUM="5c1de196f122da491be77bdc9bbc10f230a32b72" CHECKSUMTYPE="SHA-1" SIZE="194488">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:14:41" MIMETYPE="text/xml" CHECKSUM="5c1de196f122da491be77bdc9bbc10f230a32b72" CHECKSUMTYPE="SHA-1" SIZE="194488">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:14:42" MIMETYPE="text/xml"
-				CHECKSUM="df94d3ba6729a7abd068240e668d093e446c1b36" CHECKSUMTYPE="SHA-1" SIZE="197525">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:14:42" MIMETYPE="text/xml" CHECKSUM="df94d3ba6729a7abd068240e668d093e446c1b36" CHECKSUMTYPE="SHA-1" SIZE="197525">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:14:42" MIMETYPE="text/xml"
-				CHECKSUM="873acbe7e3f6e35e03930149137c3f4c6bc6979f" CHECKSUMTYPE="SHA-1" SIZE="197654">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:14:42" MIMETYPE="text/xml" CHECKSUM="873acbe7e3f6e35e03930149137c3f4c6bc6979f" CHECKSUMTYPE="SHA-1" SIZE="197654">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:14:43" MIMETYPE="text/xml"
-				CHECKSUM="9f8a1ad0107587b02fe4eb4bbafe262f025fae0c" CHECKSUMTYPE="SHA-1" SIZE="193709">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:14:43" MIMETYPE="text/xml" CHECKSUM="9f8a1ad0107587b02fe4eb4bbafe262f025fae0c" CHECKSUMTYPE="SHA-1" SIZE="193709">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:14:43" MIMETYPE="text/xml"
-				CHECKSUM="47b3d365592a8a30564fe5d1217d3c82a87cc116" CHECKSUMTYPE="SHA-1" SIZE="115723">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:14:43" MIMETYPE="text/xml" CHECKSUM="47b3d365592a8a30564fe5d1217d3c82a87cc116" CHECKSUMTYPE="SHA-1" SIZE="115723">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:14:43" MIMETYPE="text/xml"
-				CHECKSUM="044428d9c560993911dedc9d6a76935dfe8a638d" CHECKSUMTYPE="SHA-1" SIZE="5271">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:14:43" MIMETYPE="text/xml" CHECKSUM="044428d9c560993911dedc9d6a76935dfe8a638d" CHECKSUMTYPE="SHA-1" SIZE="5271">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:14:43" MIMETYPE="text/xml"
-				CHECKSUM="e7c4a9a0d7fe89537fc3dbac4ed9fe6b03629752" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:14:43" MIMETYPE="text/xml" CHECKSUM="e7c4a9a0d7fe89537fc3dbac4ed9fe6b03629752" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:14:44" MIMETYPE="text/xml"
-				CHECKSUM="3e9277614e5d73c82b383d47e3695e8c7b6ec1a1" CHECKSUMTYPE="SHA-1" SIZE="96667">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:14:44" MIMETYPE="text/xml" CHECKSUM="3e9277614e5d73c82b383d47e3695e8c7b6ec1a1" CHECKSUMTYPE="SHA-1" SIZE="96667">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:14:44" MIMETYPE="text/xml"
-				CHECKSUM="f27809ed752073f6567d59ea3095b4c97ff4034a" CHECKSUMTYPE="SHA-1" SIZE="185137">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:14:44" MIMETYPE="text/xml" CHECKSUM="f27809ed752073f6567d59ea3095b4c97ff4034a" CHECKSUMTYPE="SHA-1" SIZE="185137">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:14:44" MIMETYPE="text/xml"
-				CHECKSUM="f1920377daafeb63728d35a997e9e1e8f5ce71ad" CHECKSUMTYPE="SHA-1" SIZE="190761">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:14:44" MIMETYPE="text/xml" CHECKSUM="f1920377daafeb63728d35a997e9e1e8f5ce71ad" CHECKSUMTYPE="SHA-1" SIZE="190761">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:14:45" MIMETYPE="text/xml"
-				CHECKSUM="a07f9ecd76af687264d0bb51baf30bf6641f7a97" CHECKSUMTYPE="SHA-1" SIZE="189008">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:14:45" MIMETYPE="text/xml" CHECKSUM="a07f9ecd76af687264d0bb51baf30bf6641f7a97" CHECKSUMTYPE="SHA-1" SIZE="189008">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:14:45" MIMETYPE="text/xml"
-				CHECKSUM="2115ec0b995eaa37b82899d001b1737956f3005a" CHECKSUMTYPE="SHA-1" SIZE="188805">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:14:45" MIMETYPE="text/xml" CHECKSUM="2115ec0b995eaa37b82899d001b1737956f3005a" CHECKSUMTYPE="SHA-1" SIZE="188805">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:14:45" MIMETYPE="text/xml"
-				CHECKSUM="1ed64fee1c77ef034e84c6e30686f3ba95c6674a" CHECKSUMTYPE="SHA-1" SIZE="186879">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:14:45" MIMETYPE="text/xml" CHECKSUM="1ed64fee1c77ef034e84c6e30686f3ba95c6674a" CHECKSUMTYPE="SHA-1" SIZE="186879">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:14:46" MIMETYPE="text/xml"
-				CHECKSUM="212899935c162a7d5cbf762f492c06f0ec20796a" CHECKSUMTYPE="SHA-1" SIZE="5011">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:14:46" MIMETYPE="text/xml" CHECKSUM="212899935c162a7d5cbf762f492c06f0ec20796a" CHECKSUMTYPE="SHA-1" SIZE="5011">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:14:46" MIMETYPE="text/xml"
-				CHECKSUM="6ea48833133cefab34e3cf560d7a653bc20be5d9" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:14:46" MIMETYPE="text/xml" CHECKSUM="6ea48833133cefab34e3cf560d7a653bc20be5d9" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:14:46" MIMETYPE="text/xml"
-				CHECKSUM="02fd9117ba46be9860292d2169203a49f398f138" CHECKSUMTYPE="SHA-1" SIZE="70259">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:14:46" MIMETYPE="text/xml" CHECKSUM="02fd9117ba46be9860292d2169203a49f398f138" CHECKSUMTYPE="SHA-1" SIZE="70259">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:14:46" MIMETYPE="text/xml"
-				CHECKSUM="825f1811dc66caeb3548ae2b73712f70312cc6dc" CHECKSUMTYPE="SHA-1" SIZE="189214">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:14:46" MIMETYPE="text/xml" CHECKSUM="825f1811dc66caeb3548ae2b73712f70312cc6dc" CHECKSUMTYPE="SHA-1" SIZE="189214">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:14:47" MIMETYPE="text/xml"
-				CHECKSUM="6f85b85ae9c0683e2bdb9bae72f3ff92e0af5623" CHECKSUMTYPE="SHA-1" SIZE="185449">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:14:47" MIMETYPE="text/xml" CHECKSUM="6f85b85ae9c0683e2bdb9bae72f3ff92e0af5623" CHECKSUMTYPE="SHA-1" SIZE="185449">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:14:47" MIMETYPE="text/xml"
-				CHECKSUM="3b65348f24e6aeff964cb34e287ff653413e77cc" CHECKSUMTYPE="SHA-1" SIZE="187526">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:14:47" MIMETYPE="text/xml" CHECKSUM="3b65348f24e6aeff964cb34e287ff653413e77cc" CHECKSUMTYPE="SHA-1" SIZE="187526">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:14:48" MIMETYPE="text/xml"
-				CHECKSUM="3db3571a78510129d45da33430c019ed2363d37d" CHECKSUMTYPE="SHA-1" SIZE="6370">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:14:48" MIMETYPE="text/xml" CHECKSUM="3db3571a78510129d45da33430c019ed2363d37d" CHECKSUMTYPE="SHA-1" SIZE="6370">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:14:48" MIMETYPE="text/xml"
-				CHECKSUM="b257d8e70605f6a7311b3af23d150973af69e24c" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:14:48" MIMETYPE="text/xml" CHECKSUM="b257d8e70605f6a7311b3af23d150973af69e24c" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:14:48" MIMETYPE="text/xml"
-				CHECKSUM="7544ff511d39b3d25e2008f89896848255019c0d" CHECKSUMTYPE="SHA-1" SIZE="79341">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:14:48" MIMETYPE="text/xml" CHECKSUM="7544ff511d39b3d25e2008f89896848255019c0d" CHECKSUMTYPE="SHA-1" SIZE="79341">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:14:48" MIMETYPE="text/xml"
-				CHECKSUM="7301bb66ac98ac99228dc311080cf33cac479257" CHECKSUMTYPE="SHA-1" SIZE="188781">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:14:48" MIMETYPE="text/xml" CHECKSUM="7301bb66ac98ac99228dc311080cf33cac479257" CHECKSUMTYPE="SHA-1" SIZE="188781">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:14:49" MIMETYPE="text/xml"
-				CHECKSUM="e6eaf44e72d10b3c50adc25e335c66ae6f2c7b71" CHECKSUMTYPE="SHA-1" SIZE="196294">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:14:49" MIMETYPE="text/xml" CHECKSUM="e6eaf44e72d10b3c50adc25e335c66ae6f2c7b71" CHECKSUMTYPE="SHA-1" SIZE="196294">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:14:49" MIMETYPE="text/xml"
-				CHECKSUM="2bf5df4362ec5dc6e536862382285d5f4c487223" CHECKSUMTYPE="SHA-1" SIZE="33110">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:14:49" MIMETYPE="text/xml" CHECKSUM="2bf5df4362ec5dc6e536862382285d5f4c487223" CHECKSUMTYPE="SHA-1" SIZE="33110">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:14:49" MIMETYPE="text/xml"
-				CHECKSUM="318b7aa34848d330187a59d496f122e01920d3ed" CHECKSUMTYPE="SHA-1" SIZE="6225">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:14:49" MIMETYPE="text/xml" CHECKSUM="318b7aa34848d330187a59d496f122e01920d3ed" CHECKSUMTYPE="SHA-1" SIZE="6225">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:14:50" MIMETYPE="text/xml"
-				CHECKSUM="de790c262806c95bfd3515340f954f2448da0874" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:14:50" MIMETYPE="text/xml" CHECKSUM="de790c262806c95bfd3515340f954f2448da0874" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:14:50" MIMETYPE="text/xml"
-				CHECKSUM="df7e01e246ea44daed049be5011d87019439d49b" CHECKSUMTYPE="SHA-1" SIZE="76396">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:14:50" MIMETYPE="text/xml" CHECKSUM="df7e01e246ea44daed049be5011d87019439d49b" CHECKSUMTYPE="SHA-1" SIZE="76396">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:14:50" MIMETYPE="text/xml"
-				CHECKSUM="977f5f09491c2ec55210c8a020b4c6cab8d208ac" CHECKSUMTYPE="SHA-1" SIZE="189545">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:14:50" MIMETYPE="text/xml" CHECKSUM="977f5f09491c2ec55210c8a020b4c6cab8d208ac" CHECKSUMTYPE="SHA-1" SIZE="189545">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:14:51" MIMETYPE="text/xml"
-				CHECKSUM="fcb567e7e276d539bb70ac4f3f5ea05400cd6eef" CHECKSUMTYPE="SHA-1" SIZE="193189">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:14:51" MIMETYPE="text/xml" CHECKSUM="fcb567e7e276d539bb70ac4f3f5ea05400cd6eef" CHECKSUMTYPE="SHA-1" SIZE="193189">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:14:51" MIMETYPE="text/xml"
-				CHECKSUM="c06a879d230f67a4c2c82ab49c61afd2198d7180" CHECKSUMTYPE="SHA-1" SIZE="50120">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:14:51" MIMETYPE="text/xml" CHECKSUM="c06a879d230f67a4c2c82ab49c61afd2198d7180" CHECKSUMTYPE="SHA-1" SIZE="50120">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:14:51" MIMETYPE="text/xml"
-				CHECKSUM="5811937cefc096c914c678ec988dd25827e3783e" CHECKSUMTYPE="SHA-1" SIZE="37315">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:14:51" MIMETYPE="text/xml" CHECKSUM="5811937cefc096c914c678ec988dd25827e3783e" CHECKSUMTYPE="SHA-1" SIZE="37315">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:14:52" MIMETYPE="text/xml"
-				CHECKSUM="7cb231afa028a82daaf97525552263b71b11a07f" CHECKSUMTYPE="SHA-1" SIZE="28543">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:14:52" MIMETYPE="text/xml" CHECKSUM="7cb231afa028a82daaf97525552263b71b11a07f" CHECKSUMTYPE="SHA-1" SIZE="28543">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:14:52" MIMETYPE="text/xml"
-				CHECKSUM="161eafe79d18c66c427c41469b4aa025d409554f" CHECKSUMTYPE="SHA-1" SIZE="17053">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:14:52" MIMETYPE="text/xml" CHECKSUM="161eafe79d18c66c427c41469b4aa025d409554f" CHECKSUMTYPE="SHA-1" SIZE="17053">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:14:52" MIMETYPE="text/xml"
-				CHECKSUM="f67160b97d8546a3152bb4c96578acf0bdeb3bda" CHECKSUMTYPE="SHA-1" SIZE="41562">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:14:52" MIMETYPE="text/xml" CHECKSUM="f67160b97d8546a3152bb4c96578acf0bdeb3bda" CHECKSUMTYPE="SHA-1" SIZE="41562">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:14:53" MIMETYPE="text/xml"
-				CHECKSUM="ff2e1de8155d15754c565a22af452c96891bf281" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:14:53" MIMETYPE="text/xml" CHECKSUM="ff2e1de8155d15754c565a22af452c96891bf281" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:14:53" MIMETYPE="text/xml"
-				CHECKSUM="57f72b57f20c5ba3424e294adf1f1d5619ba2927" CHECKSUMTYPE="SHA-1" SIZE="5053">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:14:53" MIMETYPE="text/xml" CHECKSUM="57f72b57f20c5ba3424e294adf1f1d5619ba2927" CHECKSUMTYPE="SHA-1" SIZE="5053">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1898-11_01_0092.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:17:59" MIMETYPE="application/pdf" CHECKSUM="a8397d8016f6125e3853cdf35b90ed82ccb09337"
-				CHECKSUMTYPE="SHA-1" SIZE="42442633">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/bmtnabe_1898-11_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:17:59" MIMETYPE="application/pdf" CHECKSUM="a8397d8016f6125e3853cdf35b90ed82ccb09337" CHECKSUMTYPE="SHA-1" SIZE="42442633">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1898/11_01/bmtnabe_1898-11_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -10683,8 +10401,7 @@
 					</div>
 
 				</div>
-				<div ID="L.1.1.19" TYPE="TextContent" ORDER="19" DMDID="c057"
-					LABEL="TAGEBUCH-AUFZEICHNUNGEN UEBER ARNOLD BOECKLIN VON RUD. SCHICK AUS DEN JAHREN 1866, 1868, 1869">
+				<div ID="L.1.1.19" TYPE="TextContent" ORDER="19" DMDID="c057" LABEL="TAGEBUCH-AUFZEICHNUNGEN UEBER ARNOLD BOECKLIN VON RUD. SCHICK AUS DEN JAHREN 1866, 1868, 1869">
 					<div ID="L.1.1.19.1" TYPE="Head">
 						<fptr>
 							<seq>

--- a/metadata/periodicals/bmtnabe/issues/1899/04_01/bmtnabe_1899-04_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1899/04_01/bmtnabe_1899-04_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1899-04_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1899-04_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1899-04_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1899-04_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1899-04_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1899-04_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1899-04_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -7652,788 +7648,528 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:55:10" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="75964536e920693bb6dbfeb130699ea5079471fb" CHECKSUMTYPE="SHA-1" SIZE="5220128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:55:42" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="1545ab78d82b954334355fd9ee22d74d71e3a1c3" CHECKSUMTYPE="SHA-1" SIZE="5231818">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:56:13" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="2656d3d8b4069f6539dd5ea1277f6e57cd18bf91" CHECKSUMTYPE="SHA-1" SIZE="5184126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:56:37" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="fef036a14991e843d0c3a159268d44242e2b21c3" CHECKSUMTYPE="SHA-1" SIZE="5175040">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:57:02" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="a927eee44ca7ba3ba4a8a7633af313b4869e9f47" CHECKSUMTYPE="SHA-1" SIZE="5168827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:57:25" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="4fadffee008750a4db2ba774d8168d3b8a7f4b08" CHECKSUMTYPE="SHA-1" SIZE="5179623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:57:47" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="86332c19475a06f4efad81ac09dc84d5f950a424" CHECKSUMTYPE="SHA-1" SIZE="5149926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:58:11" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="49e3c9e266d8fde2f870d6b5781b3c8f3643b1ed" CHECKSUMTYPE="SHA-1" SIZE="5226425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:58:41" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="8d9b5d3ddf75ba265d57a3ac82e721c50c1ddc4d" CHECKSUMTYPE="SHA-1" SIZE="5131929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:59:07" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="e916c9c51f63f045b96882b5c60500e3a0023960" CHECKSUMTYPE="SHA-1" SIZE="5177829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:59:32" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="8d1bc9a9ec7e605f32923b5392663c699eea0bc5" CHECKSUMTYPE="SHA-1" SIZE="5144526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:59:55" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="f69db15ea4fbc311ec03fa70469f2f4df7832a4f" CHECKSUMTYPE="SHA-1" SIZE="5247128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T18:00:22" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="466d51f4cde31918162f3895b3329a359c35d83b" CHECKSUMTYPE="SHA-1" SIZE="5068027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T18:00:49" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="4b7b7dd6cb7d6dce08bbe3b2f391f038b7fea8e7" CHECKSUMTYPE="SHA-1" SIZE="5192223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T18:01:14" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="c027068bf1b74bc7c57543047f5631fac0433745" CHECKSUMTYPE="SHA-1" SIZE="5102224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T18:01:43" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="d0b3def8cb733fc774714c74cbcf13e75c13f8c8" CHECKSUMTYPE="SHA-1" SIZE="5197606">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T18:02:07" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="a59f4defce4f9170581a5c11f203e9e28a63490b" CHECKSUMTYPE="SHA-1" SIZE="5131927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T18:02:32" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="7552fa45533828e56d5287f96c83f3f9caf31a94" CHECKSUMTYPE="SHA-1" SIZE="5157129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T18:02:57" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="c882257e0cce1f3d10a56c61458521eacbc0fafe" CHECKSUMTYPE="SHA-1" SIZE="5144519">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T18:03:21" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="90395a69f0a6a903461cee51b49d69a1413423bc" CHECKSUMTYPE="SHA-1" SIZE="5149924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T18:03:47" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="0ead4738c25670ff690c1634f8434c519039dd64" CHECKSUMTYPE="SHA-1" SIZE="5129223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T18:04:13" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="543f19fd4cc44016697473f10b7a43857ea8be69" CHECKSUMTYPE="SHA-1" SIZE="5185929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T18:04:42" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="e63fce6cc38bd6bfb71e560da78c25886ffa025f" CHECKSUMTYPE="SHA-1" SIZE="5137329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T18:05:07" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="c69ffdd30bde87e4ef950d63a55497905ae9be34" CHECKSUMTYPE="SHA-1" SIZE="5164323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T18:05:31" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="62f7088c9b264e7c1392fc7c8b89b2f85b74cd13" CHECKSUMTYPE="SHA-1" SIZE="5113923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T18:05:55" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="10dd576c45181f99ff51de05089c09301b339f37" CHECKSUMTYPE="SHA-1" SIZE="5165227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T18:06:22" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="c1ebe816e1a3899cbe732e1c747bf82f419cca91" CHECKSUMTYPE="SHA-1" SIZE="5114827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T18:06:48" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="a3e0489ad2f74797678d38371b4645154dc077ca" CHECKSUMTYPE="SHA-1" SIZE="5145427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T18:07:11" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="2402a35d7ebc95ae2d0f82ed13f467b89aaf3a25" CHECKSUMTYPE="SHA-1" SIZE="5111176">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T18:07:37" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="da2a872a5ebc87abb3e26f9f8f0233511e1629fb" CHECKSUMTYPE="SHA-1" SIZE="5132829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T18:08:02" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="8cf01dc622a8e770aeabcba513d72d5c7b280897" CHECKSUMTYPE="SHA-1" SIZE="5095927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T18:08:27" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="07ed7daa0fc2b47f857af8aa5fea588fa2299a18" CHECKSUMTYPE="SHA-1" SIZE="5144528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T18:08:52" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="b4c3d71dd00cf081abe7c0e078782c52b0b10ecf" CHECKSUMTYPE="SHA-1" SIZE="5127424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T18:09:17" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="da3d9537cf95bd0a977151fb4549d0b2e99b6057" CHECKSUMTYPE="SHA-1" SIZE="5203029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T18:09:42" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="bd46c74d7699fdc0258e89b55004a76b55784399" CHECKSUMTYPE="SHA-1" SIZE="5137223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T18:10:10" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="59e1e7cf119bcf003d3b298b22211ba45e40f82d" CHECKSUMTYPE="SHA-1" SIZE="5141824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T18:10:33" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="4e3b13413e19f7498a629dbea40c05cc653341c9" CHECKSUMTYPE="SHA-1" SIZE="5137296">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T18:10:58" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="8ea0a3041421d420763f8175ae34ee1bb89f7824" CHECKSUMTYPE="SHA-1" SIZE="5099523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T18:11:24" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="8d127e8de97ac20951cd0f9fcaaa20b565deca13" CHECKSUMTYPE="SHA-1" SIZE="5113923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T18:11:50" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="6333d008fb565ba7afb1b753ae35d41d70f72327" CHECKSUMTYPE="SHA-1" SIZE="5089624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T18:12:15" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="ca7683a9a7a4ca48757b97d3da6878ce709a25ed" CHECKSUMTYPE="SHA-1" SIZE="5137308">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T18:12:42" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="15526fa89f5aaff4fa316e96a2240f8d5aafd092" CHECKSUMTYPE="SHA-1" SIZE="5022967">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T18:13:11" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="3888c1ed5d1c92ffbed4f483ea747435faaaea19" CHECKSUMTYPE="SHA-1" SIZE="5127426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T18:13:39" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="2511c4f4b2df096ed447a655a7d13ee8bdd30848" CHECKSUMTYPE="SHA-1" SIZE="5059853">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T18:14:04" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="1233544ab2c7bdb7c6603bbce78d99bc5346e63a" CHECKSUMTYPE="SHA-1" SIZE="5122028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T18:14:29" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="c9225135e6156503281a55a6afcae1c7c3d9e6b0" CHECKSUMTYPE="SHA-1" SIZE="4964527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T18:14:56" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="3b6a8433bc0835cca18f2289c05eb65eb2a2e5b8" CHECKSUMTYPE="SHA-1" SIZE="5137324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T18:15:22" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="399715a72c35e6ba6a53421553eb2aa3d02353c5" CHECKSUMTYPE="SHA-1" SIZE="4982526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T18:15:46" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="d866298cd3b976ce68b16bccee2429a1a8283503" CHECKSUMTYPE="SHA-1" SIZE="5063527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T18:16:13" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="a373bc2fd660f5f328e2b50a9af15923c58d5674" CHECKSUMTYPE="SHA-1" SIZE="5013101">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T18:16:40" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="b8b746bb1a9040bd3d64f1b08dc1b4602c3a672d" CHECKSUMTYPE="SHA-1" SIZE="5137325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T18:17:09" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="d61436a0441627ef91556dd097c14a27e87d9d04" CHECKSUMTYPE="SHA-1" SIZE="4982493">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T18:17:37" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="ab574ebcdcd08beb937b78a4da89edaba577104d" CHECKSUMTYPE="SHA-1" SIZE="5137304">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T18:18:04" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="2c672a8b386ed377c3c3c4694632da919f2962a2" CHECKSUMTYPE="SHA-1" SIZE="4937497">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T18:18:30" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="5c56e436fd8164ceeba2b82060e1f62ecafc3729" CHECKSUMTYPE="SHA-1" SIZE="5062624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T18:18:58" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="c0d7a620bb08d363158b52da04d986592b64cdc2" CHECKSUMTYPE="SHA-1" SIZE="4978914">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T18:19:22" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="2c394ef66cbad2f3fe27744d9a0fe695456b53b9" CHECKSUMTYPE="SHA-1" SIZE="5137328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T18:19:45" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="6ccfd3a3bf7e9d77f5e1f53730db86e24cbd9174" CHECKSUMTYPE="SHA-1" SIZE="5025726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:20:09" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="0a33071c9c2bd09c8370316575fc317751cf0444" CHECKSUMTYPE="SHA-1" SIZE="5137326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:20:33" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="b5cf6054d0502d2e5935bd0d4866f44fbe6fcb35" CHECKSUMTYPE="SHA-1" SIZE="4927628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:20:56" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="fc9a10ab87ced8154cdfe7d2e6ad48e3f388c1d6" CHECKSUMTYPE="SHA-1" SIZE="5137329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:21:24" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="876a70d1635c8358bf92c61488ebaa05012832f0" CHECKSUMTYPE="SHA-1" SIZE="4996929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:21:50" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="061cb239373ad02141fd086f55877e69461b21fc" CHECKSUMTYPE="SHA-1" SIZE="5097725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:22:24" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="66adacd82aa54437c6e0db762639a7dcb9c2d557" CHECKSUMTYPE="SHA-1" SIZE="4982529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:22:49" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="cf74265ed75f25dd397db55eceea1ef342c4c0da" CHECKSUMTYPE="SHA-1" SIZE="5137321">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:23:17" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="001835aa1e0e1605265a8190a486e4646f4cb883" CHECKSUMTYPE="SHA-1" SIZE="5027529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:23:47" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="c423958455303fbff14b8cb57a455c89775dbf8c" CHECKSUMTYPE="SHA-1" SIZE="5113029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:24:14" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="6bbeda95b2620cb892cb47031f291f2a6cbc883e" CHECKSUMTYPE="SHA-1" SIZE="5021144">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:24:41" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="9402a3994cdee10b7b66744f53bc453a0e6f9ef7" CHECKSUMTYPE="SHA-1" SIZE="4965427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:25:07" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="7e2a8379b478cffdd29719937dc5f68b692677bc" CHECKSUMTYPE="SHA-1" SIZE="4986129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:25:31" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="9408d1b66c385dc92714d6eb5ec511b518bccf7b" CHECKSUMTYPE="SHA-1" SIZE="5058128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:26:08" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="a30c24854eaaaf382ae60a32bcd261600f1a7aa5" CHECKSUMTYPE="SHA-1" SIZE="4998721">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:26:33" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="c7e2728a5763b7e98d937317f35d34defa0ba2ad" CHECKSUMTYPE="SHA-1" SIZE="5041922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:26:58" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="efe681f471e6b5e6c97929c0c4dd0f1be57e1c78" CHECKSUMTYPE="SHA-1" SIZE="4999624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:27:25" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="9e8dc7e902a6db08af43e31b3cb1e240c8b0721f" CHECKSUMTYPE="SHA-1" SIZE="5071627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:27:51" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="fe4df4cc95732b48ee7f71079aee05416f1d2ff3" CHECKSUMTYPE="SHA-1" SIZE="4995123">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:28:15" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="9390d5660410616c0ab38831b3b7232fd63b5840" CHECKSUMTYPE="SHA-1" SIZE="5041012">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:28:41" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="7b1c5fd3957568bb811bf09405adf6f901ecb2a7" CHECKSUMTYPE="SHA-1" SIZE="4961819">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:29:08" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="e00b56f925d65841201f3fb5908769183f035442" CHECKSUMTYPE="SHA-1" SIZE="5020319">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:29:34" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="4ebccf732bd07d6c37392107ef3e9163dbedeeb4" CHECKSUMTYPE="SHA-1" SIZE="4953726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:29:56" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="c1e8a8b926928a29793dce03b248a47016b1a2e6" CHECKSUMTYPE="SHA-1" SIZE="5012225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:30:20" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="e0366179c3077c4f8415bffe736fdcc216f73eb6" CHECKSUMTYPE="SHA-1" SIZE="4951926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:30:43" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="68c1654c44138170e5221f26bac091dc65ec23da" CHECKSUMTYPE="SHA-1" SIZE="4987026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:31:09" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="85df321b90f654a9a6c51f5402fd0da1d302442b" CHECKSUMTYPE="SHA-1" SIZE="4948326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:31:31" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="f01e51bea93f9f50088fd89aa3e30c0cff91e07a" CHECKSUMTYPE="SHA-1" SIZE="4952815">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:31:59" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="b2a9f49e0a3902be368e159863fcffa1f8aae346" CHECKSUMTYPE="SHA-1" SIZE="4964526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0086.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T17:55:10" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="75964536e920693bb6dbfeb130699ea5079471fb" CHECKSUMTYPE="SHA-1" SIZE="5220128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T17:55:42" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="1545ab78d82b954334355fd9ee22d74d71e3a1c3" CHECKSUMTYPE="SHA-1" SIZE="5231818">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T17:56:13" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="2656d3d8b4069f6539dd5ea1277f6e57cd18bf91" CHECKSUMTYPE="SHA-1" SIZE="5184126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T17:56:37" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="fef036a14991e843d0c3a159268d44242e2b21c3" CHECKSUMTYPE="SHA-1" SIZE="5175040">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T17:57:02" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="a927eee44ca7ba3ba4a8a7633af313b4869e9f47" CHECKSUMTYPE="SHA-1" SIZE="5168827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T17:57:25" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="4fadffee008750a4db2ba774d8168d3b8a7f4b08" CHECKSUMTYPE="SHA-1" SIZE="5179623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T17:57:47" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="86332c19475a06f4efad81ac09dc84d5f950a424" CHECKSUMTYPE="SHA-1" SIZE="5149926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T17:58:11" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="49e3c9e266d8fde2f870d6b5781b3c8f3643b1ed" CHECKSUMTYPE="SHA-1" SIZE="5226425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T17:58:41" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="8d9b5d3ddf75ba265d57a3ac82e721c50c1ddc4d" CHECKSUMTYPE="SHA-1" SIZE="5131929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T17:59:07" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="e916c9c51f63f045b96882b5c60500e3a0023960" CHECKSUMTYPE="SHA-1" SIZE="5177829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T17:59:32" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="8d1bc9a9ec7e605f32923b5392663c699eea0bc5" CHECKSUMTYPE="SHA-1" SIZE="5144526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T17:59:55" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="f69db15ea4fbc311ec03fa70469f2f4df7832a4f" CHECKSUMTYPE="SHA-1" SIZE="5247128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T18:00:22" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="466d51f4cde31918162f3895b3329a359c35d83b" CHECKSUMTYPE="SHA-1" SIZE="5068027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T18:00:49" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="4b7b7dd6cb7d6dce08bbe3b2f391f038b7fea8e7" CHECKSUMTYPE="SHA-1" SIZE="5192223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T18:01:14" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="c027068bf1b74bc7c57543047f5631fac0433745" CHECKSUMTYPE="SHA-1" SIZE="5102224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T18:01:43" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d0b3def8cb733fc774714c74cbcf13e75c13f8c8" CHECKSUMTYPE="SHA-1" SIZE="5197606">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T18:02:07" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="a59f4defce4f9170581a5c11f203e9e28a63490b" CHECKSUMTYPE="SHA-1" SIZE="5131927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T18:02:32" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="7552fa45533828e56d5287f96c83f3f9caf31a94" CHECKSUMTYPE="SHA-1" SIZE="5157129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T18:02:57" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="c882257e0cce1f3d10a56c61458521eacbc0fafe" CHECKSUMTYPE="SHA-1" SIZE="5144519">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T18:03:21" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="90395a69f0a6a903461cee51b49d69a1413423bc" CHECKSUMTYPE="SHA-1" SIZE="5149924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T18:03:47" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="0ead4738c25670ff690c1634f8434c519039dd64" CHECKSUMTYPE="SHA-1" SIZE="5129223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T18:04:13" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="543f19fd4cc44016697473f10b7a43857ea8be69" CHECKSUMTYPE="SHA-1" SIZE="5185929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T18:04:42" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="e63fce6cc38bd6bfb71e560da78c25886ffa025f" CHECKSUMTYPE="SHA-1" SIZE="5137329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T18:05:07" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="c69ffdd30bde87e4ef950d63a55497905ae9be34" CHECKSUMTYPE="SHA-1" SIZE="5164323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T18:05:31" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="62f7088c9b264e7c1392fc7c8b89b2f85b74cd13" CHECKSUMTYPE="SHA-1" SIZE="5113923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T18:05:55" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="10dd576c45181f99ff51de05089c09301b339f37" CHECKSUMTYPE="SHA-1" SIZE="5165227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T18:06:22" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="c1ebe816e1a3899cbe732e1c747bf82f419cca91" CHECKSUMTYPE="SHA-1" SIZE="5114827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T18:06:48" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="a3e0489ad2f74797678d38371b4645154dc077ca" CHECKSUMTYPE="SHA-1" SIZE="5145427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T18:07:11" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="2402a35d7ebc95ae2d0f82ed13f467b89aaf3a25" CHECKSUMTYPE="SHA-1" SIZE="5111176">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T18:07:37" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="da2a872a5ebc87abb3e26f9f8f0233511e1629fb" CHECKSUMTYPE="SHA-1" SIZE="5132829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T18:08:02" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="8cf01dc622a8e770aeabcba513d72d5c7b280897" CHECKSUMTYPE="SHA-1" SIZE="5095927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T18:08:27" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="07ed7daa0fc2b47f857af8aa5fea588fa2299a18" CHECKSUMTYPE="SHA-1" SIZE="5144528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T18:08:52" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="b4c3d71dd00cf081abe7c0e078782c52b0b10ecf" CHECKSUMTYPE="SHA-1" SIZE="5127424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T18:09:17" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="da3d9537cf95bd0a977151fb4549d0b2e99b6057" CHECKSUMTYPE="SHA-1" SIZE="5203029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T18:09:42" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="bd46c74d7699fdc0258e89b55004a76b55784399" CHECKSUMTYPE="SHA-1" SIZE="5137223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T18:10:10" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="59e1e7cf119bcf003d3b298b22211ba45e40f82d" CHECKSUMTYPE="SHA-1" SIZE="5141824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T18:10:33" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="4e3b13413e19f7498a629dbea40c05cc653341c9" CHECKSUMTYPE="SHA-1" SIZE="5137296">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T18:10:58" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="8ea0a3041421d420763f8175ae34ee1bb89f7824" CHECKSUMTYPE="SHA-1" SIZE="5099523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T18:11:24" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="8d127e8de97ac20951cd0f9fcaaa20b565deca13" CHECKSUMTYPE="SHA-1" SIZE="5113923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T18:11:50" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="6333d008fb565ba7afb1b753ae35d41d70f72327" CHECKSUMTYPE="SHA-1" SIZE="5089624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T18:12:15" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="ca7683a9a7a4ca48757b97d3da6878ce709a25ed" CHECKSUMTYPE="SHA-1" SIZE="5137308">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T18:12:42" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="15526fa89f5aaff4fa316e96a2240f8d5aafd092" CHECKSUMTYPE="SHA-1" SIZE="5022967">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T18:13:11" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="3888c1ed5d1c92ffbed4f483ea747435faaaea19" CHECKSUMTYPE="SHA-1" SIZE="5127426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T18:13:39" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="2511c4f4b2df096ed447a655a7d13ee8bdd30848" CHECKSUMTYPE="SHA-1" SIZE="5059853">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T18:14:04" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="1233544ab2c7bdb7c6603bbce78d99bc5346e63a" CHECKSUMTYPE="SHA-1" SIZE="5122028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T18:14:29" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="c9225135e6156503281a55a6afcae1c7c3d9e6b0" CHECKSUMTYPE="SHA-1" SIZE="4964527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T18:14:56" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="3b6a8433bc0835cca18f2289c05eb65eb2a2e5b8" CHECKSUMTYPE="SHA-1" SIZE="5137324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T18:15:22" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="399715a72c35e6ba6a53421553eb2aa3d02353c5" CHECKSUMTYPE="SHA-1" SIZE="4982526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T18:15:46" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="d866298cd3b976ce68b16bccee2429a1a8283503" CHECKSUMTYPE="SHA-1" SIZE="5063527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T18:16:13" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="a373bc2fd660f5f328e2b50a9af15923c58d5674" CHECKSUMTYPE="SHA-1" SIZE="5013101">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T18:16:40" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="b8b746bb1a9040bd3d64f1b08dc1b4602c3a672d" CHECKSUMTYPE="SHA-1" SIZE="5137325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T18:17:09" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="d61436a0441627ef91556dd097c14a27e87d9d04" CHECKSUMTYPE="SHA-1" SIZE="4982493">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T18:17:37" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="ab574ebcdcd08beb937b78a4da89edaba577104d" CHECKSUMTYPE="SHA-1" SIZE="5137304">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T18:18:04" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="2c672a8b386ed377c3c3c4694632da919f2962a2" CHECKSUMTYPE="SHA-1" SIZE="4937497">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T18:18:30" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="5c56e436fd8164ceeba2b82060e1f62ecafc3729" CHECKSUMTYPE="SHA-1" SIZE="5062624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T18:18:58" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="c0d7a620bb08d363158b52da04d986592b64cdc2" CHECKSUMTYPE="SHA-1" SIZE="4978914">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T18:19:22" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="2c394ef66cbad2f3fe27744d9a0fe695456b53b9" CHECKSUMTYPE="SHA-1" SIZE="5137328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T18:19:45" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="6ccfd3a3bf7e9d77f5e1f53730db86e24cbd9174" CHECKSUMTYPE="SHA-1" SIZE="5025726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:20:09" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="0a33071c9c2bd09c8370316575fc317751cf0444" CHECKSUMTYPE="SHA-1" SIZE="5137326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:20:33" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="b5cf6054d0502d2e5935bd0d4866f44fbe6fcb35" CHECKSUMTYPE="SHA-1" SIZE="4927628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:20:56" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="fc9a10ab87ced8154cdfe7d2e6ad48e3f388c1d6" CHECKSUMTYPE="SHA-1" SIZE="5137329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:21:24" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="876a70d1635c8358bf92c61488ebaa05012832f0" CHECKSUMTYPE="SHA-1" SIZE="4996929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:21:50" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="061cb239373ad02141fd086f55877e69461b21fc" CHECKSUMTYPE="SHA-1" SIZE="5097725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:22:24" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="66adacd82aa54437c6e0db762639a7dcb9c2d557" CHECKSUMTYPE="SHA-1" SIZE="4982529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:22:49" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="cf74265ed75f25dd397db55eceea1ef342c4c0da" CHECKSUMTYPE="SHA-1" SIZE="5137321">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:23:17" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="001835aa1e0e1605265a8190a486e4646f4cb883" CHECKSUMTYPE="SHA-1" SIZE="5027529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:23:47" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="c423958455303fbff14b8cb57a455c89775dbf8c" CHECKSUMTYPE="SHA-1" SIZE="5113029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:24:14" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="6bbeda95b2620cb892cb47031f291f2a6cbc883e" CHECKSUMTYPE="SHA-1" SIZE="5021144">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:24:41" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="9402a3994cdee10b7b66744f53bc453a0e6f9ef7" CHECKSUMTYPE="SHA-1" SIZE="4965427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:25:07" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="7e2a8379b478cffdd29719937dc5f68b692677bc" CHECKSUMTYPE="SHA-1" SIZE="4986129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:25:31" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="9408d1b66c385dc92714d6eb5ec511b518bccf7b" CHECKSUMTYPE="SHA-1" SIZE="5058128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:26:08" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="a30c24854eaaaf382ae60a32bcd261600f1a7aa5" CHECKSUMTYPE="SHA-1" SIZE="4998721">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:26:33" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="c7e2728a5763b7e98d937317f35d34defa0ba2ad" CHECKSUMTYPE="SHA-1" SIZE="5041922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:26:58" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="efe681f471e6b5e6c97929c0c4dd0f1be57e1c78" CHECKSUMTYPE="SHA-1" SIZE="4999624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:27:25" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="9e8dc7e902a6db08af43e31b3cb1e240c8b0721f" CHECKSUMTYPE="SHA-1" SIZE="5071627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:27:51" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="fe4df4cc95732b48ee7f71079aee05416f1d2ff3" CHECKSUMTYPE="SHA-1" SIZE="4995123">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:28:15" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="9390d5660410616c0ab38831b3b7232fd63b5840" CHECKSUMTYPE="SHA-1" SIZE="5041012">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:28:41" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="7b1c5fd3957568bb811bf09405adf6f901ecb2a7" CHECKSUMTYPE="SHA-1" SIZE="4961819">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:29:08" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="e00b56f925d65841201f3fb5908769183f035442" CHECKSUMTYPE="SHA-1" SIZE="5020319">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:29:34" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="4ebccf732bd07d6c37392107ef3e9163dbedeeb4" CHECKSUMTYPE="SHA-1" SIZE="4953726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:29:56" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="c1e8a8b926928a29793dce03b248a47016b1a2e6" CHECKSUMTYPE="SHA-1" SIZE="5012225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:30:20" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="e0366179c3077c4f8415bffe736fdcc216f73eb6" CHECKSUMTYPE="SHA-1" SIZE="4951926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:30:43" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="68c1654c44138170e5221f26bac091dc65ec23da" CHECKSUMTYPE="SHA-1" SIZE="4987026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:31:09" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="85df321b90f654a9a6c51f5402fd0da1d302442b" CHECKSUMTYPE="SHA-1" SIZE="4948326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:31:31" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="f01e51bea93f9f50088fd89aa3e30c0cff91e07a" CHECKSUMTYPE="SHA-1" SIZE="4952815">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:31:59" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="b2a9f49e0a3902be368e159863fcffa1f8aae346" CHECKSUMTYPE="SHA-1" SIZE="4964526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/delivery/bmtnabe_1899-04_01_0086.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:32:16" MIMETYPE="text/xml" CHECKSUM="f048a57d0db0d69c150d3c2e5b4c759082b22dad"
-				CHECKSUMTYPE="SHA-1" SIZE="2102">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:32:16" MIMETYPE="text/xml" CHECKSUM="f048a57d0db0d69c150d3c2e5b4c759082b22dad" CHECKSUMTYPE="SHA-1" SIZE="2102">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:32:17" MIMETYPE="text/xml" CHECKSUM="40cb9af8a3ff94c136dec83a76a35854914ac710"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:32:17" MIMETYPE="text/xml" CHECKSUM="40cb9af8a3ff94c136dec83a76a35854914ac710" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:32:17" MIMETYPE="text/xml" CHECKSUM="f6b75fd1af580e8479ca24b62f11e24de9fdbac9"
-				CHECKSUMTYPE="SHA-1" SIZE="1718">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:32:17" MIMETYPE="text/xml" CHECKSUM="f6b75fd1af580e8479ca24b62f11e24de9fdbac9" CHECKSUMTYPE="SHA-1" SIZE="1718">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:32:17" MIMETYPE="text/xml" CHECKSUM="19c8672ceb11385ac384c08a73dd92aaf57819e6"
-				CHECKSUMTYPE="SHA-1" SIZE="1721">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:32:17" MIMETYPE="text/xml" CHECKSUM="19c8672ceb11385ac384c08a73dd92aaf57819e6" CHECKSUMTYPE="SHA-1" SIZE="1721">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:32:17" MIMETYPE="text/xml" CHECKSUM="c9471b45b64181c5c6fab288f8a34225b9c8f7cb"
-				CHECKSUMTYPE="SHA-1" SIZE="13549">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:32:17" MIMETYPE="text/xml" CHECKSUM="c9471b45b64181c5c6fab288f8a34225b9c8f7cb" CHECKSUMTYPE="SHA-1" SIZE="13549">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:32:18" MIMETYPE="text/xml" CHECKSUM="70448053d277bf3c76919240ee537ebd47f274bd"
-				CHECKSUMTYPE="SHA-1" SIZE="3396">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:32:18" MIMETYPE="text/xml" CHECKSUM="70448053d277bf3c76919240ee537ebd47f274bd" CHECKSUMTYPE="SHA-1" SIZE="3396">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:32:18" MIMETYPE="text/xml" CHECKSUM="ff9fd050e968db8eea2994b7e2c3c332dfbfc25d"
-				CHECKSUMTYPE="SHA-1" SIZE="1716">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:32:18" MIMETYPE="text/xml" CHECKSUM="ff9fd050e968db8eea2994b7e2c3c332dfbfc25d" CHECKSUMTYPE="SHA-1" SIZE="1716">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:32:18" MIMETYPE="text/xml" CHECKSUM="aef70f530f9f7c5f9c1b9f3e834122555762a5ab"
-				CHECKSUMTYPE="SHA-1" SIZE="4984">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:32:18" MIMETYPE="text/xml" CHECKSUM="aef70f530f9f7c5f9c1b9f3e834122555762a5ab" CHECKSUMTYPE="SHA-1" SIZE="4984">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:32:18" MIMETYPE="text/xml" CHECKSUM="bd447c478fd3954e4f088ddc8ccd8abe32750d59"
-				CHECKSUMTYPE="SHA-1" SIZE="26015">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:32:18" MIMETYPE="text/xml" CHECKSUM="bd447c478fd3954e4f088ddc8ccd8abe32750d59" CHECKSUMTYPE="SHA-1" SIZE="26015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:32:19" MIMETYPE="text/xml"
-				CHECKSUM="ff531dc3a0b6fbf91fe409f0908257b224f541db" CHECKSUMTYPE="SHA-1" SIZE="36753">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:32:19" MIMETYPE="text/xml" CHECKSUM="ff531dc3a0b6fbf91fe409f0908257b224f541db" CHECKSUMTYPE="SHA-1" SIZE="36753">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:32:19" MIMETYPE="text/xml"
-				CHECKSUM="63439518142cef8205123ac46e4c6a7d86f70e3d" CHECKSUMTYPE="SHA-1" SIZE="72294">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:32:19" MIMETYPE="text/xml" CHECKSUM="63439518142cef8205123ac46e4c6a7d86f70e3d" CHECKSUMTYPE="SHA-1" SIZE="72294">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:32:19" MIMETYPE="text/xml"
-				CHECKSUM="c3482f9b42d96e2e887289f4e1676d1364007935" CHECKSUMTYPE="SHA-1" SIZE="19732">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:32:19" MIMETYPE="text/xml" CHECKSUM="c3482f9b42d96e2e887289f4e1676d1364007935" CHECKSUMTYPE="SHA-1" SIZE="19732">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:32:19" MIMETYPE="text/xml"
-				CHECKSUM="5830f608ffc598309f4da2843f2472e11835f3c6" CHECKSUMTYPE="SHA-1" SIZE="32928">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:32:19" MIMETYPE="text/xml" CHECKSUM="5830f608ffc598309f4da2843f2472e11835f3c6" CHECKSUMTYPE="SHA-1" SIZE="32928">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:32:20" MIMETYPE="text/xml"
-				CHECKSUM="f69c4d81f86a6f77e15801e30db1821f046c6144" CHECKSUMTYPE="SHA-1" SIZE="74241">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:32:20" MIMETYPE="text/xml" CHECKSUM="f69c4d81f86a6f77e15801e30db1821f046c6144" CHECKSUMTYPE="SHA-1" SIZE="74241">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:32:20" MIMETYPE="text/xml"
-				CHECKSUM="1e94b532699a621ff2f8d845953a4f79023b49c1" CHECKSUMTYPE="SHA-1" SIZE="5404">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:32:20" MIMETYPE="text/xml" CHECKSUM="1e94b532699a621ff2f8d845953a4f79023b49c1" CHECKSUMTYPE="SHA-1" SIZE="5404">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:32:20" MIMETYPE="text/xml"
-				CHECKSUM="d18416cdf75dd4d5b7ef6e95a175f12b751a6711" CHECKSUMTYPE="SHA-1" SIZE="2020">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:32:20" MIMETYPE="text/xml" CHECKSUM="d18416cdf75dd4d5b7ef6e95a175f12b751a6711" CHECKSUMTYPE="SHA-1" SIZE="2020">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:32:21" MIMETYPE="text/xml"
-				CHECKSUM="7a8bc2df62eefcb7f55911725acc529a6406128c" CHECKSUMTYPE="SHA-1" SIZE="42518">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:32:21" MIMETYPE="text/xml" CHECKSUM="7a8bc2df62eefcb7f55911725acc529a6406128c" CHECKSUMTYPE="SHA-1" SIZE="42518">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:32:21" MIMETYPE="text/xml"
-				CHECKSUM="19250308b7cc7f3cc225ddc69f23979e6ecfe805" CHECKSUMTYPE="SHA-1" SIZE="82169">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:32:21" MIMETYPE="text/xml" CHECKSUM="19250308b7cc7f3cc225ddc69f23979e6ecfe805" CHECKSUMTYPE="SHA-1" SIZE="82169">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:32:21" MIMETYPE="text/xml"
-				CHECKSUM="3da1653104447defb76d1b41c5a4836d5dda7ce1" CHECKSUMTYPE="SHA-1" SIZE="90368">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:32:21" MIMETYPE="text/xml" CHECKSUM="3da1653104447defb76d1b41c5a4836d5dda7ce1" CHECKSUMTYPE="SHA-1" SIZE="90368">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:32:21" MIMETYPE="text/xml"
-				CHECKSUM="cbd400bde2596f4bc9d4003e6e3c0a90f8aaa1aa" CHECKSUMTYPE="SHA-1" SIZE="91770">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:32:21" MIMETYPE="text/xml" CHECKSUM="cbd400bde2596f4bc9d4003e6e3c0a90f8aaa1aa" CHECKSUMTYPE="SHA-1" SIZE="91770">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:32:22" MIMETYPE="text/xml"
-				CHECKSUM="c3afbfa1bc6956bb8dd93add37c6903f9ef657cb" CHECKSUMTYPE="SHA-1" SIZE="56348">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:32:22" MIMETYPE="text/xml" CHECKSUM="c3afbfa1bc6956bb8dd93add37c6903f9ef657cb" CHECKSUMTYPE="SHA-1" SIZE="56348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:32:22" MIMETYPE="text/xml"
-				CHECKSUM="494e828c0ebf2b227fada208946463755aceba77" CHECKSUMTYPE="SHA-1" SIZE="42442">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:32:22" MIMETYPE="text/xml" CHECKSUM="494e828c0ebf2b227fada208946463755aceba77" CHECKSUMTYPE="SHA-1" SIZE="42442">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:32:22" MIMETYPE="text/xml"
-				CHECKSUM="5e45a4446e4c4a100684faa693f045cd6048175b" CHECKSUMTYPE="SHA-1" SIZE="83589">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:32:22" MIMETYPE="text/xml" CHECKSUM="5e45a4446e4c4a100684faa693f045cd6048175b" CHECKSUMTYPE="SHA-1" SIZE="83589">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:32:23" MIMETYPE="text/xml"
-				CHECKSUM="f43863793cbfd6cc0b62f15b423fa3e4f18f4db1" CHECKSUMTYPE="SHA-1" SIZE="81890">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:32:23" MIMETYPE="text/xml" CHECKSUM="f43863793cbfd6cc0b62f15b423fa3e4f18f4db1" CHECKSUMTYPE="SHA-1" SIZE="81890">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:32:23" MIMETYPE="text/xml"
-				CHECKSUM="b2249a86ae3b4db0138991f9e63b52e00ba0fbdf" CHECKSUMTYPE="SHA-1" SIZE="85407">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:32:23" MIMETYPE="text/xml" CHECKSUM="b2249a86ae3b4db0138991f9e63b52e00ba0fbdf" CHECKSUMTYPE="SHA-1" SIZE="85407">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:32:23" MIMETYPE="text/xml"
-				CHECKSUM="4de5e2ec1383fab6b0c51096ed15a1a2d689ba1b" CHECKSUMTYPE="SHA-1" SIZE="58992">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:32:23" MIMETYPE="text/xml" CHECKSUM="4de5e2ec1383fab6b0c51096ed15a1a2d689ba1b" CHECKSUMTYPE="SHA-1" SIZE="58992">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:32:24" MIMETYPE="text/xml"
-				CHECKSUM="f336336fb161ac76c964bff931ec66694be69871" CHECKSUMTYPE="SHA-1" SIZE="4597">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:32:24" MIMETYPE="text/xml" CHECKSUM="f336336fb161ac76c964bff931ec66694be69871" CHECKSUMTYPE="SHA-1" SIZE="4597">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:32:24" MIMETYPE="text/xml"
-				CHECKSUM="851392b7bafb4ef718e97fcab9b71657346f72ab" CHECKSUMTYPE="SHA-1" SIZE="2020">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:32:24" MIMETYPE="text/xml" CHECKSUM="851392b7bafb4ef718e97fcab9b71657346f72ab" CHECKSUMTYPE="SHA-1" SIZE="2020">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:32:24" MIMETYPE="text/xml"
-				CHECKSUM="28aa34ae0920cb28b8a6f8febc10bf504ad06774" CHECKSUMTYPE="SHA-1" SIZE="24889">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:32:24" MIMETYPE="text/xml" CHECKSUM="28aa34ae0920cb28b8a6f8febc10bf504ad06774" CHECKSUMTYPE="SHA-1" SIZE="24889">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:32:25" MIMETYPE="text/xml"
-				CHECKSUM="76a9cd69bb3ffda962e379b9fc03610a7207aba1" CHECKSUMTYPE="SHA-1" SIZE="48113">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:32:25" MIMETYPE="text/xml" CHECKSUM="76a9cd69bb3ffda962e379b9fc03610a7207aba1" CHECKSUMTYPE="SHA-1" SIZE="48113">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:32:25" MIMETYPE="text/xml"
-				CHECKSUM="4ef922b14b55f41659293dca1e03d9b25c570b55" CHECKSUMTYPE="SHA-1" SIZE="20185">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:32:25" MIMETYPE="text/xml" CHECKSUM="4ef922b14b55f41659293dca1e03d9b25c570b55" CHECKSUMTYPE="SHA-1" SIZE="20185">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:32:25" MIMETYPE="text/xml"
-				CHECKSUM="6ff5afbdb5be592d612e5bcad29cc7242a01e136" CHECKSUMTYPE="SHA-1" SIZE="48187">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:32:25" MIMETYPE="text/xml" CHECKSUM="6ff5afbdb5be592d612e5bcad29cc7242a01e136" CHECKSUMTYPE="SHA-1" SIZE="48187">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:32:26" MIMETYPE="text/xml"
-				CHECKSUM="aa31f269156ad92958671d7e5f73a9e1970611c3" CHECKSUMTYPE="SHA-1" SIZE="42009">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:32:26" MIMETYPE="text/xml" CHECKSUM="aa31f269156ad92958671d7e5f73a9e1970611c3" CHECKSUMTYPE="SHA-1" SIZE="42009">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:32:26" MIMETYPE="text/xml"
-				CHECKSUM="92aebc71492f0e054aebb95e6b8d66f0748baa48" CHECKSUMTYPE="SHA-1" SIZE="16543">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:32:26" MIMETYPE="text/xml" CHECKSUM="92aebc71492f0e054aebb95e6b8d66f0748baa48" CHECKSUMTYPE="SHA-1" SIZE="16543">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:32:26" MIMETYPE="text/xml"
-				CHECKSUM="30656b4a1c4b1e71537b63a08e5d15a400a0b1dd" CHECKSUMTYPE="SHA-1" SIZE="5017">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:32:26" MIMETYPE="text/xml" CHECKSUM="30656b4a1c4b1e71537b63a08e5d15a400a0b1dd" CHECKSUMTYPE="SHA-1" SIZE="5017">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:32:27" MIMETYPE="text/xml"
-				CHECKSUM="a57998dca13c24226f5d895ef97a6e68c3efb4e3" CHECKSUMTYPE="SHA-1" SIZE="2020">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:32:27" MIMETYPE="text/xml" CHECKSUM="a57998dca13c24226f5d895ef97a6e68c3efb4e3" CHECKSUMTYPE="SHA-1" SIZE="2020">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:32:27" MIMETYPE="text/xml"
-				CHECKSUM="0f9df1fa0a9df9bf0417a65220ac02eaabf53f46" CHECKSUMTYPE="SHA-1" SIZE="74557">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:32:27" MIMETYPE="text/xml" CHECKSUM="0f9df1fa0a9df9bf0417a65220ac02eaabf53f46" CHECKSUMTYPE="SHA-1" SIZE="74557">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:32:27" MIMETYPE="text/xml"
-				CHECKSUM="26a2e214106255c21ffb73a34030c3ab31a1d5fe" CHECKSUMTYPE="SHA-1" SIZE="176536">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:32:27" MIMETYPE="text/xml" CHECKSUM="26a2e214106255c21ffb73a34030c3ab31a1d5fe" CHECKSUMTYPE="SHA-1" SIZE="176536">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:32:28" MIMETYPE="text/xml"
-				CHECKSUM="797aa715dc21538d3e15072c63ef7e976f0b3c54" CHECKSUMTYPE="SHA-1" SIZE="177615">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:32:28" MIMETYPE="text/xml" CHECKSUM="797aa715dc21538d3e15072c63ef7e976f0b3c54" CHECKSUMTYPE="SHA-1" SIZE="177615">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:32:28" MIMETYPE="text/xml"
-				CHECKSUM="5dac5495659b809d4a43fb5835584858d3d181a0" CHECKSUMTYPE="SHA-1" SIZE="202303">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:32:28" MIMETYPE="text/xml" CHECKSUM="5dac5495659b809d4a43fb5835584858d3d181a0" CHECKSUMTYPE="SHA-1" SIZE="202303">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:32:28" MIMETYPE="text/xml"
-				CHECKSUM="c47e369b0847f269af12db8ed0f8a28a495febe4" CHECKSUMTYPE="SHA-1" SIZE="130428">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:32:28" MIMETYPE="text/xml" CHECKSUM="c47e369b0847f269af12db8ed0f8a28a495febe4" CHECKSUMTYPE="SHA-1" SIZE="130428">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:32:29" MIMETYPE="text/xml"
-				CHECKSUM="91dc351472f82e301723adfbd7cbec24c89674c0" CHECKSUMTYPE="SHA-1" SIZE="69968">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:32:29" MIMETYPE="text/xml" CHECKSUM="91dc351472f82e301723adfbd7cbec24c89674c0" CHECKSUMTYPE="SHA-1" SIZE="69968">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:32:29" MIMETYPE="text/xml"
-				CHECKSUM="9dacbc6a085605e7444e48510a4bae8448573ea0" CHECKSUMTYPE="SHA-1" SIZE="5881">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:32:29" MIMETYPE="text/xml" CHECKSUM="9dacbc6a085605e7444e48510a4bae8448573ea0" CHECKSUMTYPE="SHA-1" SIZE="5881">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:32:29" MIMETYPE="text/xml"
-				CHECKSUM="afed6a6519ed03e26dc330ee56cce344c7a1134e" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:32:29" MIMETYPE="text/xml" CHECKSUM="afed6a6519ed03e26dc330ee56cce344c7a1134e" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:32:30" MIMETYPE="text/xml"
-				CHECKSUM="e9bd407b7c315ecba9b70501d6ab1f668f98f652" CHECKSUMTYPE="SHA-1" SIZE="183924">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:32:30" MIMETYPE="text/xml" CHECKSUM="e9bd407b7c315ecba9b70501d6ab1f668f98f652" CHECKSUMTYPE="SHA-1" SIZE="183924">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:32:30" MIMETYPE="text/xml"
-				CHECKSUM="174a4df7c54042dcd37e118f5cd39d8d7b9dc02f" CHECKSUMTYPE="SHA-1" SIZE="195462">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:32:30" MIMETYPE="text/xml" CHECKSUM="174a4df7c54042dcd37e118f5cd39d8d7b9dc02f" CHECKSUMTYPE="SHA-1" SIZE="195462">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:32:30" MIMETYPE="text/xml"
-				CHECKSUM="97738f18690afd1596c58df772936af76f681c8a" CHECKSUMTYPE="SHA-1" SIZE="189442">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:32:30" MIMETYPE="text/xml" CHECKSUM="97738f18690afd1596c58df772936af76f681c8a" CHECKSUMTYPE="SHA-1" SIZE="189442">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:32:31" MIMETYPE="text/xml"
-				CHECKSUM="b906475719065fc47e9e3b51fc85010caee1d3a8" CHECKSUMTYPE="SHA-1" SIZE="19074">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:32:31" MIMETYPE="text/xml" CHECKSUM="b906475719065fc47e9e3b51fc85010caee1d3a8" CHECKSUMTYPE="SHA-1" SIZE="19074">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:32:31" MIMETYPE="text/xml"
-				CHECKSUM="e007304f7d3773b756a1ee37d2fa04255698e330" CHECKSUMTYPE="SHA-1" SIZE="5299">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:32:31" MIMETYPE="text/xml" CHECKSUM="e007304f7d3773b756a1ee37d2fa04255698e330" CHECKSUMTYPE="SHA-1" SIZE="5299">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:32:31" MIMETYPE="text/xml"
-				CHECKSUM="6b346d0ef8e1fad6b8726cede27999d784e33bcd" CHECKSUMTYPE="SHA-1" SIZE="2019">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:32:31" MIMETYPE="text/xml" CHECKSUM="6b346d0ef8e1fad6b8726cede27999d784e33bcd" CHECKSUMTYPE="SHA-1" SIZE="2019">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:32:31" MIMETYPE="text/xml"
-				CHECKSUM="ccb12554aaa493a96f1ca975fca40d0a786e5fdf" CHECKSUMTYPE="SHA-1" SIZE="97322">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:32:31" MIMETYPE="text/xml" CHECKSUM="ccb12554aaa493a96f1ca975fca40d0a786e5fdf" CHECKSUMTYPE="SHA-1" SIZE="97322">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:32:32" MIMETYPE="text/xml"
-				CHECKSUM="8d57d4158f8cff9d434c9732081ee9097fe2faef" CHECKSUMTYPE="SHA-1" SIZE="119362">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:32:32" MIMETYPE="text/xml" CHECKSUM="8d57d4158f8cff9d434c9732081ee9097fe2faef" CHECKSUMTYPE="SHA-1" SIZE="119362">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:32:32" MIMETYPE="text/xml"
-				CHECKSUM="f731fb2ad2ed8a42f9c1c177bd94e4cbd6223fdf" CHECKSUMTYPE="SHA-1" SIZE="4287">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:32:32" MIMETYPE="text/xml" CHECKSUM="f731fb2ad2ed8a42f9c1c177bd94e4cbd6223fdf" CHECKSUMTYPE="SHA-1" SIZE="4287">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:32:32" MIMETYPE="text/xml"
-				CHECKSUM="b861fed51921ab067b406dda21aad72e266ce787" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:32:32" MIMETYPE="text/xml" CHECKSUM="b861fed51921ab067b406dda21aad72e266ce787" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:32:33" MIMETYPE="text/xml"
-				CHECKSUM="c42919225b5bae3241ee668e36f69fcc94ad46ba" CHECKSUMTYPE="SHA-1" SIZE="64148">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:32:33" MIMETYPE="text/xml" CHECKSUM="c42919225b5bae3241ee668e36f69fcc94ad46ba" CHECKSUMTYPE="SHA-1" SIZE="64148">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:32:33" MIMETYPE="text/xml"
-				CHECKSUM="139af215caa9167842fc9c776a88ea9c389eb9ce" CHECKSUMTYPE="SHA-1" SIZE="188957">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:32:33" MIMETYPE="text/xml" CHECKSUM="139af215caa9167842fc9c776a88ea9c389eb9ce" CHECKSUMTYPE="SHA-1" SIZE="188957">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:32:33" MIMETYPE="text/xml"
-				CHECKSUM="58e2bdcc4f9567ceaf2295b6c876dba93cf3b331" CHECKSUMTYPE="SHA-1" SIZE="63342">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:32:33" MIMETYPE="text/xml" CHECKSUM="58e2bdcc4f9567ceaf2295b6c876dba93cf3b331" CHECKSUMTYPE="SHA-1" SIZE="63342">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:32:33" MIMETYPE="text/xml"
-				CHECKSUM="08d7834ebe5d3045b7707b2263b1b5d43a72a031" CHECKSUMTYPE="SHA-1" SIZE="135592">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:32:33" MIMETYPE="text/xml" CHECKSUM="08d7834ebe5d3045b7707b2263b1b5d43a72a031" CHECKSUMTYPE="SHA-1" SIZE="135592">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:32:34" MIMETYPE="text/xml"
-				CHECKSUM="67534e623f2e1f88b181bc451c1a951ea686f164" CHECKSUMTYPE="SHA-1" SIZE="5221">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:32:34" MIMETYPE="text/xml" CHECKSUM="67534e623f2e1f88b181bc451c1a951ea686f164" CHECKSUMTYPE="SHA-1" SIZE="5221">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:32:34" MIMETYPE="text/xml"
-				CHECKSUM="80a5ed150810ea5fad67a9b630cab89fd3ae1f44" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:32:34" MIMETYPE="text/xml" CHECKSUM="80a5ed150810ea5fad67a9b630cab89fd3ae1f44" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:32:34" MIMETYPE="text/xml"
-				CHECKSUM="5d9af34b352ec18bda4db3bc5eaadeb572c30cb8" CHECKSUMTYPE="SHA-1" SIZE="86956">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:32:34" MIMETYPE="text/xml" CHECKSUM="5d9af34b352ec18bda4db3bc5eaadeb572c30cb8" CHECKSUMTYPE="SHA-1" SIZE="86956">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:32:35" MIMETYPE="text/xml"
-				CHECKSUM="cf3af89b493f579c9afd3b6f46438cee27afdc29" CHECKSUMTYPE="SHA-1" SIZE="142517">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:32:35" MIMETYPE="text/xml" CHECKSUM="cf3af89b493f579c9afd3b6f46438cee27afdc29" CHECKSUMTYPE="SHA-1" SIZE="142517">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:32:35" MIMETYPE="text/xml"
-				CHECKSUM="347aa6b680f4f5f0810eb14679dfb521aac41378" CHECKSUMTYPE="SHA-1" SIZE="149338">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:32:35" MIMETYPE="text/xml" CHECKSUM="347aa6b680f4f5f0810eb14679dfb521aac41378" CHECKSUMTYPE="SHA-1" SIZE="149338">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:32:35" MIMETYPE="text/xml"
-				CHECKSUM="f879f4fce0bc7cc797f42d7e68e308da8e5d3424" CHECKSUMTYPE="SHA-1" SIZE="155188">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:32:35" MIMETYPE="text/xml" CHECKSUM="f879f4fce0bc7cc797f42d7e68e308da8e5d3424" CHECKSUMTYPE="SHA-1" SIZE="155188">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:32:36" MIMETYPE="text/xml"
-				CHECKSUM="b96ceec753eb397746fd3007d11c1390e5dd2cc8" CHECKSUMTYPE="SHA-1" SIZE="144928">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:32:36" MIMETYPE="text/xml" CHECKSUM="b96ceec753eb397746fd3007d11c1390e5dd2cc8" CHECKSUMTYPE="SHA-1" SIZE="144928">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:32:36" MIMETYPE="text/xml"
-				CHECKSUM="c0dfef5d051605497678f92a9f1c2169828b85a1" CHECKSUMTYPE="SHA-1" SIZE="130851">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:32:36" MIMETYPE="text/xml" CHECKSUM="c0dfef5d051605497678f92a9f1c2169828b85a1" CHECKSUMTYPE="SHA-1" SIZE="130851">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:32:36" MIMETYPE="text/xml"
-				CHECKSUM="45786108c67faa0e560669d224086d559baf0e2b" CHECKSUMTYPE="SHA-1" SIZE="152882">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:32:36" MIMETYPE="text/xml" CHECKSUM="45786108c67faa0e560669d224086d559baf0e2b" CHECKSUMTYPE="SHA-1" SIZE="152882">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:32:37" MIMETYPE="text/xml"
-				CHECKSUM="bd15de4f88bd3bd968643e47803f853ae54723e4" CHECKSUMTYPE="SHA-1" SIZE="109384">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:32:37" MIMETYPE="text/xml" CHECKSUM="bd15de4f88bd3bd968643e47803f853ae54723e4" CHECKSUMTYPE="SHA-1" SIZE="109384">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:32:37" MIMETYPE="text/xml"
-				CHECKSUM="a40de3f965d6fe241b0b1d05dbffc61e38b6fbf5" CHECKSUMTYPE="SHA-1" SIZE="131871">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:32:37" MIMETYPE="text/xml" CHECKSUM="a40de3f965d6fe241b0b1d05dbffc61e38b6fbf5" CHECKSUMTYPE="SHA-1" SIZE="131871">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:32:37" MIMETYPE="text/xml"
-				CHECKSUM="656dcf068c2a62f7cdfc419ae96d76b2560309f6" CHECKSUMTYPE="SHA-1" SIZE="62993">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:32:37" MIMETYPE="text/xml" CHECKSUM="656dcf068c2a62f7cdfc419ae96d76b2560309f6" CHECKSUMTYPE="SHA-1" SIZE="62993">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:32:37" MIMETYPE="text/xml"
-				CHECKSUM="543b3f03e1ec29e932a3ad5b6cefe3616ed85af0" CHECKSUMTYPE="SHA-1" SIZE="4941">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:32:37" MIMETYPE="text/xml" CHECKSUM="543b3f03e1ec29e932a3ad5b6cefe3616ed85af0" CHECKSUMTYPE="SHA-1" SIZE="4941">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:32:38" MIMETYPE="text/xml"
-				CHECKSUM="36d26a343d3d2a4a645825fcc8f6cb099c6c9c9b" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:32:38" MIMETYPE="text/xml" CHECKSUM="36d26a343d3d2a4a645825fcc8f6cb099c6c9c9b" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:32:38" MIMETYPE="text/xml"
-				CHECKSUM="85dcf0fe42da456f1047f00264ec8169551ac6b7" CHECKSUMTYPE="SHA-1" SIZE="121787">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:32:38" MIMETYPE="text/xml" CHECKSUM="85dcf0fe42da456f1047f00264ec8169551ac6b7" CHECKSUMTYPE="SHA-1" SIZE="121787">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:32:38" MIMETYPE="text/xml"
-				CHECKSUM="26705325a062f2a50f9140a0a5ae7a6f53f31e3d" CHECKSUMTYPE="SHA-1" SIZE="171688">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:32:38" MIMETYPE="text/xml" CHECKSUM="26705325a062f2a50f9140a0a5ae7a6f53f31e3d" CHECKSUMTYPE="SHA-1" SIZE="171688">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:32:39" MIMETYPE="text/xml"
-				CHECKSUM="9ec7599c29103ba889bf80a3482852eedc86099e" CHECKSUMTYPE="SHA-1" SIZE="135726">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:32:39" MIMETYPE="text/xml" CHECKSUM="9ec7599c29103ba889bf80a3482852eedc86099e" CHECKSUMTYPE="SHA-1" SIZE="135726">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:32:39" MIMETYPE="text/xml"
-				CHECKSUM="ab41c24a6e94de6a7f12c55a12dc570f43af13db" CHECKSUMTYPE="SHA-1" SIZE="130847">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:32:39" MIMETYPE="text/xml" CHECKSUM="ab41c24a6e94de6a7f12c55a12dc570f43af13db" CHECKSUMTYPE="SHA-1" SIZE="130847">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:32:39" MIMETYPE="text/xml"
-				CHECKSUM="8b5bc5993ebbddcb6414bf0f58ba4217b0a66d52" CHECKSUMTYPE="SHA-1" SIZE="162161">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:32:39" MIMETYPE="text/xml" CHECKSUM="8b5bc5993ebbddcb6414bf0f58ba4217b0a66d52" CHECKSUMTYPE="SHA-1" SIZE="162161">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:32:40" MIMETYPE="text/xml"
-				CHECKSUM="7024b32a83fadf37b220027d1180104177e37b8c" CHECKSUMTYPE="SHA-1" SIZE="150564">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:32:40" MIMETYPE="text/xml" CHECKSUM="7024b32a83fadf37b220027d1180104177e37b8c" CHECKSUMTYPE="SHA-1" SIZE="150564">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:32:40" MIMETYPE="text/xml"
-				CHECKSUM="d9dc2706f1c456f2278e7fe987baec0cfde6c7e2" CHECKSUMTYPE="SHA-1" SIZE="172167">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:32:40" MIMETYPE="text/xml" CHECKSUM="d9dc2706f1c456f2278e7fe987baec0cfde6c7e2" CHECKSUMTYPE="SHA-1" SIZE="172167">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:32:40" MIMETYPE="text/xml"
-				CHECKSUM="9a32825fc8ba00cc5d81d68903306b5c1ebd504b" CHECKSUMTYPE="SHA-1" SIZE="126457">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:32:40" MIMETYPE="text/xml" CHECKSUM="9a32825fc8ba00cc5d81d68903306b5c1ebd504b" CHECKSUMTYPE="SHA-1" SIZE="126457">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:32:41" MIMETYPE="text/xml"
-				CHECKSUM="58212f10742d3a6511f34d063f8b64eb110d56af" CHECKSUMTYPE="SHA-1" SIZE="43234">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:32:41" MIMETYPE="text/xml" CHECKSUM="58212f10742d3a6511f34d063f8b64eb110d56af" CHECKSUMTYPE="SHA-1" SIZE="43234">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:32:41" MIMETYPE="text/xml"
-				CHECKSUM="0e7302835cdafcbe20c3b30592b9604742400837" CHECKSUMTYPE="SHA-1" SIZE="46215">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:32:41" MIMETYPE="text/xml" CHECKSUM="0e7302835cdafcbe20c3b30592b9604742400837" CHECKSUMTYPE="SHA-1" SIZE="46215">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:32:41" MIMETYPE="text/xml"
-				CHECKSUM="7f46cbe685b1fab851331724584171d7d70fd3a0" CHECKSUMTYPE="SHA-1" SIZE="16723">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:32:41" MIMETYPE="text/xml" CHECKSUM="7f46cbe685b1fab851331724584171d7d70fd3a0" CHECKSUMTYPE="SHA-1" SIZE="16723">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:32:41" MIMETYPE="text/xml"
-				CHECKSUM="890face00746810feb96d2a5700c761faae6e5fc" CHECKSUMTYPE="SHA-1" SIZE="42729">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:32:41" MIMETYPE="text/xml" CHECKSUM="890face00746810feb96d2a5700c761faae6e5fc" CHECKSUMTYPE="SHA-1" SIZE="42729">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:32:42" MIMETYPE="text/xml"
-				CHECKSUM="410d477baf36932e4e191087a1275468f2cf4635" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:32:42" MIMETYPE="text/xml" CHECKSUM="410d477baf36932e4e191087a1275468f2cf4635" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:32:42" MIMETYPE="text/xml"
-				CHECKSUM="a4633ca165be9bb8de69fffd726dccd154bae1c2" CHECKSUMTYPE="SHA-1" SIZE="7419">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:32:42" MIMETYPE="text/xml" CHECKSUM="a4633ca165be9bb8de69fffd726dccd154bae1c2" CHECKSUMTYPE="SHA-1" SIZE="7419">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-04_01_0086.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:35:22" MIMETYPE="application/pdf" CHECKSUM="fbeda33ab2a34337880246db5e6241e8b9395dd7"
-				CHECKSUMTYPE="SHA-1" SIZE="39259952">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/bmtnabe_1899-04_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:35:22" MIMETYPE="application/pdf" CHECKSUM="fbeda33ab2a34337880246db5e6241e8b9395dd7" CHECKSUMTYPE="SHA-1" SIZE="39259952">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/04_01/bmtnabe_1899-04_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -10453,8 +10189,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.19.9" TYPE="Illustration" ORDER="7" DMDID="c069"
-						LABEL="SOGENANNTER SANSOVINO-KAHMEN AUS DER ZWEITEN HÄLFTE DES XV. JAHRHUNDERTS GEZEICHNET VON ALBERT KRÜGER">
+					<div ID="L.1.1.19.9" TYPE="Illustration" ORDER="7" DMDID="c069" LABEL="SOGENANNTER SANSOVINO-KAHMEN AUS DER ZWEITEN HÄLFTE DES XV. JAHRHUNDERTS GEZEICHNET VON ALBERT KRÜGER">
 						<div ID="L.1.1.19.9.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00064" BEGIN="P64_CB00001"/>

--- a/metadata/periodicals/bmtnabe/issues/1899/08_01/bmtnabe_1899-08_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1899/08_01/bmtnabe_1899-08_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1899-08_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1899-08_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1899-08_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1899-08_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1899-08_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1899-08_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1899-08_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -1780,9 +1776,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0001.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0001.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4875429</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -1855,9 +1849,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0002.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0002.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4967228</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -1930,9 +1922,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0003.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0003.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4851128</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2005,9 +1995,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0004.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0004.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4919526</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2080,9 +2068,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0005.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0005.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4870921</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2155,9 +2141,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0006.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0006.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4946519</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2230,9 +2214,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0007.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0007.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4826811</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2305,9 +2287,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0008.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0008.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4996929</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2380,9 +2360,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0009.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0009.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4780029</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2455,9 +2433,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0010.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0010.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4970828</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2530,9 +2506,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0011.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0011.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4775525</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2605,9 +2579,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0012.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0012.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4959125</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2680,9 +2652,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0013.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0013.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4689933</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2755,9 +2725,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0014.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0014.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5005929</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2830,9 +2798,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0015.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0015.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4771929</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2905,9 +2871,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0016.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0016.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5010429</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -2980,9 +2944,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0017.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0017.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4770045</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3055,9 +3017,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0018.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0018.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5030228</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3130,9 +3090,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0019.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0019.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4741264</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3205,9 +3163,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0020.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0020.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5032927</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3280,9 +3236,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0021.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0021.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4699925</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3355,9 +3309,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0022.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0022.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5018529</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3430,9 +3382,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0023.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0023.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4687208</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3505,9 +3455,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0024.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0024.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5032836</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3580,9 +3528,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0025.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0025.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4710591</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3655,9 +3601,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0026.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0026.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5048226</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3730,9 +3674,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0027.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0027.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4734127</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3805,9 +3747,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0028.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0028.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5047326</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3880,9 +3820,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0029.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0029.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4698121</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -3955,9 +3893,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0030.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0030.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5021219</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4030,9 +3966,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0031.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0031.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4639627</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4105,9 +4039,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0032.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0032.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5053626</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4180,9 +4112,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0033.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0033.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4710727</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4255,9 +4185,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0034.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0034.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5037428</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4330,9 +4258,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0035.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0035.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4687328</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4405,9 +4331,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0036.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0036.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5051826</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4480,9 +4404,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0037.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0037.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4717924</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4555,9 +4477,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0038.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0038.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5060735</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4630,9 +4550,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0039.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0039.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4702628</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4705,9 +4623,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0040.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0040.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5048222</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4780,9 +4696,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0041.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0041.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4659429</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4855,9 +4769,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0042.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0042.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5063528</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -4930,9 +4842,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0043.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0043.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4754829</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5005,9 +4915,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0044.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0044.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5043729</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5080,9 +4988,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0045.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0045.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4716128</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5155,9 +5061,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0046.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0046.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5053629</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5230,9 +5134,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0047.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0047.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4731425</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5305,9 +5207,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0048.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0048.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5062619</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5380,9 +5280,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0049.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0049.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4731420</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5455,9 +5353,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0050.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0050.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5021229</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5530,9 +5426,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0051.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0051.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4755722</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5605,9 +5499,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0052.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0052.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5067944</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5680,9 +5572,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0053.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0053.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4760228</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5755,9 +5645,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0054.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0054.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5041928</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5830,9 +5718,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0055.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0055.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4862826</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5905,9 +5791,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0056.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0056.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5045529</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -5980,9 +5864,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0057.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0057.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4775525</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6055,9 +5937,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0058.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0058.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5056300</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6130,9 +6010,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0059.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0059.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4866417</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6205,9 +6083,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0060.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0060.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5095029</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6280,9 +6156,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0061.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0061.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4860129</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6355,9 +6229,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0062.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0062.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5095027</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6430,9 +6302,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0063.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0063.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4906873</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6505,9 +6375,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0064.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0064.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5069827</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6580,9 +6448,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0065.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0065.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4883528</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6655,9 +6521,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0066.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0066.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5067129</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6730,9 +6594,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0067.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0067.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4900618</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6805,9 +6667,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0068.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0068.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5069800</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6880,9 +6740,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0069.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0069.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4902429</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -6955,9 +6813,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0070.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0070.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5060825</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7030,9 +6886,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0071.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0071.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4879924</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7105,9 +6959,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0072.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0072.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5095021</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7180,9 +7032,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0073.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0073.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4929424</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7255,9 +7105,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0074.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0074.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5072529</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7330,9 +7178,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0075.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0075.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4963567</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7405,9 +7251,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0076.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0076.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5095026</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7480,9 +7324,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0077.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0077.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4923124</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7555,9 +7397,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0078.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0078.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5079726</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7630,9 +7470,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0079.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0079.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4948326</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7705,9 +7543,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0080.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0080.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5095029</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7780,9 +7616,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0081.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0081.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4910527</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7855,9 +7689,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0082.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0082.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5094830</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -7930,9 +7762,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0083.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0083.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4964525</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8005,9 +7835,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0084.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0084.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5095028</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8080,9 +7908,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0085.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0085.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4924010</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8155,9 +7981,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0086.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0086.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5095028</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8230,9 +8054,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0087.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0087.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4926640</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8305,9 +8127,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0088.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0088.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5095028</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8380,9 +8200,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0089.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0089.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4945595</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8455,9 +8273,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0090.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0090.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5076125</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8530,9 +8346,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0091.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0091.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4964523</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8605,9 +8419,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0092.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0092.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5095025</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8680,9 +8492,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0093.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0093.jp2</mix:ImageIdentifier>
 								<mix:FileSize>4968129</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8755,9 +8565,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0094.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0094.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5094980</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8830,9 +8638,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0095.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0095.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5002317</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8905,9 +8711,7 @@
 								</mix:PhotometricInterpretation>
 							</mix:Format>
 							<mix:File>
-								<mix:ImageIdentifier
-									imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto"
-									>bmtnabe_1899-08_01_0096.jp2</mix:ImageIdentifier>
+								<mix:ImageIdentifier imageIdentifierLocation="//lib-docworks1/OUT/PUL-BlueMountain-RQA/PAN/bmtnabe/issues/1899/08_01/alto">bmtnabe_1899-08_01_0096.jp2</mix:ImageIdentifier>
 								<mix:FileSize>5095014</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -8967,878 +8771,588 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T18:13:49" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="4fe9f70d6ee4fa5e1e86bcb7377c9550e63aa24f" CHECKSUMTYPE="SHA-1" SIZE="4875429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T18:14:14" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="388814e833f57fba6a3366ee5bc22faba87ce468" CHECKSUMTYPE="SHA-1" SIZE="4967228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T18:14:38" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="df05053ef6dff4e6c386bab1adfa0d6c41944280" CHECKSUMTYPE="SHA-1" SIZE="4851128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T18:15:01" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="b5a56ed2d006b91ec3aed43ecd4f28ce5adab320" CHECKSUMTYPE="SHA-1" SIZE="4919526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T18:15:23" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="4988c8bf034c52ddf4f8f772f5726717dc968946" CHECKSUMTYPE="SHA-1" SIZE="4870921">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T18:15:49" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="b324f5fd5ebe9b6744e778eae7760a492547e27b" CHECKSUMTYPE="SHA-1" SIZE="4946519">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T18:16:12" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="02ad168771ea134f96b4c1783062377a20d5ea56" CHECKSUMTYPE="SHA-1" SIZE="4826811">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T18:16:36" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="9a06e91b0360f4c29d5cf086aa0d0ff80854f720" CHECKSUMTYPE="SHA-1" SIZE="4996929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T18:16:57" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="cb6f41d1fdceff77d66d4286c190bf60131f9909" CHECKSUMTYPE="SHA-1" SIZE="4780029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T18:17:18" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="7f8634dc67f41e32846f99c251471fff56a1ae26" CHECKSUMTYPE="SHA-1" SIZE="4970828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T18:17:38" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="a1b6a4c43107a43e4b325f3e75692bf90e860044" CHECKSUMTYPE="SHA-1" SIZE="4775525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T18:17:58" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="2652c7a0f886024446ed6a4227dd2b19b550c007" CHECKSUMTYPE="SHA-1" SIZE="4959125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T18:18:21" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="4ad1a85f27cc5e12b21873230aad99b346e2a006" CHECKSUMTYPE="SHA-1" SIZE="4689933">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T18:18:48" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="a8aac12c0f07b873a68d55839d414a34940f6835" CHECKSUMTYPE="SHA-1" SIZE="5005929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T18:19:13" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="729d7e2752005acef55297034a9413243e38bc01" CHECKSUMTYPE="SHA-1" SIZE="4771929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T18:19:34" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="5c16f79a8901a728f161431671b09643d82655bd" CHECKSUMTYPE="SHA-1" SIZE="5010429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T18:19:58" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="dc9ddf182d0eb5113a2eb75de33ceeb02d56163c" CHECKSUMTYPE="SHA-1" SIZE="4770045">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T18:20:19" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="23804b4e7cd60c3a507e8f2b148f0cd56b391f28" CHECKSUMTYPE="SHA-1" SIZE="5030228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T18:20:43" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="7a0228e691754be92b098e0c01a3274d136e98dc" CHECKSUMTYPE="SHA-1" SIZE="4741264">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T18:21:07" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="f0e25223f388f264c22f50248da485fbdf2acb5d" CHECKSUMTYPE="SHA-1" SIZE="5032927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T18:21:32" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="042b96fbb25ad7a56fd4b1fec51aeba416f136cb" CHECKSUMTYPE="SHA-1" SIZE="4699925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T18:21:54" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="a2ac02f2bf51d00bb5281774af902964e1b9d72b" CHECKSUMTYPE="SHA-1" SIZE="5018529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T18:22:19" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="b9533af385890e1d117b6df3a4f32c7f7d5bb4a6" CHECKSUMTYPE="SHA-1" SIZE="4687208">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T18:22:41" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="7df9c3f64eebf85171e56b2c9e7cec7043519b26" CHECKSUMTYPE="SHA-1" SIZE="5032836">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T18:23:03" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="8851aef26d48d61de422b80b9dde1b466488ccff" CHECKSUMTYPE="SHA-1" SIZE="4710591">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T18:23:27" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="491d39395c2e0b7f55136300a5dc15403fbf6e86" CHECKSUMTYPE="SHA-1" SIZE="5048226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T18:23:49" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="a300f6d4e2b06b0038f47a031f18a1294e659bab" CHECKSUMTYPE="SHA-1" SIZE="4734127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T18:24:13" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="dd71b606cdb809a9b7178d1fda8454619552dfee" CHECKSUMTYPE="SHA-1" SIZE="5047326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T18:24:37" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="2b53c9690fa4082ab72449644edb46bbe25401b6" CHECKSUMTYPE="SHA-1" SIZE="4698121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T18:25:00" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="7ced4aa909b7eea17b927398367427b372a34ec4" CHECKSUMTYPE="SHA-1" SIZE="5021219">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T18:25:23" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="551d05223ebb2009014fbca810cca864543fec67" CHECKSUMTYPE="SHA-1" SIZE="4639627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T18:25:49" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="e200decb13bab4b7377434ab81b991b8c69e2eb5" CHECKSUMTYPE="SHA-1" SIZE="5053626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T18:26:12" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="78fb899fa9a6c552575096cbbf0c8b5d40e52701" CHECKSUMTYPE="SHA-1" SIZE="4710727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T18:26:36" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="55514583e8124450b7b0f4bf0f0348f6db497d6e" CHECKSUMTYPE="SHA-1" SIZE="5037428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T18:27:00" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="b7af72443e21bdd4faef71dd1669126e641c18ea" CHECKSUMTYPE="SHA-1" SIZE="4687328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T18:27:24" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="d37c83418def8784ae0779dc0b780fe80b32beca" CHECKSUMTYPE="SHA-1" SIZE="5051826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T18:27:50" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="a3fa94901ae8f74b2784ec34cd2136362e5691e6" CHECKSUMTYPE="SHA-1" SIZE="4717924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T18:28:12" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="0c6a14fe348ced5ea6e4b7c234e95ac9c755c1c4" CHECKSUMTYPE="SHA-1" SIZE="5060735">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T18:28:34" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="98e09abd14868075526cf4932b05083ff5fbb430" CHECKSUMTYPE="SHA-1" SIZE="4702628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T18:28:59" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="022ed6aa0209e2bd242599b17abe696b52ada4ac" CHECKSUMTYPE="SHA-1" SIZE="5048222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T18:29:22" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="0522b3276e441febe3e803655b2d9197587635c9" CHECKSUMTYPE="SHA-1" SIZE="4659429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T18:29:45" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="721235220fa3657fb37e8ba5a36e2878ed215f0c" CHECKSUMTYPE="SHA-1" SIZE="5063528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T18:30:09" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="4f4cc678e03fcb0d287ba0cbdf67632adb6d6bfd" CHECKSUMTYPE="SHA-1" SIZE="4754829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T18:30:36" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="cd850e406eebc0098f40482293db1039fb1d90d1" CHECKSUMTYPE="SHA-1" SIZE="5043729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T18:30:59" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="4092b6a59ef87cfb2c3ad0b369956bdb016f7ff7" CHECKSUMTYPE="SHA-1" SIZE="4716128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T18:31:23" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="654e9813b332f9d1a1283c37cda0b90f1ffff3e0" CHECKSUMTYPE="SHA-1" SIZE="5053629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T18:31:48" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="ae0ea063ce1b27f37716eafc42cd4ee07e739644" CHECKSUMTYPE="SHA-1" SIZE="4731425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T18:32:12" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="06c49008cbf4ac3e0996294fea46e515022803f3" CHECKSUMTYPE="SHA-1" SIZE="5062619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T18:32:34" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="ce50bd916cbee4863408b5df1784173785937d8f" CHECKSUMTYPE="SHA-1" SIZE="4731420">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T18:32:56" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="3595b88ca22c7d62bf9f4121790a467ef0bed687" CHECKSUMTYPE="SHA-1" SIZE="5021229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T18:33:19" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="50aa51017767532566aa46f1d24d2ea3c64544a4" CHECKSUMTYPE="SHA-1" SIZE="4755722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T18:33:43" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="e61508fca98415e173590c71f12433626aeb467d" CHECKSUMTYPE="SHA-1" SIZE="5067944">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T18:34:06" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="abd09ca2a29028a0a4b7c4834310ea63fde41201" CHECKSUMTYPE="SHA-1" SIZE="4760228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T18:34:29" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="afe4d178ade20fd41fa951fe87f72d39f8f7b330" CHECKSUMTYPE="SHA-1" SIZE="5041928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T18:34:53" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="89daafd0b7c072471f0534bff4eb1adb2309566e" CHECKSUMTYPE="SHA-1" SIZE="4862826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T18:35:18" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="242b3b18a8347b761c9663573f9eabc636098675" CHECKSUMTYPE="SHA-1" SIZE="5045529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T18:35:43" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="26dcd6a372b675506310c839104e8e17b4521067" CHECKSUMTYPE="SHA-1" SIZE="4775525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T18:36:05" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="7ab90d1678f2fd6f6a1822a795a75ee3cc4f2c5e" CHECKSUMTYPE="SHA-1" SIZE="5056300">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:36:27" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="2b45a8869201b6ef7a083e23a4316555cf180035" CHECKSUMTYPE="SHA-1" SIZE="4866417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:36:52" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="91d13dbc4e594e656cf670dedd3640491979c38c" CHECKSUMTYPE="SHA-1" SIZE="5095029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:37:15" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="c129f9ffee0b74a5a770b9afcbcb8cae32f33d51" CHECKSUMTYPE="SHA-1" SIZE="4860129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:37:38" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="0cb407b1cec12fa34fa09665a84c978885dc7edc" CHECKSUMTYPE="SHA-1" SIZE="5095027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:38:05" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="1c2892f21fd434aa2a62fcfe4936dda6fb581b15" CHECKSUMTYPE="SHA-1" SIZE="4906873">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:38:27" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="a252d137bcd8aa706024dbf88655bcce99b6158f" CHECKSUMTYPE="SHA-1" SIZE="5069827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:38:51" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="e69c0eab41dd443368aa38fc78f5515942de2e56" CHECKSUMTYPE="SHA-1" SIZE="4883528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:39:16" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="764ce32a5b95bdf566cd73239889d38616daac07" CHECKSUMTYPE="SHA-1" SIZE="5067129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:39:41" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="ba56b852eb04b8aeba763ece0b2b3b734f59a081" CHECKSUMTYPE="SHA-1" SIZE="4900618">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:40:04" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="7f148b3b55e5fc0a2daad186ab5e51bcb49ef92d" CHECKSUMTYPE="SHA-1" SIZE="5069800">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:40:29" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="3838b42658a076115f811554acd706eaf308d902" CHECKSUMTYPE="SHA-1" SIZE="4902429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:40:53" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="95628ea35320c9004dcb84217a1aabc19c23c639" CHECKSUMTYPE="SHA-1" SIZE="5060825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:41:16" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="013b974d42b31d78d02f99cfc8da70b86f911c9d" CHECKSUMTYPE="SHA-1" SIZE="4879924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:41:39" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="e91250edcfcd6d85c00b026053f28f05b9ccb583" CHECKSUMTYPE="SHA-1" SIZE="5095021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:42:03" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="19b7e1e1d6f2eec9ef37deb7ceb550f3c5cd5cb4" CHECKSUMTYPE="SHA-1" SIZE="4929424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:42:27" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="13b9f0421303547b9e80007d1b39a5c1729f521a" CHECKSUMTYPE="SHA-1" SIZE="5072529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:42:51" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="73f411786a0a3aa44c1fdf6d558cddc37aa603b9" CHECKSUMTYPE="SHA-1" SIZE="4963567">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:43:16" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="b53bf0cd3e3fe1db0cfed3fbff7e8d341527890b" CHECKSUMTYPE="SHA-1" SIZE="5095026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:43:41" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="cc26bc305e8766776df038d3f572cfa44f2edab1" CHECKSUMTYPE="SHA-1" SIZE="4923124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:44:02" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="b03eec3537a73b9a6d1e72549da37a2fc2677b38" CHECKSUMTYPE="SHA-1" SIZE="5079726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:44:26" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="e78c39b94ac5d7e013d31d081046969d23c53190" CHECKSUMTYPE="SHA-1" SIZE="4948326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:44:50" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="5c7fe872bfbc13d89382978df541b13d1fe0fc85" CHECKSUMTYPE="SHA-1" SIZE="5095029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:45:12" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="02731e56df4da5eeb2cc10a9dd96a995eb32c7f4" CHECKSUMTYPE="SHA-1" SIZE="4910527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:45:36" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="d90d1f92f84836107e5b06184542b44ad9e07c9e" CHECKSUMTYPE="SHA-1" SIZE="5094830">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:46:01" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="b72631b8d6d9690b836cfb086d23b3442fa77fec" CHECKSUMTYPE="SHA-1" SIZE="4964525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:46:24" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="22e044151558b75960647e70ab85ea2135cff759" CHECKSUMTYPE="SHA-1" SIZE="5095028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:46:47" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="057b047a15ea8ed0e147fb117cc31f65c2a4b490" CHECKSUMTYPE="SHA-1" SIZE="4924010">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:47:08" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="78977418ce0b4c94074de67008a8ea8ce36b8e60" CHECKSUMTYPE="SHA-1" SIZE="5095028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T18:47:30" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="eecc80bb86b4043301e97bac3f8f0cb1fae3eb4e" CHECKSUMTYPE="SHA-1" SIZE="4926640">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T18:47:53" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="d175b459a754d223849402f7e614d1c3828365ac" CHECKSUMTYPE="SHA-1" SIZE="5095028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T18:48:19" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="0c4368686f6b09c89466cc3c716b90699ab620a2" CHECKSUMTYPE="SHA-1" SIZE="4945595">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T18:48:42" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="13c713797ce38e09b4de5aec8119a8494f7dd0cc" CHECKSUMTYPE="SHA-1" SIZE="5076125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T18:49:06" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="e464b0cfa8f0969f8a05f74aa9767ec922444baa" CHECKSUMTYPE="SHA-1" SIZE="4964523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T18:49:28" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="1894c28a2dd975c26db0f8ccd0c7131231c3ed03" CHECKSUMTYPE="SHA-1" SIZE="5095025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T18:49:53" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="4217d5949c6d23ad2bea92139a702ab607173eb5" CHECKSUMTYPE="SHA-1" SIZE="4968129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T18:50:13" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="1f0f2997096f887633afeea33db2ed1f89ed4995" CHECKSUMTYPE="SHA-1" SIZE="5094980">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0094.jp2"/>
-			</file>
-			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T18:50:36" MIMETYPE="image/jp2" SEQ="95"
-				CHECKSUM="ca01b41441d29b308a439a8daacc487be343204a" CHECKSUMTYPE="SHA-1" SIZE="5002317">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0095.jp2"/>
-			</file>
-			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T18:51:03" MIMETYPE="image/jp2" SEQ="96"
-				CHECKSUM="a79c7afeef72a3e09d003c1e7f32f3b15fc557db" CHECKSUMTYPE="SHA-1" SIZE="5095014">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0096.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T18:13:49" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="4fe9f70d6ee4fa5e1e86bcb7377c9550e63aa24f" CHECKSUMTYPE="SHA-1" SIZE="4875429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T18:14:14" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="388814e833f57fba6a3366ee5bc22faba87ce468" CHECKSUMTYPE="SHA-1" SIZE="4967228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T18:14:38" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="df05053ef6dff4e6c386bab1adfa0d6c41944280" CHECKSUMTYPE="SHA-1" SIZE="4851128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T18:15:01" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="b5a56ed2d006b91ec3aed43ecd4f28ce5adab320" CHECKSUMTYPE="SHA-1" SIZE="4919526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T18:15:23" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="4988c8bf034c52ddf4f8f772f5726717dc968946" CHECKSUMTYPE="SHA-1" SIZE="4870921">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T18:15:49" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="b324f5fd5ebe9b6744e778eae7760a492547e27b" CHECKSUMTYPE="SHA-1" SIZE="4946519">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T18:16:12" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="02ad168771ea134f96b4c1783062377a20d5ea56" CHECKSUMTYPE="SHA-1" SIZE="4826811">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T18:16:36" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="9a06e91b0360f4c29d5cf086aa0d0ff80854f720" CHECKSUMTYPE="SHA-1" SIZE="4996929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T18:16:57" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="cb6f41d1fdceff77d66d4286c190bf60131f9909" CHECKSUMTYPE="SHA-1" SIZE="4780029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T18:17:18" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="7f8634dc67f41e32846f99c251471fff56a1ae26" CHECKSUMTYPE="SHA-1" SIZE="4970828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T18:17:38" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="a1b6a4c43107a43e4b325f3e75692bf90e860044" CHECKSUMTYPE="SHA-1" SIZE="4775525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T18:17:58" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="2652c7a0f886024446ed6a4227dd2b19b550c007" CHECKSUMTYPE="SHA-1" SIZE="4959125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T18:18:21" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="4ad1a85f27cc5e12b21873230aad99b346e2a006" CHECKSUMTYPE="SHA-1" SIZE="4689933">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T18:18:48" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="a8aac12c0f07b873a68d55839d414a34940f6835" CHECKSUMTYPE="SHA-1" SIZE="5005929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T18:19:13" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="729d7e2752005acef55297034a9413243e38bc01" CHECKSUMTYPE="SHA-1" SIZE="4771929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T18:19:34" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="5c16f79a8901a728f161431671b09643d82655bd" CHECKSUMTYPE="SHA-1" SIZE="5010429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T18:19:58" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="dc9ddf182d0eb5113a2eb75de33ceeb02d56163c" CHECKSUMTYPE="SHA-1" SIZE="4770045">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T18:20:19" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="23804b4e7cd60c3a507e8f2b148f0cd56b391f28" CHECKSUMTYPE="SHA-1" SIZE="5030228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T18:20:43" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7a0228e691754be92b098e0c01a3274d136e98dc" CHECKSUMTYPE="SHA-1" SIZE="4741264">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T18:21:07" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="f0e25223f388f264c22f50248da485fbdf2acb5d" CHECKSUMTYPE="SHA-1" SIZE="5032927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T18:21:32" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="042b96fbb25ad7a56fd4b1fec51aeba416f136cb" CHECKSUMTYPE="SHA-1" SIZE="4699925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T18:21:54" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="a2ac02f2bf51d00bb5281774af902964e1b9d72b" CHECKSUMTYPE="SHA-1" SIZE="5018529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T18:22:19" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="b9533af385890e1d117b6df3a4f32c7f7d5bb4a6" CHECKSUMTYPE="SHA-1" SIZE="4687208">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T18:22:41" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="7df9c3f64eebf85171e56b2c9e7cec7043519b26" CHECKSUMTYPE="SHA-1" SIZE="5032836">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T18:23:03" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="8851aef26d48d61de422b80b9dde1b466488ccff" CHECKSUMTYPE="SHA-1" SIZE="4710591">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T18:23:27" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="491d39395c2e0b7f55136300a5dc15403fbf6e86" CHECKSUMTYPE="SHA-1" SIZE="5048226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T18:23:49" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="a300f6d4e2b06b0038f47a031f18a1294e659bab" CHECKSUMTYPE="SHA-1" SIZE="4734127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T18:24:13" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="dd71b606cdb809a9b7178d1fda8454619552dfee" CHECKSUMTYPE="SHA-1" SIZE="5047326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T18:24:37" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="2b53c9690fa4082ab72449644edb46bbe25401b6" CHECKSUMTYPE="SHA-1" SIZE="4698121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T18:25:00" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="7ced4aa909b7eea17b927398367427b372a34ec4" CHECKSUMTYPE="SHA-1" SIZE="5021219">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T18:25:23" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="551d05223ebb2009014fbca810cca864543fec67" CHECKSUMTYPE="SHA-1" SIZE="4639627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T18:25:49" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="e200decb13bab4b7377434ab81b991b8c69e2eb5" CHECKSUMTYPE="SHA-1" SIZE="5053626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T18:26:12" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="78fb899fa9a6c552575096cbbf0c8b5d40e52701" CHECKSUMTYPE="SHA-1" SIZE="4710727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T18:26:36" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="55514583e8124450b7b0f4bf0f0348f6db497d6e" CHECKSUMTYPE="SHA-1" SIZE="5037428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T18:27:00" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="b7af72443e21bdd4faef71dd1669126e641c18ea" CHECKSUMTYPE="SHA-1" SIZE="4687328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T18:27:24" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="d37c83418def8784ae0779dc0b780fe80b32beca" CHECKSUMTYPE="SHA-1" SIZE="5051826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T18:27:50" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="a3fa94901ae8f74b2784ec34cd2136362e5691e6" CHECKSUMTYPE="SHA-1" SIZE="4717924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T18:28:12" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="0c6a14fe348ced5ea6e4b7c234e95ac9c755c1c4" CHECKSUMTYPE="SHA-1" SIZE="5060735">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T18:28:34" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="98e09abd14868075526cf4932b05083ff5fbb430" CHECKSUMTYPE="SHA-1" SIZE="4702628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T18:28:59" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="022ed6aa0209e2bd242599b17abe696b52ada4ac" CHECKSUMTYPE="SHA-1" SIZE="5048222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T18:29:22" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="0522b3276e441febe3e803655b2d9197587635c9" CHECKSUMTYPE="SHA-1" SIZE="4659429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T18:29:45" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="721235220fa3657fb37e8ba5a36e2878ed215f0c" CHECKSUMTYPE="SHA-1" SIZE="5063528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T18:30:09" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="4f4cc678e03fcb0d287ba0cbdf67632adb6d6bfd" CHECKSUMTYPE="SHA-1" SIZE="4754829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T18:30:36" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="cd850e406eebc0098f40482293db1039fb1d90d1" CHECKSUMTYPE="SHA-1" SIZE="5043729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T18:30:59" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="4092b6a59ef87cfb2c3ad0b369956bdb016f7ff7" CHECKSUMTYPE="SHA-1" SIZE="4716128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T18:31:23" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="654e9813b332f9d1a1283c37cda0b90f1ffff3e0" CHECKSUMTYPE="SHA-1" SIZE="5053629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T18:31:48" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="ae0ea063ce1b27f37716eafc42cd4ee07e739644" CHECKSUMTYPE="SHA-1" SIZE="4731425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T18:32:12" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="06c49008cbf4ac3e0996294fea46e515022803f3" CHECKSUMTYPE="SHA-1" SIZE="5062619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T18:32:34" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="ce50bd916cbee4863408b5df1784173785937d8f" CHECKSUMTYPE="SHA-1" SIZE="4731420">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T18:32:56" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="3595b88ca22c7d62bf9f4121790a467ef0bed687" CHECKSUMTYPE="SHA-1" SIZE="5021229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T18:33:19" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="50aa51017767532566aa46f1d24d2ea3c64544a4" CHECKSUMTYPE="SHA-1" SIZE="4755722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T18:33:43" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="e61508fca98415e173590c71f12433626aeb467d" CHECKSUMTYPE="SHA-1" SIZE="5067944">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T18:34:06" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="abd09ca2a29028a0a4b7c4834310ea63fde41201" CHECKSUMTYPE="SHA-1" SIZE="4760228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T18:34:29" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="afe4d178ade20fd41fa951fe87f72d39f8f7b330" CHECKSUMTYPE="SHA-1" SIZE="5041928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T18:34:53" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="89daafd0b7c072471f0534bff4eb1adb2309566e" CHECKSUMTYPE="SHA-1" SIZE="4862826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T18:35:18" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="242b3b18a8347b761c9663573f9eabc636098675" CHECKSUMTYPE="SHA-1" SIZE="5045529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T18:35:43" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="26dcd6a372b675506310c839104e8e17b4521067" CHECKSUMTYPE="SHA-1" SIZE="4775525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T18:36:05" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="7ab90d1678f2fd6f6a1822a795a75ee3cc4f2c5e" CHECKSUMTYPE="SHA-1" SIZE="5056300">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:36:27" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="2b45a8869201b6ef7a083e23a4316555cf180035" CHECKSUMTYPE="SHA-1" SIZE="4866417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:36:52" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="91d13dbc4e594e656cf670dedd3640491979c38c" CHECKSUMTYPE="SHA-1" SIZE="5095029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:37:15" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="c129f9ffee0b74a5a770b9afcbcb8cae32f33d51" CHECKSUMTYPE="SHA-1" SIZE="4860129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:37:38" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="0cb407b1cec12fa34fa09665a84c978885dc7edc" CHECKSUMTYPE="SHA-1" SIZE="5095027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:38:05" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="1c2892f21fd434aa2a62fcfe4936dda6fb581b15" CHECKSUMTYPE="SHA-1" SIZE="4906873">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:38:27" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="a252d137bcd8aa706024dbf88655bcce99b6158f" CHECKSUMTYPE="SHA-1" SIZE="5069827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:38:51" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="e69c0eab41dd443368aa38fc78f5515942de2e56" CHECKSUMTYPE="SHA-1" SIZE="4883528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:39:16" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="764ce32a5b95bdf566cd73239889d38616daac07" CHECKSUMTYPE="SHA-1" SIZE="5067129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:39:41" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="ba56b852eb04b8aeba763ece0b2b3b734f59a081" CHECKSUMTYPE="SHA-1" SIZE="4900618">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:40:04" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="7f148b3b55e5fc0a2daad186ab5e51bcb49ef92d" CHECKSUMTYPE="SHA-1" SIZE="5069800">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:40:29" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="3838b42658a076115f811554acd706eaf308d902" CHECKSUMTYPE="SHA-1" SIZE="4902429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:40:53" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="95628ea35320c9004dcb84217a1aabc19c23c639" CHECKSUMTYPE="SHA-1" SIZE="5060825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:41:16" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="013b974d42b31d78d02f99cfc8da70b86f911c9d" CHECKSUMTYPE="SHA-1" SIZE="4879924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:41:39" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="e91250edcfcd6d85c00b026053f28f05b9ccb583" CHECKSUMTYPE="SHA-1" SIZE="5095021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:42:03" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="19b7e1e1d6f2eec9ef37deb7ceb550f3c5cd5cb4" CHECKSUMTYPE="SHA-1" SIZE="4929424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:42:27" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="13b9f0421303547b9e80007d1b39a5c1729f521a" CHECKSUMTYPE="SHA-1" SIZE="5072529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:42:51" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="73f411786a0a3aa44c1fdf6d558cddc37aa603b9" CHECKSUMTYPE="SHA-1" SIZE="4963567">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:43:16" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="b53bf0cd3e3fe1db0cfed3fbff7e8d341527890b" CHECKSUMTYPE="SHA-1" SIZE="5095026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:43:41" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="cc26bc305e8766776df038d3f572cfa44f2edab1" CHECKSUMTYPE="SHA-1" SIZE="4923124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:44:02" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="b03eec3537a73b9a6d1e72549da37a2fc2677b38" CHECKSUMTYPE="SHA-1" SIZE="5079726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:44:26" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="e78c39b94ac5d7e013d31d081046969d23c53190" CHECKSUMTYPE="SHA-1" SIZE="4948326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:44:50" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="5c7fe872bfbc13d89382978df541b13d1fe0fc85" CHECKSUMTYPE="SHA-1" SIZE="5095029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:45:12" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="02731e56df4da5eeb2cc10a9dd96a995eb32c7f4" CHECKSUMTYPE="SHA-1" SIZE="4910527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:45:36" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="d90d1f92f84836107e5b06184542b44ad9e07c9e" CHECKSUMTYPE="SHA-1" SIZE="5094830">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:46:01" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="b72631b8d6d9690b836cfb086d23b3442fa77fec" CHECKSUMTYPE="SHA-1" SIZE="4964525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:46:24" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="22e044151558b75960647e70ab85ea2135cff759" CHECKSUMTYPE="SHA-1" SIZE="5095028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:46:47" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="057b047a15ea8ed0e147fb117cc31f65c2a4b490" CHECKSUMTYPE="SHA-1" SIZE="4924010">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:47:08" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="78977418ce0b4c94074de67008a8ea8ce36b8e60" CHECKSUMTYPE="SHA-1" SIZE="5095028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T18:47:30" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="eecc80bb86b4043301e97bac3f8f0cb1fae3eb4e" CHECKSUMTYPE="SHA-1" SIZE="4926640">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T18:47:53" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="d175b459a754d223849402f7e614d1c3828365ac" CHECKSUMTYPE="SHA-1" SIZE="5095028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T18:48:19" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="0c4368686f6b09c89466cc3c716b90699ab620a2" CHECKSUMTYPE="SHA-1" SIZE="4945595">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T18:48:42" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="13c713797ce38e09b4de5aec8119a8494f7dd0cc" CHECKSUMTYPE="SHA-1" SIZE="5076125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T18:49:06" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="e464b0cfa8f0969f8a05f74aa9767ec922444baa" CHECKSUMTYPE="SHA-1" SIZE="4964523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T18:49:28" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="1894c28a2dd975c26db0f8ccd0c7131231c3ed03" CHECKSUMTYPE="SHA-1" SIZE="5095025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T18:49:53" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="4217d5949c6d23ad2bea92139a702ab607173eb5" CHECKSUMTYPE="SHA-1" SIZE="4968129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T18:50:13" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="1f0f2997096f887633afeea33db2ed1f89ed4995" CHECKSUMTYPE="SHA-1" SIZE="5094980">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0094.jp2"/>
+			</file>
+			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T18:50:36" MIMETYPE="image/jp2" SEQ="95" CHECKSUM="ca01b41441d29b308a439a8daacc487be343204a" CHECKSUMTYPE="SHA-1" SIZE="5002317">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0095.jp2"/>
+			</file>
+			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T18:51:03" MIMETYPE="image/jp2" SEQ="96" CHECKSUM="a79c7afeef72a3e09d003c1e7f32f3b15fc557db" CHECKSUMTYPE="SHA-1" SIZE="5095014">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/delivery/bmtnabe_1899-08_01_0096.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:51:17" MIMETYPE="text/xml" CHECKSUM="275c331c4806cd81cd2f797431e519f6105c8b17"
-				CHECKSUMTYPE="SHA-1" SIZE="2108">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:51:17" MIMETYPE="text/xml" CHECKSUM="275c331c4806cd81cd2f797431e519f6105c8b17" CHECKSUMTYPE="SHA-1" SIZE="2108">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:51:17" MIMETYPE="text/xml" CHECKSUM="1b629d5abaa511e88dcfa3534c15096c6508af2a"
-				CHECKSUMTYPE="SHA-1" SIZE="1715">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:51:17" MIMETYPE="text/xml" CHECKSUM="1b629d5abaa511e88dcfa3534c15096c6508af2a" CHECKSUMTYPE="SHA-1" SIZE="1715">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:51:17" MIMETYPE="text/xml" CHECKSUM="66df3da52767fee0b070e6ff1da9e8aba7074ceb"
-				CHECKSUMTYPE="SHA-1" SIZE="1714">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:51:17" MIMETYPE="text/xml" CHECKSUM="66df3da52767fee0b070e6ff1da9e8aba7074ceb" CHECKSUMTYPE="SHA-1" SIZE="1714">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:51:18" MIMETYPE="text/xml" CHECKSUM="cde48c233afc8f4664e7b940f69bb64ca72b1b36"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:51:18" MIMETYPE="text/xml" CHECKSUM="cde48c233afc8f4664e7b940f69bb64ca72b1b36" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:51:18" MIMETYPE="text/xml" CHECKSUM="dfa8abc1bbf6bf93aad79c77b7e4d2f8287f07a2"
-				CHECKSUMTYPE="SHA-1" SIZE="8514">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:51:18" MIMETYPE="text/xml" CHECKSUM="dfa8abc1bbf6bf93aad79c77b7e4d2f8287f07a2" CHECKSUMTYPE="SHA-1" SIZE="8514">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:51:18" MIMETYPE="text/xml" CHECKSUM="2a302347ff74c0a6d0c3d84e9eed215f1c6021e2"
-				CHECKSUMTYPE="SHA-1" SIZE="1998">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:51:18" MIMETYPE="text/xml" CHECKSUM="2a302347ff74c0a6d0c3d84e9eed215f1c6021e2" CHECKSUMTYPE="SHA-1" SIZE="1998">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:51:19" MIMETYPE="text/xml" CHECKSUM="f68ed52dd368948857021f9296c55e90dffbbca2"
-				CHECKSUMTYPE="SHA-1" SIZE="2008">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:51:19" MIMETYPE="text/xml" CHECKSUM="f68ed52dd368948857021f9296c55e90dffbbca2" CHECKSUMTYPE="SHA-1" SIZE="2008">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:51:19" MIMETYPE="text/xml" CHECKSUM="6567b5c30c7c2cc8d96e3585be882324028bf5ca"
-				CHECKSUMTYPE="SHA-1" SIZE="2008">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:51:19" MIMETYPE="text/xml" CHECKSUM="6567b5c30c7c2cc8d96e3585be882324028bf5ca" CHECKSUMTYPE="SHA-1" SIZE="2008">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:51:19" MIMETYPE="text/xml" CHECKSUM="3b357f37fa836f7a0a3419b0ba8e25ea04278836"
-				CHECKSUMTYPE="SHA-1" SIZE="12555">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:51:19" MIMETYPE="text/xml" CHECKSUM="3b357f37fa836f7a0a3419b0ba8e25ea04278836" CHECKSUMTYPE="SHA-1" SIZE="12555">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:51:19" MIMETYPE="text/xml"
-				CHECKSUM="9e001afec89f8103d9adecc26cd039c2c2329814" CHECKSUMTYPE="SHA-1" SIZE="3819">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:51:19" MIMETYPE="text/xml" CHECKSUM="9e001afec89f8103d9adecc26cd039c2c2329814" CHECKSUMTYPE="SHA-1" SIZE="3819">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:51:20" MIMETYPE="text/xml"
-				CHECKSUM="3b4c30ce451259090fb037e20a360acebf778ba9" CHECKSUMTYPE="SHA-1" SIZE="2011">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:51:20" MIMETYPE="text/xml" CHECKSUM="3b4c30ce451259090fb037e20a360acebf778ba9" CHECKSUMTYPE="SHA-1" SIZE="2011">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:51:20" MIMETYPE="text/xml"
-				CHECKSUM="75794b5c6cdbd2570dadb707512eae498dcf6c57" CHECKSUMTYPE="SHA-1" SIZE="5211">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:51:20" MIMETYPE="text/xml" CHECKSUM="75794b5c6cdbd2570dadb707512eae498dcf6c57" CHECKSUMTYPE="SHA-1" SIZE="5211">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:51:20" MIMETYPE="text/xml"
-				CHECKSUM="1d0a0e4b3d37a69c99429b02035a7c674d4a64de" CHECKSUMTYPE="SHA-1" SIZE="19016">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:51:20" MIMETYPE="text/xml" CHECKSUM="1d0a0e4b3d37a69c99429b02035a7c674d4a64de" CHECKSUMTYPE="SHA-1" SIZE="19016">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:51:20" MIMETYPE="text/xml"
-				CHECKSUM="b6144d170f37fa07787b0759e156cb252d69e303" CHECKSUMTYPE="SHA-1" SIZE="2016">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:51:20" MIMETYPE="text/xml" CHECKSUM="b6144d170f37fa07787b0759e156cb252d69e303" CHECKSUMTYPE="SHA-1" SIZE="2016">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:51:21" MIMETYPE="text/xml"
-				CHECKSUM="1c5303f1d405b3f6326db854fd52358bc763f869" CHECKSUMTYPE="SHA-1" SIZE="6411">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:51:21" MIMETYPE="text/xml" CHECKSUM="1c5303f1d405b3f6326db854fd52358bc763f869" CHECKSUMTYPE="SHA-1" SIZE="6411">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:51:21" MIMETYPE="text/xml"
-				CHECKSUM="3be0f1d39d228848b6d7a17023a4e60e596efae8" CHECKSUMTYPE="SHA-1" SIZE="2420">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:51:21" MIMETYPE="text/xml" CHECKSUM="3be0f1d39d228848b6d7a17023a4e60e596efae8" CHECKSUMTYPE="SHA-1" SIZE="2420">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:51:21" MIMETYPE="text/xml"
-				CHECKSUM="f69b8065a72a34b98e179f8a43de430de3f8f0ce" CHECKSUMTYPE="SHA-1" SIZE="2419">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:51:21" MIMETYPE="text/xml" CHECKSUM="f69b8065a72a34b98e179f8a43de430de3f8f0ce" CHECKSUMTYPE="SHA-1" SIZE="2419">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:51:21" MIMETYPE="text/xml"
-				CHECKSUM="ed529c040d16a4f747bdef61fcc4aa2dd2470151" CHECKSUMTYPE="SHA-1" SIZE="22980">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:51:21" MIMETYPE="text/xml" CHECKSUM="ed529c040d16a4f747bdef61fcc4aa2dd2470151" CHECKSUMTYPE="SHA-1" SIZE="22980">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:51:22" MIMETYPE="text/xml"
-				CHECKSUM="7f142275965de590df8679ce5da437c73e64841f" CHECKSUMTYPE="SHA-1" SIZE="5467">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:51:22" MIMETYPE="text/xml" CHECKSUM="7f142275965de590df8679ce5da437c73e64841f" CHECKSUMTYPE="SHA-1" SIZE="5467">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:51:22" MIMETYPE="text/xml"
-				CHECKSUM="10e521b2b2a2985a8ed50750f219b9414757a9fc" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:51:22" MIMETYPE="text/xml" CHECKSUM="10e521b2b2a2985a8ed50750f219b9414757a9fc" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:51:22" MIMETYPE="text/xml"
-				CHECKSUM="4eef0a4db5fe9e061db95a569d443c0943a6e931" CHECKSUMTYPE="SHA-1" SIZE="30868">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:51:22" MIMETYPE="text/xml" CHECKSUM="4eef0a4db5fe9e061db95a569d443c0943a6e931" CHECKSUMTYPE="SHA-1" SIZE="30868">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:51:22" MIMETYPE="text/xml"
-				CHECKSUM="f639d0e56401bb3f346b5d3b92da6d938b1623df" CHECKSUMTYPE="SHA-1" SIZE="36108">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:51:22" MIMETYPE="text/xml" CHECKSUM="f639d0e56401bb3f346b5d3b92da6d938b1623df" CHECKSUMTYPE="SHA-1" SIZE="36108">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:51:23" MIMETYPE="text/xml"
-				CHECKSUM="ab49ee99d9b0b6fa6e0d15644e7da6376fcaa433" CHECKSUMTYPE="SHA-1" SIZE="41737">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:51:23" MIMETYPE="text/xml" CHECKSUM="ab49ee99d9b0b6fa6e0d15644e7da6376fcaa433" CHECKSUMTYPE="SHA-1" SIZE="41737">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:51:23" MIMETYPE="text/xml"
-				CHECKSUM="12584891f43609dbf5a5392f1cc1d7b07fda0526" CHECKSUMTYPE="SHA-1" SIZE="15877">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:51:23" MIMETYPE="text/xml" CHECKSUM="12584891f43609dbf5a5392f1cc1d7b07fda0526" CHECKSUMTYPE="SHA-1" SIZE="15877">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:51:23" MIMETYPE="text/xml"
-				CHECKSUM="5389b75c0c178c237a05f5309e5a05912dda04fc" CHECKSUMTYPE="SHA-1" SIZE="5416">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:51:23" MIMETYPE="text/xml" CHECKSUM="5389b75c0c178c237a05f5309e5a05912dda04fc" CHECKSUMTYPE="SHA-1" SIZE="5416">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:51:23" MIMETYPE="text/xml"
-				CHECKSUM="a1f1503fceb6f00de4d7cb1a5d04ae7d4b9ec06d" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:51:23" MIMETYPE="text/xml" CHECKSUM="a1f1503fceb6f00de4d7cb1a5d04ae7d4b9ec06d" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:51:24" MIMETYPE="text/xml"
-				CHECKSUM="0e57892a7c9a36b75c636de8ac0224e15fbd5e13" CHECKSUMTYPE="SHA-1" SIZE="29193">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:51:24" MIMETYPE="text/xml" CHECKSUM="0e57892a7c9a36b75c636de8ac0224e15fbd5e13" CHECKSUMTYPE="SHA-1" SIZE="29193">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:51:24" MIMETYPE="text/xml"
-				CHECKSUM="5293ba171fcdb8046886f963ebbb313280c86ca9" CHECKSUMTYPE="SHA-1" SIZE="30496">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:51:24" MIMETYPE="text/xml" CHECKSUM="5293ba171fcdb8046886f963ebbb313280c86ca9" CHECKSUMTYPE="SHA-1" SIZE="30496">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:51:24" MIMETYPE="text/xml"
-				CHECKSUM="d57a50e545c8873a679531deba0529695e9a5a6b" CHECKSUMTYPE="SHA-1" SIZE="62930">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:51:24" MIMETYPE="text/xml" CHECKSUM="d57a50e545c8873a679531deba0529695e9a5a6b" CHECKSUMTYPE="SHA-1" SIZE="62930">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:51:24" MIMETYPE="text/xml"
-				CHECKSUM="43e93b7b5c4c2ab04ccf9dd60e41755685ecb41e" CHECKSUMTYPE="SHA-1" SIZE="124090">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:51:24" MIMETYPE="text/xml" CHECKSUM="43e93b7b5c4c2ab04ccf9dd60e41755685ecb41e" CHECKSUMTYPE="SHA-1" SIZE="124090">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:51:25" MIMETYPE="text/xml"
-				CHECKSUM="d968313a6ba6bdd9f03a43ea60e89c3b2828549f" CHECKSUMTYPE="SHA-1" SIZE="113724">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:51:25" MIMETYPE="text/xml" CHECKSUM="d968313a6ba6bdd9f03a43ea60e89c3b2828549f" CHECKSUMTYPE="SHA-1" SIZE="113724">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:51:26" MIMETYPE="text/xml"
-				CHECKSUM="977e7192e02981e80b0b3952c0c6924f08d713c9" CHECKSUMTYPE="SHA-1" SIZE="123581">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:51:26" MIMETYPE="text/xml" CHECKSUM="977e7192e02981e80b0b3952c0c6924f08d713c9" CHECKSUMTYPE="SHA-1" SIZE="123581">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:51:26" MIMETYPE="text/xml"
-				CHECKSUM="a6520e17e094ceae6d146aa1f81ee303f08a9d54" CHECKSUMTYPE="SHA-1" SIZE="124272">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:51:26" MIMETYPE="text/xml" CHECKSUM="a6520e17e094ceae6d146aa1f81ee303f08a9d54" CHECKSUMTYPE="SHA-1" SIZE="124272">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:51:27" MIMETYPE="text/xml"
-				CHECKSUM="e198f5f5167dcedfc75e2275228feae178036440" CHECKSUMTYPE="SHA-1" SIZE="126639">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:51:27" MIMETYPE="text/xml" CHECKSUM="e198f5f5167dcedfc75e2275228feae178036440" CHECKSUMTYPE="SHA-1" SIZE="126639">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:51:27" MIMETYPE="text/xml"
-				CHECKSUM="64e31eb07f8f2ff095045bcc219a94498ee96d9c" CHECKSUMTYPE="SHA-1" SIZE="136725">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:51:27" MIMETYPE="text/xml" CHECKSUM="64e31eb07f8f2ff095045bcc219a94498ee96d9c" CHECKSUMTYPE="SHA-1" SIZE="136725">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:51:27" MIMETYPE="text/xml"
-				CHECKSUM="c914da7bdc0dbf69706517a6b3141d62e2456885" CHECKSUMTYPE="SHA-1" SIZE="133327">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:51:27" MIMETYPE="text/xml" CHECKSUM="c914da7bdc0dbf69706517a6b3141d62e2456885" CHECKSUMTYPE="SHA-1" SIZE="133327">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:51:28" MIMETYPE="text/xml"
-				CHECKSUM="70f073562ae85b215903e4505a3c6d90df38ba91" CHECKSUMTYPE="SHA-1" SIZE="83926">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:51:28" MIMETYPE="text/xml" CHECKSUM="70f073562ae85b215903e4505a3c6d90df38ba91" CHECKSUMTYPE="SHA-1" SIZE="83926">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:51:28" MIMETYPE="text/xml"
-				CHECKSUM="53d9dc2080d39df34dc538a8196ebdd766709848" CHECKSUMTYPE="SHA-1" SIZE="32060">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:51:28" MIMETYPE="text/xml" CHECKSUM="53d9dc2080d39df34dc538a8196ebdd766709848" CHECKSUMTYPE="SHA-1" SIZE="32060">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:51:28" MIMETYPE="text/xml"
-				CHECKSUM="46e6b5e994ae017b7e4f093e1960015410078208" CHECKSUMTYPE="SHA-1" SIZE="62692">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:51:28" MIMETYPE="text/xml" CHECKSUM="46e6b5e994ae017b7e4f093e1960015410078208" CHECKSUMTYPE="SHA-1" SIZE="62692">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:51:28" MIMETYPE="text/xml"
-				CHECKSUM="d19f02daadab5ff470c7d35345c721e87c30f895" CHECKSUMTYPE="SHA-1" SIZE="30699">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:51:28" MIMETYPE="text/xml" CHECKSUM="d19f02daadab5ff470c7d35345c721e87c30f895" CHECKSUMTYPE="SHA-1" SIZE="30699">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:51:29" MIMETYPE="text/xml"
-				CHECKSUM="bc31a7daf615fe3589a0b643da264d6eae7bbf15" CHECKSUMTYPE="SHA-1" SIZE="40961">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:51:29" MIMETYPE="text/xml" CHECKSUM="bc31a7daf615fe3589a0b643da264d6eae7bbf15" CHECKSUMTYPE="SHA-1" SIZE="40961">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:51:29" MIMETYPE="text/xml"
-				CHECKSUM="2c4d3ab8c6e0d07bab1d25ff32c124c7382a0785" CHECKSUMTYPE="SHA-1" SIZE="48048">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:51:29" MIMETYPE="text/xml" CHECKSUM="2c4d3ab8c6e0d07bab1d25ff32c124c7382a0785" CHECKSUMTYPE="SHA-1" SIZE="48048">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:51:29" MIMETYPE="text/xml"
-				CHECKSUM="ec3f3b7de8dd5da271af9ea1b5b59964af906f78" CHECKSUMTYPE="SHA-1" SIZE="4641">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:51:29" MIMETYPE="text/xml" CHECKSUM="ec3f3b7de8dd5da271af9ea1b5b59964af906f78" CHECKSUMTYPE="SHA-1" SIZE="4641">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:51:29" MIMETYPE="text/xml"
-				CHECKSUM="d069d53e76a5323b37bd03fbe35ecfe0446348c5" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:51:29" MIMETYPE="text/xml" CHECKSUM="d069d53e76a5323b37bd03fbe35ecfe0446348c5" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:51:30" MIMETYPE="text/xml"
-				CHECKSUM="da02863df3e86a13acd5f1965d2c39cad459ab93" CHECKSUMTYPE="SHA-1" SIZE="100855">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:51:30" MIMETYPE="text/xml" CHECKSUM="da02863df3e86a13acd5f1965d2c39cad459ab93" CHECKSUMTYPE="SHA-1" SIZE="100855">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:51:30" MIMETYPE="text/xml"
-				CHECKSUM="b889a7182221cd9dd5f08a2de459fd1bde854c04" CHECKSUMTYPE="SHA-1" SIZE="192341">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:51:30" MIMETYPE="text/xml" CHECKSUM="b889a7182221cd9dd5f08a2de459fd1bde854c04" CHECKSUMTYPE="SHA-1" SIZE="192341">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:51:30" MIMETYPE="text/xml"
-				CHECKSUM="465e67b25579c8d1e395402e2cdda0201e448960" CHECKSUMTYPE="SHA-1" SIZE="5401">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:51:30" MIMETYPE="text/xml" CHECKSUM="465e67b25579c8d1e395402e2cdda0201e448960" CHECKSUMTYPE="SHA-1" SIZE="5401">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:51:30" MIMETYPE="text/xml"
-				CHECKSUM="7102db7d50ecb1da854a2db3b26e18e760ca3dee" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:51:30" MIMETYPE="text/xml" CHECKSUM="7102db7d50ecb1da854a2db3b26e18e760ca3dee" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:51:31" MIMETYPE="text/xml"
-				CHECKSUM="18515583951dd5e50821ac0069941dea287e636c" CHECKSUMTYPE="SHA-1" SIZE="90689">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:51:31" MIMETYPE="text/xml" CHECKSUM="18515583951dd5e50821ac0069941dea287e636c" CHECKSUMTYPE="SHA-1" SIZE="90689">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:51:31" MIMETYPE="text/xml"
-				CHECKSUM="c51f53168fff0cd192bbfaf469f75c9f36ddcc92" CHECKSUMTYPE="SHA-1" SIZE="194317">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:51:31" MIMETYPE="text/xml" CHECKSUM="c51f53168fff0cd192bbfaf469f75c9f36ddcc92" CHECKSUMTYPE="SHA-1" SIZE="194317">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:51:31" MIMETYPE="text/xml"
-				CHECKSUM="c5a4ae7472b9a4134571a48fc6fc1fb7d51db9b5" CHECKSUMTYPE="SHA-1" SIZE="97043">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:51:31" MIMETYPE="text/xml" CHECKSUM="c5a4ae7472b9a4134571a48fc6fc1fb7d51db9b5" CHECKSUMTYPE="SHA-1" SIZE="97043">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:51:32" MIMETYPE="text/xml"
-				CHECKSUM="d645357f7db248bf0ac2fb667913d4004f4afe11" CHECKSUMTYPE="SHA-1" SIZE="192898">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:51:32" MIMETYPE="text/xml" CHECKSUM="d645357f7db248bf0ac2fb667913d4004f4afe11" CHECKSUMTYPE="SHA-1" SIZE="192898">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:51:32" MIMETYPE="text/xml"
-				CHECKSUM="fc6ee3d19b4c6fff82262f7454284aec20d95803" CHECKSUMTYPE="SHA-1" SIZE="120233">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:51:32" MIMETYPE="text/xml" CHECKSUM="fc6ee3d19b4c6fff82262f7454284aec20d95803" CHECKSUMTYPE="SHA-1" SIZE="120233">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:51:32" MIMETYPE="text/xml"
-				CHECKSUM="259354e3583ff83072ea678802ba2c343b4c4c32" CHECKSUMTYPE="SHA-1" SIZE="192504">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:51:32" MIMETYPE="text/xml" CHECKSUM="259354e3583ff83072ea678802ba2c343b4c4c32" CHECKSUMTYPE="SHA-1" SIZE="192504">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:51:33" MIMETYPE="text/xml"
-				CHECKSUM="ab763df7ee14a66a29a2d9bc40055c98c3c257f3" CHECKSUMTYPE="SHA-1" SIZE="120366">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:51:33" MIMETYPE="text/xml" CHECKSUM="ab763df7ee14a66a29a2d9bc40055c98c3c257f3" CHECKSUMTYPE="SHA-1" SIZE="120366">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:51:33" MIMETYPE="text/xml"
-				CHECKSUM="1aa87bcdb7e63095bd8b7d7e3649a96037698621" CHECKSUMTYPE="SHA-1" SIZE="165399">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:51:33" MIMETYPE="text/xml" CHECKSUM="1aa87bcdb7e63095bd8b7d7e3649a96037698621" CHECKSUMTYPE="SHA-1" SIZE="165399">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:51:33" MIMETYPE="text/xml"
-				CHECKSUM="69e0f7a2c71b9623cc368f9f057a0a97dab9eae1" CHECKSUMTYPE="SHA-1" SIZE="7201">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:51:33" MIMETYPE="text/xml" CHECKSUM="69e0f7a2c71b9623cc368f9f057a0a97dab9eae1" CHECKSUMTYPE="SHA-1" SIZE="7201">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:51:34" MIMETYPE="text/xml"
-				CHECKSUM="0169c6b3c11a3113dbb2a421522b6fc24609abd2" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:51:34" MIMETYPE="text/xml" CHECKSUM="0169c6b3c11a3113dbb2a421522b6fc24609abd2" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:51:34" MIMETYPE="text/xml"
-				CHECKSUM="5de3242848ce2d662f04b1b411acd6da2ac9471a" CHECKSUMTYPE="SHA-1" SIZE="136403">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:51:34" MIMETYPE="text/xml" CHECKSUM="5de3242848ce2d662f04b1b411acd6da2ac9471a" CHECKSUMTYPE="SHA-1" SIZE="136403">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:51:34" MIMETYPE="text/xml"
-				CHECKSUM="0b803d0fbc30f6a9c4aca90ce93e405497826eba" CHECKSUMTYPE="SHA-1" SIZE="36881">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:51:34" MIMETYPE="text/xml" CHECKSUM="0b803d0fbc30f6a9c4aca90ce93e405497826eba" CHECKSUMTYPE="SHA-1" SIZE="36881">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:51:34" MIMETYPE="text/xml"
-				CHECKSUM="31bbe645ce5360e9d535ef26fcbaad7d1dbcc109" CHECKSUMTYPE="SHA-1" SIZE="192206">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:51:34" MIMETYPE="text/xml" CHECKSUM="31bbe645ce5360e9d535ef26fcbaad7d1dbcc109" CHECKSUMTYPE="SHA-1" SIZE="192206">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:51:35" MIMETYPE="text/xml"
-				CHECKSUM="66a1b32ffba05775f49c053b764be2ec6c543dc7" CHECKSUMTYPE="SHA-1" SIZE="173170">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:51:35" MIMETYPE="text/xml" CHECKSUM="66a1b32ffba05775f49c053b764be2ec6c543dc7" CHECKSUMTYPE="SHA-1" SIZE="173170">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:51:35" MIMETYPE="text/xml"
-				CHECKSUM="3dc37139a49f8f261d4887e8c58e74c3c7ad8bf8" CHECKSUMTYPE="SHA-1" SIZE="198776">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:51:35" MIMETYPE="text/xml" CHECKSUM="3dc37139a49f8f261d4887e8c58e74c3c7ad8bf8" CHECKSUMTYPE="SHA-1" SIZE="198776">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:51:36" MIMETYPE="text/xml"
-				CHECKSUM="1ccb06373e0504f14ac8a6a70fbe46b776c90a3d" CHECKSUMTYPE="SHA-1" SIZE="184840">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:51:36" MIMETYPE="text/xml" CHECKSUM="1ccb06373e0504f14ac8a6a70fbe46b776c90a3d" CHECKSUMTYPE="SHA-1" SIZE="184840">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:51:36" MIMETYPE="text/xml"
-				CHECKSUM="abea71882f47c60aedc6e39580558832249f352e" CHECKSUMTYPE="SHA-1" SIZE="194451">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:51:36" MIMETYPE="text/xml" CHECKSUM="abea71882f47c60aedc6e39580558832249f352e" CHECKSUMTYPE="SHA-1" SIZE="194451">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:51:37" MIMETYPE="text/xml"
-				CHECKSUM="b97ada3cb0710bcb4944aae08e5e03312937823b" CHECKSUMTYPE="SHA-1" SIZE="167156">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:51:37" MIMETYPE="text/xml" CHECKSUM="b97ada3cb0710bcb4944aae08e5e03312937823b" CHECKSUMTYPE="SHA-1" SIZE="167156">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:51:39" MIMETYPE="text/xml"
-				CHECKSUM="2514ceefe7df5835588a5e8251cdd21fe953c3b6" CHECKSUMTYPE="SHA-1" SIZE="83586">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:51:39" MIMETYPE="text/xml" CHECKSUM="2514ceefe7df5835588a5e8251cdd21fe953c3b6" CHECKSUMTYPE="SHA-1" SIZE="83586">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:51:39" MIMETYPE="text/xml"
-				CHECKSUM="b2672457b915fd8ab825714b944442aaab3ab8c5" CHECKSUMTYPE="SHA-1" SIZE="180978">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:51:39" MIMETYPE="text/xml" CHECKSUM="b2672457b915fd8ab825714b944442aaab3ab8c5" CHECKSUMTYPE="SHA-1" SIZE="180978">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:51:40" MIMETYPE="text/xml"
-				CHECKSUM="64971e53d9596db318986aa8c1eadfdc1acf69cb" CHECKSUMTYPE="SHA-1" SIZE="5096">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:51:40" MIMETYPE="text/xml" CHECKSUM="64971e53d9596db318986aa8c1eadfdc1acf69cb" CHECKSUMTYPE="SHA-1" SIZE="5096">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:51:40" MIMETYPE="text/xml"
-				CHECKSUM="eb85de0032b9c05db1614f64b884e07785677c06" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:51:40" MIMETYPE="text/xml" CHECKSUM="eb85de0032b9c05db1614f64b884e07785677c06" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:51:40" MIMETYPE="text/xml"
-				CHECKSUM="8449bf2406c4ce80a796c86d40e90672aba018a2" CHECKSUMTYPE="SHA-1" SIZE="59347">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:51:40" MIMETYPE="text/xml" CHECKSUM="8449bf2406c4ce80a796c86d40e90672aba018a2" CHECKSUMTYPE="SHA-1" SIZE="59347">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:51:41" MIMETYPE="text/xml"
-				CHECKSUM="578693e9ee5d7180a08df5e94164818f23230062" CHECKSUMTYPE="SHA-1" SIZE="185749">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:51:41" MIMETYPE="text/xml" CHECKSUM="578693e9ee5d7180a08df5e94164818f23230062" CHECKSUMTYPE="SHA-1" SIZE="185749">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:51:41" MIMETYPE="text/xml"
-				CHECKSUM="81856d4bb8d6da4a0c3b13e5a8b283177cbd8985" CHECKSUMTYPE="SHA-1" SIZE="191266">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:51:41" MIMETYPE="text/xml" CHECKSUM="81856d4bb8d6da4a0c3b13e5a8b283177cbd8985" CHECKSUMTYPE="SHA-1" SIZE="191266">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:51:41" MIMETYPE="text/xml"
-				CHECKSUM="8d0a238d64ff2d08467fd744e2199a3f919ebe1a" CHECKSUMTYPE="SHA-1" SIZE="192355">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:51:41" MIMETYPE="text/xml" CHECKSUM="8d0a238d64ff2d08467fd744e2199a3f919ebe1a" CHECKSUMTYPE="SHA-1" SIZE="192355">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:51:42" MIMETYPE="text/xml"
-				CHECKSUM="250cd4865030de6ce6326c4c88bd6fb292101780" CHECKSUMTYPE="SHA-1" SIZE="184435">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:51:42" MIMETYPE="text/xml" CHECKSUM="250cd4865030de6ce6326c4c88bd6fb292101780" CHECKSUMTYPE="SHA-1" SIZE="184435">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:51:42" MIMETYPE="text/xml"
-				CHECKSUM="8ba2b3e7c71db307d0ecbbb6a7339355b2e0b3a0" CHECKSUMTYPE="SHA-1" SIZE="62792">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:51:42" MIMETYPE="text/xml" CHECKSUM="8ba2b3e7c71db307d0ecbbb6a7339355b2e0b3a0" CHECKSUMTYPE="SHA-1" SIZE="62792">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:51:42" MIMETYPE="text/xml"
-				CHECKSUM="f45695c0ffb8b9e3d8675f59c8fb4005c3972fbe" CHECKSUMTYPE="SHA-1" SIZE="4921">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:51:42" MIMETYPE="text/xml" CHECKSUM="f45695c0ffb8b9e3d8675f59c8fb4005c3972fbe" CHECKSUMTYPE="SHA-1" SIZE="4921">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:51:42" MIMETYPE="text/xml"
-				CHECKSUM="c9662ffabe49ec699a7a746dee200ef26c86d7f3" CHECKSUMTYPE="SHA-1" SIZE="2014">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:51:42" MIMETYPE="text/xml" CHECKSUM="c9662ffabe49ec699a7a746dee200ef26c86d7f3" CHECKSUMTYPE="SHA-1" SIZE="2014">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:51:43" MIMETYPE="text/xml"
-				CHECKSUM="16b29d53169a66a0bd10fc3212f82808e7932c4d" CHECKSUMTYPE="SHA-1" SIZE="23991">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:51:43" MIMETYPE="text/xml" CHECKSUM="16b29d53169a66a0bd10fc3212f82808e7932c4d" CHECKSUMTYPE="SHA-1" SIZE="23991">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:51:43" MIMETYPE="text/xml"
-				CHECKSUM="c893490cbdf159f3768832382f5a85e65cc7cfb8" CHECKSUMTYPE="SHA-1" SIZE="46369">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:51:43" MIMETYPE="text/xml" CHECKSUM="c893490cbdf159f3768832382f5a85e65cc7cfb8" CHECKSUMTYPE="SHA-1" SIZE="46369">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:51:44" MIMETYPE="text/xml"
-				CHECKSUM="7a2324e97c8521a3e925151cf443e40f667a59b9" CHECKSUMTYPE="SHA-1" SIZE="52854">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:51:44" MIMETYPE="text/xml" CHECKSUM="7a2324e97c8521a3e925151cf443e40f667a59b9" CHECKSUMTYPE="SHA-1" SIZE="52854">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:51:44" MIMETYPE="text/xml"
-				CHECKSUM="46502d153c9696740d25f8349c4e97b9e9e4a855" CHECKSUMTYPE="SHA-1" SIZE="81729">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:51:44" MIMETYPE="text/xml" CHECKSUM="46502d153c9696740d25f8349c4e97b9e9e4a855" CHECKSUMTYPE="SHA-1" SIZE="81729">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:51:44" MIMETYPE="text/xml"
-				CHECKSUM="f87981c84ba0ed0f9fa7bf8250adc69ee660beed" CHECKSUMTYPE="SHA-1" SIZE="190975">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:51:44" MIMETYPE="text/xml" CHECKSUM="f87981c84ba0ed0f9fa7bf8250adc69ee660beed" CHECKSUMTYPE="SHA-1" SIZE="190975">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:51:45" MIMETYPE="text/xml"
-				CHECKSUM="db8459038ad5361c8d4bb6bd1c7ccc1ddac4a124" CHECKSUMTYPE="SHA-1" SIZE="131145">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:51:45" MIMETYPE="text/xml" CHECKSUM="db8459038ad5361c8d4bb6bd1c7ccc1ddac4a124" CHECKSUMTYPE="SHA-1" SIZE="131145">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:51:45" MIMETYPE="text/xml"
-				CHECKSUM="6dc3072bb375a289930ab6ee3830ad15a478cea1" CHECKSUMTYPE="SHA-1" SIZE="5113">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:51:45" MIMETYPE="text/xml" CHECKSUM="6dc3072bb375a289930ab6ee3830ad15a478cea1" CHECKSUMTYPE="SHA-1" SIZE="5113">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:51:45" MIMETYPE="text/xml"
-				CHECKSUM="31767bb9b245a36c2d3022a67635c2de19778e9b" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:51:45" MIMETYPE="text/xml" CHECKSUM="31767bb9b245a36c2d3022a67635c2de19778e9b" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:51:46" MIMETYPE="text/xml"
-				CHECKSUM="22ce7301826b4a2b5c2638fc330eca6da09a8114" CHECKSUMTYPE="SHA-1" SIZE="76304">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T18:51:46" MIMETYPE="text/xml" CHECKSUM="22ce7301826b4a2b5c2638fc330eca6da09a8114" CHECKSUMTYPE="SHA-1" SIZE="76304">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:51:46" MIMETYPE="text/xml"
-				CHECKSUM="938c26654a89a22beb6b05b3b6d8d8137b3d5a93" CHECKSUMTYPE="SHA-1" SIZE="198170">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T18:51:46" MIMETYPE="text/xml" CHECKSUM="938c26654a89a22beb6b05b3b6d8d8137b3d5a93" CHECKSUMTYPE="SHA-1" SIZE="198170">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:51:46" MIMETYPE="text/xml"
-				CHECKSUM="9638408e29cba136e90d9cffa283741dbc23c86a" CHECKSUMTYPE="SHA-1" SIZE="193157">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T18:51:46" MIMETYPE="text/xml" CHECKSUM="9638408e29cba136e90d9cffa283741dbc23c86a" CHECKSUMTYPE="SHA-1" SIZE="193157">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:51:47" MIMETYPE="text/xml"
-				CHECKSUM="dbc9c42fd36f7d163c64b6ef29563b2feb0cf4e8" CHECKSUMTYPE="SHA-1" SIZE="41242">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T18:51:47" MIMETYPE="text/xml" CHECKSUM="dbc9c42fd36f7d163c64b6ef29563b2feb0cf4e8" CHECKSUMTYPE="SHA-1" SIZE="41242">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:51:47" MIMETYPE="text/xml"
-				CHECKSUM="13d0c71ddc5bfeb40068140703767da300b86650" CHECKSUMTYPE="SHA-1" SIZE="51956">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T18:51:47" MIMETYPE="text/xml" CHECKSUM="13d0c71ddc5bfeb40068140703767da300b86650" CHECKSUMTYPE="SHA-1" SIZE="51956">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:51:47" MIMETYPE="text/xml"
-				CHECKSUM="41b096d2bb48b6a0c5e91966ada16630c43c1249" CHECKSUMTYPE="SHA-1" SIZE="34839">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T18:51:47" MIMETYPE="text/xml" CHECKSUM="41b096d2bb48b6a0c5e91966ada16630c43c1249" CHECKSUMTYPE="SHA-1" SIZE="34839">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T18:51:47" MIMETYPE="text/xml"
-				CHECKSUM="c6ce30f6e8e91d1b8e604bd22ef5a8dab97e4357" CHECKSUMTYPE="SHA-1" SIZE="16420">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T18:51:47" MIMETYPE="text/xml" CHECKSUM="c6ce30f6e8e91d1b8e604bd22ef5a8dab97e4357" CHECKSUMTYPE="SHA-1" SIZE="16420">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T18:51:48" MIMETYPE="text/xml"
-				CHECKSUM="028295e34d6c9a6b38d85b9be756433bde0a67b3" CHECKSUMTYPE="SHA-1" SIZE="42860">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T18:51:48" MIMETYPE="text/xml" CHECKSUM="028295e34d6c9a6b38d85b9be756433bde0a67b3" CHECKSUMTYPE="SHA-1" SIZE="42860">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0094.alto.xml"/>
 			</file>
-			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T18:51:48" MIMETYPE="text/xml"
-				CHECKSUM="07c8dc440e5a1856c86b2129c92b5682ae058e7b" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T18:51:48" MIMETYPE="text/xml" CHECKSUM="07c8dc440e5a1856c86b2129c92b5682ae058e7b" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0095.alto.xml"/>
 			</file>
-			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T18:51:48" MIMETYPE="text/xml"
-				CHECKSUM="705e8d9e91a8755b5f1767e2f3f7bb717f6beab7" CHECKSUMTYPE="SHA-1" SIZE="10142">
+			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T18:51:48" MIMETYPE="text/xml" CHECKSUM="705e8d9e91a8755b5f1767e2f3f7bb717f6beab7" CHECKSUMTYPE="SHA-1" SIZE="10142">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-08_01_0096.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:54:51" MIMETYPE="application/pdf" CHECKSUM="4814b47232ed1ec79b620efc71f8c87314592c76"
-				CHECKSUMTYPE="SHA-1" SIZE="40790393">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/bmtnabe_1899-08_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:54:51" MIMETYPE="application/pdf" CHECKSUM="4814b47232ed1ec79b620efc71f8c87314592c76" CHECKSUMTYPE="SHA-1" SIZE="40790393">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/08_01/bmtnabe_1899-08_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -10725,8 +10239,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c007"
-						LABEL="PAN V I FACSIMILE DER ORIGINALNIEDERSCHRIFT (31. AUGUST 1898)">
+					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c007" LABEL="PAN V I FACSIMILE DER ORIGINALNIEDERSCHRIFT (31. AUGUST 1898)">
 						<div ID="L.1.1.5.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00001"/>
@@ -10800,8 +10313,7 @@
 					</div>
 
 				</div>
-				<div ID="L.1.1.8" TYPE="TextContent" ORDER="8" DMDID="c013"
-					LABEL="AUS DEM NACHLASS THEODOR FONTANES* VERÄNDERUNGEN IN DER MARK DIE MARK UND DIE MÄRKER">
+				<div ID="L.1.1.8" TYPE="TextContent" ORDER="8" DMDID="c013" LABEL="AUS DEM NACHLASS THEODOR FONTANES* VERÄNDERUNGEN IN DER MARK DIE MARK UND DIE MÄRKER">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
@@ -11814,8 +11326,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.18.12" TYPE="Illustration" ORDER="9" DMDID="c077"
-						LABEL="THONMASKE DER AUFBLICKENDEN VOM SOCKEL DES CHRISTUS IM OLYMP">
+					<div ID="L.1.1.18.12" TYPE="Illustration" ORDER="9" DMDID="c077" LABEL="THONMASKE DER AUFBLICKENDEN VOM SOCKEL DES CHRISTUS IM OLYMP">
 						<div ID="L.1.1.18.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00056" BEGIN="P56_TB00008"/>

--- a/metadata/periodicals/bmtnabe/issues/1899/11_01/bmtnabe_1899-11_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1899/11_01/bmtnabe_1899-11_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1899-11_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1899-11_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1899-11_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1899-11_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1899-11_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1899-11_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1899-11_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -7714,788 +7710,528 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T18:19:31" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="cefd286ffcbd25c86e78e6cf1226dd87109a033e" CHECKSUMTYPE="SHA-1" SIZE="4947428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T18:19:58" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="185438533ef105adc3ad476bb6cdad20f2193b47" CHECKSUMTYPE="SHA-1" SIZE="5095027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T18:20:22" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="23bd8145ed7d06a2e3f5852b1ad52b65df905546" CHECKSUMTYPE="SHA-1" SIZE="4989727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T18:20:44" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="5ec35d0c1bdca3565bd6e5e24d7ec85d549229cb" CHECKSUMTYPE="SHA-1" SIZE="5095028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T18:21:07" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="63072493accc4212688d32be89bab960073d1dbd" CHECKSUMTYPE="SHA-1" SIZE="4971729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T18:21:34" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="d86f4180d6715bc39fe8966b32c8cb3b99141b06" CHECKSUMTYPE="SHA-1" SIZE="5095025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T18:21:56" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="e657688e8a886581fdad8e927d4205da97f8f92b" CHECKSUMTYPE="SHA-1" SIZE="5032023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T18:22:22" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="a8fc4b68ec757b8fd4a69520683cbe98ffd18f29" CHECKSUMTYPE="SHA-1" SIZE="5193063">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T18:22:47" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="31bd0a7f0c9cf3723bdbfc1cb4023752a58b9195" CHECKSUMTYPE="SHA-1" SIZE="5017628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T18:23:08" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="8c68323648caa60e5061c6de9c5c049f1063de58" CHECKSUMTYPE="SHA-1" SIZE="5156218">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T18:23:31" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="c597ab69e900c97e696652137a3e83f1ea78037b" CHECKSUMTYPE="SHA-1" SIZE="5024829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T18:23:53" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="75344c547cea78f5655fb6c07256b5570f88df81" CHECKSUMTYPE="SHA-1" SIZE="5206629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T18:24:16" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="2bdc39cf42cc017f2f3bc8f023b1b5e9015586ef" CHECKSUMTYPE="SHA-1" SIZE="5019428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T18:24:41" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="2c2e8735346137e02e483b3f4d61e85b06afe4dd" CHECKSUMTYPE="SHA-1" SIZE="5178728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T18:25:03" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="0611e91ec700ec5b4249a2ced8860396a3f40c7a" CHECKSUMTYPE="SHA-1" SIZE="4988828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T18:25:28" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="97693ea4da3557b7c3f524e7603d47b281258255" CHECKSUMTYPE="SHA-1" SIZE="5165229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T18:25:54" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="c2b111670ae61997fcbb64f179ae969e9563cfa6" CHECKSUMTYPE="SHA-1" SIZE="4987929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T18:26:20" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="61e766d43e0616204b959b95b6060911bb84c8dd" CHECKSUMTYPE="SHA-1" SIZE="5190426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T18:26:44" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="122693c4691c72f5b3edec0acac27eb45a10f2a2" CHECKSUMTYPE="SHA-1" SIZE="4994228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T18:27:07" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="95b888e72b50757bd63b4510f275d50590b48814" CHECKSUMTYPE="SHA-1" SIZE="5171529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T18:27:31" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="01e28b991e4c1d2463295d67d8f81f7b82fb4473" CHECKSUMTYPE="SHA-1" SIZE="4984328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T18:27:54" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="ff60adc1c25931606511722b2121c283e08ced12" CHECKSUMTYPE="SHA-1" SIZE="5230929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T18:28:17" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="4d47d9a84b224b8388b09655ef9c5fc1a8f77210" CHECKSUMTYPE="SHA-1" SIZE="4970791">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T18:28:42" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="3a120146697494ef84c4ba0d2558d86aee0c7dc3" CHECKSUMTYPE="SHA-1" SIZE="5207486">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T18:29:07" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="75a58baded4045d0431d18d44aa094f8619d796f" CHECKSUMTYPE="SHA-1" SIZE="5005028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T18:29:33" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="86097c9ab33cd41489b448adc6b2be64acd86f3e" CHECKSUMTYPE="SHA-1" SIZE="5246219">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T18:29:59" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="8d6720b297c53b8d7b468264d0f16a1cd041f89e" CHECKSUMTYPE="SHA-1" SIZE="5024820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T18:30:26" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="e491385e62bebf9c1c49b9a888da16d0efa901d0" CHECKSUMTYPE="SHA-1" SIZE="5246229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T18:30:50" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="78659f7e595971bb68c7c3208195c0066dc59b68" CHECKSUMTYPE="SHA-1" SIZE="4990625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T18:31:14" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="2d1aa0152a33558f03094d04b658373732ab0766" CHECKSUMTYPE="SHA-1" SIZE="5230027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T18:31:38" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="eb506d592d8838b82e637d0961d342b0fb779bfc" CHECKSUMTYPE="SHA-1" SIZE="5047327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T18:32:03" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="f5f2ecab8c15db419bc048d844a43bb6d33aca2e" CHECKSUMTYPE="SHA-1" SIZE="5249829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T18:32:25" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="3524ad3e123e13c0570ae69264e8d85bf9811fa6" CHECKSUMTYPE="SHA-1" SIZE="5012227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T18:32:49" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="6172cab206b8dc3f74b7a527d2daa434422f91b0" CHECKSUMTYPE="SHA-1" SIZE="5165229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T18:33:12" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="01bb1325bce4fc86b369335c60d9e032349769e9" CHECKSUMTYPE="SHA-1" SIZE="4998723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T18:33:36" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="cfa7edc882798f5d5c120bb6fe492bf741cd2146" CHECKSUMTYPE="SHA-1" SIZE="5236314">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T18:33:59" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="c3a3d472f91d8c335429034fc2d096e901656f5c" CHECKSUMTYPE="SHA-1" SIZE="4955528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T18:34:24" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="1258252d1387348dac44617674576f2985dc7302" CHECKSUMTYPE="SHA-1" SIZE="5189526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T18:34:48" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="d6bd9f249e90a540eb2881d13d83b4a115d7ca5f" CHECKSUMTYPE="SHA-1" SIZE="5044629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T18:35:10" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="cd40b35a1d5b7a5ed9e6921e14478d97cac0ccbb" CHECKSUMTYPE="SHA-1" SIZE="5210210">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T18:35:34" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="a99ffc98810507fbffc3317af6605b8f75faf3f1" CHECKSUMTYPE="SHA-1" SIZE="4980712">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T18:35:56" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="00b3c22343be684d9c7fa0f7f770bbd7ca22af33" CHECKSUMTYPE="SHA-1" SIZE="5227328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T18:36:20" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="48d1fab90da1cfcf9a707e7d3226a27640f7dccb" CHECKSUMTYPE="SHA-1" SIZE="5006827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T18:36:44" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="2744333ad21f6c2cf352276585e85ee0973f0fea" CHECKSUMTYPE="SHA-1" SIZE="5260629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T18:37:08" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="10388819d12a0fa17a9090e2b33dbc8b87e54d11" CHECKSUMTYPE="SHA-1" SIZE="5050929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T18:37:31" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="b4440e218e523ce85669e7683d91b92b40206275" CHECKSUMTYPE="SHA-1" SIZE="5221927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T18:37:57" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="76f1ee8dc3715ed3978d4f088fff77373c8f0a7a" CHECKSUMTYPE="SHA-1" SIZE="4970818">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T18:38:21" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="167acff749673be6a8f87a22722487292bb02430" CHECKSUMTYPE="SHA-1" SIZE="5277725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T18:38:46" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="10c3df7b61cd4368673e3134faaf51843cb808a3" CHECKSUMTYPE="SHA-1" SIZE="5050920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T18:39:11" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="4f3c1cff24d41c88588ad034708fb4a80ad33e13" CHECKSUMTYPE="SHA-1" SIZE="5211126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T18:39:35" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="f058b21961c4ee7b0233c5b93d41c92b2d8098bb" CHECKSUMTYPE="SHA-1" SIZE="5001428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T18:40:03" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="0f044c4c1ffa7a56ac49307270a5400089bbdb26" CHECKSUMTYPE="SHA-1" SIZE="5227317">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T18:40:28" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="bc6afa87a8f47f2de533ca48566ed7fa222b9817" CHECKSUMTYPE="SHA-1" SIZE="5137316">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T18:40:54" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="e318a011aa3b301c79d3848fc1df531257da75b0" CHECKSUMTYPE="SHA-1" SIZE="5241729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T18:41:18" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="71dc82494a707eeb707f2dc5c2c8a65429edff1f" CHECKSUMTYPE="SHA-1" SIZE="5084228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T18:41:43" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="db80cdf9769a16b93edd368c4062515d7dafdda7" CHECKSUMTYPE="SHA-1" SIZE="5245328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T18:42:05" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="07c0a9bfc2b3c572e4b44f6b9fce480ee68a6c6b" CHECKSUMTYPE="SHA-1" SIZE="5084229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T18:42:30" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="8978609705c8a797f36d6a300a59b4548d250694" CHECKSUMTYPE="SHA-1" SIZE="5300220">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:42:54" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="7a77ebfd6d37893d98f2ae20463f32721a936403" CHECKSUMTYPE="SHA-1" SIZE="5050908">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:43:18" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="6c983a6a20fb5d9965cac4890af4e5c4d07e9de4" CHECKSUMTYPE="SHA-1" SIZE="5278629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:43:42" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="9195d877a0f6d755f7271fe6fb37ed576de53119" CHECKSUMTYPE="SHA-1" SIZE="5079722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:44:06" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="19802a35b766d2678988b467cf045a809de19621" CHECKSUMTYPE="SHA-1" SIZE="5239017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:44:32" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="5fba51c4a8c01e668c306f75b76ab98345fa7ba8" CHECKSUMTYPE="SHA-1" SIZE="5080628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:44:57" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="e8ab87d65b0cff7240ca2f492353b15fe55050f8" CHECKSUMTYPE="SHA-1" SIZE="5248027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:45:24" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="d4718abaaeb775c6678875ca94d24abd62c1f41f" CHECKSUMTYPE="SHA-1" SIZE="5068929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:45:49" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="ec51742b23093d374a0bdd0493ea899e22aec07d" CHECKSUMTYPE="SHA-1" SIZE="5234529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:46:12" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="95b482aba44c155e296d8d8b4e749b7c08966e41" CHECKSUMTYPE="SHA-1" SIZE="5080622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:46:37" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="749d13a5f4bec7acc5c87857b74dd44dcd8c887f" CHECKSUMTYPE="SHA-1" SIZE="5235427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:47:01" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="323f749e5ded43fb14e729197e461ecd283627b0" CHECKSUMTYPE="SHA-1" SIZE="5086027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:47:25" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="d3150babf3f609f94c399a03444f8a20c1bf288a" CHECKSUMTYPE="SHA-1" SIZE="5246222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:47:50" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="afd0950de87a2f250e2168144c961ff86257fc00" CHECKSUMTYPE="SHA-1" SIZE="5083328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:48:19" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="c5d65739f4be64c7443402cd7a95dee704c3e551" CHECKSUMTYPE="SHA-1" SIZE="5245329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:48:42" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="3cf230ac982c8f0380f286d26a139eca96f37efb" CHECKSUMTYPE="SHA-1" SIZE="5107628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:49:08" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="22f4b028cc57307ccf4202ac5d38f90806bc1cff" CHECKSUMTYPE="SHA-1" SIZE="5225506">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:49:37" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="ae7383f3d628aa4d477e47276daed279e30e3b0b" CHECKSUMTYPE="SHA-1" SIZE="5134587">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:50:03" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="921f62cfcf72b5ab1df2576666eea23c43dae55b" CHECKSUMTYPE="SHA-1" SIZE="5244392">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:50:25" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="ce37db83963212807990a2141a60cf1772b761dd" CHECKSUMTYPE="SHA-1" SIZE="5131928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:50:50" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="aae1eb7b720343bb54f00e45da1617840decb3e3" CHECKSUMTYPE="SHA-1" SIZE="5251629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:51:16" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="c1c34b02ff023554ae0c1b65f80ab8a60d659d53" CHECKSUMTYPE="SHA-1" SIZE="5140018">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:51:41" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="a9c0f18cf73f0475ef1464cb4f47ecaff7b09287" CHECKSUMTYPE="SHA-1" SIZE="5254294">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:52:06" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="4a5adb51bb6dd04490f25224f93f2d9dddf6dfb4" CHECKSUMTYPE="SHA-1" SIZE="5135526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:52:30" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="dcce36f2c0c541442662a63f73a9aa854ad725bd" CHECKSUMTYPE="SHA-1" SIZE="5241725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:52:54" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="79c07e0a13a95e4e7ec96b36adc9bef1bbf2030e" CHECKSUMTYPE="SHA-1" SIZE="5143628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:53:18" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="71ec9c86a4f601bcc23b8f0501659c72711cc7dd" CHECKSUMTYPE="SHA-1" SIZE="5182329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:53:42" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="02167972500401700cd5cd6c15dde7af1cb67e78" CHECKSUMTYPE="SHA-1" SIZE="5146327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:54:09" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="7b624af6967b18c842deb5b961a79fc3cedcf8de" CHECKSUMTYPE="SHA-1" SIZE="5253407">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0086.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T18:19:31" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="cefd286ffcbd25c86e78e6cf1226dd87109a033e" CHECKSUMTYPE="SHA-1" SIZE="4947428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T18:19:58" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="185438533ef105adc3ad476bb6cdad20f2193b47" CHECKSUMTYPE="SHA-1" SIZE="5095027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T18:20:22" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="23bd8145ed7d06a2e3f5852b1ad52b65df905546" CHECKSUMTYPE="SHA-1" SIZE="4989727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T18:20:44" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="5ec35d0c1bdca3565bd6e5e24d7ec85d549229cb" CHECKSUMTYPE="SHA-1" SIZE="5095028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T18:21:07" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="63072493accc4212688d32be89bab960073d1dbd" CHECKSUMTYPE="SHA-1" SIZE="4971729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T18:21:34" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="d86f4180d6715bc39fe8966b32c8cb3b99141b06" CHECKSUMTYPE="SHA-1" SIZE="5095025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T18:21:56" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="e657688e8a886581fdad8e927d4205da97f8f92b" CHECKSUMTYPE="SHA-1" SIZE="5032023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T18:22:22" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a8fc4b68ec757b8fd4a69520683cbe98ffd18f29" CHECKSUMTYPE="SHA-1" SIZE="5193063">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T18:22:47" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="31bd0a7f0c9cf3723bdbfc1cb4023752a58b9195" CHECKSUMTYPE="SHA-1" SIZE="5017628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T18:23:08" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="8c68323648caa60e5061c6de9c5c049f1063de58" CHECKSUMTYPE="SHA-1" SIZE="5156218">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T18:23:31" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="c597ab69e900c97e696652137a3e83f1ea78037b" CHECKSUMTYPE="SHA-1" SIZE="5024829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T18:23:53" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="75344c547cea78f5655fb6c07256b5570f88df81" CHECKSUMTYPE="SHA-1" SIZE="5206629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T18:24:16" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="2bdc39cf42cc017f2f3bc8f023b1b5e9015586ef" CHECKSUMTYPE="SHA-1" SIZE="5019428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T18:24:41" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="2c2e8735346137e02e483b3f4d61e85b06afe4dd" CHECKSUMTYPE="SHA-1" SIZE="5178728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T18:25:03" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="0611e91ec700ec5b4249a2ced8860396a3f40c7a" CHECKSUMTYPE="SHA-1" SIZE="4988828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T18:25:28" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="97693ea4da3557b7c3f524e7603d47b281258255" CHECKSUMTYPE="SHA-1" SIZE="5165229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T18:25:54" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="c2b111670ae61997fcbb64f179ae969e9563cfa6" CHECKSUMTYPE="SHA-1" SIZE="4987929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T18:26:20" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="61e766d43e0616204b959b95b6060911bb84c8dd" CHECKSUMTYPE="SHA-1" SIZE="5190426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T18:26:44" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="122693c4691c72f5b3edec0acac27eb45a10f2a2" CHECKSUMTYPE="SHA-1" SIZE="4994228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T18:27:07" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="95b888e72b50757bd63b4510f275d50590b48814" CHECKSUMTYPE="SHA-1" SIZE="5171529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T18:27:31" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="01e28b991e4c1d2463295d67d8f81f7b82fb4473" CHECKSUMTYPE="SHA-1" SIZE="4984328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T18:27:54" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="ff60adc1c25931606511722b2121c283e08ced12" CHECKSUMTYPE="SHA-1" SIZE="5230929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T18:28:17" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="4d47d9a84b224b8388b09655ef9c5fc1a8f77210" CHECKSUMTYPE="SHA-1" SIZE="4970791">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T18:28:42" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="3a120146697494ef84c4ba0d2558d86aee0c7dc3" CHECKSUMTYPE="SHA-1" SIZE="5207486">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T18:29:07" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="75a58baded4045d0431d18d44aa094f8619d796f" CHECKSUMTYPE="SHA-1" SIZE="5005028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T18:29:33" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="86097c9ab33cd41489b448adc6b2be64acd86f3e" CHECKSUMTYPE="SHA-1" SIZE="5246219">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T18:29:59" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="8d6720b297c53b8d7b468264d0f16a1cd041f89e" CHECKSUMTYPE="SHA-1" SIZE="5024820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T18:30:26" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="e491385e62bebf9c1c49b9a888da16d0efa901d0" CHECKSUMTYPE="SHA-1" SIZE="5246229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T18:30:50" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="78659f7e595971bb68c7c3208195c0066dc59b68" CHECKSUMTYPE="SHA-1" SIZE="4990625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T18:31:14" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="2d1aa0152a33558f03094d04b658373732ab0766" CHECKSUMTYPE="SHA-1" SIZE="5230027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T18:31:38" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="eb506d592d8838b82e637d0961d342b0fb779bfc" CHECKSUMTYPE="SHA-1" SIZE="5047327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T18:32:03" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="f5f2ecab8c15db419bc048d844a43bb6d33aca2e" CHECKSUMTYPE="SHA-1" SIZE="5249829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T18:32:25" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="3524ad3e123e13c0570ae69264e8d85bf9811fa6" CHECKSUMTYPE="SHA-1" SIZE="5012227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T18:32:49" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="6172cab206b8dc3f74b7a527d2daa434422f91b0" CHECKSUMTYPE="SHA-1" SIZE="5165229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T18:33:12" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="01bb1325bce4fc86b369335c60d9e032349769e9" CHECKSUMTYPE="SHA-1" SIZE="4998723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T18:33:36" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="cfa7edc882798f5d5c120bb6fe492bf741cd2146" CHECKSUMTYPE="SHA-1" SIZE="5236314">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T18:33:59" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="c3a3d472f91d8c335429034fc2d096e901656f5c" CHECKSUMTYPE="SHA-1" SIZE="4955528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T18:34:24" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="1258252d1387348dac44617674576f2985dc7302" CHECKSUMTYPE="SHA-1" SIZE="5189526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T18:34:48" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="d6bd9f249e90a540eb2881d13d83b4a115d7ca5f" CHECKSUMTYPE="SHA-1" SIZE="5044629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T18:35:10" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="cd40b35a1d5b7a5ed9e6921e14478d97cac0ccbb" CHECKSUMTYPE="SHA-1" SIZE="5210210">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T18:35:34" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="a99ffc98810507fbffc3317af6605b8f75faf3f1" CHECKSUMTYPE="SHA-1" SIZE="4980712">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T18:35:56" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="00b3c22343be684d9c7fa0f7f770bbd7ca22af33" CHECKSUMTYPE="SHA-1" SIZE="5227328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T18:36:20" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="48d1fab90da1cfcf9a707e7d3226a27640f7dccb" CHECKSUMTYPE="SHA-1" SIZE="5006827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T18:36:44" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="2744333ad21f6c2cf352276585e85ee0973f0fea" CHECKSUMTYPE="SHA-1" SIZE="5260629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T18:37:08" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="10388819d12a0fa17a9090e2b33dbc8b87e54d11" CHECKSUMTYPE="SHA-1" SIZE="5050929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T18:37:31" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="b4440e218e523ce85669e7683d91b92b40206275" CHECKSUMTYPE="SHA-1" SIZE="5221927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T18:37:57" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="76f1ee8dc3715ed3978d4f088fff77373c8f0a7a" CHECKSUMTYPE="SHA-1" SIZE="4970818">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T18:38:21" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="167acff749673be6a8f87a22722487292bb02430" CHECKSUMTYPE="SHA-1" SIZE="5277725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T18:38:46" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="10c3df7b61cd4368673e3134faaf51843cb808a3" CHECKSUMTYPE="SHA-1" SIZE="5050920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T18:39:11" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="4f3c1cff24d41c88588ad034708fb4a80ad33e13" CHECKSUMTYPE="SHA-1" SIZE="5211126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T18:39:35" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="f058b21961c4ee7b0233c5b93d41c92b2d8098bb" CHECKSUMTYPE="SHA-1" SIZE="5001428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T18:40:03" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="0f044c4c1ffa7a56ac49307270a5400089bbdb26" CHECKSUMTYPE="SHA-1" SIZE="5227317">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T18:40:28" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="bc6afa87a8f47f2de533ca48566ed7fa222b9817" CHECKSUMTYPE="SHA-1" SIZE="5137316">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T18:40:54" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="e318a011aa3b301c79d3848fc1df531257da75b0" CHECKSUMTYPE="SHA-1" SIZE="5241729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T18:41:18" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="71dc82494a707eeb707f2dc5c2c8a65429edff1f" CHECKSUMTYPE="SHA-1" SIZE="5084228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T18:41:43" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="db80cdf9769a16b93edd368c4062515d7dafdda7" CHECKSUMTYPE="SHA-1" SIZE="5245328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T18:42:05" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="07c0a9bfc2b3c572e4b44f6b9fce480ee68a6c6b" CHECKSUMTYPE="SHA-1" SIZE="5084229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T18:42:30" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="8978609705c8a797f36d6a300a59b4548d250694" CHECKSUMTYPE="SHA-1" SIZE="5300220">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:42:54" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="7a77ebfd6d37893d98f2ae20463f32721a936403" CHECKSUMTYPE="SHA-1" SIZE="5050908">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:43:18" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="6c983a6a20fb5d9965cac4890af4e5c4d07e9de4" CHECKSUMTYPE="SHA-1" SIZE="5278629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:43:42" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="9195d877a0f6d755f7271fe6fb37ed576de53119" CHECKSUMTYPE="SHA-1" SIZE="5079722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:44:06" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="19802a35b766d2678988b467cf045a809de19621" CHECKSUMTYPE="SHA-1" SIZE="5239017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:44:32" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="5fba51c4a8c01e668c306f75b76ab98345fa7ba8" CHECKSUMTYPE="SHA-1" SIZE="5080628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:44:57" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="e8ab87d65b0cff7240ca2f492353b15fe55050f8" CHECKSUMTYPE="SHA-1" SIZE="5248027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:45:24" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="d4718abaaeb775c6678875ca94d24abd62c1f41f" CHECKSUMTYPE="SHA-1" SIZE="5068929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:45:49" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="ec51742b23093d374a0bdd0493ea899e22aec07d" CHECKSUMTYPE="SHA-1" SIZE="5234529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:46:12" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="95b482aba44c155e296d8d8b4e749b7c08966e41" CHECKSUMTYPE="SHA-1" SIZE="5080622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:46:37" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="749d13a5f4bec7acc5c87857b74dd44dcd8c887f" CHECKSUMTYPE="SHA-1" SIZE="5235427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:47:01" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="323f749e5ded43fb14e729197e461ecd283627b0" CHECKSUMTYPE="SHA-1" SIZE="5086027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:47:25" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="d3150babf3f609f94c399a03444f8a20c1bf288a" CHECKSUMTYPE="SHA-1" SIZE="5246222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:47:50" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="afd0950de87a2f250e2168144c961ff86257fc00" CHECKSUMTYPE="SHA-1" SIZE="5083328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:48:19" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="c5d65739f4be64c7443402cd7a95dee704c3e551" CHECKSUMTYPE="SHA-1" SIZE="5245329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:48:42" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="3cf230ac982c8f0380f286d26a139eca96f37efb" CHECKSUMTYPE="SHA-1" SIZE="5107628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:49:08" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="22f4b028cc57307ccf4202ac5d38f90806bc1cff" CHECKSUMTYPE="SHA-1" SIZE="5225506">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:49:37" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="ae7383f3d628aa4d477e47276daed279e30e3b0b" CHECKSUMTYPE="SHA-1" SIZE="5134587">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:50:03" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="921f62cfcf72b5ab1df2576666eea23c43dae55b" CHECKSUMTYPE="SHA-1" SIZE="5244392">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:50:25" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="ce37db83963212807990a2141a60cf1772b761dd" CHECKSUMTYPE="SHA-1" SIZE="5131928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:50:50" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="aae1eb7b720343bb54f00e45da1617840decb3e3" CHECKSUMTYPE="SHA-1" SIZE="5251629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:51:16" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="c1c34b02ff023554ae0c1b65f80ab8a60d659d53" CHECKSUMTYPE="SHA-1" SIZE="5140018">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:51:41" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="a9c0f18cf73f0475ef1464cb4f47ecaff7b09287" CHECKSUMTYPE="SHA-1" SIZE="5254294">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:52:06" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="4a5adb51bb6dd04490f25224f93f2d9dddf6dfb4" CHECKSUMTYPE="SHA-1" SIZE="5135526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:52:30" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="dcce36f2c0c541442662a63f73a9aa854ad725bd" CHECKSUMTYPE="SHA-1" SIZE="5241725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:52:54" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="79c07e0a13a95e4e7ec96b36adc9bef1bbf2030e" CHECKSUMTYPE="SHA-1" SIZE="5143628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:53:18" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="71ec9c86a4f601bcc23b8f0501659c72711cc7dd" CHECKSUMTYPE="SHA-1" SIZE="5182329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:53:42" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="02167972500401700cd5cd6c15dde7af1cb67e78" CHECKSUMTYPE="SHA-1" SIZE="5146327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:54:09" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="7b624af6967b18c842deb5b961a79fc3cedcf8de" CHECKSUMTYPE="SHA-1" SIZE="5253407">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/delivery/bmtnabe_1899-11_01_0086.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:54:24" MIMETYPE="text/xml" CHECKSUM="6d61a121161636317351137979bff12e0df53968"
-				CHECKSUMTYPE="SHA-1" SIZE="2109">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:54:24" MIMETYPE="text/xml" CHECKSUM="6d61a121161636317351137979bff12e0df53968" CHECKSUMTYPE="SHA-1" SIZE="2109">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:54:24" MIMETYPE="text/xml" CHECKSUM="17751a3373b2523fe0e7bdabf71d54045c7d39c4"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:54:24" MIMETYPE="text/xml" CHECKSUM="17751a3373b2523fe0e7bdabf71d54045c7d39c4" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:54:24" MIMETYPE="text/xml" CHECKSUM="ce33a6c165e774d0f9c1f068e013abebf2865966"
-				CHECKSUMTYPE="SHA-1" SIZE="1713">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:54:24" MIMETYPE="text/xml" CHECKSUM="ce33a6c165e774d0f9c1f068e013abebf2865966" CHECKSUMTYPE="SHA-1" SIZE="1713">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:54:25" MIMETYPE="text/xml" CHECKSUM="8dbfb7eb4153df3fa0ca5b3a4f1bb25ccd035e18"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:54:25" MIMETYPE="text/xml" CHECKSUM="8dbfb7eb4153df3fa0ca5b3a4f1bb25ccd035e18" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:54:25" MIMETYPE="text/xml" CHECKSUM="7e9cad9ed9b11177df9b0f7ab0ed156c1f14113f"
-				CHECKSUMTYPE="SHA-1" SIZE="13093">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:54:25" MIMETYPE="text/xml" CHECKSUM="7e9cad9ed9b11177df9b0f7ab0ed156c1f14113f" CHECKSUMTYPE="SHA-1" SIZE="13093">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:54:25" MIMETYPE="text/xml" CHECKSUM="d8b891cd6f198ca7d034af0d95babe54ab8a061c"
-				CHECKSUMTYPE="SHA-1" SIZE="3380">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:54:25" MIMETYPE="text/xml" CHECKSUM="d8b891cd6f198ca7d034af0d95babe54ab8a061c" CHECKSUMTYPE="SHA-1" SIZE="3380">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:54:25" MIMETYPE="text/xml" CHECKSUM="b351d4f15560d425bdfaf65af69e5f914135f8e2"
-				CHECKSUMTYPE="SHA-1" SIZE="1715">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:54:25" MIMETYPE="text/xml" CHECKSUM="b351d4f15560d425bdfaf65af69e5f914135f8e2" CHECKSUMTYPE="SHA-1" SIZE="1715">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:54:26" MIMETYPE="text/xml" CHECKSUM="539827550eafac8d38e717652e226cd7ea51cefb"
-				CHECKSUMTYPE="SHA-1" SIZE="6780">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:54:26" MIMETYPE="text/xml" CHECKSUM="539827550eafac8d38e717652e226cd7ea51cefb" CHECKSUMTYPE="SHA-1" SIZE="6780">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:54:26" MIMETYPE="text/xml" CHECKSUM="8ca8dd1ce3d4d2a3af5650bf54699650e68b9e94"
-				CHECKSUMTYPE="SHA-1" SIZE="27093">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:54:26" MIMETYPE="text/xml" CHECKSUM="8ca8dd1ce3d4d2a3af5650bf54699650e68b9e94" CHECKSUMTYPE="SHA-1" SIZE="27093">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:54:26" MIMETYPE="text/xml"
-				CHECKSUM="61d6eeba0faf31b749f9712ce7c4627ca989dea4" CHECKSUMTYPE="SHA-1" SIZE="47726">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:54:26" MIMETYPE="text/xml" CHECKSUM="61d6eeba0faf31b749f9712ce7c4627ca989dea4" CHECKSUMTYPE="SHA-1" SIZE="47726">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:54:27" MIMETYPE="text/xml"
-				CHECKSUM="c06d35afeddd002cc8fa0659a7810340c25147d5" CHECKSUMTYPE="SHA-1" SIZE="25662">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:54:27" MIMETYPE="text/xml" CHECKSUM="c06d35afeddd002cc8fa0659a7810340c25147d5" CHECKSUMTYPE="SHA-1" SIZE="25662">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:54:27" MIMETYPE="text/xml"
-				CHECKSUM="f98a37a005a870fc1bbd945965151d3179ef91c0" CHECKSUMTYPE="SHA-1" SIZE="50245">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:54:27" MIMETYPE="text/xml" CHECKSUM="f98a37a005a870fc1bbd945965151d3179ef91c0" CHECKSUMTYPE="SHA-1" SIZE="50245">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:54:27" MIMETYPE="text/xml"
-				CHECKSUM="11dfcf55913383288d9544622ac8a8469bfd7575" CHECKSUMTYPE="SHA-1" SIZE="5752">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:54:27" MIMETYPE="text/xml" CHECKSUM="11dfcf55913383288d9544622ac8a8469bfd7575" CHECKSUMTYPE="SHA-1" SIZE="5752">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:54:27" MIMETYPE="text/xml"
-				CHECKSUM="a76b1f8f78472bdf73d30c538005855f3a3ec56b" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:54:27" MIMETYPE="text/xml" CHECKSUM="a76b1f8f78472bdf73d30c538005855f3a3ec56b" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:54:28" MIMETYPE="text/xml"
-				CHECKSUM="d0af36f580cb2e989c08e8b84bf5b0205c06d81b" CHECKSUMTYPE="SHA-1" SIZE="71530">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:54:28" MIMETYPE="text/xml" CHECKSUM="d0af36f580cb2e989c08e8b84bf5b0205c06d81b" CHECKSUMTYPE="SHA-1" SIZE="71530">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:54:28" MIMETYPE="text/xml"
-				CHECKSUM="9eeee21840976823fb1e35f57722c9b1028fabd9" CHECKSUMTYPE="SHA-1" SIZE="114633">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:54:28" MIMETYPE="text/xml" CHECKSUM="9eeee21840976823fb1e35f57722c9b1028fabd9" CHECKSUMTYPE="SHA-1" SIZE="114633">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:54:28" MIMETYPE="text/xml"
-				CHECKSUM="e07e3a75e8021196d9e9db8d2414168ec30a4a0e" CHECKSUMTYPE="SHA-1" SIZE="110572">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:54:28" MIMETYPE="text/xml" CHECKSUM="e07e3a75e8021196d9e9db8d2414168ec30a4a0e" CHECKSUMTYPE="SHA-1" SIZE="110572">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:54:29" MIMETYPE="text/xml"
-				CHECKSUM="8b0bf0d1e9705caad7375dd71e0da58b857d2415" CHECKSUMTYPE="SHA-1" SIZE="123370">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:54:29" MIMETYPE="text/xml" CHECKSUM="8b0bf0d1e9705caad7375dd71e0da58b857d2415" CHECKSUMTYPE="SHA-1" SIZE="123370">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:54:29" MIMETYPE="text/xml"
-				CHECKSUM="73137cb6c8f30de488c5d01b2084aff5eb2e0170" CHECKSUMTYPE="SHA-1" SIZE="93369">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:54:29" MIMETYPE="text/xml" CHECKSUM="73137cb6c8f30de488c5d01b2084aff5eb2e0170" CHECKSUMTYPE="SHA-1" SIZE="93369">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:54:29" MIMETYPE="text/xml"
-				CHECKSUM="f2584dae4512bae836fb6781cc9fbc61cc44d831" CHECKSUMTYPE="SHA-1" SIZE="91187">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:54:29" MIMETYPE="text/xml" CHECKSUM="f2584dae4512bae836fb6781cc9fbc61cc44d831" CHECKSUMTYPE="SHA-1" SIZE="91187">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:54:30" MIMETYPE="text/xml"
-				CHECKSUM="06386bb732a65778d76d3590245b645ead1a65a3" CHECKSUMTYPE="SHA-1" SIZE="5210">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:54:30" MIMETYPE="text/xml" CHECKSUM="06386bb732a65778d76d3590245b645ead1a65a3" CHECKSUMTYPE="SHA-1" SIZE="5210">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:54:30" MIMETYPE="text/xml"
-				CHECKSUM="0cbac6ade2f2d0ac16af4d4deb11bf73e1954db0" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:54:30" MIMETYPE="text/xml" CHECKSUM="0cbac6ade2f2d0ac16af4d4deb11bf73e1954db0" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:54:30" MIMETYPE="text/xml"
-				CHECKSUM="17fb021632a006d9307e9e8fc4e41aa4ebeea310" CHECKSUMTYPE="SHA-1" SIZE="76396">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:54:30" MIMETYPE="text/xml" CHECKSUM="17fb021632a006d9307e9e8fc4e41aa4ebeea310" CHECKSUMTYPE="SHA-1" SIZE="76396">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:54:30" MIMETYPE="text/xml"
-				CHECKSUM="e3335171e65a5cdb1b0b2c92a35ace6c6f21db4d" CHECKSUMTYPE="SHA-1" SIZE="153427">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:54:30" MIMETYPE="text/xml" CHECKSUM="e3335171e65a5cdb1b0b2c92a35ace6c6f21db4d" CHECKSUMTYPE="SHA-1" SIZE="153427">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:54:31" MIMETYPE="text/xml"
-				CHECKSUM="21d252cec9c3dd5b996f4afdfc7c547fab98e320" CHECKSUMTYPE="SHA-1" SIZE="155003">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:54:31" MIMETYPE="text/xml" CHECKSUM="21d252cec9c3dd5b996f4afdfc7c547fab98e320" CHECKSUMTYPE="SHA-1" SIZE="155003">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:54:31" MIMETYPE="text/xml"
-				CHECKSUM="719170557e967664c2e6fa7228f23f32d4e5348e" CHECKSUMTYPE="SHA-1" SIZE="164561">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:54:31" MIMETYPE="text/xml" CHECKSUM="719170557e967664c2e6fa7228f23f32d4e5348e" CHECKSUMTYPE="SHA-1" SIZE="164561">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:54:32" MIMETYPE="text/xml"
-				CHECKSUM="ec3c4e60b861405aa40f6e13a7423c770c71eb2a" CHECKSUMTYPE="SHA-1" SIZE="158050">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:54:32" MIMETYPE="text/xml" CHECKSUM="ec3c4e60b861405aa40f6e13a7423c770c71eb2a" CHECKSUMTYPE="SHA-1" SIZE="158050">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:54:33" MIMETYPE="text/xml"
-				CHECKSUM="4f274235d5424b6dc317294edb7ea798fb2da6db" CHECKSUMTYPE="SHA-1" SIZE="157002">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:54:33" MIMETYPE="text/xml" CHECKSUM="4f274235d5424b6dc317294edb7ea798fb2da6db" CHECKSUMTYPE="SHA-1" SIZE="157002">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:54:33" MIMETYPE="text/xml"
-				CHECKSUM="970297e26bd2a6393f050cf5662a297d726c5b0d" CHECKSUMTYPE="SHA-1" SIZE="5191">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:54:33" MIMETYPE="text/xml" CHECKSUM="970297e26bd2a6393f050cf5662a297d726c5b0d" CHECKSUMTYPE="SHA-1" SIZE="5191">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:54:33" MIMETYPE="text/xml"
-				CHECKSUM="15ad87fdbdfece1be8281e18a8415d6ae8c0432e" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:54:33" MIMETYPE="text/xml" CHECKSUM="15ad87fdbdfece1be8281e18a8415d6ae8c0432e" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:54:34" MIMETYPE="text/xml"
-				CHECKSUM="9d4b209312271456d2e3143147edad9044807050" CHECKSUMTYPE="SHA-1" SIZE="21044">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:54:34" MIMETYPE="text/xml" CHECKSUM="9d4b209312271456d2e3143147edad9044807050" CHECKSUMTYPE="SHA-1" SIZE="21044">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:54:34" MIMETYPE="text/xml"
-				CHECKSUM="f13773414e244e63d48e68c333657869099c1e91" CHECKSUMTYPE="SHA-1" SIZE="24291">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:54:34" MIMETYPE="text/xml" CHECKSUM="f13773414e244e63d48e68c333657869099c1e91" CHECKSUMTYPE="SHA-1" SIZE="24291">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:54:34" MIMETYPE="text/xml"
-				CHECKSUM="179b1ac19fd19c458251a6d49a3b3af5c77c0e37" CHECKSUMTYPE="SHA-1" SIZE="28928">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:54:34" MIMETYPE="text/xml" CHECKSUM="179b1ac19fd19c458251a6d49a3b3af5c77c0e37" CHECKSUMTYPE="SHA-1" SIZE="28928">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:54:34" MIMETYPE="text/xml"
-				CHECKSUM="633da81b50dfd8e9420f2e0722544a01c5aed768" CHECKSUMTYPE="SHA-1" SIZE="38265">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:54:34" MIMETYPE="text/xml" CHECKSUM="633da81b50dfd8e9420f2e0722544a01c5aed768" CHECKSUMTYPE="SHA-1" SIZE="38265">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:54:35" MIMETYPE="text/xml"
-				CHECKSUM="502a1f711cbca6a0382ca7a2ade6688479f7c402" CHECKSUMTYPE="SHA-1" SIZE="31312">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:54:35" MIMETYPE="text/xml" CHECKSUM="502a1f711cbca6a0382ca7a2ade6688479f7c402" CHECKSUMTYPE="SHA-1" SIZE="31312">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:54:35" MIMETYPE="text/xml"
-				CHECKSUM="ef4a73fcdf2b20b8dc129c95c7c2a9cc1dff26dc" CHECKSUMTYPE="SHA-1" SIZE="73146">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:54:35" MIMETYPE="text/xml" CHECKSUM="ef4a73fcdf2b20b8dc129c95c7c2a9cc1dff26dc" CHECKSUMTYPE="SHA-1" SIZE="73146">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:54:35" MIMETYPE="text/xml"
-				CHECKSUM="92c405effc7580f201c4e137f09ff5ea28a12378" CHECKSUMTYPE="SHA-1" SIZE="58041">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:54:35" MIMETYPE="text/xml" CHECKSUM="92c405effc7580f201c4e137f09ff5ea28a12378" CHECKSUMTYPE="SHA-1" SIZE="58041">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:54:35" MIMETYPE="text/xml"
-				CHECKSUM="8eab9144f9fe2061250c00515ef4d9c4d64254db" CHECKSUMTYPE="SHA-1" SIZE="91480">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:54:35" MIMETYPE="text/xml" CHECKSUM="8eab9144f9fe2061250c00515ef4d9c4d64254db" CHECKSUMTYPE="SHA-1" SIZE="91480">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:54:36" MIMETYPE="text/xml"
-				CHECKSUM="10ad750c7ec797a21291f1996c06f2be4447e56d" CHECKSUMTYPE="SHA-1" SIZE="86428">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:54:36" MIMETYPE="text/xml" CHECKSUM="10ad750c7ec797a21291f1996c06f2be4447e56d" CHECKSUMTYPE="SHA-1" SIZE="86428">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:54:36" MIMETYPE="text/xml"
-				CHECKSUM="4716a2faf2605fdf0debd9e278b7f8e96297b9ea" CHECKSUMTYPE="SHA-1" SIZE="86332">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:54:36" MIMETYPE="text/xml" CHECKSUM="4716a2faf2605fdf0debd9e278b7f8e96297b9ea" CHECKSUMTYPE="SHA-1" SIZE="86332">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:54:36" MIMETYPE="text/xml"
-				CHECKSUM="ee715aa485c7b896330b41c6b9c6f633dba9583a" CHECKSUMTYPE="SHA-1" SIZE="5345">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:54:36" MIMETYPE="text/xml" CHECKSUM="ee715aa485c7b896330b41c6b9c6f633dba9583a" CHECKSUMTYPE="SHA-1" SIZE="5345">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:54:37" MIMETYPE="text/xml"
-				CHECKSUM="098f116b5554c718173be9df6b0e61b520b5ad93" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:54:37" MIMETYPE="text/xml" CHECKSUM="098f116b5554c718173be9df6b0e61b520b5ad93" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:54:37" MIMETYPE="text/xml"
-				CHECKSUM="caefe4b875b6fe762520032d9701462127a0be4f" CHECKSUMTYPE="SHA-1" SIZE="70672">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:54:37" MIMETYPE="text/xml" CHECKSUM="caefe4b875b6fe762520032d9701462127a0be4f" CHECKSUMTYPE="SHA-1" SIZE="70672">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:54:37" MIMETYPE="text/xml"
-				CHECKSUM="b9a1945b53511ecfbb623b2577c70ec3d72d4fc0" CHECKSUMTYPE="SHA-1" SIZE="196711">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:54:37" MIMETYPE="text/xml" CHECKSUM="b9a1945b53511ecfbb623b2577c70ec3d72d4fc0" CHECKSUMTYPE="SHA-1" SIZE="196711">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:54:38" MIMETYPE="text/xml"
-				CHECKSUM="ff20d857d948d84348a09a1fa81d1322f20c516a" CHECKSUMTYPE="SHA-1" SIZE="185639">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:54:38" MIMETYPE="text/xml" CHECKSUM="ff20d857d948d84348a09a1fa81d1322f20c516a" CHECKSUMTYPE="SHA-1" SIZE="185639">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:54:38" MIMETYPE="text/xml"
-				CHECKSUM="36d5ad1a860ecede3c69dbf9b48a5c730ba86f54" CHECKSUMTYPE="SHA-1" SIZE="186558">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:54:38" MIMETYPE="text/xml" CHECKSUM="36d5ad1a860ecede3c69dbf9b48a5c730ba86f54" CHECKSUMTYPE="SHA-1" SIZE="186558">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:54:38" MIMETYPE="text/xml"
-				CHECKSUM="20cb7a98a2a72a3f57006086c64d68d539e0f18e" CHECKSUMTYPE="SHA-1" SIZE="191764">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:54:38" MIMETYPE="text/xml" CHECKSUM="20cb7a98a2a72a3f57006086c64d68d539e0f18e" CHECKSUMTYPE="SHA-1" SIZE="191764">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:54:39" MIMETYPE="text/xml"
-				CHECKSUM="37ea253885acac554810a047d7c9ffeacd047850" CHECKSUMTYPE="SHA-1" SIZE="193579">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:54:39" MIMETYPE="text/xml" CHECKSUM="37ea253885acac554810a047d7c9ffeacd047850" CHECKSUMTYPE="SHA-1" SIZE="193579">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:54:39" MIMETYPE="text/xml"
-				CHECKSUM="35c02be02fe6e728b7ddb1bc6acede05c4bd6855" CHECKSUMTYPE="SHA-1" SIZE="196175">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:54:39" MIMETYPE="text/xml" CHECKSUM="35c02be02fe6e728b7ddb1bc6acede05c4bd6855" CHECKSUMTYPE="SHA-1" SIZE="196175">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:54:39" MIMETYPE="text/xml"
-				CHECKSUM="e4437e9cd90abe5513757c4bfc0658f8acf7fd12" CHECKSUMTYPE="SHA-1" SIZE="195583">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:54:39" MIMETYPE="text/xml" CHECKSUM="e4437e9cd90abe5513757c4bfc0658f8acf7fd12" CHECKSUMTYPE="SHA-1" SIZE="195583">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:54:40" MIMETYPE="text/xml"
-				CHECKSUM="edbb116f6881007085739dc41e6a5b94cc0de246" CHECKSUMTYPE="SHA-1" SIZE="72693">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:54:40" MIMETYPE="text/xml" CHECKSUM="edbb116f6881007085739dc41e6a5b94cc0de246" CHECKSUMTYPE="SHA-1" SIZE="72693">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:54:40" MIMETYPE="text/xml"
-				CHECKSUM="d194349177222833bac01a256154090a9cb5401c" CHECKSUMTYPE="SHA-1" SIZE="77865">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:54:40" MIMETYPE="text/xml" CHECKSUM="d194349177222833bac01a256154090a9cb5401c" CHECKSUMTYPE="SHA-1" SIZE="77865">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:54:40" MIMETYPE="text/xml"
-				CHECKSUM="c874b1ac87040910cc8737160c1b1c5caf42b817" CHECKSUMTYPE="SHA-1" SIZE="193828">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:54:40" MIMETYPE="text/xml" CHECKSUM="c874b1ac87040910cc8737160c1b1c5caf42b817" CHECKSUMTYPE="SHA-1" SIZE="193828">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:54:41" MIMETYPE="text/xml"
-				CHECKSUM="dcf9ab38d1b136501728cc14abdb1e00c9c64eb9" CHECKSUMTYPE="SHA-1" SIZE="195569">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:54:41" MIMETYPE="text/xml" CHECKSUM="dcf9ab38d1b136501728cc14abdb1e00c9c64eb9" CHECKSUMTYPE="SHA-1" SIZE="195569">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:54:41" MIMETYPE="text/xml"
-				CHECKSUM="7e9c9f6ea71245930861396a33fb5c9976f1c1b2" CHECKSUMTYPE="SHA-1" SIZE="5969">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:54:41" MIMETYPE="text/xml" CHECKSUM="7e9c9f6ea71245930861396a33fb5c9976f1c1b2" CHECKSUMTYPE="SHA-1" SIZE="5969">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:54:41" MIMETYPE="text/xml"
-				CHECKSUM="17c787570889e27abfd992119ec616fe4248ae67" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:54:41" MIMETYPE="text/xml" CHECKSUM="17c787570889e27abfd992119ec616fe4248ae67" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:54:42" MIMETYPE="text/xml"
-				CHECKSUM="16260d8aa4fd225ef9beb6de19f6cb4cfe8b0572" CHECKSUMTYPE="SHA-1" SIZE="60864">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:54:42" MIMETYPE="text/xml" CHECKSUM="16260d8aa4fd225ef9beb6de19f6cb4cfe8b0572" CHECKSUMTYPE="SHA-1" SIZE="60864">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:54:42" MIMETYPE="text/xml"
-				CHECKSUM="8dfe6cb90e4f56d7f233838d635f38ef4eeb603e" CHECKSUMTYPE="SHA-1" SIZE="189645">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:54:42" MIMETYPE="text/xml" CHECKSUM="8dfe6cb90e4f56d7f233838d635f38ef4eeb603e" CHECKSUMTYPE="SHA-1" SIZE="189645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:54:42" MIMETYPE="text/xml"
-				CHECKSUM="36d139411da244658077fd812f595ee412fce525" CHECKSUMTYPE="SHA-1" SIZE="180346">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:54:42" MIMETYPE="text/xml" CHECKSUM="36d139411da244658077fd812f595ee412fce525" CHECKSUMTYPE="SHA-1" SIZE="180346">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:54:43" MIMETYPE="text/xml"
-				CHECKSUM="87d2a61d8abe026de8b69475116cae5cfe7bc3e4" CHECKSUMTYPE="SHA-1" SIZE="184024">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:54:43" MIMETYPE="text/xml" CHECKSUM="87d2a61d8abe026de8b69475116cae5cfe7bc3e4" CHECKSUMTYPE="SHA-1" SIZE="184024">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:54:43" MIMETYPE="text/xml"
-				CHECKSUM="99fd8c853bae5ef916a4759058c7aac4c242b83d" CHECKSUMTYPE="SHA-1" SIZE="191679">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:54:43" MIMETYPE="text/xml" CHECKSUM="99fd8c853bae5ef916a4759058c7aac4c242b83d" CHECKSUMTYPE="SHA-1" SIZE="191679">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:54:43" MIMETYPE="text/xml"
-				CHECKSUM="031f2129e22cac82d1919a1fa6247938aa3af885" CHECKSUMTYPE="SHA-1" SIZE="179158">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:54:43" MIMETYPE="text/xml" CHECKSUM="031f2129e22cac82d1919a1fa6247938aa3af885" CHECKSUMTYPE="SHA-1" SIZE="179158">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:54:44" MIMETYPE="text/xml"
-				CHECKSUM="60e4a0dafd6879407ad53c08e9d03ba14ba7386c" CHECKSUMTYPE="SHA-1" SIZE="78068">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:54:44" MIMETYPE="text/xml" CHECKSUM="60e4a0dafd6879407ad53c08e9d03ba14ba7386c" CHECKSUMTYPE="SHA-1" SIZE="78068">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:54:44" MIMETYPE="text/xml"
-				CHECKSUM="a6b490ebce28da14de7b9bfe021705b2fbe6d3b9" CHECKSUMTYPE="SHA-1" SIZE="124195">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T18:54:44" MIMETYPE="text/xml" CHECKSUM="a6b490ebce28da14de7b9bfe021705b2fbe6d3b9" CHECKSUMTYPE="SHA-1" SIZE="124195">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:54:44" MIMETYPE="text/xml"
-				CHECKSUM="998c53a8cc5f56ec02d6fa11c9ad677fce3f0664" CHECKSUMTYPE="SHA-1" SIZE="5025">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T18:54:44" MIMETYPE="text/xml" CHECKSUM="998c53a8cc5f56ec02d6fa11c9ad677fce3f0664" CHECKSUMTYPE="SHA-1" SIZE="5025">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:54:45" MIMETYPE="text/xml"
-				CHECKSUM="b3fc4dc9c8e273bc48123bbe80020df2797eba29" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T18:54:45" MIMETYPE="text/xml" CHECKSUM="b3fc4dc9c8e273bc48123bbe80020df2797eba29" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:54:45" MIMETYPE="text/xml"
-				CHECKSUM="bb67a7e61f0387647fe1588b21a7671237f5c4b2" CHECKSUMTYPE="SHA-1" SIZE="196594">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T18:54:45" MIMETYPE="text/xml" CHECKSUM="bb67a7e61f0387647fe1588b21a7671237f5c4b2" CHECKSUMTYPE="SHA-1" SIZE="196594">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:54:45" MIMETYPE="text/xml"
-				CHECKSUM="b5720f1a6f29ecf07327a9049429a70e08034ee0" CHECKSUMTYPE="SHA-1" SIZE="134201">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T18:54:45" MIMETYPE="text/xml" CHECKSUM="b5720f1a6f29ecf07327a9049429a70e08034ee0" CHECKSUMTYPE="SHA-1" SIZE="134201">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:54:46" MIMETYPE="text/xml"
-				CHECKSUM="cc0be918b4fcf83e109ef19082023845ce27dbb2" CHECKSUMTYPE="SHA-1" SIZE="192705">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T18:54:46" MIMETYPE="text/xml" CHECKSUM="cc0be918b4fcf83e109ef19082023845ce27dbb2" CHECKSUMTYPE="SHA-1" SIZE="192705">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:54:46" MIMETYPE="text/xml"
-				CHECKSUM="b9b14a58c3527ce7b1e27661f9cd5856a1f90a1c" CHECKSUMTYPE="SHA-1" SIZE="54790">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T18:54:46" MIMETYPE="text/xml" CHECKSUM="b9b14a58c3527ce7b1e27661f9cd5856a1f90a1c" CHECKSUMTYPE="SHA-1" SIZE="54790">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:54:46" MIMETYPE="text/xml"
-				CHECKSUM="9e8c14fe793a56c7131403a1a251cdc1f23e2369" CHECKSUMTYPE="SHA-1" SIZE="4920">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T18:54:46" MIMETYPE="text/xml" CHECKSUM="9e8c14fe793a56c7131403a1a251cdc1f23e2369" CHECKSUMTYPE="SHA-1" SIZE="4920">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:54:46" MIMETYPE="text/xml"
-				CHECKSUM="7092917439e1105dfddd56594e73ec8e0c44c193" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T18:54:46" MIMETYPE="text/xml" CHECKSUM="7092917439e1105dfddd56594e73ec8e0c44c193" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:54:47" MIMETYPE="text/xml"
-				CHECKSUM="4e35340c3ec00fc8ef70e4362ca76db03eea60b7" CHECKSUMTYPE="SHA-1" SIZE="95995">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T18:54:47" MIMETYPE="text/xml" CHECKSUM="4e35340c3ec00fc8ef70e4362ca76db03eea60b7" CHECKSUMTYPE="SHA-1" SIZE="95995">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:54:47" MIMETYPE="text/xml"
-				CHECKSUM="e1c2a2247e65559d37588da969edfd42f5b43e66" CHECKSUMTYPE="SHA-1" SIZE="105831">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T18:54:47" MIMETYPE="text/xml" CHECKSUM="e1c2a2247e65559d37588da969edfd42f5b43e66" CHECKSUMTYPE="SHA-1" SIZE="105831">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:54:47" MIMETYPE="text/xml"
-				CHECKSUM="7fb2acb03cc7b74fe5edcf6ab2c09a4227ab5866" CHECKSUMTYPE="SHA-1" SIZE="102812">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T18:54:47" MIMETYPE="text/xml" CHECKSUM="7fb2acb03cc7b74fe5edcf6ab2c09a4227ab5866" CHECKSUMTYPE="SHA-1" SIZE="102812">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:54:48" MIMETYPE="text/xml"
-				CHECKSUM="d0f4eae061edd332745a57c0ea6964c25e56beb9" CHECKSUMTYPE="SHA-1" SIZE="74023">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T18:54:48" MIMETYPE="text/xml" CHECKSUM="d0f4eae061edd332745a57c0ea6964c25e56beb9" CHECKSUMTYPE="SHA-1" SIZE="74023">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:54:48" MIMETYPE="text/xml"
-				CHECKSUM="f9921d93026b8e2e385c6358508a6728ec81a1f9" CHECKSUMTYPE="SHA-1" SIZE="4712">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T18:54:48" MIMETYPE="text/xml" CHECKSUM="f9921d93026b8e2e385c6358508a6728ec81a1f9" CHECKSUMTYPE="SHA-1" SIZE="4712">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:54:48" MIMETYPE="text/xml"
-				CHECKSUM="25a1f7d18d0130ba1fe70fa632cf5d1995c9997c" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T18:54:48" MIMETYPE="text/xml" CHECKSUM="25a1f7d18d0130ba1fe70fa632cf5d1995c9997c" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:54:48" MIMETYPE="text/xml"
-				CHECKSUM="7257949e0a804f253007a9a0c56de4d8f7c1ebdf" CHECKSUMTYPE="SHA-1" SIZE="191494">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T18:54:48" MIMETYPE="text/xml" CHECKSUM="7257949e0a804f253007a9a0c56de4d8f7c1ebdf" CHECKSUMTYPE="SHA-1" SIZE="191494">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:54:49" MIMETYPE="text/xml"
-				CHECKSUM="0fd482ff3ed05703291b36afe1105fd7cb800b2e" CHECKSUMTYPE="SHA-1" SIZE="24068">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T18:54:49" MIMETYPE="text/xml" CHECKSUM="0fd482ff3ed05703291b36afe1105fd7cb800b2e" CHECKSUMTYPE="SHA-1" SIZE="24068">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:54:49" MIMETYPE="text/xml"
-				CHECKSUM="fc3251b3dbdd8af1b390f2e6db208eee04704f2f" CHECKSUMTYPE="SHA-1" SIZE="45008">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T18:54:49" MIMETYPE="text/xml" CHECKSUM="fc3251b3dbdd8af1b390f2e6db208eee04704f2f" CHECKSUMTYPE="SHA-1" SIZE="45008">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:54:49" MIMETYPE="text/xml"
-				CHECKSUM="352e04ecea87149d01ccf076e9d8cd259dff1e9f" CHECKSUMTYPE="SHA-1" SIZE="27712">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T18:54:49" MIMETYPE="text/xml" CHECKSUM="352e04ecea87149d01ccf076e9d8cd259dff1e9f" CHECKSUMTYPE="SHA-1" SIZE="27712">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:54:49" MIMETYPE="text/xml"
-				CHECKSUM="a34cdc0b69af680c59371d5051660a5581202a97" CHECKSUMTYPE="SHA-1" SIZE="15725">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T18:54:49" MIMETYPE="text/xml" CHECKSUM="a34cdc0b69af680c59371d5051660a5581202a97" CHECKSUMTYPE="SHA-1" SIZE="15725">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:54:50" MIMETYPE="text/xml"
-				CHECKSUM="8a47d40de792caf6b5ea85afd5327e0413d95900" CHECKSUMTYPE="SHA-1" SIZE="42481">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T18:54:50" MIMETYPE="text/xml" CHECKSUM="8a47d40de792caf6b5ea85afd5327e0413d95900" CHECKSUMTYPE="SHA-1" SIZE="42481">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:54:50" MIMETYPE="text/xml"
-				CHECKSUM="1289dbce8268c1a5615060731709428866123393" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T18:54:50" MIMETYPE="text/xml" CHECKSUM="1289dbce8268c1a5615060731709428866123393" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:54:50" MIMETYPE="text/xml"
-				CHECKSUM="5adc4e09e90ed8639b7940ef1fe76c2bd6751ebf" CHECKSUMTYPE="SHA-1" SIZE="3514">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T18:54:50" MIMETYPE="text/xml" CHECKSUM="5adc4e09e90ed8639b7940ef1fe76c2bd6751ebf" CHECKSUMTYPE="SHA-1" SIZE="3514">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1899-11_01_0086.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:57:37" MIMETYPE="application/pdf" CHECKSUM="5435ccec977cc62023452e4d885ec2e09e3d3c46"
-				CHECKSUMTYPE="SHA-1" SIZE="40751431">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/bmtnabe_1899-11_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T18:57:37" MIMETYPE="application/pdf" CHECKSUM="5435ccec977cc62023452e4d885ec2e09e3d3c46" CHECKSUMTYPE="SHA-1" SIZE="40751431">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1899/11_01/bmtnabe_1899-11_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -10176,8 +9912,7 @@
 
 					</div>
 				</div>
-				<div ID="L.1.1.17" TYPE="TextContent" ORDER="17" DMDID="c064"
-					LABEL="EINIGES UEBER DIE BEDEUTUNG VON GROESSENVORSTELLUNGEN IN DER ARCHITEKTUR">
+				<div ID="L.1.1.17" TYPE="TextContent" ORDER="17" DMDID="c064" LABEL="EINIGES UEBER DIE BEDEUTUNG VON GROESSENVORSTELLUNGEN IN DER ARCHITEKTUR">
 					<div ID="L.1.1.17.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00052" BEGIN="P52_TB00002"/>

--- a/metadata/periodicals/bmtnabe/issues/1900/02_01/bmtnabe_1900-02_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1900/02_01/bmtnabe_1900-02_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1900-02_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1900-02_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1900-02_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1900-02_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1900-02_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1900-02_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1900-02_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -7615,806 +7611,540 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T18:23:42" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="cd4673a5b6681a595873e345a002d75a59b60519" CHECKSUMTYPE="SHA-1" SIZE="5125629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T18:24:09" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="6c90518b096badf7e85b2536ec5d883609b60ab4" CHECKSUMTYPE="SHA-1" SIZE="5237229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T18:24:35" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="385e1e90ec223c99479a99e1641f1e1f40faf8cd" CHECKSUMTYPE="SHA-1" SIZE="5189527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T18:24:59" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="cdff6205918b8c6c9128a3223a5961154a48deaa" CHECKSUMTYPE="SHA-1" SIZE="5242629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T18:25:21" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="ecb9af23640ce6a7cf75740edcde8237c2402cc6" CHECKSUMTYPE="SHA-1" SIZE="5196721">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T18:25:48" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="33970225f1b2732486a48a4f2f6736d50d5c65b7" CHECKSUMTYPE="SHA-1" SIZE="5268725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T18:26:13" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="e43834ccfc51e08f826fee9fd36c4aeb61543913" CHECKSUMTYPE="SHA-1" SIZE="5229128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T18:26:38" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="5ef7179bdb152dcceb14e4c055d2ec24e7f772ad" CHECKSUMTYPE="SHA-1" SIZE="5245224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T18:27:00" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="dba5a99496bfba8f72f2c27e888cb79d2eb35a80" CHECKSUMTYPE="SHA-1" SIZE="5195823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T18:27:27" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="4a0131a2e6caaebb91012834ee70f138b8238b05" CHECKSUMTYPE="SHA-1" SIZE="5140024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T18:27:50" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="3af03077d6a28df0e8ce5833aedc62e0b4cc0dfa" CHECKSUMTYPE="SHA-1" SIZE="5159787">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T18:28:14" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="c02ed048fadf27746ee497b1eb4488948c51fb11" CHECKSUMTYPE="SHA-1" SIZE="5282225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T18:28:42" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="6b95dbfada9dfd1bc47ca9789c283a5050383b43" CHECKSUMTYPE="SHA-1" SIZE="5146329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T18:29:07" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="34a2c153c1c4bf9ae9e38e133c5c1fe69b96c31b" CHECKSUMTYPE="SHA-1" SIZE="5308327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T18:29:33" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="533575e1c473791031cec0543dbb1a1f495025ae" CHECKSUMTYPE="SHA-1" SIZE="5184127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T18:29:58" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="abba6524b0cd767a2fe4a781b9b752700d5c0f70" CHECKSUMTYPE="SHA-1" SIZE="5294816">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T18:30:24" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="623f394885ca5ace54f1b7c46623fc98749392f3" CHECKSUMTYPE="SHA-1" SIZE="5139938">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T18:30:47" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="41fdef6b2d76af6a34a12da293bd29046860abf2" CHECKSUMTYPE="SHA-1" SIZE="5221027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T18:31:11" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="a2fa63eb6b3050b5825b492273be4e71bf1ab1f9" CHECKSUMTYPE="SHA-1" SIZE="5203927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T18:31:38" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="96e6697ddf55ad007db2e7a9b23a50a2cf54eb2a" CHECKSUMTYPE="SHA-1" SIZE="5279529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T18:32:01" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="9b6d2e4a9589f893a551f3b64d5ab6f56c773f9f" CHECKSUMTYPE="SHA-1" SIZE="5211080">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T18:32:27" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="3561dc698ca11dacf85d481e3559698d121d3974" CHECKSUMTYPE="SHA-1" SIZE="5259728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T18:32:51" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="26d237a1963797a4bd11e5a40ae6174e247ac2bc" CHECKSUMTYPE="SHA-1" SIZE="5197605">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T18:33:16" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="350991a3a2d2358a95d43458e9df6afae60c83fc" CHECKSUMTYPE="SHA-1" SIZE="5294828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T18:33:40" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="d1b98ac3047150e8b0a8491488f9512399573169" CHECKSUMTYPE="SHA-1" SIZE="5222829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T18:34:06" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="9297f20932b0524a7c94a75d4e36b534c817c70b" CHECKSUMTYPE="SHA-1" SIZE="5296625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T18:34:32" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="bc4417a220a93558c390af1d300cc7a340ccc60f" CHECKSUMTYPE="SHA-1" SIZE="5226428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T18:34:56" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="f4df2ec325b0d637197bf245c8a00310b56396e3" CHECKSUMTYPE="SHA-1" SIZE="5242627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T18:35:20" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="f3206c3786024b26f5227a930802145d85e5e9e0" CHECKSUMTYPE="SHA-1" SIZE="5215626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T18:35:45" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="a1c7fe2e14254ed4c179e04ea487a1fc317c17cc" CHECKSUMTYPE="SHA-1" SIZE="5280429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T18:36:08" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="108f37502e0460c61a8e7c6a60d4e1dd023f3411" CHECKSUMTYPE="SHA-1" SIZE="5170629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T18:36:32" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="04822dce60e374bd3829fd245d2c8e46fd11737b" CHECKSUMTYPE="SHA-1" SIZE="5248929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T18:36:56" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="ca114a4b9eb2cdfd59585d4cb56bedb0c4147bc8" CHECKSUMTYPE="SHA-1" SIZE="5203928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T18:37:21" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="8b75bdb9dc5d3883a68eca0a5368d0b6b39944a9" CHECKSUMTYPE="SHA-1" SIZE="5238126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T18:37:45" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="05deffc790184cbb1033e5325a08ae65d7373587" CHECKSUMTYPE="SHA-1" SIZE="5194921">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T18:38:08" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="fa148a69cc48e76e5b1dfff012ddd5c85331e082" CHECKSUMTYPE="SHA-1" SIZE="5253427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T18:38:33" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="41bc87a0f11a478fc77b360c33f2989b56151215" CHECKSUMTYPE="SHA-1" SIZE="5247105">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T18:38:56" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="9730b7ea1f0128fe3dd29bf372cee557891cfd76" CHECKSUMTYPE="SHA-1" SIZE="5257027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T18:39:20" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="6e551a68e73965abf37f1353172a24a1b779cbb8" CHECKSUMTYPE="SHA-1" SIZE="5200328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T18:39:45" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="708e12041eaeaf16afdd16cf0a6cb3f153b42b23" CHECKSUMTYPE="SHA-1" SIZE="5220990">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T18:40:08" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="f51a6aa168f202218cbcdcdb9c19d3e67af68bae" CHECKSUMTYPE="SHA-1" SIZE="5199425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T18:40:32" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="1d6b7524c29a187c567761c09b005bb2a897b0fa" CHECKSUMTYPE="SHA-1" SIZE="5245318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T18:40:57" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="89c394724537122e7c951f3e37dc73d97f74f445" CHECKSUMTYPE="SHA-1" SIZE="5218328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T18:41:20" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="adb67b2827932c60c48c6dee8828ccabe632d9b3" CHECKSUMTYPE="SHA-1" SIZE="5289425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T18:41:45" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="264f451e5dc6ae4c3a0bb2275cfe5d03fc742a9d" CHECKSUMTYPE="SHA-1" SIZE="5213829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T18:42:10" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="ad674057431f6577cf4abcdc5f47c594ed343f9d" CHECKSUMTYPE="SHA-1" SIZE="5258826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T18:42:35" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="4241f51cea822d2c3793f1f4fb627979f76dd5dc" CHECKSUMTYPE="SHA-1" SIZE="5266021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T18:42:59" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="785dee2d5de3d198872597a8a4843838a9b2b889" CHECKSUMTYPE="SHA-1" SIZE="5242629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T18:43:22" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="6bb2256bec57307180c8cd0965591ccc257794ab" CHECKSUMTYPE="SHA-1" SIZE="5225528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T18:43:45" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="6f7e696837f75a7669a52e594f48cdd43158c82a" CHECKSUMTYPE="SHA-1" SIZE="5292124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T18:44:09" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="ab9c65f519c8b52abf7c0998a6054ba4474d3779" CHECKSUMTYPE="SHA-1" SIZE="5204805">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T18:44:35" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="0afda6a9f845630c43c6025b6cf9a6420223846f" CHECKSUMTYPE="SHA-1" SIZE="5293911">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T18:45:00" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="08efbc2104777fbd9083f48fefb3074e7c2c3f70" CHECKSUMTYPE="SHA-1" SIZE="5261388">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T18:45:24" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="c2ffd5a10a9d90dbe8772436aef52665c38d90d7" CHECKSUMTYPE="SHA-1" SIZE="5221028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T18:45:49" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="66d094001ec33f09dd189a99ce12d97927d49f69" CHECKSUMTYPE="SHA-1" SIZE="5236326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T18:46:14" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="c53ef939208a214507365d2358ad83d079d18cc6" CHECKSUMTYPE="SHA-1" SIZE="5215612">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T18:46:40" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="4f00d5d42132bd96a3bcab823f91c753ccbaa9f4" CHECKSUMTYPE="SHA-1" SIZE="5219228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T18:47:03" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="ef3d0807173262cd51f7afa8149184ce85b2c212" CHECKSUMTYPE="SHA-1" SIZE="5200329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:47:27" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="1c728fddb89b87d0bc9bb061f83e238389081c2d" CHECKSUMTYPE="SHA-1" SIZE="5201229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:47:50" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="c79487120e375c03dd91059eaf0d8c6a176d08bd" CHECKSUMTYPE="SHA-1" SIZE="5240828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:48:15" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="ab555e89f76909b23e50997845c9cac1f9d305ec" CHECKSUMTYPE="SHA-1" SIZE="5222824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:48:44" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="028cfa06bbb8099ca4ab74b49b0d7919c1d223fa" CHECKSUMTYPE="SHA-1" SIZE="5255228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:49:10" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="386ef6d0651ccf743d5483ecf3f219ebf4f6b4e2" CHECKSUMTYPE="SHA-1" SIZE="5234365">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:49:37" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="f4c6e308d7c2d3c7e5d4ab16558a48d071fe629a" CHECKSUMTYPE="SHA-1" SIZE="5260611">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:50:00" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="efa1bb8dff173007514bf3c5a69d71d4cc8b0579" CHECKSUMTYPE="SHA-1" SIZE="5206628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:50:24" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="9434332ebf254cdb0229c86705adca36048265b3" CHECKSUMTYPE="SHA-1" SIZE="5191327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:50:50" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="ab48de6931d85730b89d2a34f0e3cf815072eb58" CHECKSUMTYPE="SHA-1" SIZE="5212029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:51:16" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="b37f0cac654a61cd776b12fc81da6758cc9e4664" CHECKSUMTYPE="SHA-1" SIZE="5220125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:51:41" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="7e6c122a2b2953e41da2886f27f868fd1748830d" CHECKSUMTYPE="SHA-1" SIZE="5264225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:52:06" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="0aa61544569a9c8b811393f3809e9966b76a0826" CHECKSUMTYPE="SHA-1" SIZE="5242608">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:52:32" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="23ba1c64aa65e4c1a2262703014161b5d5c797d2" CHECKSUMTYPE="SHA-1" SIZE="5222776">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:52:58" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="9c6a45acbf47fa1cdd297da39a501e1b724ba081" CHECKSUMTYPE="SHA-1" SIZE="5252529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:53:22" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="55bf98648e9d470de397eee293579651193ec36d" CHECKSUMTYPE="SHA-1" SIZE="5127429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:53:45" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="923bb77d39dcf34f08300bf1d83ee8c031889773" CHECKSUMTYPE="SHA-1" SIZE="5224621">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:54:09" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="9bfbd4b7c67dd54dfc373cda7841bcf1a5d22045" CHECKSUMTYPE="SHA-1" SIZE="5164236">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:54:34" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="24c46bae2ffa08aaaded79f9257f2822128327fd" CHECKSUMTYPE="SHA-1" SIZE="5196727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:54:57" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="a7e02eb3de15e1dbabc52d454483cfbae26733e1" CHECKSUMTYPE="SHA-1" SIZE="5202999">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:55:22" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="be51ce48849979a9ba5d0c278f50b0b6ce2adcec" CHECKSUMTYPE="SHA-1" SIZE="5206628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:55:47" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="17d021529cd37331ef19b5423b048f3c555cdce0" CHECKSUMTYPE="SHA-1" SIZE="5193997">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:56:13" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="9e4f9db855460218f19a96e2457f0bc472c4a997" CHECKSUMTYPE="SHA-1" SIZE="5231825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:56:38" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="401d4a6b76d22de2b91ff6fabe617c4479c6442a" CHECKSUMTYPE="SHA-1" SIZE="5166086">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:57:01" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="a1a3418b1874fde6d69e7ede4aa609cadd39db7d" CHECKSUMTYPE="SHA-1" SIZE="5212929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:57:23" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="ab95e9bbe0e44242eb3720977f2e91cb155a9332" CHECKSUMTYPE="SHA-1" SIZE="5176028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:57:45" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="b3e33ea1038f71cb65817c81b2d4b41b59d03915" CHECKSUMTYPE="SHA-1" SIZE="5211129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:58:09" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="4739dd534ce6b39538d6405615855f7744bdf76f" CHECKSUMTYPE="SHA-1" SIZE="5093200">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:58:33" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="3903c2b7607df935ac1d898be57df3506fc2124f" CHECKSUMTYPE="SHA-1" SIZE="5231827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T18:58:58" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="d01befd543828fb7b5eea2ffb2f8b9196beff249" CHECKSUMTYPE="SHA-1" SIZE="5296629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T18:59:25" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="c3a3861d8cd406d217a5204ddac6c914e73534c2" CHECKSUMTYPE="SHA-1" SIZE="5277729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0088.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T18:23:42" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="cd4673a5b6681a595873e345a002d75a59b60519" CHECKSUMTYPE="SHA-1" SIZE="5125629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T18:24:09" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="6c90518b096badf7e85b2536ec5d883609b60ab4" CHECKSUMTYPE="SHA-1" SIZE="5237229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T18:24:35" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="385e1e90ec223c99479a99e1641f1e1f40faf8cd" CHECKSUMTYPE="SHA-1" SIZE="5189527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T18:24:59" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="cdff6205918b8c6c9128a3223a5961154a48deaa" CHECKSUMTYPE="SHA-1" SIZE="5242629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T18:25:21" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="ecb9af23640ce6a7cf75740edcde8237c2402cc6" CHECKSUMTYPE="SHA-1" SIZE="5196721">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T18:25:48" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="33970225f1b2732486a48a4f2f6736d50d5c65b7" CHECKSUMTYPE="SHA-1" SIZE="5268725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T18:26:13" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="e43834ccfc51e08f826fee9fd36c4aeb61543913" CHECKSUMTYPE="SHA-1" SIZE="5229128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T18:26:38" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="5ef7179bdb152dcceb14e4c055d2ec24e7f772ad" CHECKSUMTYPE="SHA-1" SIZE="5245224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T18:27:00" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="dba5a99496bfba8f72f2c27e888cb79d2eb35a80" CHECKSUMTYPE="SHA-1" SIZE="5195823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T18:27:27" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="4a0131a2e6caaebb91012834ee70f138b8238b05" CHECKSUMTYPE="SHA-1" SIZE="5140024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T18:27:50" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="3af03077d6a28df0e8ce5833aedc62e0b4cc0dfa" CHECKSUMTYPE="SHA-1" SIZE="5159787">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T18:28:14" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="c02ed048fadf27746ee497b1eb4488948c51fb11" CHECKSUMTYPE="SHA-1" SIZE="5282225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T18:28:42" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="6b95dbfada9dfd1bc47ca9789c283a5050383b43" CHECKSUMTYPE="SHA-1" SIZE="5146329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T18:29:07" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="34a2c153c1c4bf9ae9e38e133c5c1fe69b96c31b" CHECKSUMTYPE="SHA-1" SIZE="5308327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T18:29:33" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="533575e1c473791031cec0543dbb1a1f495025ae" CHECKSUMTYPE="SHA-1" SIZE="5184127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T18:29:58" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="abba6524b0cd767a2fe4a781b9b752700d5c0f70" CHECKSUMTYPE="SHA-1" SIZE="5294816">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T18:30:24" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="623f394885ca5ace54f1b7c46623fc98749392f3" CHECKSUMTYPE="SHA-1" SIZE="5139938">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T18:30:47" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="41fdef6b2d76af6a34a12da293bd29046860abf2" CHECKSUMTYPE="SHA-1" SIZE="5221027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T18:31:11" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="a2fa63eb6b3050b5825b492273be4e71bf1ab1f9" CHECKSUMTYPE="SHA-1" SIZE="5203927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T18:31:38" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="96e6697ddf55ad007db2e7a9b23a50a2cf54eb2a" CHECKSUMTYPE="SHA-1" SIZE="5279529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T18:32:01" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="9b6d2e4a9589f893a551f3b64d5ab6f56c773f9f" CHECKSUMTYPE="SHA-1" SIZE="5211080">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T18:32:27" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="3561dc698ca11dacf85d481e3559698d121d3974" CHECKSUMTYPE="SHA-1" SIZE="5259728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T18:32:51" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="26d237a1963797a4bd11e5a40ae6174e247ac2bc" CHECKSUMTYPE="SHA-1" SIZE="5197605">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T18:33:16" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="350991a3a2d2358a95d43458e9df6afae60c83fc" CHECKSUMTYPE="SHA-1" SIZE="5294828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T18:33:40" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="d1b98ac3047150e8b0a8491488f9512399573169" CHECKSUMTYPE="SHA-1" SIZE="5222829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T18:34:06" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="9297f20932b0524a7c94a75d4e36b534c817c70b" CHECKSUMTYPE="SHA-1" SIZE="5296625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T18:34:32" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="bc4417a220a93558c390af1d300cc7a340ccc60f" CHECKSUMTYPE="SHA-1" SIZE="5226428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T18:34:56" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="f4df2ec325b0d637197bf245c8a00310b56396e3" CHECKSUMTYPE="SHA-1" SIZE="5242627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T18:35:20" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="f3206c3786024b26f5227a930802145d85e5e9e0" CHECKSUMTYPE="SHA-1" SIZE="5215626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T18:35:45" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="a1c7fe2e14254ed4c179e04ea487a1fc317c17cc" CHECKSUMTYPE="SHA-1" SIZE="5280429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T18:36:08" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="108f37502e0460c61a8e7c6a60d4e1dd023f3411" CHECKSUMTYPE="SHA-1" SIZE="5170629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T18:36:32" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="04822dce60e374bd3829fd245d2c8e46fd11737b" CHECKSUMTYPE="SHA-1" SIZE="5248929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T18:36:56" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="ca114a4b9eb2cdfd59585d4cb56bedb0c4147bc8" CHECKSUMTYPE="SHA-1" SIZE="5203928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T18:37:21" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="8b75bdb9dc5d3883a68eca0a5368d0b6b39944a9" CHECKSUMTYPE="SHA-1" SIZE="5238126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T18:37:45" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="05deffc790184cbb1033e5325a08ae65d7373587" CHECKSUMTYPE="SHA-1" SIZE="5194921">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T18:38:08" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="fa148a69cc48e76e5b1dfff012ddd5c85331e082" CHECKSUMTYPE="SHA-1" SIZE="5253427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T18:38:33" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="41bc87a0f11a478fc77b360c33f2989b56151215" CHECKSUMTYPE="SHA-1" SIZE="5247105">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T18:38:56" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="9730b7ea1f0128fe3dd29bf372cee557891cfd76" CHECKSUMTYPE="SHA-1" SIZE="5257027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T18:39:20" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="6e551a68e73965abf37f1353172a24a1b779cbb8" CHECKSUMTYPE="SHA-1" SIZE="5200328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T18:39:45" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="708e12041eaeaf16afdd16cf0a6cb3f153b42b23" CHECKSUMTYPE="SHA-1" SIZE="5220990">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T18:40:08" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="f51a6aa168f202218cbcdcdb9c19d3e67af68bae" CHECKSUMTYPE="SHA-1" SIZE="5199425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T18:40:32" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="1d6b7524c29a187c567761c09b005bb2a897b0fa" CHECKSUMTYPE="SHA-1" SIZE="5245318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T18:40:57" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="89c394724537122e7c951f3e37dc73d97f74f445" CHECKSUMTYPE="SHA-1" SIZE="5218328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T18:41:20" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="adb67b2827932c60c48c6dee8828ccabe632d9b3" CHECKSUMTYPE="SHA-1" SIZE="5289425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T18:41:45" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="264f451e5dc6ae4c3a0bb2275cfe5d03fc742a9d" CHECKSUMTYPE="SHA-1" SIZE="5213829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T18:42:10" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="ad674057431f6577cf4abcdc5f47c594ed343f9d" CHECKSUMTYPE="SHA-1" SIZE="5258826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T18:42:35" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="4241f51cea822d2c3793f1f4fb627979f76dd5dc" CHECKSUMTYPE="SHA-1" SIZE="5266021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T18:42:59" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="785dee2d5de3d198872597a8a4843838a9b2b889" CHECKSUMTYPE="SHA-1" SIZE="5242629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T18:43:22" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="6bb2256bec57307180c8cd0965591ccc257794ab" CHECKSUMTYPE="SHA-1" SIZE="5225528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T18:43:45" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="6f7e696837f75a7669a52e594f48cdd43158c82a" CHECKSUMTYPE="SHA-1" SIZE="5292124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T18:44:09" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="ab9c65f519c8b52abf7c0998a6054ba4474d3779" CHECKSUMTYPE="SHA-1" SIZE="5204805">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T18:44:35" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="0afda6a9f845630c43c6025b6cf9a6420223846f" CHECKSUMTYPE="SHA-1" SIZE="5293911">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T18:45:00" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="08efbc2104777fbd9083f48fefb3074e7c2c3f70" CHECKSUMTYPE="SHA-1" SIZE="5261388">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T18:45:24" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="c2ffd5a10a9d90dbe8772436aef52665c38d90d7" CHECKSUMTYPE="SHA-1" SIZE="5221028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T18:45:49" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="66d094001ec33f09dd189a99ce12d97927d49f69" CHECKSUMTYPE="SHA-1" SIZE="5236326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T18:46:14" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="c53ef939208a214507365d2358ad83d079d18cc6" CHECKSUMTYPE="SHA-1" SIZE="5215612">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T18:46:40" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="4f00d5d42132bd96a3bcab823f91c753ccbaa9f4" CHECKSUMTYPE="SHA-1" SIZE="5219228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T18:47:03" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="ef3d0807173262cd51f7afa8149184ce85b2c212" CHECKSUMTYPE="SHA-1" SIZE="5200329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:47:27" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="1c728fddb89b87d0bc9bb061f83e238389081c2d" CHECKSUMTYPE="SHA-1" SIZE="5201229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:47:50" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="c79487120e375c03dd91059eaf0d8c6a176d08bd" CHECKSUMTYPE="SHA-1" SIZE="5240828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:48:15" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="ab555e89f76909b23e50997845c9cac1f9d305ec" CHECKSUMTYPE="SHA-1" SIZE="5222824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:48:44" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="028cfa06bbb8099ca4ab74b49b0d7919c1d223fa" CHECKSUMTYPE="SHA-1" SIZE="5255228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:49:10" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="386ef6d0651ccf743d5483ecf3f219ebf4f6b4e2" CHECKSUMTYPE="SHA-1" SIZE="5234365">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:49:37" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="f4c6e308d7c2d3c7e5d4ab16558a48d071fe629a" CHECKSUMTYPE="SHA-1" SIZE="5260611">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:50:00" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="efa1bb8dff173007514bf3c5a69d71d4cc8b0579" CHECKSUMTYPE="SHA-1" SIZE="5206628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:50:24" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="9434332ebf254cdb0229c86705adca36048265b3" CHECKSUMTYPE="SHA-1" SIZE="5191327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:50:50" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="ab48de6931d85730b89d2a34f0e3cf815072eb58" CHECKSUMTYPE="SHA-1" SIZE="5212029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:51:16" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="b37f0cac654a61cd776b12fc81da6758cc9e4664" CHECKSUMTYPE="SHA-1" SIZE="5220125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:51:41" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="7e6c122a2b2953e41da2886f27f868fd1748830d" CHECKSUMTYPE="SHA-1" SIZE="5264225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:52:06" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="0aa61544569a9c8b811393f3809e9966b76a0826" CHECKSUMTYPE="SHA-1" SIZE="5242608">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:52:32" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="23ba1c64aa65e4c1a2262703014161b5d5c797d2" CHECKSUMTYPE="SHA-1" SIZE="5222776">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:52:58" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="9c6a45acbf47fa1cdd297da39a501e1b724ba081" CHECKSUMTYPE="SHA-1" SIZE="5252529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:53:22" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="55bf98648e9d470de397eee293579651193ec36d" CHECKSUMTYPE="SHA-1" SIZE="5127429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:53:45" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="923bb77d39dcf34f08300bf1d83ee8c031889773" CHECKSUMTYPE="SHA-1" SIZE="5224621">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:54:09" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="9bfbd4b7c67dd54dfc373cda7841bcf1a5d22045" CHECKSUMTYPE="SHA-1" SIZE="5164236">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T18:54:34" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="24c46bae2ffa08aaaded79f9257f2822128327fd" CHECKSUMTYPE="SHA-1" SIZE="5196727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T18:54:57" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="a7e02eb3de15e1dbabc52d454483cfbae26733e1" CHECKSUMTYPE="SHA-1" SIZE="5202999">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T18:55:22" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="be51ce48849979a9ba5d0c278f50b0b6ce2adcec" CHECKSUMTYPE="SHA-1" SIZE="5206628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T18:55:47" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="17d021529cd37331ef19b5423b048f3c555cdce0" CHECKSUMTYPE="SHA-1" SIZE="5193997">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T18:56:13" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="9e4f9db855460218f19a96e2457f0bc472c4a997" CHECKSUMTYPE="SHA-1" SIZE="5231825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T18:56:38" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="401d4a6b76d22de2b91ff6fabe617c4479c6442a" CHECKSUMTYPE="SHA-1" SIZE="5166086">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T18:57:01" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="a1a3418b1874fde6d69e7ede4aa609cadd39db7d" CHECKSUMTYPE="SHA-1" SIZE="5212929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T18:57:23" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="ab95e9bbe0e44242eb3720977f2e91cb155a9332" CHECKSUMTYPE="SHA-1" SIZE="5176028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T18:57:45" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="b3e33ea1038f71cb65817c81b2d4b41b59d03915" CHECKSUMTYPE="SHA-1" SIZE="5211129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T18:58:09" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="4739dd534ce6b39538d6405615855f7744bdf76f" CHECKSUMTYPE="SHA-1" SIZE="5093200">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T18:58:33" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="3903c2b7607df935ac1d898be57df3506fc2124f" CHECKSUMTYPE="SHA-1" SIZE="5231827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T18:58:58" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="d01befd543828fb7b5eea2ffb2f8b9196beff249" CHECKSUMTYPE="SHA-1" SIZE="5296629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T18:59:25" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="c3a3861d8cd406d217a5204ddac6c914e73534c2" CHECKSUMTYPE="SHA-1" SIZE="5277729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/delivery/bmtnabe_1900-02_01_0088.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:59:40" MIMETYPE="text/xml" CHECKSUM="2dcccb3e52a5c57594470e6d5defd24fe9d2b3b4"
-				CHECKSUMTYPE="SHA-1" SIZE="2108">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T18:59:40" MIMETYPE="text/xml" CHECKSUM="2dcccb3e52a5c57594470e6d5defd24fe9d2b3b4" CHECKSUMTYPE="SHA-1" SIZE="2108">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:59:40" MIMETYPE="text/xml" CHECKSUM="0fbd639ab68a845be56f4af3845ee3affa6ae89a"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T18:59:40" MIMETYPE="text/xml" CHECKSUM="0fbd639ab68a845be56f4af3845ee3affa6ae89a" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:59:40" MIMETYPE="text/xml" CHECKSUM="59c5636b52028d963cc04ccc2610577648886bd6"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T18:59:40" MIMETYPE="text/xml" CHECKSUM="59c5636b52028d963cc04ccc2610577648886bd6" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:59:40" MIMETYPE="text/xml" CHECKSUM="517d853f21b7a6c3939f3c0d5451aad67d3f4e31"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T18:59:40" MIMETYPE="text/xml" CHECKSUM="517d853f21b7a6c3939f3c0d5451aad67d3f4e31" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:59:41" MIMETYPE="text/xml" CHECKSUM="ced8553f526394f7b539d1179e2f557d3c12d483"
-				CHECKSUMTYPE="SHA-1" SIZE="7921">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T18:59:41" MIMETYPE="text/xml" CHECKSUM="ced8553f526394f7b539d1179e2f557d3c12d483" CHECKSUMTYPE="SHA-1" SIZE="7921">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:59:41" MIMETYPE="text/xml" CHECKSUM="21a3b3a620188bfa409aee8a1d0491efe49661fe"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T18:59:41" MIMETYPE="text/xml" CHECKSUM="21a3b3a620188bfa409aee8a1d0491efe49661fe" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:59:41" MIMETYPE="text/xml" CHECKSUM="1d9fe772591a6047db584e668b69b897d81fa3d7"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T18:59:41" MIMETYPE="text/xml" CHECKSUM="1d9fe772591a6047db584e668b69b897d81fa3d7" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:59:41" MIMETYPE="text/xml" CHECKSUM="4dfdf923b57b16b6ff86786e1e47900fd632736b"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T18:59:41" MIMETYPE="text/xml" CHECKSUM="4dfdf923b57b16b6ff86786e1e47900fd632736b" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:59:42" MIMETYPE="text/xml" CHECKSUM="c193c1b941e6db81505f32573193cc156bfe3b1d"
-				CHECKSUMTYPE="SHA-1" SIZE="13112">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T18:59:42" MIMETYPE="text/xml" CHECKSUM="c193c1b941e6db81505f32573193cc156bfe3b1d" CHECKSUMTYPE="SHA-1" SIZE="13112">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:59:42" MIMETYPE="text/xml"
-				CHECKSUM="ddee19ba6b7daf7cc3f633d26899ff6c1dc35b40" CHECKSUMTYPE="SHA-1" SIZE="3425">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T18:59:42" MIMETYPE="text/xml" CHECKSUM="ddee19ba6b7daf7cc3f633d26899ff6c1dc35b40" CHECKSUMTYPE="SHA-1" SIZE="3425">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:59:42" MIMETYPE="text/xml"
-				CHECKSUM="6fc4c63afc83fb452438caab334460de0db0c854" CHECKSUMTYPE="SHA-1" SIZE="1713">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T18:59:42" MIMETYPE="text/xml" CHECKSUM="6fc4c63afc83fb452438caab334460de0db0c854" CHECKSUMTYPE="SHA-1" SIZE="1713">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:59:42" MIMETYPE="text/xml"
-				CHECKSUM="2c8ac4556603160285fc43e5d505ed6cccdb6d78" CHECKSUMTYPE="SHA-1" SIZE="5627">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T18:59:42" MIMETYPE="text/xml" CHECKSUM="2c8ac4556603160285fc43e5d505ed6cccdb6d78" CHECKSUMTYPE="SHA-1" SIZE="5627">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:59:43" MIMETYPE="text/xml"
-				CHECKSUM="20d9df94401f2f643b4d17be35efc07829aaa5cf" CHECKSUMTYPE="SHA-1" SIZE="27102">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T18:59:43" MIMETYPE="text/xml" CHECKSUM="20d9df94401f2f643b4d17be35efc07829aaa5cf" CHECKSUMTYPE="SHA-1" SIZE="27102">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:59:43" MIMETYPE="text/xml"
-				CHECKSUM="77c79df3b76c759fac9444bae46539de8471a18f" CHECKSUMTYPE="SHA-1" SIZE="56630">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T18:59:43" MIMETYPE="text/xml" CHECKSUM="77c79df3b76c759fac9444bae46539de8471a18f" CHECKSUMTYPE="SHA-1" SIZE="56630">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:59:43" MIMETYPE="text/xml"
-				CHECKSUM="4e4d83b40834f207d30149e2ffbef7ff1743dbbb" CHECKSUMTYPE="SHA-1" SIZE="53176">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T18:59:43" MIMETYPE="text/xml" CHECKSUM="4e4d83b40834f207d30149e2ffbef7ff1743dbbb" CHECKSUMTYPE="SHA-1" SIZE="53176">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:59:43" MIMETYPE="text/xml"
-				CHECKSUM="66303d01dabf18d47c9e638fb27677a68eb1ce81" CHECKSUMTYPE="SHA-1" SIZE="43873">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T18:59:43" MIMETYPE="text/xml" CHECKSUM="66303d01dabf18d47c9e638fb27677a68eb1ce81" CHECKSUMTYPE="SHA-1" SIZE="43873">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:59:44" MIMETYPE="text/xml"
-				CHECKSUM="7a1cfbd728865187c9581e77469802069a711d5a" CHECKSUMTYPE="SHA-1" SIZE="5329">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T18:59:44" MIMETYPE="text/xml" CHECKSUM="7a1cfbd728865187c9581e77469802069a711d5a" CHECKSUMTYPE="SHA-1" SIZE="5329">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:59:44" MIMETYPE="text/xml"
-				CHECKSUM="96d68e7fbe8c03f08abbfd06cd9a6ba43c8fe043" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T18:59:44" MIMETYPE="text/xml" CHECKSUM="96d68e7fbe8c03f08abbfd06cd9a6ba43c8fe043" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:59:44" MIMETYPE="text/xml"
-				CHECKSUM="551fd118a3016016b2a5c781a903f5ca08fdbc0a" CHECKSUMTYPE="SHA-1" SIZE="41036">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T18:59:44" MIMETYPE="text/xml" CHECKSUM="551fd118a3016016b2a5c781a903f5ca08fdbc0a" CHECKSUMTYPE="SHA-1" SIZE="41036">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:59:45" MIMETYPE="text/xml"
-				CHECKSUM="6da241aaa12974d905a50ec9f32a6068a8672678" CHECKSUMTYPE="SHA-1" SIZE="40308">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T18:59:45" MIMETYPE="text/xml" CHECKSUM="6da241aaa12974d905a50ec9f32a6068a8672678" CHECKSUMTYPE="SHA-1" SIZE="40308">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:59:45" MIMETYPE="text/xml"
-				CHECKSUM="336a0c668b5939683ebcaac2ba7fae47fdd06d45" CHECKSUMTYPE="SHA-1" SIZE="4967">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T18:59:45" MIMETYPE="text/xml" CHECKSUM="336a0c668b5939683ebcaac2ba7fae47fdd06d45" CHECKSUMTYPE="SHA-1" SIZE="4967">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:59:45" MIMETYPE="text/xml"
-				CHECKSUM="7f99261dfc92154793e44b4ca1c5ad94548e72ad" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T18:59:45" MIMETYPE="text/xml" CHECKSUM="7f99261dfc92154793e44b4ca1c5ad94548e72ad" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:59:45" MIMETYPE="text/xml"
-				CHECKSUM="dadaaf65b80fe46000eb0046aeff15ffa035e60f" CHECKSUMTYPE="SHA-1" SIZE="80319">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T18:59:45" MIMETYPE="text/xml" CHECKSUM="dadaaf65b80fe46000eb0046aeff15ffa035e60f" CHECKSUMTYPE="SHA-1" SIZE="80319">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:59:46" MIMETYPE="text/xml"
-				CHECKSUM="0bce558ba7aa8d70cb0f005ff7d29fb2512fc3c8" CHECKSUMTYPE="SHA-1" SIZE="125169">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T18:59:46" MIMETYPE="text/xml" CHECKSUM="0bce558ba7aa8d70cb0f005ff7d29fb2512fc3c8" CHECKSUMTYPE="SHA-1" SIZE="125169">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:59:46" MIMETYPE="text/xml"
-				CHECKSUM="500d82923a77ec48a566707a5f14fc7564c2ea2c" CHECKSUMTYPE="SHA-1" SIZE="138183">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T18:59:46" MIMETYPE="text/xml" CHECKSUM="500d82923a77ec48a566707a5f14fc7564c2ea2c" CHECKSUMTYPE="SHA-1" SIZE="138183">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:59:46" MIMETYPE="text/xml"
-				CHECKSUM="841181bd8c080b409f9f3443f7451b4a21971ea2" CHECKSUMTYPE="SHA-1" SIZE="133150">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T18:59:46" MIMETYPE="text/xml" CHECKSUM="841181bd8c080b409f9f3443f7451b4a21971ea2" CHECKSUMTYPE="SHA-1" SIZE="133150">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:59:47" MIMETYPE="text/xml"
-				CHECKSUM="39d5adb59f571786ac9c5f23685a8106558322c3" CHECKSUMTYPE="SHA-1" SIZE="127754">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T18:59:47" MIMETYPE="text/xml" CHECKSUM="39d5adb59f571786ac9c5f23685a8106558322c3" CHECKSUMTYPE="SHA-1" SIZE="127754">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:59:47" MIMETYPE="text/xml"
-				CHECKSUM="ced0bd2aea539b82fe84eb4abe3d70c208c681a1" CHECKSUMTYPE="SHA-1" SIZE="137943">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T18:59:47" MIMETYPE="text/xml" CHECKSUM="ced0bd2aea539b82fe84eb4abe3d70c208c681a1" CHECKSUMTYPE="SHA-1" SIZE="137943">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:59:48" MIMETYPE="text/xml"
-				CHECKSUM="4f058ca7d86d8ecf72d2a719a0ae24a4fd97ac61" CHECKSUMTYPE="SHA-1" SIZE="114799">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T18:59:48" MIMETYPE="text/xml" CHECKSUM="4f058ca7d86d8ecf72d2a719a0ae24a4fd97ac61" CHECKSUMTYPE="SHA-1" SIZE="114799">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:59:48" MIMETYPE="text/xml"
-				CHECKSUM="00e3c186abea49600687de9c4684449846cd494d" CHECKSUMTYPE="SHA-1" SIZE="134371">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T18:59:48" MIMETYPE="text/xml" CHECKSUM="00e3c186abea49600687de9c4684449846cd494d" CHECKSUMTYPE="SHA-1" SIZE="134371">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:59:48" MIMETYPE="text/xml"
-				CHECKSUM="feae6dbaccf1641ef97ab30258d46e9e2285cc6f" CHECKSUMTYPE="SHA-1" SIZE="50456">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T18:59:48" MIMETYPE="text/xml" CHECKSUM="feae6dbaccf1641ef97ab30258d46e9e2285cc6f" CHECKSUMTYPE="SHA-1" SIZE="50456">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:59:49" MIMETYPE="text/xml"
-				CHECKSUM="3ff6dc9363f94e59a52828c0aa9585996fa0132b" CHECKSUMTYPE="SHA-1" SIZE="38157">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T18:59:49" MIMETYPE="text/xml" CHECKSUM="3ff6dc9363f94e59a52828c0aa9585996fa0132b" CHECKSUMTYPE="SHA-1" SIZE="38157">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:59:49" MIMETYPE="text/xml"
-				CHECKSUM="dc34a4ef7d68f93e157631a5e3b080dbf7ccfead" CHECKSUMTYPE="SHA-1" SIZE="4890">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T18:59:49" MIMETYPE="text/xml" CHECKSUM="dc34a4ef7d68f93e157631a5e3b080dbf7ccfead" CHECKSUMTYPE="SHA-1" SIZE="4890">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:59:49" MIMETYPE="text/xml"
-				CHECKSUM="266dfe037661f21e9a0a1d6f270878901f41b751" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T18:59:49" MIMETYPE="text/xml" CHECKSUM="266dfe037661f21e9a0a1d6f270878901f41b751" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:59:49" MIMETYPE="text/xml"
-				CHECKSUM="5b1923a9d84c785e47f1f0a3f88c168a95230be9" CHECKSUMTYPE="SHA-1" SIZE="61996">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T18:59:49" MIMETYPE="text/xml" CHECKSUM="5b1923a9d84c785e47f1f0a3f88c168a95230be9" CHECKSUMTYPE="SHA-1" SIZE="61996">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:59:50" MIMETYPE="text/xml"
-				CHECKSUM="afd678987530f4570b4bbddbe5a4b3b373c52dd5" CHECKSUMTYPE="SHA-1" SIZE="77713">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T18:59:50" MIMETYPE="text/xml" CHECKSUM="afd678987530f4570b4bbddbe5a4b3b373c52dd5" CHECKSUMTYPE="SHA-1" SIZE="77713">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:59:50" MIMETYPE="text/xml"
-				CHECKSUM="8142db26a00cc6113299cb86bb12e85c5e8a9971" CHECKSUMTYPE="SHA-1" SIZE="28421">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T18:59:50" MIMETYPE="text/xml" CHECKSUM="8142db26a00cc6113299cb86bb12e85c5e8a9971" CHECKSUMTYPE="SHA-1" SIZE="28421">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:59:50" MIMETYPE="text/xml"
-				CHECKSUM="eae11a7f1489cf41ba823a7a7a14935494bf0765" CHECKSUMTYPE="SHA-1" SIZE="40400">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T18:59:50" MIMETYPE="text/xml" CHECKSUM="eae11a7f1489cf41ba823a7a7a14935494bf0765" CHECKSUMTYPE="SHA-1" SIZE="40400">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:59:51" MIMETYPE="text/xml"
-				CHECKSUM="9bbc3affdc6adc51d9a9a32d509427db7c8ec90e" CHECKSUMTYPE="SHA-1" SIZE="5050">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T18:59:51" MIMETYPE="text/xml" CHECKSUM="9bbc3affdc6adc51d9a9a32d509427db7c8ec90e" CHECKSUMTYPE="SHA-1" SIZE="5050">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:59:51" MIMETYPE="text/xml"
-				CHECKSUM="3044ee53cb624ffa1ff18cd7f9055a37efb247f4" CHECKSUMTYPE="SHA-1" SIZE="2017">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T18:59:51" MIMETYPE="text/xml" CHECKSUM="3044ee53cb624ffa1ff18cd7f9055a37efb247f4" CHECKSUMTYPE="SHA-1" SIZE="2017">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:59:51" MIMETYPE="text/xml"
-				CHECKSUM="dd8a5633247b7c503ca7b3be81a4976312dc2191" CHECKSUMTYPE="SHA-1" SIZE="94144">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T18:59:51" MIMETYPE="text/xml" CHECKSUM="dd8a5633247b7c503ca7b3be81a4976312dc2191" CHECKSUMTYPE="SHA-1" SIZE="94144">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:59:51" MIMETYPE="text/xml"
-				CHECKSUM="9b026b6fb29939f93e6d1396993d32db2d3243bd" CHECKSUMTYPE="SHA-1" SIZE="196634">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T18:59:51" MIMETYPE="text/xml" CHECKSUM="9b026b6fb29939f93e6d1396993d32db2d3243bd" CHECKSUMTYPE="SHA-1" SIZE="196634">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:59:52" MIMETYPE="text/xml"
-				CHECKSUM="6739346efecc7261a57b0639999df07893e46a47" CHECKSUMTYPE="SHA-1" SIZE="192410">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T18:59:52" MIMETYPE="text/xml" CHECKSUM="6739346efecc7261a57b0639999df07893e46a47" CHECKSUMTYPE="SHA-1" SIZE="192410">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:59:52" MIMETYPE="text/xml"
-				CHECKSUM="ed7f13580b3048a96a8b95ca30a3010bd09631e5" CHECKSUMTYPE="SHA-1" SIZE="192842">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T18:59:52" MIMETYPE="text/xml" CHECKSUM="ed7f13580b3048a96a8b95ca30a3010bd09631e5" CHECKSUMTYPE="SHA-1" SIZE="192842">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:59:53" MIMETYPE="text/xml"
-				CHECKSUM="96a82860bdb100c9b06dc0c995e39d0881e69632" CHECKSUMTYPE="SHA-1" SIZE="191902">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T18:59:53" MIMETYPE="text/xml" CHECKSUM="96a82860bdb100c9b06dc0c995e39d0881e69632" CHECKSUMTYPE="SHA-1" SIZE="191902">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:59:53" MIMETYPE="text/xml"
-				CHECKSUM="30183a4b9c355cd2af9ae98e0a12b69922ad87ad" CHECKSUMTYPE="SHA-1" SIZE="196647">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T18:59:53" MIMETYPE="text/xml" CHECKSUM="30183a4b9c355cd2af9ae98e0a12b69922ad87ad" CHECKSUMTYPE="SHA-1" SIZE="196647">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:59:53" MIMETYPE="text/xml"
-				CHECKSUM="c83e25fb0bf1b504947dd418e08f0ec079a6f244" CHECKSUMTYPE="SHA-1" SIZE="201350">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T18:59:53" MIMETYPE="text/xml" CHECKSUM="c83e25fb0bf1b504947dd418e08f0ec079a6f244" CHECKSUMTYPE="SHA-1" SIZE="201350">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:59:54" MIMETYPE="text/xml"
-				CHECKSUM="90cc03c884cbed530da0d89f7f3cbc7e881af7bb" CHECKSUMTYPE="SHA-1" SIZE="110855">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T18:59:54" MIMETYPE="text/xml" CHECKSUM="90cc03c884cbed530da0d89f7f3cbc7e881af7bb" CHECKSUMTYPE="SHA-1" SIZE="110855">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:59:54" MIMETYPE="text/xml"
-				CHECKSUM="326ea7d69f46e247b1d17a2e90cc99931e54bdf7" CHECKSUMTYPE="SHA-1" SIZE="4776">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T18:59:54" MIMETYPE="text/xml" CHECKSUM="326ea7d69f46e247b1d17a2e90cc99931e54bdf7" CHECKSUMTYPE="SHA-1" SIZE="4776">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:59:54" MIMETYPE="text/xml"
-				CHECKSUM="4117cbd0c209628defb6739077d57cade1a60539" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T18:59:54" MIMETYPE="text/xml" CHECKSUM="4117cbd0c209628defb6739077d57cade1a60539" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:59:55" MIMETYPE="text/xml"
-				CHECKSUM="d3b52da42b44f7548e6c74867556ee9bdcb61223" CHECKSUMTYPE="SHA-1" SIZE="145368">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T18:59:55" MIMETYPE="text/xml" CHECKSUM="d3b52da42b44f7548e6c74867556ee9bdcb61223" CHECKSUMTYPE="SHA-1" SIZE="145368">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:59:55" MIMETYPE="text/xml"
-				CHECKSUM="59b17566941b9f65dd7e9014b497d9e5dfcfc2f5" CHECKSUMTYPE="SHA-1" SIZE="203616">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T18:59:55" MIMETYPE="text/xml" CHECKSUM="59b17566941b9f65dd7e9014b497d9e5dfcfc2f5" CHECKSUMTYPE="SHA-1" SIZE="203616">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:59:55" MIMETYPE="text/xml"
-				CHECKSUM="65e3fa5af9be3ba8598dd9587d10d20dc185cc05" CHECKSUMTYPE="SHA-1" SIZE="66061">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T18:59:55" MIMETYPE="text/xml" CHECKSUM="65e3fa5af9be3ba8598dd9587d10d20dc185cc05" CHECKSUMTYPE="SHA-1" SIZE="66061">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:59:56" MIMETYPE="text/xml"
-				CHECKSUM="478c816ddbec678bdbeecb88bd6fc9513127fcac" CHECKSUMTYPE="SHA-1" SIZE="192998">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T18:59:56" MIMETYPE="text/xml" CHECKSUM="478c816ddbec678bdbeecb88bd6fc9513127fcac" CHECKSUMTYPE="SHA-1" SIZE="192998">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:59:56" MIMETYPE="text/xml"
-				CHECKSUM="be49e7936c32533123e3f46de00b5d7d3bb0b430" CHECKSUMTYPE="SHA-1" SIZE="182609">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T18:59:56" MIMETYPE="text/xml" CHECKSUM="be49e7936c32533123e3f46de00b5d7d3bb0b430" CHECKSUMTYPE="SHA-1" SIZE="182609">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:59:56" MIMETYPE="text/xml"
-				CHECKSUM="26d378d15d9a99ce758300f500072d8f71171843" CHECKSUMTYPE="SHA-1" SIZE="186508">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T18:59:56" MIMETYPE="text/xml" CHECKSUM="26d378d15d9a99ce758300f500072d8f71171843" CHECKSUMTYPE="SHA-1" SIZE="186508">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:59:57" MIMETYPE="text/xml"
-				CHECKSUM="3b95b7f433e7fe14de95518430f5f1e8bb6f1f3a" CHECKSUMTYPE="SHA-1" SIZE="192120">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T18:59:57" MIMETYPE="text/xml" CHECKSUM="3b95b7f433e7fe14de95518430f5f1e8bb6f1f3a" CHECKSUMTYPE="SHA-1" SIZE="192120">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:59:57" MIMETYPE="text/xml"
-				CHECKSUM="fe24e0c16b810a129de4d81cac35f8ca2def99e9" CHECKSUMTYPE="SHA-1" SIZE="194805">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T18:59:57" MIMETYPE="text/xml" CHECKSUM="fe24e0c16b810a129de4d81cac35f8ca2def99e9" CHECKSUMTYPE="SHA-1" SIZE="194805">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:59:58" MIMETYPE="text/xml"
-				CHECKSUM="fe389a1c44a647ac558c072339e339eb8b13a689" CHECKSUMTYPE="SHA-1" SIZE="198969">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T18:59:58" MIMETYPE="text/xml" CHECKSUM="fe389a1c44a647ac558c072339e339eb8b13a689" CHECKSUMTYPE="SHA-1" SIZE="198969">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:59:58" MIMETYPE="text/xml"
-				CHECKSUM="78f482e4ad51aeef512057c22c5b4db0fdd5f1f4" CHECKSUMTYPE="SHA-1" SIZE="195269">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T18:59:58" MIMETYPE="text/xml" CHECKSUM="78f482e4ad51aeef512057c22c5b4db0fdd5f1f4" CHECKSUMTYPE="SHA-1" SIZE="195269">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:59:58" MIMETYPE="text/xml"
-				CHECKSUM="40e736f1b715a0a390ccef11aee7c588c73737f5" CHECKSUMTYPE="SHA-1" SIZE="189263">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T18:59:58" MIMETYPE="text/xml" CHECKSUM="40e736f1b715a0a390ccef11aee7c588c73737f5" CHECKSUMTYPE="SHA-1" SIZE="189263">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:59:59" MIMETYPE="text/xml"
-				CHECKSUM="6cf42a29579cfcd3c49673117d4e8f671e1df658" CHECKSUMTYPE="SHA-1" SIZE="191189">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T18:59:59" MIMETYPE="text/xml" CHECKSUM="6cf42a29579cfcd3c49673117d4e8f671e1df658" CHECKSUMTYPE="SHA-1" SIZE="191189">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:59:59" MIMETYPE="text/xml"
-				CHECKSUM="12326a97c0d1f5dec930407dd91931948020b7c9" CHECKSUMTYPE="SHA-1" SIZE="188384">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T18:59:59" MIMETYPE="text/xml" CHECKSUM="12326a97c0d1f5dec930407dd91931948020b7c9" CHECKSUMTYPE="SHA-1" SIZE="188384">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T19:00:00" MIMETYPE="text/xml"
-				CHECKSUM="4b73ac15da4b8f808220fddbe859d796799b98d7" CHECKSUMTYPE="SHA-1" SIZE="193368">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T19:00:00" MIMETYPE="text/xml" CHECKSUM="4b73ac15da4b8f808220fddbe859d796799b98d7" CHECKSUMTYPE="SHA-1" SIZE="193368">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T19:00:00" MIMETYPE="text/xml"
-				CHECKSUM="e5b0c3180a90e8af2878d242800c1653f5cc11c7" CHECKSUMTYPE="SHA-1" SIZE="188718">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T19:00:00" MIMETYPE="text/xml" CHECKSUM="e5b0c3180a90e8af2878d242800c1653f5cc11c7" CHECKSUMTYPE="SHA-1" SIZE="188718">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T19:00:00" MIMETYPE="text/xml"
-				CHECKSUM="8ebf28db096120e38cae7857b62db0b91fd9d999" CHECKSUMTYPE="SHA-1" SIZE="61260">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T19:00:00" MIMETYPE="text/xml" CHECKSUM="8ebf28db096120e38cae7857b62db0b91fd9d999" CHECKSUMTYPE="SHA-1" SIZE="61260">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T19:00:01" MIMETYPE="text/xml"
-				CHECKSUM="1adebb520abd9f81033c8b3caff512d6e5427974" CHECKSUMTYPE="SHA-1" SIZE="5108">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T19:00:01" MIMETYPE="text/xml" CHECKSUM="1adebb520abd9f81033c8b3caff512d6e5427974" CHECKSUMTYPE="SHA-1" SIZE="5108">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T19:00:01" MIMETYPE="text/xml"
-				CHECKSUM="6239a4f99098c7fdb5dfaa3b4abe649afec396ad" CHECKSUMTYPE="SHA-1" SIZE="2019">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T19:00:01" MIMETYPE="text/xml" CHECKSUM="6239a4f99098c7fdb5dfaa3b4abe649afec396ad" CHECKSUMTYPE="SHA-1" SIZE="2019">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T19:00:01" MIMETYPE="text/xml"
-				CHECKSUM="842e671f873ba6fd27e655d926e8396258da86f2" CHECKSUMTYPE="SHA-1" SIZE="67118">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T19:00:01" MIMETYPE="text/xml" CHECKSUM="842e671f873ba6fd27e655d926e8396258da86f2" CHECKSUMTYPE="SHA-1" SIZE="67118">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T19:00:01" MIMETYPE="text/xml"
-				CHECKSUM="2a7948df9db574c61b3ae05c51c596e0bb7131b6" CHECKSUMTYPE="SHA-1" SIZE="193516">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T19:00:01" MIMETYPE="text/xml" CHECKSUM="2a7948df9db574c61b3ae05c51c596e0bb7131b6" CHECKSUMTYPE="SHA-1" SIZE="193516">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T19:00:02" MIMETYPE="text/xml"
-				CHECKSUM="5f011869591b2f840a3374496ab51a47ae343b13" CHECKSUMTYPE="SHA-1" SIZE="186988">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T19:00:02" MIMETYPE="text/xml" CHECKSUM="5f011869591b2f840a3374496ab51a47ae343b13" CHECKSUMTYPE="SHA-1" SIZE="186988">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T19:00:02" MIMETYPE="text/xml"
-				CHECKSUM="55203caa3e0e7686a770490dc10780b044c60a12" CHECKSUMTYPE="SHA-1" SIZE="178866">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T19:00:02" MIMETYPE="text/xml" CHECKSUM="55203caa3e0e7686a770490dc10780b044c60a12" CHECKSUMTYPE="SHA-1" SIZE="178866">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T19:00:03" MIMETYPE="text/xml"
-				CHECKSUM="d9a84ca6cbb8ff4d5e5dfec2d847868a83a3f4bb" CHECKSUMTYPE="SHA-1" SIZE="180089">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T19:00:03" MIMETYPE="text/xml" CHECKSUM="d9a84ca6cbb8ff4d5e5dfec2d847868a83a3f4bb" CHECKSUMTYPE="SHA-1" SIZE="180089">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T19:00:03" MIMETYPE="text/xml"
-				CHECKSUM="da0bba61f17c35e818816928ba99ad90d23a3c5e" CHECKSUMTYPE="SHA-1" SIZE="131957">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T19:00:03" MIMETYPE="text/xml" CHECKSUM="da0bba61f17c35e818816928ba99ad90d23a3c5e" CHECKSUMTYPE="SHA-1" SIZE="131957">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T19:00:03" MIMETYPE="text/xml"
-				CHECKSUM="233e4dd8876d1343b78d6a2bbabd3ef82502c5a2" CHECKSUMTYPE="SHA-1" SIZE="4755">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T19:00:03" MIMETYPE="text/xml" CHECKSUM="233e4dd8876d1343b78d6a2bbabd3ef82502c5a2" CHECKSUMTYPE="SHA-1" SIZE="4755">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T19:00:04" MIMETYPE="text/xml"
-				CHECKSUM="ceedcd94b2a57b73e35ecc72fa8d679a5dc1bc04" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T19:00:04" MIMETYPE="text/xml" CHECKSUM="ceedcd94b2a57b73e35ecc72fa8d679a5dc1bc04" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T19:00:04" MIMETYPE="text/xml"
-				CHECKSUM="51db804eacac9bd86e82e0232895604caa733e3c" CHECKSUMTYPE="SHA-1" SIZE="90277">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T19:00:04" MIMETYPE="text/xml" CHECKSUM="51db804eacac9bd86e82e0232895604caa733e3c" CHECKSUMTYPE="SHA-1" SIZE="90277">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T19:00:04" MIMETYPE="text/xml"
-				CHECKSUM="56b43dfbc10b184f8bb95ee7e362bc87f0d72960" CHECKSUMTYPE="SHA-1" SIZE="195902">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T19:00:04" MIMETYPE="text/xml" CHECKSUM="56b43dfbc10b184f8bb95ee7e362bc87f0d72960" CHECKSUMTYPE="SHA-1" SIZE="195902">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T19:00:05" MIMETYPE="text/xml"
-				CHECKSUM="e804964ce7493bad26d3d786930640c7f9a7ced5" CHECKSUMTYPE="SHA-1" SIZE="192790">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T19:00:05" MIMETYPE="text/xml" CHECKSUM="e804964ce7493bad26d3d786930640c7f9a7ced5" CHECKSUMTYPE="SHA-1" SIZE="192790">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T19:00:05" MIMETYPE="text/xml"
-				CHECKSUM="309ead0202faf8e6e43c45c0f081a7019c27bd54" CHECKSUMTYPE="SHA-1" SIZE="188980">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T19:00:05" MIMETYPE="text/xml" CHECKSUM="309ead0202faf8e6e43c45c0f081a7019c27bd54" CHECKSUMTYPE="SHA-1" SIZE="188980">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T19:00:06" MIMETYPE="text/xml"
-				CHECKSUM="e15644cb4e38e216023ed19765e005a7e8ab69e6" CHECKSUMTYPE="SHA-1" SIZE="185853">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T19:00:06" MIMETYPE="text/xml" CHECKSUM="e15644cb4e38e216023ed19765e005a7e8ab69e6" CHECKSUMTYPE="SHA-1" SIZE="185853">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T19:00:06" MIMETYPE="text/xml"
-				CHECKSUM="8aa915a19e2ab30cb2591e5351e5d8572892e8f0" CHECKSUMTYPE="SHA-1" SIZE="2403">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T19:00:06" MIMETYPE="text/xml" CHECKSUM="8aa915a19e2ab30cb2591e5351e5d8572892e8f0" CHECKSUMTYPE="SHA-1" SIZE="2403">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T19:00:06" MIMETYPE="text/xml"
-				CHECKSUM="0ea9ebca178c24d67f7901d256cb382805680133" CHECKSUMTYPE="SHA-1" SIZE="36370">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T19:00:06" MIMETYPE="text/xml" CHECKSUM="0ea9ebca178c24d67f7901d256cb382805680133" CHECKSUMTYPE="SHA-1" SIZE="36370">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T19:00:06" MIMETYPE="text/xml"
-				CHECKSUM="09ba1063c5fca90e781f31c7f45e01738fc4ddea" CHECKSUMTYPE="SHA-1" SIZE="19073">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T19:00:06" MIMETYPE="text/xml" CHECKSUM="09ba1063c5fca90e781f31c7f45e01738fc4ddea" CHECKSUMTYPE="SHA-1" SIZE="19073">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T19:00:07" MIMETYPE="text/xml"
-				CHECKSUM="751bdcc0b73dc1626c0722b9dbace6d3acce639a" CHECKSUMTYPE="SHA-1" SIZE="18343">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T19:00:07" MIMETYPE="text/xml" CHECKSUM="751bdcc0b73dc1626c0722b9dbace6d3acce639a" CHECKSUMTYPE="SHA-1" SIZE="18343">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T19:00:07" MIMETYPE="text/xml"
-				CHECKSUM="48f92559780e3bbe453ab4207c027d6959d31cd3" CHECKSUMTYPE="SHA-1" SIZE="36311">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T19:00:07" MIMETYPE="text/xml" CHECKSUM="48f92559780e3bbe453ab4207c027d6959d31cd3" CHECKSUMTYPE="SHA-1" SIZE="36311">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T19:00:07" MIMETYPE="text/xml"
-				CHECKSUM="c11bee75bce3ceba6eb87008f25a5966fd5295f7" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T19:00:07" MIMETYPE="text/xml" CHECKSUM="c11bee75bce3ceba6eb87008f25a5966fd5295f7" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T19:00:08" MIMETYPE="text/xml"
-				CHECKSUM="718ef0d46175b9e128c8e18f74f8dea2c14ae148" CHECKSUMTYPE="SHA-1" SIZE="5586">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T19:00:08" MIMETYPE="text/xml" CHECKSUM="718ef0d46175b9e128c8e18f74f8dea2c14ae148" CHECKSUMTYPE="SHA-1" SIZE="5586">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-02_01_0088.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T19:03:48" MIMETYPE="application/pdf" CHECKSUM="03b6391cc416240009835037c8c49eba967b5b4b"
-				CHECKSUMTYPE="SHA-1" SIZE="44629453">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/bmtnabe_1900-02_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T19:03:48" MIMETYPE="application/pdf" CHECKSUM="03b6391cc416240009835037c8c49eba967b5b4b" CHECKSUMTYPE="SHA-1" SIZE="44629453">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/02_01/bmtnabe_1900-02_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -9788,8 +9518,7 @@
 
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="TextContent" ORDER="15" DMDID="c045"
-					LABEL="Wahrlich! Da safsen die Helden mit ihren blanken Schwertern und mit">
+				<div ID="L.1.1.15" TYPE="TextContent" ORDER="15" DMDID="c045" LABEL="Wahrlich! Da safsen die Helden mit ihren blanken Schwertern und mit">
 					<div ID="L.1.1.15.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_TB00002"/>

--- a/metadata/periodicals/bmtnabe/issues/1900/04_01/bmtnabe_1900-04_01.mets.xml
+++ b/metadata/periodicals/bmtnabe/issues/1900/04_01/bmtnabe_1900-04_01.mets.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1900-04_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabe_1900-04_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -18,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1900-04_01</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1900-04_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1900-04_01</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabe_1900-04_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre authority="bmtn">Periodicals-Issue</genre>
 					<titleInfo>
@@ -46,7 +42,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabe">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabe_1900-04_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -10425,1022 +10421,684 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T18:28:46" MIMETYPE="image/jp2" SEQ="1"
-				CHECKSUM="8d8613515e9e5863a63c75d62051c1e5240af550" CHECKSUMTYPE="SHA-1" SIZE="5170629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0001.jp2"/>
-			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T18:29:16" MIMETYPE="image/jp2" SEQ="2"
-				CHECKSUM="5bb2c3e67dd7b24ed24119df8ff0792d4f4ed88e" CHECKSUMTYPE="SHA-1" SIZE="5280427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0002.jp2"/>
-			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T18:29:44" MIMETYPE="image/jp2" SEQ="3"
-				CHECKSUM="a35c745d7f5655dad219e93d51938217cadcd336" CHECKSUMTYPE="SHA-1" SIZE="5142728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0003.jp2"/>
-			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T18:30:06" MIMETYPE="image/jp2" SEQ="4"
-				CHECKSUM="25509c2fbdad8ae08aac096f403ad4990e643a98" CHECKSUMTYPE="SHA-1" SIZE="5192229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0004.jp2"/>
-			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T18:30:29" MIMETYPE="image/jp2" SEQ="5"
-				CHECKSUM="255a348e32d40efd7f33c4631f111ad101400b8e" CHECKSUMTYPE="SHA-1" SIZE="5148127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0005.jp2"/>
-			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T18:30:52" MIMETYPE="image/jp2" SEQ="6"
-				CHECKSUM="e39df5a169d32da8ab88027a4cfa4dd2c204cf45" CHECKSUMTYPE="SHA-1" SIZE="5175106">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0006.jp2"/>
-			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T18:31:16" MIMETYPE="image/jp2" SEQ="7"
-				CHECKSUM="b1cc2d8621bb0de460100edcc2ae717ab86107ea" CHECKSUMTYPE="SHA-1" SIZE="5157058">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0007.jp2"/>
-			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T18:31:40" MIMETYPE="image/jp2" SEQ="8"
-				CHECKSUM="ea0bc6e8dc8afb80cd8d0c14bb55e29521c74639" CHECKSUMTYPE="SHA-1" SIZE="5232628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0008.jp2"/>
-			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T18:32:05" MIMETYPE="image/jp2" SEQ="9"
-				CHECKSUM="45187278a86ec8c427a2009b5020b257728fb88b" CHECKSUMTYPE="SHA-1" SIZE="5068028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0009.jp2"/>
-			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T18:32:27" MIMETYPE="image/jp2" SEQ="10"
-				CHECKSUM="750caa2f377078a119e118060d623112b44ae5ed" CHECKSUMTYPE="SHA-1" SIZE="5158928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0010.jp2"/>
-			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T18:32:50" MIMETYPE="image/jp2" SEQ="11"
-				CHECKSUM="1021fdfa837adb40e3a765f4faf5eaae75e4abc5" CHECKSUMTYPE="SHA-1" SIZE="5136429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0011.jp2"/>
-			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T18:33:15" MIMETYPE="image/jp2" SEQ="12"
-				CHECKSUM="a3ee8a79c800efc53020a169bf47b4c695541e28" CHECKSUMTYPE="SHA-1" SIZE="5292128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0012.jp2"/>
-			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T18:33:37" MIMETYPE="image/jp2" SEQ="13"
-				CHECKSUM="d9cf6277b79b51a117ce576edf92452413cd2601" CHECKSUMTYPE="SHA-1" SIZE="5145416">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0013.jp2"/>
-			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T18:34:00" MIMETYPE="image/jp2" SEQ="14"
-				CHECKSUM="57868dbcd81b6714b2016fe09315c856ca3e3c43" CHECKSUMTYPE="SHA-1" SIZE="5210228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0014.jp2"/>
-			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T18:34:23" MIMETYPE="image/jp2" SEQ="15"
-				CHECKSUM="e337647c73da1c3dcb5ad4b82754533b534cd8d0" CHECKSUMTYPE="SHA-1" SIZE="5132822">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0015.jp2"/>
-			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T18:34:46" MIMETYPE="image/jp2" SEQ="16"
-				CHECKSUM="de0148899b9f1a8f187984162737919edcdf6189" CHECKSUMTYPE="SHA-1" SIZE="5275929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0016.jp2"/>
-			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T18:35:11" MIMETYPE="image/jp2" SEQ="17"
-				CHECKSUM="3dc3757a781dfea987a1d3fad6407901fc117f51" CHECKSUMTYPE="SHA-1" SIZE="5117529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0017.jp2"/>
-			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T18:35:36" MIMETYPE="image/jp2" SEQ="18"
-				CHECKSUM="3d2beb641fe91a9e8f9ef9bbf85f9ab4b5cf7ea6" CHECKSUMTYPE="SHA-1" SIZE="5145429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0018.jp2"/>
-			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T18:35:59" MIMETYPE="image/jp2" SEQ="19"
-				CHECKSUM="6525297a08cb43345425c55d4f7ddd0760a1fb60" CHECKSUMTYPE="SHA-1" SIZE="5168828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0019.jp2"/>
-			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T18:36:23" MIMETYPE="image/jp2" SEQ="20"
-				CHECKSUM="c9183bb5f4b58799cd8e1284f3f65c8d6a7515a0" CHECKSUMTYPE="SHA-1" SIZE="5174228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0020.jp2"/>
-			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T18:36:45" MIMETYPE="image/jp2" SEQ="21"
-				CHECKSUM="24016e7fb96ea5c9d469a6aa53e255ec60bba464" CHECKSUMTYPE="SHA-1" SIZE="5149926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0021.jp2"/>
-			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T18:37:08" MIMETYPE="image/jp2" SEQ="22"
-				CHECKSUM="5333468c94af9a549a43a2bf063c8a811c1f5cdb" CHECKSUMTYPE="SHA-1" SIZE="5177829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0022.jp2"/>
-			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T18:37:30" MIMETYPE="image/jp2" SEQ="23"
-				CHECKSUM="badccae7ed52c6baf239f2797798d8f5f646c512" CHECKSUMTYPE="SHA-1" SIZE="5140028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0023.jp2"/>
-			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T18:37:58" MIMETYPE="image/jp2" SEQ="24"
-				CHECKSUM="4053476d9b9335331a8ba010e1180dc02f6f5f0b" CHECKSUMTYPE="SHA-1" SIZE="5174226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0024.jp2"/>
-			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T18:38:24" MIMETYPE="image/jp2" SEQ="25"
-				CHECKSUM="3b4043002043eccff413a3e7a1e655454adb60b3" CHECKSUMTYPE="SHA-1" SIZE="5123828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0025.jp2"/>
-			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T18:38:50" MIMETYPE="image/jp2" SEQ="26"
-				CHECKSUM="f41b28b638eb0193f38d6f315b82ab38a3111bfb" CHECKSUMTYPE="SHA-1" SIZE="5197541">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0026.jp2"/>
-			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T18:39:16" MIMETYPE="image/jp2" SEQ="27"
-				CHECKSUM="c45c73845bac89b9788144014a8965daa46bcf7d" CHECKSUMTYPE="SHA-1" SIZE="5148129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0027.jp2"/>
-			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T18:39:41" MIMETYPE="image/jp2" SEQ="28"
-				CHECKSUM="bf55845b39e10d07e36d5b7562b713c17d682f74" CHECKSUMTYPE="SHA-1" SIZE="5195827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0028.jp2"/>
-			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T18:40:04" MIMETYPE="image/jp2" SEQ="29"
-				CHECKSUM="bb9ad722e7d8fe4a16c3cd6946b6bc83b48bb997" CHECKSUMTYPE="SHA-1" SIZE="5130127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0029.jp2"/>
-			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T18:40:29" MIMETYPE="image/jp2" SEQ="30"
-				CHECKSUM="f62cc134aced934553ad91b0d64f7ba21f2703f8" CHECKSUMTYPE="SHA-1" SIZE="5170628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0030.jp2"/>
-			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T18:40:53" MIMETYPE="image/jp2" SEQ="31"
-				CHECKSUM="1b7d20a921d12596f70ca4db0f6b52d85085ff44" CHECKSUMTYPE="SHA-1" SIZE="5126527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0031.jp2"/>
-			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T18:41:17" MIMETYPE="image/jp2" SEQ="32"
-				CHECKSUM="26f7741369b0f9018816a9b7d005ba20afc79cd9" CHECKSUMTYPE="SHA-1" SIZE="5149926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0032.jp2"/>
-			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T18:41:43" MIMETYPE="image/jp2" SEQ="33"
-				CHECKSUM="4abfcdaff45d67f8d22e8f77a031af41e8eceec1" CHECKSUMTYPE="SHA-1" SIZE="5158810">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0033.jp2"/>
-			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T18:42:08" MIMETYPE="image/jp2" SEQ="34"
-				CHECKSUM="b9b40e848077c280456b32c83045330161755461" CHECKSUMTYPE="SHA-1" SIZE="5192225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0034.jp2"/>
-			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T18:42:32" MIMETYPE="image/jp2" SEQ="35"
-				CHECKSUM="2e9dfb818cd6eb6b3b035091e753781cdb92bd96" CHECKSUMTYPE="SHA-1" SIZE="5085127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0035.jp2"/>
-			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T18:42:54" MIMETYPE="image/jp2" SEQ="36"
-				CHECKSUM="1594963e680fb277b37cd2ca09213a23418738cc" CHECKSUMTYPE="SHA-1" SIZE="5171524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0036.jp2"/>
-			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T18:43:15" MIMETYPE="image/jp2" SEQ="37"
-				CHECKSUM="e83f86fdb7fb20f20c3ba58455acb6b881eba28f" CHECKSUMTYPE="SHA-1" SIZE="5115712">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0037.jp2"/>
-			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T18:43:40" MIMETYPE="image/jp2" SEQ="38"
-				CHECKSUM="7a6e130dfadc2ec9a2cd4491e56bb5f5f92b1d01" CHECKSUMTYPE="SHA-1" SIZE="5147225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0038.jp2"/>
-			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T18:44:03" MIMETYPE="image/jp2" SEQ="39"
-				CHECKSUM="41edabdcdacaf3abae08b4ac9b4244e2115ba207" CHECKSUMTYPE="SHA-1" SIZE="5112128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0039.jp2"/>
-			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T18:44:26" MIMETYPE="image/jp2" SEQ="40"
-				CHECKSUM="6f5ace5ffcd5589e5249dbe96d229cd7265c992d" CHECKSUMTYPE="SHA-1" SIZE="5152626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0040.jp2"/>
-			</file>
-			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T18:44:52" MIMETYPE="image/jp2" SEQ="41"
-				CHECKSUM="bde9c61db6bedd568da30dd8b1181f61ab4a9925" CHECKSUMTYPE="SHA-1" SIZE="5154427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0041.jp2"/>
-			</file>
-			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T18:45:17" MIMETYPE="image/jp2" SEQ="42"
-				CHECKSUM="33c500842666689b1feb36dd11df0c0eae6f5d3d" CHECKSUMTYPE="SHA-1" SIZE="5149926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0042.jp2"/>
-			</file>
-			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T18:45:42" MIMETYPE="image/jp2" SEQ="43"
-				CHECKSUM="5f231641a3b8ae89bc4e62013bf75a9daeae0436" CHECKSUMTYPE="SHA-1" SIZE="5104028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0043.jp2"/>
-			</file>
-			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T18:46:06" MIMETYPE="image/jp2" SEQ="44"
-				CHECKSUM="cffe46329411daa0b00d7ed37586185d0a8403ed" CHECKSUMTYPE="SHA-1" SIZE="5118359">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0044.jp2"/>
-			</file>
-			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T18:46:28" MIMETYPE="image/jp2" SEQ="45"
-				CHECKSUM="1fc0b077b235b89e3ea12519197148201327cd82" CHECKSUMTYPE="SHA-1" SIZE="5117527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0045.jp2"/>
-			</file>
-			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T18:46:51" MIMETYPE="image/jp2" SEQ="46"
-				CHECKSUM="28e40fa8ec4c6af70d0b10ee5c5409b082c49596" CHECKSUMTYPE="SHA-1" SIZE="5125628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0046.jp2"/>
-			</file>
-			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T18:47:16" MIMETYPE="image/jp2" SEQ="47"
-				CHECKSUM="f3ad91f23ee2bbcc592931f9d4f2fff79b35264f" CHECKSUMTYPE="SHA-1" SIZE="5078828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0047.jp2"/>
-			</file>
-			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T18:47:45" MIMETYPE="image/jp2" SEQ="48"
-				CHECKSUM="c82cdf64672e630fc1d1eed0b46977bbe165ad75" CHECKSUMTYPE="SHA-1" SIZE="5095027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0048.jp2"/>
-			</file>
-			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T18:48:09" MIMETYPE="image/jp2" SEQ="49"
-				CHECKSUM="0c56112ad5e314d8ede698e678b2002a0f69454a" CHECKSUMTYPE="SHA-1" SIZE="5023924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0049.jp2"/>
-			</file>
-			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T18:48:34" MIMETYPE="image/jp2" SEQ="50"
-				CHECKSUM="21748a98864b79613e70b851e9a14601223baaa0" CHECKSUMTYPE="SHA-1" SIZE="5095025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0050.jp2"/>
-			</file>
-			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T18:48:58" MIMETYPE="image/jp2" SEQ="51"
-				CHECKSUM="90e9aeb03ab30dfddd46fefdb657ff912d8b8ffc" CHECKSUMTYPE="SHA-1" SIZE="5083314">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0051.jp2"/>
-			</file>
-			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T18:49:24" MIMETYPE="image/jp2" SEQ="52"
-				CHECKSUM="879faa03fdc3d2d39da458e856dd382be74d7052" CHECKSUMTYPE="SHA-1" SIZE="5095028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0052.jp2"/>
-			</file>
-			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T18:49:46" MIMETYPE="image/jp2" SEQ="53"
-				CHECKSUM="871f123f6474f94d2fce5a125cb2402e7b3af828" CHECKSUMTYPE="SHA-1" SIZE="5039226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0053.jp2"/>
-			</file>
-			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T18:50:11" MIMETYPE="image/jp2" SEQ="54"
-				CHECKSUM="1b6e1b465a09ae7d1f96aaf660e51cc5efdd03a4" CHECKSUMTYPE="SHA-1" SIZE="5095029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0054.jp2"/>
-			</file>
-			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T18:50:35" MIMETYPE="image/jp2" SEQ="55"
-				CHECKSUM="a576647f837488d20b34678c3bc920258b85b87c" CHECKSUMTYPE="SHA-1" SIZE="5071627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0055.jp2"/>
-			</file>
-			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T18:51:01" MIMETYPE="image/jp2" SEQ="56"
-				CHECKSUM="d64cf0e92080dcf1562333005df7a779525d233d" CHECKSUMTYPE="SHA-1" SIZE="5095014">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0056.jp2"/>
-			</file>
-			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T18:51:28" MIMETYPE="image/jp2" SEQ="57"
-				CHECKSUM="bb7c7570c9715f5dc0f1643d7a3b14941a6a0e11" CHECKSUMTYPE="SHA-1" SIZE="5111227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0057.jp2"/>
-			</file>
-			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T18:51:54" MIMETYPE="image/jp2" SEQ="58"
-				CHECKSUM="dcdfcf8ab436efa4fa0d4a06fc7ee0f634d76c7d" CHECKSUMTYPE="SHA-1" SIZE="5095029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0058.jp2"/>
-			</file>
-			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:52:18" MIMETYPE="image/jp2" SEQ="59"
-				CHECKSUM="1981b8f5bfb89034bc994389b7de3dfcbea99a34" CHECKSUMTYPE="SHA-1" SIZE="5101324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0059.jp2"/>
-			</file>
-			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:52:46" MIMETYPE="image/jp2" SEQ="60"
-				CHECKSUM="33e80105872085d10400c4c7bc1293cbeda70b2c" CHECKSUMTYPE="SHA-1" SIZE="5095029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0060.jp2"/>
-			</file>
-			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:53:12" MIMETYPE="image/jp2" SEQ="61"
-				CHECKSUM="699f71b362754b44044168cee5b9604b3a2807df" CHECKSUMTYPE="SHA-1" SIZE="5066134">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0061.jp2"/>
-			</file>
-			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:53:38" MIMETYPE="image/jp2" SEQ="62"
-				CHECKSUM="40e93377b4510edca15271c3f8a9a29f57aa6c11" CHECKSUMTYPE="SHA-1" SIZE="5095028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0062.jp2"/>
-			</file>
-			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:54:05" MIMETYPE="image/jp2" SEQ="63"
-				CHECKSUM="e678f3e2f6c7098adeb4ac2d5980bf32a1f3f00e" CHECKSUMTYPE="SHA-1" SIZE="5077029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0063.jp2"/>
-			</file>
-			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:54:37" MIMETYPE="image/jp2" SEQ="64"
-				CHECKSUM="e83da9e225eb4cf904b09ddae2757bea0d399672" CHECKSUMTYPE="SHA-1" SIZE="5066226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0064.jp2"/>
-			</file>
-			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:55:03" MIMETYPE="image/jp2" SEQ="65"
-				CHECKSUM="363016b454bc6db22892b65abd63dd4aca6d3998" CHECKSUMTYPE="SHA-1" SIZE="5052719">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0065.jp2"/>
-			</file>
-			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:55:33" MIMETYPE="image/jp2" SEQ="66"
-				CHECKSUM="a886343e18adf02da2cc5ae19fcb352dc4fd3f87" CHECKSUMTYPE="SHA-1" SIZE="5086925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0066.jp2"/>
-			</file>
-			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:56:01" MIMETYPE="image/jp2" SEQ="67"
-				CHECKSUM="65ab6f41a380198bff985a522c1ed822888344cd" CHECKSUMTYPE="SHA-1" SIZE="5025727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0067.jp2"/>
-			</file>
-			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:56:30" MIMETYPE="image/jp2" SEQ="68"
-				CHECKSUM="0b8b6db594574806754a0419755287e4234ac37c" CHECKSUMTYPE="SHA-1" SIZE="5050025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0068.jp2"/>
-			</file>
-			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:56:57" MIMETYPE="image/jp2" SEQ="69"
-				CHECKSUM="2b18b69c1c3d5fa027a35c0ea43c6d69e630c9bf" CHECKSUMTYPE="SHA-1" SIZE="5050022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0069.jp2"/>
-			</file>
-			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:57:25" MIMETYPE="image/jp2" SEQ="70"
-				CHECKSUM="a942766c192333bb966953289417e6f8fba3f09d" CHECKSUMTYPE="SHA-1" SIZE="5032827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0070.jp2"/>
-			</file>
-			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:57:51" MIMETYPE="image/jp2" SEQ="71"
-				CHECKSUM="0aa41eb423434036082c29f855950128b0dc5942" CHECKSUMTYPE="SHA-1" SIZE="5031122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0071.jp2"/>
-			</file>
-			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:58:20" MIMETYPE="image/jp2" SEQ="72"
-				CHECKSUM="e8565d74f9ce5650043ab722ce13ce9879799288" CHECKSUMTYPE="SHA-1" SIZE="5005026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0072.jp2"/>
-			</file>
-			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:58:48" MIMETYPE="image/jp2" SEQ="73"
-				CHECKSUM="31862164e94759edde89dd8d6d657452a1726e2a" CHECKSUMTYPE="SHA-1" SIZE="5081520">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0073.jp2"/>
-			</file>
-			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:59:18" MIMETYPE="image/jp2" SEQ="74"
-				CHECKSUM="82b434756fe4404d316585bb33fc65fe46656a1f" CHECKSUMTYPE="SHA-1" SIZE="4991514">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0074.jp2"/>
-			</file>
-			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:59:45" MIMETYPE="image/jp2" SEQ="75"
-				CHECKSUM="170b19cfe8436d66f019352c2cb1439a8e232cee" CHECKSUMTYPE="SHA-1" SIZE="5111223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0075.jp2"/>
-			</file>
-			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T19:00:14" MIMETYPE="image/jp2" SEQ="76"
-				CHECKSUM="6a7e2b02073b3cf8901b0530c8951d0af96bfc06" CHECKSUMTYPE="SHA-1" SIZE="5017569">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0076.jp2"/>
-			</file>
-			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T19:00:42" MIMETYPE="image/jp2" SEQ="77"
-				CHECKSUM="3b77117d82f1ec2c06a18b8e56b5daa293e2a511" CHECKSUMTYPE="SHA-1" SIZE="5082427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0077.jp2"/>
-			</file>
-			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T19:01:11" MIMETYPE="image/jp2" SEQ="78"
-				CHECKSUM="f9da3e62bf4227ccbfec7e051345fdc54e2bf0eb" CHECKSUMTYPE="SHA-1" SIZE="5018529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0078.jp2"/>
-			</file>
-			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T19:01:39" MIMETYPE="image/jp2" SEQ="79"
-				CHECKSUM="ed2ba3e9718596ad682c92c5475063084976f9f6" CHECKSUMTYPE="SHA-1" SIZE="5061712">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0079.jp2"/>
-			</file>
-			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T19:02:09" MIMETYPE="image/jp2" SEQ="80"
-				CHECKSUM="f6080c43d54f7ea2e80a75e0ccc5224775d0b0c7" CHECKSUMTYPE="SHA-1" SIZE="5010428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0080.jp2"/>
-			</file>
-			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T19:02:35" MIMETYPE="image/jp2" SEQ="81"
-				CHECKSUM="2e9130000e2895c456454f9e1b462ca61dda87fc" CHECKSUMTYPE="SHA-1" SIZE="5027527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0081.jp2"/>
-			</file>
-			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T19:03:03" MIMETYPE="image/jp2" SEQ="82"
-				CHECKSUM="67096c663968e2be5ac1dd7555558bd0f1bd3ec4" CHECKSUMTYPE="SHA-1" SIZE="5015829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0082.jp2"/>
-			</file>
-			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T19:03:32" MIMETYPE="image/jp2" SEQ="83"
-				CHECKSUM="81a731bcdd5a51409c9d0ec10ec6493fe1b4111c" CHECKSUMTYPE="SHA-1" SIZE="5048228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0083.jp2"/>
-			</file>
-			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T19:04:00" MIMETYPE="image/jp2" SEQ="84"
-				CHECKSUM="62f97b5406cf63f5a9708ff984fddab96b4028ca" CHECKSUMTYPE="SHA-1" SIZE="4969027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0084.jp2"/>
-			</file>
-			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T19:04:28" MIMETYPE="image/jp2" SEQ="85"
-				CHECKSUM="879c42659cc16d3697f5674283cde2f11a411a40" CHECKSUMTYPE="SHA-1" SIZE="5047324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0085.jp2"/>
-			</file>
-			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T19:04:58" MIMETYPE="image/jp2" SEQ="86"
-				CHECKSUM="8f345608f60fa7976ca1a91339714f19f00459ff" CHECKSUMTYPE="SHA-1" SIZE="4955522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0086.jp2"/>
-			</file>
-			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T19:05:25" MIMETYPE="image/jp2" SEQ="87"
-				CHECKSUM="f471e1174d615416848010e7f66319d2586a2909" CHECKSUMTYPE="SHA-1" SIZE="5026615">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0087.jp2"/>
-			</file>
-			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T19:05:55" MIMETYPE="image/jp2" SEQ="88"
-				CHECKSUM="1f43a3a31968ac7b60c59a6c0306e9189ddbc672" CHECKSUMTYPE="SHA-1" SIZE="4966329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0088.jp2"/>
-			</file>
-			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T19:06:21" MIMETYPE="image/jp2" SEQ="89"
-				CHECKSUM="2bb190ae3dcaf7354ae1e1a910bf644ca4e363c9" CHECKSUMTYPE="SHA-1" SIZE="5046299">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0089.jp2"/>
-			</file>
-			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T19:06:47" MIMETYPE="image/jp2" SEQ="90"
-				CHECKSUM="0ca7ab7638b769caaceef3ff5de2e400e158a8ad" CHECKSUMTYPE="SHA-1" SIZE="4985197">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0090.jp2"/>
-			</file>
-			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T19:07:12" MIMETYPE="image/jp2" SEQ="91"
-				CHECKSUM="18d934bdfa76421b8084bb86e453b6f5e714365e" CHECKSUMTYPE="SHA-1" SIZE="4991528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0091.jp2"/>
-			</file>
-			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T19:07:40" MIMETYPE="image/jp2" SEQ="92"
-				CHECKSUM="37ebc1aa13cf138bd4af692ba93ed83c139403a6" CHECKSUMTYPE="SHA-1" SIZE="4948328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0092.jp2"/>
-			</file>
-			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T19:08:07" MIMETYPE="image/jp2" SEQ="93"
-				CHECKSUM="1785d2c015c63720db3a441677299c9c309fe422" CHECKSUMTYPE="SHA-1" SIZE="4996922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0093.jp2"/>
-			</file>
-			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T19:08:37" MIMETYPE="image/jp2" SEQ="94"
-				CHECKSUM="84f3d3e208acbadc4a413912f96001c24f792677" CHECKSUMTYPE="SHA-1" SIZE="4965425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0094.jp2"/>
-			</file>
-			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T19:09:05" MIMETYPE="image/jp2" SEQ="95"
-				CHECKSUM="04ae1c90a0d0517b183219b4da0ed9fdc7e2eb3f" CHECKSUMTYPE="SHA-1" SIZE="4960029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0095.jp2"/>
-			</file>
-			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T19:09:33" MIMETYPE="image/jp2" SEQ="96"
-				CHECKSUM="41878de4a2fce3634d7ece206097cb98694923cc" CHECKSUMTYPE="SHA-1" SIZE="5006821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0096.jp2"/>
-			</file>
-			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T19:10:01" MIMETYPE="image/jp2" SEQ="97"
-				CHECKSUM="f506416baf4856bb6559c82fa94cd51ecdf01b7c" CHECKSUMTYPE="SHA-1" SIZE="4960926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0097.jp2"/>
-			</file>
-			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T19:10:31" MIMETYPE="image/jp2" SEQ="98"
-				CHECKSUM="72cdbc0e30545debab8fe75e645ff6caa81b476e" CHECKSUMTYPE="SHA-1" SIZE="4923122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0098.jp2"/>
-			</file>
-			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T19:10:59" MIMETYPE="image/jp2" SEQ="99"
-				CHECKSUM="bcd7cfb09cd6eb4a8b607e03b20d82daeb099a8c" CHECKSUMTYPE="SHA-1" SIZE="4937525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0099.jp2"/>
-			</file>
-			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T19:11:27" MIMETYPE="image/jp2" SEQ="100"
-				CHECKSUM="aaf906b30a37968e509eec38b91f4f25501a2708" CHECKSUMTYPE="SHA-1" SIZE="4915928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0100.jp2"/>
-			</file>
-			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T19:11:56" MIMETYPE="image/jp2" SEQ="101"
-				CHECKSUM="33cb67d83fe2c97f43e8ec9d065faf02b39e662d" CHECKSUMTYPE="SHA-1" SIZE="4906028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0101.jp2"/>
-			</file>
-			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T19:12:23" MIMETYPE="image/jp2" SEQ="102"
-				CHECKSUM="744002ddd37aa2a48176ed8cc8c1a42a312d6122" CHECKSUMTYPE="SHA-1" SIZE="4931229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0102.jp2"/>
-			</file>
-			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T19:12:47" MIMETYPE="image/jp2" SEQ="103"
-				CHECKSUM="b28b340568c7a7f450327d62aeec42dc2adcb114" CHECKSUMTYPE="SHA-1" SIZE="4879024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0103.jp2"/>
-			</file>
-			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T19:13:12" MIMETYPE="image/jp2" SEQ="104"
-				CHECKSUM="03adfd2db027765356ce6d28b9f8ff71105723ce" CHECKSUMTYPE="SHA-1" SIZE="4951918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0104.jp2"/>
-			</file>
-			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T19:13:39" MIMETYPE="image/jp2" SEQ="105"
-				CHECKSUM="56bf139bc040f4330ab7a6b0bfc86ebe1a03d919" CHECKSUMTYPE="SHA-1" SIZE="4902429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0105.jp2"/>
-			</file>
-			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T19:14:07" MIMETYPE="image/jp2" SEQ="106"
-				CHECKSUM="a462987de55dbc7987b6bf59449819907a729007" CHECKSUMTYPE="SHA-1" SIZE="4938414">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0106.jp2"/>
-			</file>
-			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T19:14:34" MIMETYPE="image/jp2" SEQ="107"
-				CHECKSUM="d25869b3f17a61cf5729b11506d5620d003c9af3" CHECKSUMTYPE="SHA-1" SIZE="4891628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0107.jp2"/>
-			</file>
-			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T19:15:02" MIMETYPE="image/jp2" SEQ="108"
-				CHECKSUM="a956c20784523ff8b587f65cda13be6e072b8b85" CHECKSUMTYPE="SHA-1" SIZE="4942922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0108.jp2"/>
-			</file>
-			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T19:15:29" MIMETYPE="image/jp2" SEQ="109"
-				CHECKSUM="ab7a793dfcaf6bb1b124c604e670a9db2852ee63" CHECKSUMTYPE="SHA-1" SIZE="4884429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0109.jp2"/>
-			</file>
-			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T19:15:55" MIMETYPE="image/jp2" SEQ="110"
-				CHECKSUM="67ba48c9cc9f3fcf22357693a78bd3e10dddfe49" CHECKSUMTYPE="SHA-1" SIZE="4898829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0110.jp2"/>
-			</file>
-			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-07-30T19:16:19" MIMETYPE="image/jp2" SEQ="111"
-				CHECKSUM="b27a6615d59be907dc047d400c3ab1dace4f9c04" CHECKSUMTYPE="SHA-1" SIZE="4940228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0111.jp2"/>
-			</file>
-			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-07-30T19:16:51" MIMETYPE="image/jp2" SEQ="112"
-				CHECKSUM="d1e620bbf860e635c5cf766402b76cb8c1895c44" CHECKSUMTYPE="SHA-1" SIZE="4959982">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0112.jp2"/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-07-30T18:28:46" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="8d8613515e9e5863a63c75d62051c1e5240af550" CHECKSUMTYPE="SHA-1" SIZE="5170629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0001.jp2"/>
+			</file>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-07-30T18:29:16" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="5bb2c3e67dd7b24ed24119df8ff0792d4f4ed88e" CHECKSUMTYPE="SHA-1" SIZE="5280427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0002.jp2"/>
+			</file>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-07-30T18:29:44" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="a35c745d7f5655dad219e93d51938217cadcd336" CHECKSUMTYPE="SHA-1" SIZE="5142728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0003.jp2"/>
+			</file>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-07-30T18:30:06" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="25509c2fbdad8ae08aac096f403ad4990e643a98" CHECKSUMTYPE="SHA-1" SIZE="5192229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0004.jp2"/>
+			</file>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-07-30T18:30:29" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="255a348e32d40efd7f33c4631f111ad101400b8e" CHECKSUMTYPE="SHA-1" SIZE="5148127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0005.jp2"/>
+			</file>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-07-30T18:30:52" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="e39df5a169d32da8ab88027a4cfa4dd2c204cf45" CHECKSUMTYPE="SHA-1" SIZE="5175106">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0006.jp2"/>
+			</file>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-07-30T18:31:16" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="b1cc2d8621bb0de460100edcc2ae717ab86107ea" CHECKSUMTYPE="SHA-1" SIZE="5157058">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0007.jp2"/>
+			</file>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-07-30T18:31:40" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="ea0bc6e8dc8afb80cd8d0c14bb55e29521c74639" CHECKSUMTYPE="SHA-1" SIZE="5232628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0008.jp2"/>
+			</file>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-07-30T18:32:05" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="45187278a86ec8c427a2009b5020b257728fb88b" CHECKSUMTYPE="SHA-1" SIZE="5068028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0009.jp2"/>
+			</file>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-07-30T18:32:27" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="750caa2f377078a119e118060d623112b44ae5ed" CHECKSUMTYPE="SHA-1" SIZE="5158928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0010.jp2"/>
+			</file>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-07-30T18:32:50" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="1021fdfa837adb40e3a765f4faf5eaae75e4abc5" CHECKSUMTYPE="SHA-1" SIZE="5136429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0011.jp2"/>
+			</file>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-07-30T18:33:15" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="a3ee8a79c800efc53020a169bf47b4c695541e28" CHECKSUMTYPE="SHA-1" SIZE="5292128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0012.jp2"/>
+			</file>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-07-30T18:33:37" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="d9cf6277b79b51a117ce576edf92452413cd2601" CHECKSUMTYPE="SHA-1" SIZE="5145416">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0013.jp2"/>
+			</file>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-07-30T18:34:00" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="57868dbcd81b6714b2016fe09315c856ca3e3c43" CHECKSUMTYPE="SHA-1" SIZE="5210228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0014.jp2"/>
+			</file>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-07-30T18:34:23" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="e337647c73da1c3dcb5ad4b82754533b534cd8d0" CHECKSUMTYPE="SHA-1" SIZE="5132822">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0015.jp2"/>
+			</file>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-07-30T18:34:46" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="de0148899b9f1a8f187984162737919edcdf6189" CHECKSUMTYPE="SHA-1" SIZE="5275929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0016.jp2"/>
+			</file>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-07-30T18:35:11" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="3dc3757a781dfea987a1d3fad6407901fc117f51" CHECKSUMTYPE="SHA-1" SIZE="5117529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0017.jp2"/>
+			</file>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-07-30T18:35:36" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="3d2beb641fe91a9e8f9ef9bbf85f9ab4b5cf7ea6" CHECKSUMTYPE="SHA-1" SIZE="5145429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0018.jp2"/>
+			</file>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-07-30T18:35:59" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="6525297a08cb43345425c55d4f7ddd0760a1fb60" CHECKSUMTYPE="SHA-1" SIZE="5168828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0019.jp2"/>
+			</file>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-07-30T18:36:23" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="c9183bb5f4b58799cd8e1284f3f65c8d6a7515a0" CHECKSUMTYPE="SHA-1" SIZE="5174228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0020.jp2"/>
+			</file>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-07-30T18:36:45" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="24016e7fb96ea5c9d469a6aa53e255ec60bba464" CHECKSUMTYPE="SHA-1" SIZE="5149926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0021.jp2"/>
+			</file>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-07-30T18:37:08" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="5333468c94af9a549a43a2bf063c8a811c1f5cdb" CHECKSUMTYPE="SHA-1" SIZE="5177829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0022.jp2"/>
+			</file>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-07-30T18:37:30" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="badccae7ed52c6baf239f2797798d8f5f646c512" CHECKSUMTYPE="SHA-1" SIZE="5140028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0023.jp2"/>
+			</file>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-07-30T18:37:58" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="4053476d9b9335331a8ba010e1180dc02f6f5f0b" CHECKSUMTYPE="SHA-1" SIZE="5174226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0024.jp2"/>
+			</file>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-07-30T18:38:24" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="3b4043002043eccff413a3e7a1e655454adb60b3" CHECKSUMTYPE="SHA-1" SIZE="5123828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0025.jp2"/>
+			</file>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-07-30T18:38:50" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="f41b28b638eb0193f38d6f315b82ab38a3111bfb" CHECKSUMTYPE="SHA-1" SIZE="5197541">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0026.jp2"/>
+			</file>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-07-30T18:39:16" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="c45c73845bac89b9788144014a8965daa46bcf7d" CHECKSUMTYPE="SHA-1" SIZE="5148129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0027.jp2"/>
+			</file>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-07-30T18:39:41" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="bf55845b39e10d07e36d5b7562b713c17d682f74" CHECKSUMTYPE="SHA-1" SIZE="5195827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0028.jp2"/>
+			</file>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-07-30T18:40:04" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="bb9ad722e7d8fe4a16c3cd6946b6bc83b48bb997" CHECKSUMTYPE="SHA-1" SIZE="5130127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0029.jp2"/>
+			</file>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-07-30T18:40:29" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="f62cc134aced934553ad91b0d64f7ba21f2703f8" CHECKSUMTYPE="SHA-1" SIZE="5170628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0030.jp2"/>
+			</file>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-07-30T18:40:53" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="1b7d20a921d12596f70ca4db0f6b52d85085ff44" CHECKSUMTYPE="SHA-1" SIZE="5126527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0031.jp2"/>
+			</file>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-07-30T18:41:17" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="26f7741369b0f9018816a9b7d005ba20afc79cd9" CHECKSUMTYPE="SHA-1" SIZE="5149926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0032.jp2"/>
+			</file>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-07-30T18:41:43" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="4abfcdaff45d67f8d22e8f77a031af41e8eceec1" CHECKSUMTYPE="SHA-1" SIZE="5158810">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0033.jp2"/>
+			</file>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-07-30T18:42:08" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="b9b40e848077c280456b32c83045330161755461" CHECKSUMTYPE="SHA-1" SIZE="5192225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0034.jp2"/>
+			</file>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-07-30T18:42:32" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="2e9dfb818cd6eb6b3b035091e753781cdb92bd96" CHECKSUMTYPE="SHA-1" SIZE="5085127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0035.jp2"/>
+			</file>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-07-30T18:42:54" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="1594963e680fb277b37cd2ca09213a23418738cc" CHECKSUMTYPE="SHA-1" SIZE="5171524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0036.jp2"/>
+			</file>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-07-30T18:43:15" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="e83f86fdb7fb20f20c3ba58455acb6b881eba28f" CHECKSUMTYPE="SHA-1" SIZE="5115712">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0037.jp2"/>
+			</file>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-07-30T18:43:40" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="7a6e130dfadc2ec9a2cd4491e56bb5f5f92b1d01" CHECKSUMTYPE="SHA-1" SIZE="5147225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0038.jp2"/>
+			</file>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-07-30T18:44:03" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="41edabdcdacaf3abae08b4ac9b4244e2115ba207" CHECKSUMTYPE="SHA-1" SIZE="5112128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0039.jp2"/>
+			</file>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-07-30T18:44:26" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="6f5ace5ffcd5589e5249dbe96d229cd7265c992d" CHECKSUMTYPE="SHA-1" SIZE="5152626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0040.jp2"/>
+			</file>
+			<file ID="IMG00041" ADMID="techmd41" GROUPID="page41" CREATED="2015-07-30T18:44:52" MIMETYPE="image/jp2" SEQ="41" CHECKSUM="bde9c61db6bedd568da30dd8b1181f61ab4a9925" CHECKSUMTYPE="SHA-1" SIZE="5154427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0041.jp2"/>
+			</file>
+			<file ID="IMG00042" ADMID="techmd42" GROUPID="page42" CREATED="2015-07-30T18:45:17" MIMETYPE="image/jp2" SEQ="42" CHECKSUM="33c500842666689b1feb36dd11df0c0eae6f5d3d" CHECKSUMTYPE="SHA-1" SIZE="5149926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0042.jp2"/>
+			</file>
+			<file ID="IMG00043" ADMID="techmd43" GROUPID="page43" CREATED="2015-07-30T18:45:42" MIMETYPE="image/jp2" SEQ="43" CHECKSUM="5f231641a3b8ae89bc4e62013bf75a9daeae0436" CHECKSUMTYPE="SHA-1" SIZE="5104028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0043.jp2"/>
+			</file>
+			<file ID="IMG00044" ADMID="techmd44" GROUPID="page44" CREATED="2015-07-30T18:46:06" MIMETYPE="image/jp2" SEQ="44" CHECKSUM="cffe46329411daa0b00d7ed37586185d0a8403ed" CHECKSUMTYPE="SHA-1" SIZE="5118359">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0044.jp2"/>
+			</file>
+			<file ID="IMG00045" ADMID="techmd45" GROUPID="page45" CREATED="2015-07-30T18:46:28" MIMETYPE="image/jp2" SEQ="45" CHECKSUM="1fc0b077b235b89e3ea12519197148201327cd82" CHECKSUMTYPE="SHA-1" SIZE="5117527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0045.jp2"/>
+			</file>
+			<file ID="IMG00046" ADMID="techmd46" GROUPID="page46" CREATED="2015-07-30T18:46:51" MIMETYPE="image/jp2" SEQ="46" CHECKSUM="28e40fa8ec4c6af70d0b10ee5c5409b082c49596" CHECKSUMTYPE="SHA-1" SIZE="5125628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0046.jp2"/>
+			</file>
+			<file ID="IMG00047" ADMID="techmd47" GROUPID="page47" CREATED="2015-07-30T18:47:16" MIMETYPE="image/jp2" SEQ="47" CHECKSUM="f3ad91f23ee2bbcc592931f9d4f2fff79b35264f" CHECKSUMTYPE="SHA-1" SIZE="5078828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0047.jp2"/>
+			</file>
+			<file ID="IMG00048" ADMID="techmd48" GROUPID="page48" CREATED="2015-07-30T18:47:45" MIMETYPE="image/jp2" SEQ="48" CHECKSUM="c82cdf64672e630fc1d1eed0b46977bbe165ad75" CHECKSUMTYPE="SHA-1" SIZE="5095027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0048.jp2"/>
+			</file>
+			<file ID="IMG00049" ADMID="techmd49" GROUPID="page49" CREATED="2015-07-30T18:48:09" MIMETYPE="image/jp2" SEQ="49" CHECKSUM="0c56112ad5e314d8ede698e678b2002a0f69454a" CHECKSUMTYPE="SHA-1" SIZE="5023924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0049.jp2"/>
+			</file>
+			<file ID="IMG00050" ADMID="techmd50" GROUPID="page50" CREATED="2015-07-30T18:48:34" MIMETYPE="image/jp2" SEQ="50" CHECKSUM="21748a98864b79613e70b851e9a14601223baaa0" CHECKSUMTYPE="SHA-1" SIZE="5095025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0050.jp2"/>
+			</file>
+			<file ID="IMG00051" ADMID="techmd51" GROUPID="page51" CREATED="2015-07-30T18:48:58" MIMETYPE="image/jp2" SEQ="51" CHECKSUM="90e9aeb03ab30dfddd46fefdb657ff912d8b8ffc" CHECKSUMTYPE="SHA-1" SIZE="5083314">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0051.jp2"/>
+			</file>
+			<file ID="IMG00052" ADMID="techmd52" GROUPID="page52" CREATED="2015-07-30T18:49:24" MIMETYPE="image/jp2" SEQ="52" CHECKSUM="879faa03fdc3d2d39da458e856dd382be74d7052" CHECKSUMTYPE="SHA-1" SIZE="5095028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0052.jp2"/>
+			</file>
+			<file ID="IMG00053" ADMID="techmd53" GROUPID="page53" CREATED="2015-07-30T18:49:46" MIMETYPE="image/jp2" SEQ="53" CHECKSUM="871f123f6474f94d2fce5a125cb2402e7b3af828" CHECKSUMTYPE="SHA-1" SIZE="5039226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0053.jp2"/>
+			</file>
+			<file ID="IMG00054" ADMID="techmd54" GROUPID="page54" CREATED="2015-07-30T18:50:11" MIMETYPE="image/jp2" SEQ="54" CHECKSUM="1b6e1b465a09ae7d1f96aaf660e51cc5efdd03a4" CHECKSUMTYPE="SHA-1" SIZE="5095029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0054.jp2"/>
+			</file>
+			<file ID="IMG00055" ADMID="techmd55" GROUPID="page55" CREATED="2015-07-30T18:50:35" MIMETYPE="image/jp2" SEQ="55" CHECKSUM="a576647f837488d20b34678c3bc920258b85b87c" CHECKSUMTYPE="SHA-1" SIZE="5071627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0055.jp2"/>
+			</file>
+			<file ID="IMG00056" ADMID="techmd56" GROUPID="page56" CREATED="2015-07-30T18:51:01" MIMETYPE="image/jp2" SEQ="56" CHECKSUM="d64cf0e92080dcf1562333005df7a779525d233d" CHECKSUMTYPE="SHA-1" SIZE="5095014">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0056.jp2"/>
+			</file>
+			<file ID="IMG00057" ADMID="techmd57" GROUPID="page57" CREATED="2015-07-30T18:51:28" MIMETYPE="image/jp2" SEQ="57" CHECKSUM="bb7c7570c9715f5dc0f1643d7a3b14941a6a0e11" CHECKSUMTYPE="SHA-1" SIZE="5111227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0057.jp2"/>
+			</file>
+			<file ID="IMG00058" ADMID="techmd58" GROUPID="page58" CREATED="2015-07-30T18:51:54" MIMETYPE="image/jp2" SEQ="58" CHECKSUM="dcdfcf8ab436efa4fa0d4a06fc7ee0f634d76c7d" CHECKSUMTYPE="SHA-1" SIZE="5095029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0058.jp2"/>
+			</file>
+			<file ID="IMG00059" ADMID="techmd59" GROUPID="page59" CREATED="2015-07-30T18:52:18" MIMETYPE="image/jp2" SEQ="59" CHECKSUM="1981b8f5bfb89034bc994389b7de3dfcbea99a34" CHECKSUMTYPE="SHA-1" SIZE="5101324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0059.jp2"/>
+			</file>
+			<file ID="IMG00060" ADMID="techmd60" GROUPID="page60" CREATED="2015-07-30T18:52:46" MIMETYPE="image/jp2" SEQ="60" CHECKSUM="33e80105872085d10400c4c7bc1293cbeda70b2c" CHECKSUMTYPE="SHA-1" SIZE="5095029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0060.jp2"/>
+			</file>
+			<file ID="IMG00061" ADMID="techmd61" GROUPID="page61" CREATED="2015-07-30T18:53:12" MIMETYPE="image/jp2" SEQ="61" CHECKSUM="699f71b362754b44044168cee5b9604b3a2807df" CHECKSUMTYPE="SHA-1" SIZE="5066134">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0061.jp2"/>
+			</file>
+			<file ID="IMG00062" ADMID="techmd62" GROUPID="page62" CREATED="2015-07-30T18:53:38" MIMETYPE="image/jp2" SEQ="62" CHECKSUM="40e93377b4510edca15271c3f8a9a29f57aa6c11" CHECKSUMTYPE="SHA-1" SIZE="5095028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0062.jp2"/>
+			</file>
+			<file ID="IMG00063" ADMID="techmd63" GROUPID="page63" CREATED="2015-07-30T18:54:05" MIMETYPE="image/jp2" SEQ="63" CHECKSUM="e678f3e2f6c7098adeb4ac2d5980bf32a1f3f00e" CHECKSUMTYPE="SHA-1" SIZE="5077029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0063.jp2"/>
+			</file>
+			<file ID="IMG00064" ADMID="techmd64" GROUPID="page64" CREATED="2015-07-30T18:54:37" MIMETYPE="image/jp2" SEQ="64" CHECKSUM="e83da9e225eb4cf904b09ddae2757bea0d399672" CHECKSUMTYPE="SHA-1" SIZE="5066226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0064.jp2"/>
+			</file>
+			<file ID="IMG00065" ADMID="techmd65" GROUPID="page65" CREATED="2015-07-30T18:55:03" MIMETYPE="image/jp2" SEQ="65" CHECKSUM="363016b454bc6db22892b65abd63dd4aca6d3998" CHECKSUMTYPE="SHA-1" SIZE="5052719">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0065.jp2"/>
+			</file>
+			<file ID="IMG00066" ADMID="techmd66" GROUPID="page66" CREATED="2015-07-30T18:55:33" MIMETYPE="image/jp2" SEQ="66" CHECKSUM="a886343e18adf02da2cc5ae19fcb352dc4fd3f87" CHECKSUMTYPE="SHA-1" SIZE="5086925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0066.jp2"/>
+			</file>
+			<file ID="IMG00067" ADMID="techmd67" GROUPID="page67" CREATED="2015-07-30T18:56:01" MIMETYPE="image/jp2" SEQ="67" CHECKSUM="65ab6f41a380198bff985a522c1ed822888344cd" CHECKSUMTYPE="SHA-1" SIZE="5025727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0067.jp2"/>
+			</file>
+			<file ID="IMG00068" ADMID="techmd68" GROUPID="page68" CREATED="2015-07-30T18:56:30" MIMETYPE="image/jp2" SEQ="68" CHECKSUM="0b8b6db594574806754a0419755287e4234ac37c" CHECKSUMTYPE="SHA-1" SIZE="5050025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0068.jp2"/>
+			</file>
+			<file ID="IMG00069" ADMID="techmd69" GROUPID="page69" CREATED="2015-07-30T18:56:57" MIMETYPE="image/jp2" SEQ="69" CHECKSUM="2b18b69c1c3d5fa027a35c0ea43c6d69e630c9bf" CHECKSUMTYPE="SHA-1" SIZE="5050022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0069.jp2"/>
+			</file>
+			<file ID="IMG00070" ADMID="techmd70" GROUPID="page70" CREATED="2015-07-30T18:57:25" MIMETYPE="image/jp2" SEQ="70" CHECKSUM="a942766c192333bb966953289417e6f8fba3f09d" CHECKSUMTYPE="SHA-1" SIZE="5032827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0070.jp2"/>
+			</file>
+			<file ID="IMG00071" ADMID="techmd71" GROUPID="page71" CREATED="2015-07-30T18:57:51" MIMETYPE="image/jp2" SEQ="71" CHECKSUM="0aa41eb423434036082c29f855950128b0dc5942" CHECKSUMTYPE="SHA-1" SIZE="5031122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0071.jp2"/>
+			</file>
+			<file ID="IMG00072" ADMID="techmd72" GROUPID="page72" CREATED="2015-07-30T18:58:20" MIMETYPE="image/jp2" SEQ="72" CHECKSUM="e8565d74f9ce5650043ab722ce13ce9879799288" CHECKSUMTYPE="SHA-1" SIZE="5005026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0072.jp2"/>
+			</file>
+			<file ID="IMG00073" ADMID="techmd73" GROUPID="page73" CREATED="2015-07-30T18:58:48" MIMETYPE="image/jp2" SEQ="73" CHECKSUM="31862164e94759edde89dd8d6d657452a1726e2a" CHECKSUMTYPE="SHA-1" SIZE="5081520">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0073.jp2"/>
+			</file>
+			<file ID="IMG00074" ADMID="techmd74" GROUPID="page74" CREATED="2015-07-30T18:59:18" MIMETYPE="image/jp2" SEQ="74" CHECKSUM="82b434756fe4404d316585bb33fc65fe46656a1f" CHECKSUMTYPE="SHA-1" SIZE="4991514">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0074.jp2"/>
+			</file>
+			<file ID="IMG00075" ADMID="techmd75" GROUPID="page75" CREATED="2015-07-30T18:59:45" MIMETYPE="image/jp2" SEQ="75" CHECKSUM="170b19cfe8436d66f019352c2cb1439a8e232cee" CHECKSUMTYPE="SHA-1" SIZE="5111223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0075.jp2"/>
+			</file>
+			<file ID="IMG00076" ADMID="techmd76" GROUPID="page76" CREATED="2015-07-30T19:00:14" MIMETYPE="image/jp2" SEQ="76" CHECKSUM="6a7e2b02073b3cf8901b0530c8951d0af96bfc06" CHECKSUMTYPE="SHA-1" SIZE="5017569">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0076.jp2"/>
+			</file>
+			<file ID="IMG00077" ADMID="techmd77" GROUPID="page77" CREATED="2015-07-30T19:00:42" MIMETYPE="image/jp2" SEQ="77" CHECKSUM="3b77117d82f1ec2c06a18b8e56b5daa293e2a511" CHECKSUMTYPE="SHA-1" SIZE="5082427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0077.jp2"/>
+			</file>
+			<file ID="IMG00078" ADMID="techmd78" GROUPID="page78" CREATED="2015-07-30T19:01:11" MIMETYPE="image/jp2" SEQ="78" CHECKSUM="f9da3e62bf4227ccbfec7e051345fdc54e2bf0eb" CHECKSUMTYPE="SHA-1" SIZE="5018529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0078.jp2"/>
+			</file>
+			<file ID="IMG00079" ADMID="techmd79" GROUPID="page79" CREATED="2015-07-30T19:01:39" MIMETYPE="image/jp2" SEQ="79" CHECKSUM="ed2ba3e9718596ad682c92c5475063084976f9f6" CHECKSUMTYPE="SHA-1" SIZE="5061712">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0079.jp2"/>
+			</file>
+			<file ID="IMG00080" ADMID="techmd80" GROUPID="page80" CREATED="2015-07-30T19:02:09" MIMETYPE="image/jp2" SEQ="80" CHECKSUM="f6080c43d54f7ea2e80a75e0ccc5224775d0b0c7" CHECKSUMTYPE="SHA-1" SIZE="5010428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0080.jp2"/>
+			</file>
+			<file ID="IMG00081" ADMID="techmd81" GROUPID="page81" CREATED="2015-07-30T19:02:35" MIMETYPE="image/jp2" SEQ="81" CHECKSUM="2e9130000e2895c456454f9e1b462ca61dda87fc" CHECKSUMTYPE="SHA-1" SIZE="5027527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0081.jp2"/>
+			</file>
+			<file ID="IMG00082" ADMID="techmd82" GROUPID="page82" CREATED="2015-07-30T19:03:03" MIMETYPE="image/jp2" SEQ="82" CHECKSUM="67096c663968e2be5ac1dd7555558bd0f1bd3ec4" CHECKSUMTYPE="SHA-1" SIZE="5015829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0082.jp2"/>
+			</file>
+			<file ID="IMG00083" ADMID="techmd83" GROUPID="page83" CREATED="2015-07-30T19:03:32" MIMETYPE="image/jp2" SEQ="83" CHECKSUM="81a731bcdd5a51409c9d0ec10ec6493fe1b4111c" CHECKSUMTYPE="SHA-1" SIZE="5048228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0083.jp2"/>
+			</file>
+			<file ID="IMG00084" ADMID="techmd84" GROUPID="page84" CREATED="2015-07-30T19:04:00" MIMETYPE="image/jp2" SEQ="84" CHECKSUM="62f97b5406cf63f5a9708ff984fddab96b4028ca" CHECKSUMTYPE="SHA-1" SIZE="4969027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0084.jp2"/>
+			</file>
+			<file ID="IMG00085" ADMID="techmd85" GROUPID="page85" CREATED="2015-07-30T19:04:28" MIMETYPE="image/jp2" SEQ="85" CHECKSUM="879c42659cc16d3697f5674283cde2f11a411a40" CHECKSUMTYPE="SHA-1" SIZE="5047324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0085.jp2"/>
+			</file>
+			<file ID="IMG00086" ADMID="techmd86" GROUPID="page86" CREATED="2015-07-30T19:04:58" MIMETYPE="image/jp2" SEQ="86" CHECKSUM="8f345608f60fa7976ca1a91339714f19f00459ff" CHECKSUMTYPE="SHA-1" SIZE="4955522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0086.jp2"/>
+			</file>
+			<file ID="IMG00087" ADMID="techmd87" GROUPID="page87" CREATED="2015-07-30T19:05:25" MIMETYPE="image/jp2" SEQ="87" CHECKSUM="f471e1174d615416848010e7f66319d2586a2909" CHECKSUMTYPE="SHA-1" SIZE="5026615">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0087.jp2"/>
+			</file>
+			<file ID="IMG00088" ADMID="techmd88" GROUPID="page88" CREATED="2015-07-30T19:05:55" MIMETYPE="image/jp2" SEQ="88" CHECKSUM="1f43a3a31968ac7b60c59a6c0306e9189ddbc672" CHECKSUMTYPE="SHA-1" SIZE="4966329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0088.jp2"/>
+			</file>
+			<file ID="IMG00089" ADMID="techmd89" GROUPID="page89" CREATED="2015-07-30T19:06:21" MIMETYPE="image/jp2" SEQ="89" CHECKSUM="2bb190ae3dcaf7354ae1e1a910bf644ca4e363c9" CHECKSUMTYPE="SHA-1" SIZE="5046299">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0089.jp2"/>
+			</file>
+			<file ID="IMG00090" ADMID="techmd90" GROUPID="page90" CREATED="2015-07-30T19:06:47" MIMETYPE="image/jp2" SEQ="90" CHECKSUM="0ca7ab7638b769caaceef3ff5de2e400e158a8ad" CHECKSUMTYPE="SHA-1" SIZE="4985197">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0090.jp2"/>
+			</file>
+			<file ID="IMG00091" ADMID="techmd91" GROUPID="page91" CREATED="2015-07-30T19:07:12" MIMETYPE="image/jp2" SEQ="91" CHECKSUM="18d934bdfa76421b8084bb86e453b6f5e714365e" CHECKSUMTYPE="SHA-1" SIZE="4991528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0091.jp2"/>
+			</file>
+			<file ID="IMG00092" ADMID="techmd92" GROUPID="page92" CREATED="2015-07-30T19:07:40" MIMETYPE="image/jp2" SEQ="92" CHECKSUM="37ebc1aa13cf138bd4af692ba93ed83c139403a6" CHECKSUMTYPE="SHA-1" SIZE="4948328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0092.jp2"/>
+			</file>
+			<file ID="IMG00093" ADMID="techmd93" GROUPID="page93" CREATED="2015-07-30T19:08:07" MIMETYPE="image/jp2" SEQ="93" CHECKSUM="1785d2c015c63720db3a441677299c9c309fe422" CHECKSUMTYPE="SHA-1" SIZE="4996922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0093.jp2"/>
+			</file>
+			<file ID="IMG00094" ADMID="techmd94" GROUPID="page94" CREATED="2015-07-30T19:08:37" MIMETYPE="image/jp2" SEQ="94" CHECKSUM="84f3d3e208acbadc4a413912f96001c24f792677" CHECKSUMTYPE="SHA-1" SIZE="4965425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0094.jp2"/>
+			</file>
+			<file ID="IMG00095" ADMID="techmd95" GROUPID="page95" CREATED="2015-07-30T19:09:05" MIMETYPE="image/jp2" SEQ="95" CHECKSUM="04ae1c90a0d0517b183219b4da0ed9fdc7e2eb3f" CHECKSUMTYPE="SHA-1" SIZE="4960029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0095.jp2"/>
+			</file>
+			<file ID="IMG00096" ADMID="techmd96" GROUPID="page96" CREATED="2015-07-30T19:09:33" MIMETYPE="image/jp2" SEQ="96" CHECKSUM="41878de4a2fce3634d7ece206097cb98694923cc" CHECKSUMTYPE="SHA-1" SIZE="5006821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0096.jp2"/>
+			</file>
+			<file ID="IMG00097" ADMID="techmd97" GROUPID="page97" CREATED="2015-07-30T19:10:01" MIMETYPE="image/jp2" SEQ="97" CHECKSUM="f506416baf4856bb6559c82fa94cd51ecdf01b7c" CHECKSUMTYPE="SHA-1" SIZE="4960926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0097.jp2"/>
+			</file>
+			<file ID="IMG00098" ADMID="techmd98" GROUPID="page98" CREATED="2015-07-30T19:10:31" MIMETYPE="image/jp2" SEQ="98" CHECKSUM="72cdbc0e30545debab8fe75e645ff6caa81b476e" CHECKSUMTYPE="SHA-1" SIZE="4923122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0098.jp2"/>
+			</file>
+			<file ID="IMG00099" ADMID="techmd99" GROUPID="page99" CREATED="2015-07-30T19:10:59" MIMETYPE="image/jp2" SEQ="99" CHECKSUM="bcd7cfb09cd6eb4a8b607e03b20d82daeb099a8c" CHECKSUMTYPE="SHA-1" SIZE="4937525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0099.jp2"/>
+			</file>
+			<file ID="IMG00100" ADMID="techmd100" GROUPID="page100" CREATED="2015-07-30T19:11:27" MIMETYPE="image/jp2" SEQ="100" CHECKSUM="aaf906b30a37968e509eec38b91f4f25501a2708" CHECKSUMTYPE="SHA-1" SIZE="4915928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0100.jp2"/>
+			</file>
+			<file ID="IMG00101" ADMID="techmd101" GROUPID="page101" CREATED="2015-07-30T19:11:56" MIMETYPE="image/jp2" SEQ="101" CHECKSUM="33cb67d83fe2c97f43e8ec9d065faf02b39e662d" CHECKSUMTYPE="SHA-1" SIZE="4906028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0101.jp2"/>
+			</file>
+			<file ID="IMG00102" ADMID="techmd102" GROUPID="page102" CREATED="2015-07-30T19:12:23" MIMETYPE="image/jp2" SEQ="102" CHECKSUM="744002ddd37aa2a48176ed8cc8c1a42a312d6122" CHECKSUMTYPE="SHA-1" SIZE="4931229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0102.jp2"/>
+			</file>
+			<file ID="IMG00103" ADMID="techmd103" GROUPID="page103" CREATED="2015-07-30T19:12:47" MIMETYPE="image/jp2" SEQ="103" CHECKSUM="b28b340568c7a7f450327d62aeec42dc2adcb114" CHECKSUMTYPE="SHA-1" SIZE="4879024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0103.jp2"/>
+			</file>
+			<file ID="IMG00104" ADMID="techmd104" GROUPID="page104" CREATED="2015-07-30T19:13:12" MIMETYPE="image/jp2" SEQ="104" CHECKSUM="03adfd2db027765356ce6d28b9f8ff71105723ce" CHECKSUMTYPE="SHA-1" SIZE="4951918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0104.jp2"/>
+			</file>
+			<file ID="IMG00105" ADMID="techmd105" GROUPID="page105" CREATED="2015-07-30T19:13:39" MIMETYPE="image/jp2" SEQ="105" CHECKSUM="56bf139bc040f4330ab7a6b0bfc86ebe1a03d919" CHECKSUMTYPE="SHA-1" SIZE="4902429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0105.jp2"/>
+			</file>
+			<file ID="IMG00106" ADMID="techmd106" GROUPID="page106" CREATED="2015-07-30T19:14:07" MIMETYPE="image/jp2" SEQ="106" CHECKSUM="a462987de55dbc7987b6bf59449819907a729007" CHECKSUMTYPE="SHA-1" SIZE="4938414">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0106.jp2"/>
+			</file>
+			<file ID="IMG00107" ADMID="techmd107" GROUPID="page107" CREATED="2015-07-30T19:14:34" MIMETYPE="image/jp2" SEQ="107" CHECKSUM="d25869b3f17a61cf5729b11506d5620d003c9af3" CHECKSUMTYPE="SHA-1" SIZE="4891628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0107.jp2"/>
+			</file>
+			<file ID="IMG00108" ADMID="techmd108" GROUPID="page108" CREATED="2015-07-30T19:15:02" MIMETYPE="image/jp2" SEQ="108" CHECKSUM="a956c20784523ff8b587f65cda13be6e072b8b85" CHECKSUMTYPE="SHA-1" SIZE="4942922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0108.jp2"/>
+			</file>
+			<file ID="IMG00109" ADMID="techmd109" GROUPID="page109" CREATED="2015-07-30T19:15:29" MIMETYPE="image/jp2" SEQ="109" CHECKSUM="ab7a793dfcaf6bb1b124c604e670a9db2852ee63" CHECKSUMTYPE="SHA-1" SIZE="4884429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0109.jp2"/>
+			</file>
+			<file ID="IMG00110" ADMID="techmd110" GROUPID="page110" CREATED="2015-07-30T19:15:55" MIMETYPE="image/jp2" SEQ="110" CHECKSUM="67ba48c9cc9f3fcf22357693a78bd3e10dddfe49" CHECKSUMTYPE="SHA-1" SIZE="4898829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0110.jp2"/>
+			</file>
+			<file ID="IMG00111" ADMID="techmd111" GROUPID="page111" CREATED="2015-07-30T19:16:19" MIMETYPE="image/jp2" SEQ="111" CHECKSUM="b27a6615d59be907dc047d400c3ab1dace4f9c04" CHECKSUMTYPE="SHA-1" SIZE="4940228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0111.jp2"/>
+			</file>
+			<file ID="IMG00112" ADMID="techmd112" GROUPID="page112" CREATED="2015-07-30T19:16:51" MIMETYPE="image/jp2" SEQ="112" CHECKSUM="d1e620bbf860e635c5cf766402b76cb8c1895c44" CHECKSUMTYPE="SHA-1" SIZE="4959982">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/delivery/bmtnabe_1900-04_01_0112.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T19:17:10" MIMETYPE="text/xml" CHECKSUM="b93a70cb0096425907b0aa279041523f7ab5bdfc"
-				CHECKSUMTYPE="SHA-1" SIZE="2102">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-07-30T19:17:10" MIMETYPE="text/xml" CHECKSUM="b93a70cb0096425907b0aa279041523f7ab5bdfc" CHECKSUMTYPE="SHA-1" SIZE="2102">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T19:17:10" MIMETYPE="text/xml" CHECKSUM="0530992b3482ebc2d3fb595f7a2607de23b0170f"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-07-30T19:17:10" MIMETYPE="text/xml" CHECKSUM="0530992b3482ebc2d3fb595f7a2607de23b0170f" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T19:17:10" MIMETYPE="text/xml" CHECKSUM="c56e6f71e2985d225f0386cea98504576d6e2702"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-07-30T19:17:10" MIMETYPE="text/xml" CHECKSUM="c56e6f71e2985d225f0386cea98504576d6e2702" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T19:17:10" MIMETYPE="text/xml" CHECKSUM="a4313f1c0e1e0f84a3d353a5b6dc688d6607b0b6"
-				CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-07-30T19:17:10" MIMETYPE="text/xml" CHECKSUM="a4313f1c0e1e0f84a3d353a5b6dc688d6607b0b6" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T19:17:11" MIMETYPE="text/xml" CHECKSUM="cc51966f63f41c6ea9c9599ed2ea5752f1de2a90"
-				CHECKSUMTYPE="SHA-1" SIZE="13562">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-07-30T19:17:11" MIMETYPE="text/xml" CHECKSUM="cc51966f63f41c6ea9c9599ed2ea5752f1de2a90" CHECKSUMTYPE="SHA-1" SIZE="13562">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T19:17:11" MIMETYPE="text/xml" CHECKSUM="1228bef244fd78ea9c039322f86c436c6e2dc9ea"
-				CHECKSUMTYPE="SHA-1" SIZE="3380">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-07-30T19:17:11" MIMETYPE="text/xml" CHECKSUM="1228bef244fd78ea9c039322f86c436c6e2dc9ea" CHECKSUMTYPE="SHA-1" SIZE="3380">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T19:17:11" MIMETYPE="text/xml" CHECKSUM="64d7909d4f50fabcef3e3b6411804a3757a81c0c"
-				CHECKSUMTYPE="SHA-1" SIZE="1715">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-07-30T19:17:11" MIMETYPE="text/xml" CHECKSUM="64d7909d4f50fabcef3e3b6411804a3757a81c0c" CHECKSUMTYPE="SHA-1" SIZE="1715">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T19:17:11" MIMETYPE="text/xml" CHECKSUM="aa8a092689374b310de2f9ec600b059e0e06260a"
-				CHECKSUMTYPE="SHA-1" SIZE="5117">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-07-30T19:17:11" MIMETYPE="text/xml" CHECKSUM="aa8a092689374b310de2f9ec600b059e0e06260a" CHECKSUMTYPE="SHA-1" SIZE="5117">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T19:17:12" MIMETYPE="text/xml" CHECKSUM="1cdcba3d4e024591ca101d6b860c940586a6fa65"
-				CHECKSUMTYPE="SHA-1" SIZE="31906">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-07-30T19:17:12" MIMETYPE="text/xml" CHECKSUM="1cdcba3d4e024591ca101d6b860c940586a6fa65" CHECKSUMTYPE="SHA-1" SIZE="31906">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T19:17:12" MIMETYPE="text/xml"
-				CHECKSUM="3f3025a47f5344be797ef1ac3a59ea31270ad26b" CHECKSUMTYPE="SHA-1" SIZE="32476">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-07-30T19:17:12" MIMETYPE="text/xml" CHECKSUM="3f3025a47f5344be797ef1ac3a59ea31270ad26b" CHECKSUMTYPE="SHA-1" SIZE="32476">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T19:17:12" MIMETYPE="text/xml"
-				CHECKSUM="919b708c078b0498cb765702eda31508aee69570" CHECKSUMTYPE="SHA-1" SIZE="65279">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-07-30T19:17:12" MIMETYPE="text/xml" CHECKSUM="919b708c078b0498cb765702eda31508aee69570" CHECKSUMTYPE="SHA-1" SIZE="65279">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T19:17:13" MIMETYPE="text/xml"
-				CHECKSUM="711ac2762627547adfa9ae51c0225969d4319349" CHECKSUMTYPE="SHA-1" SIZE="115057">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-07-30T19:17:13" MIMETYPE="text/xml" CHECKSUM="711ac2762627547adfa9ae51c0225969d4319349" CHECKSUMTYPE="SHA-1" SIZE="115057">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T19:17:13" MIMETYPE="text/xml"
-				CHECKSUM="94f6f03ac987183e1b998a3040c79d93bc78a699" CHECKSUMTYPE="SHA-1" SIZE="102583">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-07-30T19:17:13" MIMETYPE="text/xml" CHECKSUM="94f6f03ac987183e1b998a3040c79d93bc78a699" CHECKSUMTYPE="SHA-1" SIZE="102583">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T19:17:13" MIMETYPE="text/xml"
-				CHECKSUM="1dc1a3db1993533b16300823f9b2100e556acadf" CHECKSUMTYPE="SHA-1" SIZE="82655">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-07-30T19:17:13" MIMETYPE="text/xml" CHECKSUM="1dc1a3db1993533b16300823f9b2100e556acadf" CHECKSUMTYPE="SHA-1" SIZE="82655">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T19:17:14" MIMETYPE="text/xml"
-				CHECKSUM="ab8d1d25c420d41f94ee06c58511b769aa9627af" CHECKSUMTYPE="SHA-1" SIZE="128884">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-07-30T19:17:14" MIMETYPE="text/xml" CHECKSUM="ab8d1d25c420d41f94ee06c58511b769aa9627af" CHECKSUMTYPE="SHA-1" SIZE="128884">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T19:17:14" MIMETYPE="text/xml"
-				CHECKSUM="8c04db968e25b3167d4cfcd8083b054ccf60a48c" CHECKSUMTYPE="SHA-1" SIZE="52633">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-07-30T19:17:14" MIMETYPE="text/xml" CHECKSUM="8c04db968e25b3167d4cfcd8083b054ccf60a48c" CHECKSUMTYPE="SHA-1" SIZE="52633">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T19:17:14" MIMETYPE="text/xml"
-				CHECKSUM="728277abcbd845f1bad293ddcfcf453fe43a4a92" CHECKSUMTYPE="SHA-1" SIZE="5197">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-07-30T19:17:14" MIMETYPE="text/xml" CHECKSUM="728277abcbd845f1bad293ddcfcf453fe43a4a92" CHECKSUMTYPE="SHA-1" SIZE="5197">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T19:17:15" MIMETYPE="text/xml"
-				CHECKSUM="c1943d29bd624c24df6ee62916ab57341427ba89" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-07-30T19:17:15" MIMETYPE="text/xml" CHECKSUM="c1943d29bd624c24df6ee62916ab57341427ba89" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T19:17:15" MIMETYPE="text/xml"
-				CHECKSUM="f900ee59002df310e93cfd884b841eb17c380f4d" CHECKSUMTYPE="SHA-1" SIZE="33419">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-07-30T19:17:15" MIMETYPE="text/xml" CHECKSUM="f900ee59002df310e93cfd884b841eb17c380f4d" CHECKSUMTYPE="SHA-1" SIZE="33419">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T19:17:15" MIMETYPE="text/xml"
-				CHECKSUM="e492acdc37e2bff379f255d72b908ee9f111810a" CHECKSUMTYPE="SHA-1" SIZE="40598">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-07-30T19:17:15" MIMETYPE="text/xml" CHECKSUM="e492acdc37e2bff379f255d72b908ee9f111810a" CHECKSUMTYPE="SHA-1" SIZE="40598">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T19:17:16" MIMETYPE="text/xml"
-				CHECKSUM="9868312c5245ea1374cf5265437f2044acd8897c" CHECKSUMTYPE="SHA-1" SIZE="53807">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-07-30T19:17:16" MIMETYPE="text/xml" CHECKSUM="9868312c5245ea1374cf5265437f2044acd8897c" CHECKSUMTYPE="SHA-1" SIZE="53807">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T19:17:16" MIMETYPE="text/xml"
-				CHECKSUM="05df6e8de76a02575c5aa6ac26eff9ba9e46bea5" CHECKSUMTYPE="SHA-1" SIZE="36339">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-07-30T19:17:16" MIMETYPE="text/xml" CHECKSUM="05df6e8de76a02575c5aa6ac26eff9ba9e46bea5" CHECKSUMTYPE="SHA-1" SIZE="36339">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T19:17:16" MIMETYPE="text/xml"
-				CHECKSUM="ecbcc5f193f3705bb82279daa98c104567e7044e" CHECKSUMTYPE="SHA-1" SIZE="29337">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-07-30T19:17:16" MIMETYPE="text/xml" CHECKSUM="ecbcc5f193f3705bb82279daa98c104567e7044e" CHECKSUMTYPE="SHA-1" SIZE="29337">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T19:17:17" MIMETYPE="text/xml"
-				CHECKSUM="1ec733676b6de1f9522f28dadca3339c5bb38fc5" CHECKSUMTYPE="SHA-1" SIZE="47912">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-07-30T19:17:17" MIMETYPE="text/xml" CHECKSUM="1ec733676b6de1f9522f28dadca3339c5bb38fc5" CHECKSUMTYPE="SHA-1" SIZE="47912">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T19:17:17" MIMETYPE="text/xml"
-				CHECKSUM="74213501261c1a809b334ce06ac0b9311fbe7f25" CHECKSUMTYPE="SHA-1" SIZE="54591">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-07-30T19:17:17" MIMETYPE="text/xml" CHECKSUM="74213501261c1a809b334ce06ac0b9311fbe7f25" CHECKSUMTYPE="SHA-1" SIZE="54591">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T19:17:17" MIMETYPE="text/xml"
-				CHECKSUM="6f81c6622bc2405b41934b1cf78a46a86b24408e" CHECKSUMTYPE="SHA-1" SIZE="98680">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-07-30T19:17:17" MIMETYPE="text/xml" CHECKSUM="6f81c6622bc2405b41934b1cf78a46a86b24408e" CHECKSUMTYPE="SHA-1" SIZE="98680">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T19:17:18" MIMETYPE="text/xml"
-				CHECKSUM="65a8aa4108140d43d960c86bf84eb22b4c421e81" CHECKSUMTYPE="SHA-1" SIZE="159908">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-07-30T19:17:18" MIMETYPE="text/xml" CHECKSUM="65a8aa4108140d43d960c86bf84eb22b4c421e81" CHECKSUMTYPE="SHA-1" SIZE="159908">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T19:17:18" MIMETYPE="text/xml"
-				CHECKSUM="0b68e49df8f1bdccc424dd0543d521cc5cd95d1a" CHECKSUMTYPE="SHA-1" SIZE="158141">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-07-30T19:17:18" MIMETYPE="text/xml" CHECKSUM="0b68e49df8f1bdccc424dd0543d521cc5cd95d1a" CHECKSUMTYPE="SHA-1" SIZE="158141">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T19:17:18" MIMETYPE="text/xml"
-				CHECKSUM="ce9a8efdf1b4673954836ed724162541d7106464" CHECKSUMTYPE="SHA-1" SIZE="147937">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-07-30T19:17:18" MIMETYPE="text/xml" CHECKSUM="ce9a8efdf1b4673954836ed724162541d7106464" CHECKSUMTYPE="SHA-1" SIZE="147937">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T19:17:19" MIMETYPE="text/xml"
-				CHECKSUM="5e416beb54691715fc9f0a76b26f10706253db9d" CHECKSUMTYPE="SHA-1" SIZE="153169">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-07-30T19:17:19" MIMETYPE="text/xml" CHECKSUM="5e416beb54691715fc9f0a76b26f10706253db9d" CHECKSUMTYPE="SHA-1" SIZE="153169">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T19:17:19" MIMETYPE="text/xml"
-				CHECKSUM="d433d7061f0472b75a16815647f36bd39f4b11e1" CHECKSUMTYPE="SHA-1" SIZE="147795">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-07-30T19:17:19" MIMETYPE="text/xml" CHECKSUM="d433d7061f0472b75a16815647f36bd39f4b11e1" CHECKSUMTYPE="SHA-1" SIZE="147795">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T19:17:20" MIMETYPE="text/xml"
-				CHECKSUM="cf083482d57fe9d1bb29c16929cd87c1fb781a4f" CHECKSUMTYPE="SHA-1" SIZE="128406">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-07-30T19:17:20" MIMETYPE="text/xml" CHECKSUM="cf083482d57fe9d1bb29c16929cd87c1fb781a4f" CHECKSUMTYPE="SHA-1" SIZE="128406">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T19:17:20" MIMETYPE="text/xml"
-				CHECKSUM="070dc9f83a0490982a9e7505ebce427387a3fc36" CHECKSUMTYPE="SHA-1" SIZE="111201">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-07-30T19:17:20" MIMETYPE="text/xml" CHECKSUM="070dc9f83a0490982a9e7505ebce427387a3fc36" CHECKSUMTYPE="SHA-1" SIZE="111201">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T19:17:20" MIMETYPE="text/xml"
-				CHECKSUM="2ff54d588fa0f2ce281c8d05a28455aa4874cb10" CHECKSUMTYPE="SHA-1" SIZE="27522">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-07-30T19:17:20" MIMETYPE="text/xml" CHECKSUM="2ff54d588fa0f2ce281c8d05a28455aa4874cb10" CHECKSUMTYPE="SHA-1" SIZE="27522">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T19:17:21" MIMETYPE="text/xml"
-				CHECKSUM="ed7520a1fbbbff0e45ab20f5c8a4296bab2710bd" CHECKSUMTYPE="SHA-1" SIZE="34401">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-07-30T19:17:21" MIMETYPE="text/xml" CHECKSUM="ed7520a1fbbbff0e45ab20f5c8a4296bab2710bd" CHECKSUMTYPE="SHA-1" SIZE="34401">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T19:17:21" MIMETYPE="text/xml"
-				CHECKSUM="aef9112e6b6a05fe50ce92b1fbeab9e8b87617b7" CHECKSUMTYPE="SHA-1" SIZE="24348">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-07-30T19:17:21" MIMETYPE="text/xml" CHECKSUM="aef9112e6b6a05fe50ce92b1fbeab9e8b87617b7" CHECKSUMTYPE="SHA-1" SIZE="24348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T19:17:21" MIMETYPE="text/xml"
-				CHECKSUM="65321dd683d84ce0dbb289615a57fce3b2dc3950" CHECKSUMTYPE="SHA-1" SIZE="5300">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-07-30T19:17:21" MIMETYPE="text/xml" CHECKSUM="65321dd683d84ce0dbb289615a57fce3b2dc3950" CHECKSUMTYPE="SHA-1" SIZE="5300">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T19:17:22" MIMETYPE="text/xml"
-				CHECKSUM="133060dbe00e68b39f1717b4cafe96ccb712d82a" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-07-30T19:17:22" MIMETYPE="text/xml" CHECKSUM="133060dbe00e68b39f1717b4cafe96ccb712d82a" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T19:17:22" MIMETYPE="text/xml"
-				CHECKSUM="17bdd749fefbbebd9f4adf2e6ae857243f6ea002" CHECKSUMTYPE="SHA-1" SIZE="19339">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-07-30T19:17:22" MIMETYPE="text/xml" CHECKSUM="17bdd749fefbbebd9f4adf2e6ae857243f6ea002" CHECKSUMTYPE="SHA-1" SIZE="19339">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T19:17:22" MIMETYPE="text/xml"
-				CHECKSUM="d47c2db629ab7c0ba6bbfeae5516884bfdce518c" CHECKSUMTYPE="SHA-1" SIZE="56921">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-07-30T19:17:22" MIMETYPE="text/xml" CHECKSUM="d47c2db629ab7c0ba6bbfeae5516884bfdce518c" CHECKSUMTYPE="SHA-1" SIZE="56921">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0040.alto.xml"/>
 			</file>
-			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T19:17:23" MIMETYPE="text/xml"
-				CHECKSUM="6ad59d0714f75879526b449f9c86f3cd56789e6c" CHECKSUMTYPE="SHA-1" SIZE="15934">
+			<file ID="ALTO00041" GROUPID="page41" CREATED="2015-07-30T19:17:23" MIMETYPE="text/xml" CHECKSUM="6ad59d0714f75879526b449f9c86f3cd56789e6c" CHECKSUMTYPE="SHA-1" SIZE="15934">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0041.alto.xml"/>
 			</file>
-			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T19:17:23" MIMETYPE="text/xml"
-				CHECKSUM="dd8e6fa35613ab7a51be9938a42201852f4bd233" CHECKSUMTYPE="SHA-1" SIZE="70095">
+			<file ID="ALTO00042" GROUPID="page42" CREATED="2015-07-30T19:17:23" MIMETYPE="text/xml" CHECKSUM="dd8e6fa35613ab7a51be9938a42201852f4bd233" CHECKSUMTYPE="SHA-1" SIZE="70095">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0042.alto.xml"/>
 			</file>
-			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T19:17:23" MIMETYPE="text/xml"
-				CHECKSUM="2042c9f01d03ef07e00cfedec9e0d62b0463526b" CHECKSUMTYPE="SHA-1" SIZE="5117">
+			<file ID="ALTO00043" GROUPID="page43" CREATED="2015-07-30T19:17:23" MIMETYPE="text/xml" CHECKSUM="2042c9f01d03ef07e00cfedec9e0d62b0463526b" CHECKSUMTYPE="SHA-1" SIZE="5117">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0043.alto.xml"/>
 			</file>
-			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T19:17:23" MIMETYPE="text/xml"
-				CHECKSUM="82dbec450dfc9100e8941e8d32cd2963714e5132" CHECKSUMTYPE="SHA-1" SIZE="2015">
+			<file ID="ALTO00044" GROUPID="page44" CREATED="2015-07-30T19:17:23" MIMETYPE="text/xml" CHECKSUM="82dbec450dfc9100e8941e8d32cd2963714e5132" CHECKSUMTYPE="SHA-1" SIZE="2015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0044.alto.xml"/>
 			</file>
-			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T19:17:24" MIMETYPE="text/xml"
-				CHECKSUM="fceefec5b39329bad8046176b4546faddc13d571" CHECKSUMTYPE="SHA-1" SIZE="38557">
+			<file ID="ALTO00045" GROUPID="page45" CREATED="2015-07-30T19:17:24" MIMETYPE="text/xml" CHECKSUM="fceefec5b39329bad8046176b4546faddc13d571" CHECKSUMTYPE="SHA-1" SIZE="38557">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0045.alto.xml"/>
 			</file>
-			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T19:17:24" MIMETYPE="text/xml"
-				CHECKSUM="8a0bedc9c2d05a62024367a5dd9497b2a366c823" CHECKSUMTYPE="SHA-1" SIZE="78836">
+			<file ID="ALTO00046" GROUPID="page46" CREATED="2015-07-30T19:17:24" MIMETYPE="text/xml" CHECKSUM="8a0bedc9c2d05a62024367a5dd9497b2a366c823" CHECKSUMTYPE="SHA-1" SIZE="78836">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0046.alto.xml"/>
 			</file>
-			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T19:17:24" MIMETYPE="text/xml"
-				CHECKSUM="22fe74ffbb2e9bef017224150da7c78e5401f9b0" CHECKSUMTYPE="SHA-1" SIZE="40160">
+			<file ID="ALTO00047" GROUPID="page47" CREATED="2015-07-30T19:17:24" MIMETYPE="text/xml" CHECKSUM="22fe74ffbb2e9bef017224150da7c78e5401f9b0" CHECKSUMTYPE="SHA-1" SIZE="40160">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0047.alto.xml"/>
 			</file>
-			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T19:17:25" MIMETYPE="text/xml"
-				CHECKSUM="fb3a1429a10b7b87f0301ded373626e6d3aec528" CHECKSUMTYPE="SHA-1" SIZE="72254">
+			<file ID="ALTO00048" GROUPID="page48" CREATED="2015-07-30T19:17:25" MIMETYPE="text/xml" CHECKSUM="fb3a1429a10b7b87f0301ded373626e6d3aec528" CHECKSUMTYPE="SHA-1" SIZE="72254">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0048.alto.xml"/>
 			</file>
-			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T19:17:25" MIMETYPE="text/xml"
-				CHECKSUM="02c1792d0c0ee374853afd6acc477f9b010357d3" CHECKSUMTYPE="SHA-1" SIZE="2419">
+			<file ID="ALTO00049" GROUPID="page49" CREATED="2015-07-30T19:17:25" MIMETYPE="text/xml" CHECKSUM="02c1792d0c0ee374853afd6acc477f9b010357d3" CHECKSUMTYPE="SHA-1" SIZE="2419">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0049.alto.xml"/>
 			</file>
-			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T19:17:25" MIMETYPE="text/xml"
-				CHECKSUM="37ee9c52766f3a4b0c3b0325e12528edbeb8007e" CHECKSUMTYPE="SHA-1" SIZE="2021">
+			<file ID="ALTO00050" GROUPID="page50" CREATED="2015-07-30T19:17:25" MIMETYPE="text/xml" CHECKSUM="37ee9c52766f3a4b0c3b0325e12528edbeb8007e" CHECKSUMTYPE="SHA-1" SIZE="2021">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0050.alto.xml"/>
 			</file>
-			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T19:17:26" MIMETYPE="text/xml"
-				CHECKSUM="22c002e92e875fb83222f4ee8d04d4d004bd2387" CHECKSUMTYPE="SHA-1" SIZE="105987">
+			<file ID="ALTO00051" GROUPID="page51" CREATED="2015-07-30T19:17:26" MIMETYPE="text/xml" CHECKSUM="22c002e92e875fb83222f4ee8d04d4d004bd2387" CHECKSUMTYPE="SHA-1" SIZE="105987">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0051.alto.xml"/>
 			</file>
-			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T19:17:26" MIMETYPE="text/xml"
-				CHECKSUM="056121bc0eaa47138b3b54940e7036073b326e11" CHECKSUMTYPE="SHA-1" SIZE="100722">
+			<file ID="ALTO00052" GROUPID="page52" CREATED="2015-07-30T19:17:26" MIMETYPE="text/xml" CHECKSUM="056121bc0eaa47138b3b54940e7036073b326e11" CHECKSUMTYPE="SHA-1" SIZE="100722">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0052.alto.xml"/>
 			</file>
-			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T19:17:26" MIMETYPE="text/xml"
-				CHECKSUM="d67941aefc51abb62d9fb9e9edd6b29b00471328" CHECKSUMTYPE="SHA-1" SIZE="4891">
+			<file ID="ALTO00053" GROUPID="page53" CREATED="2015-07-30T19:17:26" MIMETYPE="text/xml" CHECKSUM="d67941aefc51abb62d9fb9e9edd6b29b00471328" CHECKSUMTYPE="SHA-1" SIZE="4891">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0053.alto.xml"/>
 			</file>
-			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T19:17:27" MIMETYPE="text/xml"
-				CHECKSUM="1b63449916e513777b1d8e635423124a27f8de2e" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00054" GROUPID="page54" CREATED="2015-07-30T19:17:27" MIMETYPE="text/xml" CHECKSUM="1b63449916e513777b1d8e635423124a27f8de2e" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0054.alto.xml"/>
 			</file>
-			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T19:17:27" MIMETYPE="text/xml"
-				CHECKSUM="9e8681186369fbe317065d4cc3f738b04f2796ca" CHECKSUMTYPE="SHA-1" SIZE="74962">
+			<file ID="ALTO00055" GROUPID="page55" CREATED="2015-07-30T19:17:27" MIMETYPE="text/xml" CHECKSUM="9e8681186369fbe317065d4cc3f738b04f2796ca" CHECKSUMTYPE="SHA-1" SIZE="74962">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0055.alto.xml"/>
 			</file>
-			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T19:17:27" MIMETYPE="text/xml"
-				CHECKSUM="4056f30c652958a2419ba2f6daa55fdd468dc6b7" CHECKSUMTYPE="SHA-1" SIZE="104398">
+			<file ID="ALTO00056" GROUPID="page56" CREATED="2015-07-30T19:17:27" MIMETYPE="text/xml" CHECKSUM="4056f30c652958a2419ba2f6daa55fdd468dc6b7" CHECKSUMTYPE="SHA-1" SIZE="104398">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0056.alto.xml"/>
 			</file>
-			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T19:17:28" MIMETYPE="text/xml"
-				CHECKSUM="7583a8bdcecf86a4d928239c61e5c2ac379512df" CHECKSUMTYPE="SHA-1" SIZE="111221">
+			<file ID="ALTO00057" GROUPID="page57" CREATED="2015-07-30T19:17:28" MIMETYPE="text/xml" CHECKSUM="7583a8bdcecf86a4d928239c61e5c2ac379512df" CHECKSUMTYPE="SHA-1" SIZE="111221">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0057.alto.xml"/>
 			</file>
-			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T19:17:28" MIMETYPE="text/xml"
-				CHECKSUM="0d0ee53b18f2ad16779c841b1e5460ac0bce0e7e" CHECKSUMTYPE="SHA-1" SIZE="79056">
+			<file ID="ALTO00058" GROUPID="page58" CREATED="2015-07-30T19:17:28" MIMETYPE="text/xml" CHECKSUM="0d0ee53b18f2ad16779c841b1e5460ac0bce0e7e" CHECKSUMTYPE="SHA-1" SIZE="79056">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0058.alto.xml"/>
 			</file>
-			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T19:17:28" MIMETYPE="text/xml"
-				CHECKSUM="7b2d3931a84fe6ccee8d66a434109311dd9b0f66" CHECKSUMTYPE="SHA-1" SIZE="194128">
+			<file ID="ALTO00059" GROUPID="page59" CREATED="2015-07-30T19:17:28" MIMETYPE="text/xml" CHECKSUM="7b2d3931a84fe6ccee8d66a434109311dd9b0f66" CHECKSUMTYPE="SHA-1" SIZE="194128">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0059.alto.xml"/>
 			</file>
-			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T19:17:29" MIMETYPE="text/xml"
-				CHECKSUM="e7e4ae9a20ba256ee42c504bf8ea80c4ac486adc" CHECKSUMTYPE="SHA-1" SIZE="196091">
+			<file ID="ALTO00060" GROUPID="page60" CREATED="2015-07-30T19:17:29" MIMETYPE="text/xml" CHECKSUM="e7e4ae9a20ba256ee42c504bf8ea80c4ac486adc" CHECKSUMTYPE="SHA-1" SIZE="196091">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0060.alto.xml"/>
 			</file>
-			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T19:17:29" MIMETYPE="text/xml"
-				CHECKSUM="3ee3d310f53cc013b0e85bb9331635b1b26497ed" CHECKSUMTYPE="SHA-1" SIZE="202964">
+			<file ID="ALTO00061" GROUPID="page61" CREATED="2015-07-30T19:17:29" MIMETYPE="text/xml" CHECKSUM="3ee3d310f53cc013b0e85bb9331635b1b26497ed" CHECKSUMTYPE="SHA-1" SIZE="202964">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0061.alto.xml"/>
 			</file>
-			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T19:17:30" MIMETYPE="text/xml"
-				CHECKSUM="7422d8cf3db7b381090c20f8332ce0cd54081ce1" CHECKSUMTYPE="SHA-1" SIZE="78084">
+			<file ID="ALTO00062" GROUPID="page62" CREATED="2015-07-30T19:17:30" MIMETYPE="text/xml" CHECKSUM="7422d8cf3db7b381090c20f8332ce0cd54081ce1" CHECKSUMTYPE="SHA-1" SIZE="78084">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0062.alto.xml"/>
 			</file>
-			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T19:17:30" MIMETYPE="text/xml"
-				CHECKSUM="77788e8f658200c87b9dc5f14bb3a0153988a309" CHECKSUMTYPE="SHA-1" SIZE="4810">
+			<file ID="ALTO00063" GROUPID="page63" CREATED="2015-07-30T19:17:30" MIMETYPE="text/xml" CHECKSUM="77788e8f658200c87b9dc5f14bb3a0153988a309" CHECKSUMTYPE="SHA-1" SIZE="4810">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0063.alto.xml"/>
 			</file>
-			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T19:17:30" MIMETYPE="text/xml"
-				CHECKSUM="6b109a8c43b2d4e22ff92c87a15dfdee694ad769" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00064" GROUPID="page64" CREATED="2015-07-30T19:17:30" MIMETYPE="text/xml" CHECKSUM="6b109a8c43b2d4e22ff92c87a15dfdee694ad769" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0064.alto.xml"/>
 			</file>
-			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T19:17:31" MIMETYPE="text/xml"
-				CHECKSUM="425c89b62c52a0d2555345c090d8e9e19696c117" CHECKSUMTYPE="SHA-1" SIZE="101089">
+			<file ID="ALTO00065" GROUPID="page65" CREATED="2015-07-30T19:17:31" MIMETYPE="text/xml" CHECKSUM="425c89b62c52a0d2555345c090d8e9e19696c117" CHECKSUMTYPE="SHA-1" SIZE="101089">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0065.alto.xml"/>
 			</file>
-			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T19:17:31" MIMETYPE="text/xml"
-				CHECKSUM="7eedae2ba33f10b3699b6eb36bff50ec1d5099b2" CHECKSUMTYPE="SHA-1" SIZE="195329">
+			<file ID="ALTO00066" GROUPID="page66" CREATED="2015-07-30T19:17:31" MIMETYPE="text/xml" CHECKSUM="7eedae2ba33f10b3699b6eb36bff50ec1d5099b2" CHECKSUMTYPE="SHA-1" SIZE="195329">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0066.alto.xml"/>
 			</file>
-			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T19:17:31" MIMETYPE="text/xml"
-				CHECKSUM="e69d163f8a4edfbcded9cd88ecf273796a6fd311" CHECKSUMTYPE="SHA-1" SIZE="195463">
+			<file ID="ALTO00067" GROUPID="page67" CREATED="2015-07-30T19:17:31" MIMETYPE="text/xml" CHECKSUM="e69d163f8a4edfbcded9cd88ecf273796a6fd311" CHECKSUMTYPE="SHA-1" SIZE="195463">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0067.alto.xml"/>
 			</file>
-			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T19:17:32" MIMETYPE="text/xml"
-				CHECKSUM="0391cf046b32fdf06ca6511acd379cbbb34b8eea" CHECKSUMTYPE="SHA-1" SIZE="52282">
+			<file ID="ALTO00068" GROUPID="page68" CREATED="2015-07-30T19:17:32" MIMETYPE="text/xml" CHECKSUM="0391cf046b32fdf06ca6511acd379cbbb34b8eea" CHECKSUMTYPE="SHA-1" SIZE="52282">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0068.alto.xml"/>
 			</file>
-			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T19:17:32" MIMETYPE="text/xml"
-				CHECKSUM="a9768358bff4758ba7440c43498b8d95d36ff41d" CHECKSUMTYPE="SHA-1" SIZE="5690">
+			<file ID="ALTO00069" GROUPID="page69" CREATED="2015-07-30T19:17:32" MIMETYPE="text/xml" CHECKSUM="a9768358bff4758ba7440c43498b8d95d36ff41d" CHECKSUMTYPE="SHA-1" SIZE="5690">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0069.alto.xml"/>
 			</file>
-			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T19:17:33" MIMETYPE="text/xml"
-				CHECKSUM="4d343f089b0f2d98f15ace04914ca865fa8591c8" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00070" GROUPID="page70" CREATED="2015-07-30T19:17:33" MIMETYPE="text/xml" CHECKSUM="4d343f089b0f2d98f15ace04914ca865fa8591c8" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0070.alto.xml"/>
 			</file>
-			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T19:17:33" MIMETYPE="text/xml"
-				CHECKSUM="fbf0119ddfd7787a59cbfdcc03037b5b29d567ca" CHECKSUMTYPE="SHA-1" SIZE="75057">
+			<file ID="ALTO00071" GROUPID="page71" CREATED="2015-07-30T19:17:33" MIMETYPE="text/xml" CHECKSUM="fbf0119ddfd7787a59cbfdcc03037b5b29d567ca" CHECKSUMTYPE="SHA-1" SIZE="75057">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0071.alto.xml"/>
 			</file>
-			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T19:17:33" MIMETYPE="text/xml"
-				CHECKSUM="2b459feb0c7dd676fb5fa12d6ef06234f9ddc03d" CHECKSUMTYPE="SHA-1" SIZE="203782">
+			<file ID="ALTO00072" GROUPID="page72" CREATED="2015-07-30T19:17:33" MIMETYPE="text/xml" CHECKSUM="2b459feb0c7dd676fb5fa12d6ef06234f9ddc03d" CHECKSUMTYPE="SHA-1" SIZE="203782">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0072.alto.xml"/>
 			</file>
-			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T19:17:34" MIMETYPE="text/xml"
-				CHECKSUM="5fd960daacfc28fa0a1595a6bd5ffe76a160c45a" CHECKSUMTYPE="SHA-1" SIZE="196440">
+			<file ID="ALTO00073" GROUPID="page73" CREATED="2015-07-30T19:17:34" MIMETYPE="text/xml" CHECKSUM="5fd960daacfc28fa0a1595a6bd5ffe76a160c45a" CHECKSUMTYPE="SHA-1" SIZE="196440">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0073.alto.xml"/>
 			</file>
-			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T19:17:34" MIMETYPE="text/xml"
-				CHECKSUM="4531b9c867cc9bccdbcd4f02dc8696767a88af7f" CHECKSUMTYPE="SHA-1" SIZE="192960">
+			<file ID="ALTO00074" GROUPID="page74" CREATED="2015-07-30T19:17:34" MIMETYPE="text/xml" CHECKSUM="4531b9c867cc9bccdbcd4f02dc8696767a88af7f" CHECKSUMTYPE="SHA-1" SIZE="192960">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0074.alto.xml"/>
 			</file>
-			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T19:17:35" MIMETYPE="text/xml"
-				CHECKSUM="2960846b561798385175943d8ef0f07511e6a498" CHECKSUMTYPE="SHA-1" SIZE="191116">
+			<file ID="ALTO00075" GROUPID="page75" CREATED="2015-07-30T19:17:35" MIMETYPE="text/xml" CHECKSUM="2960846b561798385175943d8ef0f07511e6a498" CHECKSUMTYPE="SHA-1" SIZE="191116">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0075.alto.xml"/>
 			</file>
-			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T19:17:35" MIMETYPE="text/xml"
-				CHECKSUM="75c9cf336f6358dd13e8db28b83bcfc1b936d4c8" CHECKSUMTYPE="SHA-1" SIZE="69873">
+			<file ID="ALTO00076" GROUPID="page76" CREATED="2015-07-30T19:17:35" MIMETYPE="text/xml" CHECKSUM="75c9cf336f6358dd13e8db28b83bcfc1b936d4c8" CHECKSUMTYPE="SHA-1" SIZE="69873">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0076.alto.xml"/>
 			</file>
-			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T19:17:35" MIMETYPE="text/xml"
-				CHECKSUM="29f6c78029810cbabb2b66f448852f1388f5c1a3" CHECKSUMTYPE="SHA-1" SIZE="183733">
+			<file ID="ALTO00077" GROUPID="page77" CREATED="2015-07-30T19:17:35" MIMETYPE="text/xml" CHECKSUM="29f6c78029810cbabb2b66f448852f1388f5c1a3" CHECKSUMTYPE="SHA-1" SIZE="183733">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0077.alto.xml"/>
 			</file>
-			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T19:17:36" MIMETYPE="text/xml"
-				CHECKSUM="f5585ab53ad21fb567ae43fc332733edaba3afb5" CHECKSUMTYPE="SHA-1" SIZE="152116">
+			<file ID="ALTO00078" GROUPID="page78" CREATED="2015-07-30T19:17:36" MIMETYPE="text/xml" CHECKSUM="f5585ab53ad21fb567ae43fc332733edaba3afb5" CHECKSUMTYPE="SHA-1" SIZE="152116">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0078.alto.xml"/>
 			</file>
-			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T19:17:36" MIMETYPE="text/xml"
-				CHECKSUM="0f7085408d2b3d87b3239c659cd80b6fb16cca65" CHECKSUMTYPE="SHA-1" SIZE="5543">
+			<file ID="ALTO00079" GROUPID="page79" CREATED="2015-07-30T19:17:36" MIMETYPE="text/xml" CHECKSUM="0f7085408d2b3d87b3239c659cd80b6fb16cca65" CHECKSUMTYPE="SHA-1" SIZE="5543">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0079.alto.xml"/>
 			</file>
-			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T19:17:36" MIMETYPE="text/xml"
-				CHECKSUM="0466b88322692a4c1fd1db3c558bf8b4f5111159" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00080" GROUPID="page80" CREATED="2015-07-30T19:17:36" MIMETYPE="text/xml" CHECKSUM="0466b88322692a4c1fd1db3c558bf8b4f5111159" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0080.alto.xml"/>
 			</file>
-			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T19:17:37" MIMETYPE="text/xml"
-				CHECKSUM="241bdf41fa24c6eb7e0edfd1416edcc77320c77c" CHECKSUMTYPE="SHA-1" SIZE="82916">
+			<file ID="ALTO00081" GROUPID="page81" CREATED="2015-07-30T19:17:37" MIMETYPE="text/xml" CHECKSUM="241bdf41fa24c6eb7e0edfd1416edcc77320c77c" CHECKSUMTYPE="SHA-1" SIZE="82916">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0081.alto.xml"/>
 			</file>
-			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T19:17:37" MIMETYPE="text/xml"
-				CHECKSUM="de5ee5b986ac4b29cb8fd084dc20002fd779f9fe" CHECKSUMTYPE="SHA-1" SIZE="99430">
+			<file ID="ALTO00082" GROUPID="page82" CREATED="2015-07-30T19:17:37" MIMETYPE="text/xml" CHECKSUM="de5ee5b986ac4b29cb8fd084dc20002fd779f9fe" CHECKSUMTYPE="SHA-1" SIZE="99430">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0082.alto.xml"/>
 			</file>
-			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T19:17:38" MIMETYPE="text/xml"
-				CHECKSUM="409bf9816d8eb4b35ffff537f8c4dc9646197290" CHECKSUMTYPE="SHA-1" SIZE="100152">
+			<file ID="ALTO00083" GROUPID="page83" CREATED="2015-07-30T19:17:38" MIMETYPE="text/xml" CHECKSUM="409bf9816d8eb4b35ffff537f8c4dc9646197290" CHECKSUMTYPE="SHA-1" SIZE="100152">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0083.alto.xml"/>
 			</file>
-			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T19:17:38" MIMETYPE="text/xml"
-				CHECKSUM="e3fccd0f6c2112a07f2ddcff99363575bb9373d2" CHECKSUMTYPE="SHA-1" SIZE="89348">
+			<file ID="ALTO00084" GROUPID="page84" CREATED="2015-07-30T19:17:38" MIMETYPE="text/xml" CHECKSUM="e3fccd0f6c2112a07f2ddcff99363575bb9373d2" CHECKSUMTYPE="SHA-1" SIZE="89348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0084.alto.xml"/>
 			</file>
-			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T19:17:38" MIMETYPE="text/xml"
-				CHECKSUM="fdbf92ac9af8f7a97bc5b7408723860b8812e046" CHECKSUMTYPE="SHA-1" SIZE="151991">
+			<file ID="ALTO00085" GROUPID="page85" CREATED="2015-07-30T19:17:38" MIMETYPE="text/xml" CHECKSUM="fdbf92ac9af8f7a97bc5b7408723860b8812e046" CHECKSUMTYPE="SHA-1" SIZE="151991">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0085.alto.xml"/>
 			</file>
-			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T19:17:39" MIMETYPE="text/xml"
-				CHECKSUM="a01af0108bbf4d2d3864df5b44cbcebe8ba46aa6" CHECKSUMTYPE="SHA-1" SIZE="209758">
+			<file ID="ALTO00086" GROUPID="page86" CREATED="2015-07-30T19:17:39" MIMETYPE="text/xml" CHECKSUM="a01af0108bbf4d2d3864df5b44cbcebe8ba46aa6" CHECKSUMTYPE="SHA-1" SIZE="209758">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0086.alto.xml"/>
 			</file>
-			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T19:17:39" MIMETYPE="text/xml"
-				CHECKSUM="5f1be1b720799fa6cb49d864e501126f2bdc2244" CHECKSUMTYPE="SHA-1" SIZE="179120">
+			<file ID="ALTO00087" GROUPID="page87" CREATED="2015-07-30T19:17:39" MIMETYPE="text/xml" CHECKSUM="5f1be1b720799fa6cb49d864e501126f2bdc2244" CHECKSUMTYPE="SHA-1" SIZE="179120">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0087.alto.xml"/>
 			</file>
-			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T19:17:40" MIMETYPE="text/xml"
-				CHECKSUM="0b1c7f35d3be63f3c2281cef0ec9d2db31f9d5f8" CHECKSUMTYPE="SHA-1" SIZE="63254">
+			<file ID="ALTO00088" GROUPID="page88" CREATED="2015-07-30T19:17:40" MIMETYPE="text/xml" CHECKSUM="0b1c7f35d3be63f3c2281cef0ec9d2db31f9d5f8" CHECKSUMTYPE="SHA-1" SIZE="63254">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0088.alto.xml"/>
 			</file>
-			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T19:17:40" MIMETYPE="text/xml"
-				CHECKSUM="58d66775b73500b315369387ec9cca18f192cacc" CHECKSUMTYPE="SHA-1" SIZE="4908">
+			<file ID="ALTO00089" GROUPID="page89" CREATED="2015-07-30T19:17:40" MIMETYPE="text/xml" CHECKSUM="58d66775b73500b315369387ec9cca18f192cacc" CHECKSUMTYPE="SHA-1" SIZE="4908">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0089.alto.xml"/>
 			</file>
-			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T19:17:40" MIMETYPE="text/xml"
-				CHECKSUM="43037e944379b8a8ebc538ccbbabd67c7047b2b4" CHECKSUMTYPE="SHA-1" SIZE="2005">
+			<file ID="ALTO00090" GROUPID="page90" CREATED="2015-07-30T19:17:40" MIMETYPE="text/xml" CHECKSUM="43037e944379b8a8ebc538ccbbabd67c7047b2b4" CHECKSUMTYPE="SHA-1" SIZE="2005">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0090.alto.xml"/>
 			</file>
-			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T19:17:40" MIMETYPE="text/xml"
-				CHECKSUM="bb30e02c1ecbbbfee74ebaf219209acecd469bf0" CHECKSUMTYPE="SHA-1" SIZE="113989">
+			<file ID="ALTO00091" GROUPID="page91" CREATED="2015-07-30T19:17:40" MIMETYPE="text/xml" CHECKSUM="bb30e02c1ecbbbfee74ebaf219209acecd469bf0" CHECKSUMTYPE="SHA-1" SIZE="113989">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0091.alto.xml"/>
 			</file>
-			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T19:17:41" MIMETYPE="text/xml"
-				CHECKSUM="43af22e046f165074ccdfd0185df196553b34b59" CHECKSUMTYPE="SHA-1" SIZE="192456">
+			<file ID="ALTO00092" GROUPID="page92" CREATED="2015-07-30T19:17:41" MIMETYPE="text/xml" CHECKSUM="43af22e046f165074ccdfd0185df196553b34b59" CHECKSUMTYPE="SHA-1" SIZE="192456">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0092.alto.xml"/>
 			</file>
-			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T19:17:41" MIMETYPE="text/xml"
-				CHECKSUM="315f7b84d434aeb46b45bfa17ded3849d44fa816" CHECKSUMTYPE="SHA-1" SIZE="184267">
+			<file ID="ALTO00093" GROUPID="page93" CREATED="2015-07-30T19:17:41" MIMETYPE="text/xml" CHECKSUM="315f7b84d434aeb46b45bfa17ded3849d44fa816" CHECKSUMTYPE="SHA-1" SIZE="184267">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0093.alto.xml"/>
 			</file>
-			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T19:17:42" MIMETYPE="text/xml"
-				CHECKSUM="5d71e79df33b9111b121923e8059af6e46344fc7" CHECKSUMTYPE="SHA-1" SIZE="191785">
+			<file ID="ALTO00094" GROUPID="page94" CREATED="2015-07-30T19:17:42" MIMETYPE="text/xml" CHECKSUM="5d71e79df33b9111b121923e8059af6e46344fc7" CHECKSUMTYPE="SHA-1" SIZE="191785">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0094.alto.xml"/>
 			</file>
-			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T19:17:42" MIMETYPE="text/xml"
-				CHECKSUM="1a037fe54a429eb4574d23f55a820a2887cdc6da" CHECKSUMTYPE="SHA-1" SIZE="189477">
+			<file ID="ALTO00095" GROUPID="page95" CREATED="2015-07-30T19:17:42" MIMETYPE="text/xml" CHECKSUM="1a037fe54a429eb4574d23f55a820a2887cdc6da" CHECKSUMTYPE="SHA-1" SIZE="189477">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0095.alto.xml"/>
 			</file>
-			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T19:17:43" MIMETYPE="text/xml"
-				CHECKSUM="4b25b3d2599933198d1819e6b79cbe5ab4fd7171" CHECKSUMTYPE="SHA-1" SIZE="194657">
+			<file ID="ALTO00096" GROUPID="page96" CREATED="2015-07-30T19:17:43" MIMETYPE="text/xml" CHECKSUM="4b25b3d2599933198d1819e6b79cbe5ab4fd7171" CHECKSUMTYPE="SHA-1" SIZE="194657">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0096.alto.xml"/>
 			</file>
-			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T19:17:43" MIMETYPE="text/xml"
-				CHECKSUM="fd90f689f5bc49259cb106521d31d2d4805770f5" CHECKSUMTYPE="SHA-1" SIZE="195348">
+			<file ID="ALTO00097" GROUPID="page97" CREATED="2015-07-30T19:17:43" MIMETYPE="text/xml" CHECKSUM="fd90f689f5bc49259cb106521d31d2d4805770f5" CHECKSUMTYPE="SHA-1" SIZE="195348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0097.alto.xml"/>
 			</file>
-			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T19:17:44" MIMETYPE="text/xml"
-				CHECKSUM="8c9b54542b32eb7a4837f1582ff8fac90fba6c55" CHECKSUMTYPE="SHA-1" SIZE="190812">
+			<file ID="ALTO00098" GROUPID="page98" CREATED="2015-07-30T19:17:44" MIMETYPE="text/xml" CHECKSUM="8c9b54542b32eb7a4837f1582ff8fac90fba6c55" CHECKSUMTYPE="SHA-1" SIZE="190812">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0098.alto.xml"/>
 			</file>
-			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T19:17:44" MIMETYPE="text/xml"
-				CHECKSUM="16201bb10fe2f190d7e2ee97f14cd1801b41c32e" CHECKSUMTYPE="SHA-1" SIZE="188424">
+			<file ID="ALTO00099" GROUPID="page99" CREATED="2015-07-30T19:17:44" MIMETYPE="text/xml" CHECKSUM="16201bb10fe2f190d7e2ee97f14cd1801b41c32e" CHECKSUMTYPE="SHA-1" SIZE="188424">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0099.alto.xml"/>
 			</file>
-			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T19:17:45" MIMETYPE="text/xml"
-				CHECKSUM="784a7bab8b5e1be8b30b6cb195e77b08b57f36d3" CHECKSUMTYPE="SHA-1" SIZE="124103">
+			<file ID="ALTO00100" GROUPID="page100" CREATED="2015-07-30T19:17:45" MIMETYPE="text/xml" CHECKSUM="784a7bab8b5e1be8b30b6cb195e77b08b57f36d3" CHECKSUMTYPE="SHA-1" SIZE="124103">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0100.alto.xml"/>
 			</file>
-			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T19:17:45" MIMETYPE="text/xml"
-				CHECKSUM="82d6268e4c3fe468e9124a505749a45cabeee22c" CHECKSUMTYPE="SHA-1" SIZE="53425">
+			<file ID="ALTO00101" GROUPID="page101" CREATED="2015-07-30T19:17:45" MIMETYPE="text/xml" CHECKSUM="82d6268e4c3fe468e9124a505749a45cabeee22c" CHECKSUMTYPE="SHA-1" SIZE="53425">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0101.alto.xml"/>
 			</file>
-			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T19:17:45" MIMETYPE="text/xml"
-				CHECKSUM="c8d5ab521812d625da9a85ce2332a4332320c438" CHECKSUMTYPE="SHA-1" SIZE="29281">
+			<file ID="ALTO00102" GROUPID="page102" CREATED="2015-07-30T19:17:45" MIMETYPE="text/xml" CHECKSUM="c8d5ab521812d625da9a85ce2332a4332320c438" CHECKSUMTYPE="SHA-1" SIZE="29281">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0102.alto.xml"/>
 			</file>
-			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T19:17:46" MIMETYPE="text/xml"
-				CHECKSUM="1f74015bd5ec50e2a100c1bb9b070f82541e4d61" CHECKSUMTYPE="SHA-1" SIZE="18863">
+			<file ID="ALTO00103" GROUPID="page103" CREATED="2015-07-30T19:17:46" MIMETYPE="text/xml" CHECKSUM="1f74015bd5ec50e2a100c1bb9b070f82541e4d61" CHECKSUMTYPE="SHA-1" SIZE="18863">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0103.alto.xml"/>
 			</file>
-			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T19:17:46" MIMETYPE="text/xml"
-				CHECKSUM="418b29e49112a849ab2c9ec7cf0a5b57e31052f1" CHECKSUMTYPE="SHA-1" SIZE="41015">
+			<file ID="ALTO00104" GROUPID="page104" CREATED="2015-07-30T19:17:46" MIMETYPE="text/xml" CHECKSUM="418b29e49112a849ab2c9ec7cf0a5b57e31052f1" CHECKSUMTYPE="SHA-1" SIZE="41015">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0104.alto.xml"/>
 			</file>
-			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T19:17:46" MIMETYPE="text/xml"
-				CHECKSUM="75415d073b36c7dd586eb7c50c22f375b12afff4" CHECKSUMTYPE="SHA-1" SIZE="208820">
+			<file ID="ALTO00105" GROUPID="page105" CREATED="2015-07-30T19:17:46" MIMETYPE="text/xml" CHECKSUM="75415d073b36c7dd586eb7c50c22f375b12afff4" CHECKSUMTYPE="SHA-1" SIZE="208820">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0105.alto.xml"/>
 			</file>
-			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T19:17:47" MIMETYPE="text/xml"
-				CHECKSUM="73cdd1215b6372ff70869e2757548c742186fe76" CHECKSUMTYPE="SHA-1" SIZE="239548">
+			<file ID="ALTO00106" GROUPID="page106" CREATED="2015-07-30T19:17:47" MIMETYPE="text/xml" CHECKSUM="73cdd1215b6372ff70869e2757548c742186fe76" CHECKSUMTYPE="SHA-1" SIZE="239548">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0106.alto.xml"/>
 			</file>
-			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T19:17:47" MIMETYPE="text/xml"
-				CHECKSUM="e4341b171e98e0d61c73526c47bc3b9b3bb0892c" CHECKSUMTYPE="SHA-1" SIZE="245266">
+			<file ID="ALTO00107" GROUPID="page107" CREATED="2015-07-30T19:17:47" MIMETYPE="text/xml" CHECKSUM="e4341b171e98e0d61c73526c47bc3b9b3bb0892c" CHECKSUMTYPE="SHA-1" SIZE="245266">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0107.alto.xml"/>
 			</file>
-			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T19:17:48" MIMETYPE="text/xml"
-				CHECKSUM="d87451142ff85f5d5e8386703d771dc7ae3b1625" CHECKSUMTYPE="SHA-1" SIZE="189139">
+			<file ID="ALTO00108" GROUPID="page108" CREATED="2015-07-30T19:17:48" MIMETYPE="text/xml" CHECKSUM="d87451142ff85f5d5e8386703d771dc7ae3b1625" CHECKSUMTYPE="SHA-1" SIZE="189139">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0108.alto.xml"/>
 			</file>
-			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T19:17:48" MIMETYPE="text/xml"
-				CHECKSUM="f1b1aa0e8f17a9d2cf5f51e49da7871d06a244ce" CHECKSUMTYPE="SHA-1" SIZE="21517">
+			<file ID="ALTO00109" GROUPID="page109" CREATED="2015-07-30T19:17:48" MIMETYPE="text/xml" CHECKSUM="f1b1aa0e8f17a9d2cf5f51e49da7871d06a244ce" CHECKSUMTYPE="SHA-1" SIZE="21517">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0109.alto.xml"/>
 			</file>
-			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T19:17:49" MIMETYPE="text/xml"
-				CHECKSUM="1ebf783499e0311cf452f9620063a7e470734eef" CHECKSUMTYPE="SHA-1" SIZE="16899">
+			<file ID="ALTO00110" GROUPID="page110" CREATED="2015-07-30T19:17:49" MIMETYPE="text/xml" CHECKSUM="1ebf783499e0311cf452f9620063a7e470734eef" CHECKSUMTYPE="SHA-1" SIZE="16899">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0110.alto.xml"/>
 			</file>
-			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-07-30T19:17:49" MIMETYPE="text/xml"
-				CHECKSUM="5274685b80043e4087abcf18205aeb7e6bf83030" CHECKSUMTYPE="SHA-1" SIZE="2018">
+			<file ID="ALTO00111" GROUPID="page111" CREATED="2015-07-30T19:17:49" MIMETYPE="text/xml" CHECKSUM="5274685b80043e4087abcf18205aeb7e6bf83030" CHECKSUMTYPE="SHA-1" SIZE="2018">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0111.alto.xml"/>
 			</file>
-			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-07-30T19:17:49" MIMETYPE="text/xml"
-				CHECKSUM="adc97a0c7aa0b89f50a681fd551c76c6f0d7e2b7" CHECKSUMTYPE="SHA-1" SIZE="2618">
+			<file ID="ALTO00112" GROUPID="page112" CREATED="2015-07-30T19:17:49" MIMETYPE="text/xml" CHECKSUM="adc97a0c7aa0b89f50a681fd551c76c6f0d7e2b7" CHECKSUMTYPE="SHA-1" SIZE="2618">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabe_1900-04_01_0112.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T19:22:52" MIMETYPE="application/pdf" CHECKSUM="00d02fae536b7da088271e7a8847c75f06bd2bdd"
-				CHECKSUMTYPE="SHA-1" SIZE="51501161">
-				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/bmtnabe_1900-04_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-07-30T19:22:52" MIMETYPE="application/pdf" CHECKSUM="00d02fae536b7da088271e7a8847c75f06bd2bdd" CHECKSUMTYPE="SHA-1" SIZE="51501161">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabe/issues/1900/04_01/bmtnabe_1900-04_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -12835,8 +12493,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="TextContent" ORDER="10" DMDID="c029"
-					LABEL="MAURICE MAETERLINCK ÜBERTRAGUNGEN VON GEDICHTEN AUS: SERRES CHAUDES">
+				<div ID="L.1.1.10" TYPE="TextContent" ORDER="10" DMDID="c029" LABEL="MAURICE MAETERLINCK ÜBERTRAGUNGEN VON GEDICHTEN AUS: SERRES CHAUDES">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
@@ -13958,8 +13615,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.24.8" TYPE="Illustration" ORDER="6" DMDID="c091"
-						LABEL="BLIERN FRIEDRICH NIETZSCHES NACH DAGUERREOTYPIEN AUS DEM JAHRE 1847.">
+					<div ID="L.1.1.24.8" TYPE="Illustration" ORDER="6" DMDID="c091" LABEL="BLIERN FRIEDRICH NIETZSCHES NACH DAGUERREOTYPIEN AUS DEM JAHRE 1847.">
 						<div ID="L.1.1.24.8.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00057" BEGIN="P57_CB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1898/01_01/bmtnabf_1898-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1898/01_01/bmtnabf_1898-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1898-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1898/02_01/bmtnabf_1898-02_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1898/02_01/bmtnabf_1898-02_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-02_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-02_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-02_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1898-02_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-02_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -4048,439 +4042,228 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:05:30"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="bc78c2ae0f4640424ce464647a9a4400e02a740b"
-				CHECKSUMTYPE="SHA-1" SIZE="6328027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:05:30" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="bc78c2ae0f4640424ce464647a9a4400e02a740b" CHECKSUMTYPE="SHA-1" SIZE="6328027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:06:09"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="4866e3589fc6706e7fffb45d3c0ef3eb502c9b74"
-				CHECKSUMTYPE="SHA-1" SIZE="6300125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:06:09" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="4866e3589fc6706e7fffb45d3c0ef3eb502c9b74" CHECKSUMTYPE="SHA-1" SIZE="6300125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:06:45"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="40dd6848b7778febbeac70f19855090b0241b8eb"
-				CHECKSUMTYPE="SHA-1" SIZE="6274026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:06:45" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="40dd6848b7778febbeac70f19855090b0241b8eb" CHECKSUMTYPE="SHA-1" SIZE="6274026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:07:19"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="5ddcf0af0ba1553d947951b44f737654d8a17b07"
-				CHECKSUMTYPE="SHA-1" SIZE="6301024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:07:19" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="5ddcf0af0ba1553d947951b44f737654d8a17b07" CHECKSUMTYPE="SHA-1" SIZE="6301024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:07:52"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2495947ccc885df005a4370615c2f52d3709efe0"
-				CHECKSUMTYPE="SHA-1" SIZE="6274917">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:07:52" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2495947ccc885df005a4370615c2f52d3709efe0" CHECKSUMTYPE="SHA-1" SIZE="6274917">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:08:26"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="d8b95fe14c6d30751a343cdfbd960d77a3d9e706"
-				CHECKSUMTYPE="SHA-1" SIZE="6256021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:08:26" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="d8b95fe14c6d30751a343cdfbd960d77a3d9e706" CHECKSUMTYPE="SHA-1" SIZE="6256021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:08:59"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="8d1646e72c1bbe765f2c3a07402bc6003cc2c78a"
-				CHECKSUMTYPE="SHA-1" SIZE="6274017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:08:59" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="8d1646e72c1bbe765f2c3a07402bc6003cc2c78a" CHECKSUMTYPE="SHA-1" SIZE="6274017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:09:31"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="e35c6c7ba03aa3f8e26237581866cd78eae82c3a"
-				CHECKSUMTYPE="SHA-1" SIZE="6256028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:09:31" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="e35c6c7ba03aa3f8e26237581866cd78eae82c3a" CHECKSUMTYPE="SHA-1" SIZE="6256028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:10:02"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="c61afdae1d8525a6a97bd074a90e52558d1b97fe"
-				CHECKSUMTYPE="SHA-1" SIZE="6273128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:10:02" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="c61afdae1d8525a6a97bd074a90e52558d1b97fe" CHECKSUMTYPE="SHA-1" SIZE="6273128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:10:35"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="d80f7f208bfd35e994f549b67b1bae6ff6503474"
-				CHECKSUMTYPE="SHA-1" SIZE="6229923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:10:35" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="d80f7f208bfd35e994f549b67b1bae6ff6503474" CHECKSUMTYPE="SHA-1" SIZE="6229923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:11:07"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="318aa54235bb5ea9d871ebf7422eb4ddd001bc44"
-				CHECKSUMTYPE="SHA-1" SIZE="6274920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:11:07" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="318aa54235bb5ea9d871ebf7422eb4ddd001bc44" CHECKSUMTYPE="SHA-1" SIZE="6274920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:11:41"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="0c3ebedb048705111fba18fda7f91b0ab1b32682"
-				CHECKSUMTYPE="SHA-1" SIZE="6254223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:11:41" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="0c3ebedb048705111fba18fda7f91b0ab1b32682" CHECKSUMTYPE="SHA-1" SIZE="6254223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:12:14"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="11ecb96d56f93439770a322d7fb3aa9dd594e7ba"
-				CHECKSUMTYPE="SHA-1" SIZE="6235327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:12:14" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="11ecb96d56f93439770a322d7fb3aa9dd594e7ba" CHECKSUMTYPE="SHA-1" SIZE="6235327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:12:46"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="98716ef4c963508b9bb5216996adbb73c640068e"
-				CHECKSUMTYPE="SHA-1" SIZE="6267729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:12:46" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="98716ef4c963508b9bb5216996adbb73c640068e" CHECKSUMTYPE="SHA-1" SIZE="6267729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:13:20"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="d0aac8cc5248d728b3a6dd16b885f82a69b390e1"
-				CHECKSUMTYPE="SHA-1" SIZE="6234426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:13:20" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="d0aac8cc5248d728b3a6dd16b885f82a69b390e1" CHECKSUMTYPE="SHA-1" SIZE="6234426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:13:54"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="3e8a35bd390384110b96d19c1cf7541a4793b8ca"
-				CHECKSUMTYPE="SHA-1" SIZE="6268627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:13:54" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="3e8a35bd390384110b96d19c1cf7541a4793b8ca" CHECKSUMTYPE="SHA-1" SIZE="6268627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:14:27"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="2832dca8f5fd9d596b1c99c5a323dbd4be7cd1e1"
-				CHECKSUMTYPE="SHA-1" SIZE="6235288">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:14:27" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="2832dca8f5fd9d596b1c99c5a323dbd4be7cd1e1" CHECKSUMTYPE="SHA-1" SIZE="6235288">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:15:00"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="c0f282818c810fbf0538d345af7952499c417405"
-				CHECKSUMTYPE="SHA-1" SIZE="6267728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:15:00" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="c0f282818c810fbf0538d345af7952499c417405" CHECKSUMTYPE="SHA-1" SIZE="6267728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:15:35"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="5176e425d32e0231fc04874f2f30dbd3b623aa00"
-				CHECKSUMTYPE="SHA-1" SIZE="6235329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:15:35" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="5176e425d32e0231fc04874f2f30dbd3b623aa00" CHECKSUMTYPE="SHA-1" SIZE="6235329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:16:09"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="b709d08c57082d1b8b132aeccdac2adb465a36e3"
-				CHECKSUMTYPE="SHA-1" SIZE="6228118">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:16:09" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="b709d08c57082d1b8b132aeccdac2adb465a36e3" CHECKSUMTYPE="SHA-1" SIZE="6228118">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:16:42"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="2db72940e07ac45bc9752a83f83dc1b18939f9ab"
-				CHECKSUMTYPE="SHA-1" SIZE="6235316">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:16:42" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="2db72940e07ac45bc9752a83f83dc1b18939f9ab" CHECKSUMTYPE="SHA-1" SIZE="6235316">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:17:13"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="5506f4a78809f0c3c4215687baed7222e652560f"
-				CHECKSUMTYPE="SHA-1" SIZE="6229018">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:17:13" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="5506f4a78809f0c3c4215687baed7222e652560f" CHECKSUMTYPE="SHA-1" SIZE="6229018">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:17:44"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="2468f75ffe9c268a861ea272604724257ad63d28"
-				CHECKSUMTYPE="SHA-1" SIZE="6235321">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:17:44" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="2468f75ffe9c268a861ea272604724257ad63d28" CHECKSUMTYPE="SHA-1" SIZE="6235321">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:18:16"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="91e8653a6a0867da1089ac9b371a8cb214a4ff16"
-				CHECKSUMTYPE="SHA-1" SIZE="6210127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:18:16" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="91e8653a6a0867da1089ac9b371a8cb214a4ff16" CHECKSUMTYPE="SHA-1" SIZE="6210127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:18:48"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="0fd4de8b8ad622aebae53d76edb40f4f9b508d07"
-				CHECKSUMTYPE="SHA-1" SIZE="6236199">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:18:48" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="0fd4de8b8ad622aebae53d76edb40f4f9b508d07" CHECKSUMTYPE="SHA-1" SIZE="6236199">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:19:19"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="8ee6b946aa0cb0182ba520ccd3c6d5547b0fc9e5"
-				CHECKSUMTYPE="SHA-1" SIZE="6265028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:19:19" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="8ee6b946aa0cb0182ba520ccd3c6d5547b0fc9e5" CHECKSUMTYPE="SHA-1" SIZE="6265028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:19:51"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="a2a76d5f6832c82af2fb7488d945800cfada247c"
-				CHECKSUMTYPE="SHA-1" SIZE="6170529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:19:51" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="a2a76d5f6832c82af2fb7488d945800cfada247c" CHECKSUMTYPE="SHA-1" SIZE="6170529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:20:21"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="c23084d3d4a32a60c852a84aa66d70f7b951804d"
-				CHECKSUMTYPE="SHA-1" SIZE="6264120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:20:21" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="c23084d3d4a32a60c852a84aa66d70f7b951804d" CHECKSUMTYPE="SHA-1" SIZE="6264120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:20:53"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="5f4c9b56c0cd72da50bcd80fb81f7517c6ba7945"
-				CHECKSUMTYPE="SHA-1" SIZE="6170527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:20:53" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="5f4c9b56c0cd72da50bcd80fb81f7517c6ba7945" CHECKSUMTYPE="SHA-1" SIZE="6170527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:21:24"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="7f50cbe8f4357c145dbbcac1dec0eed0cdd6e8e1"
-				CHECKSUMTYPE="SHA-1" SIZE="6265028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:21:24" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="7f50cbe8f4357c145dbbcac1dec0eed0cdd6e8e1" CHECKSUMTYPE="SHA-1" SIZE="6265028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:21:56"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="2a4752e292fdee6cd09a82bc5129f4bcef244d3d"
-				CHECKSUMTYPE="SHA-1" SIZE="6171425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:21:56" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="2a4752e292fdee6cd09a82bc5129f4bcef244d3d" CHECKSUMTYPE="SHA-1" SIZE="6171425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:22:29"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="bcacee91e70261059d7c7dd9d157ca710b98e81c"
-				CHECKSUMTYPE="SHA-1" SIZE="6265021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:22:29" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="bcacee91e70261059d7c7dd9d157ca710b98e81c" CHECKSUMTYPE="SHA-1" SIZE="6265021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T16:23:01"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="bd455c978aae6759c88e11f0e464d09cf4fdbdec"
-				CHECKSUMTYPE="SHA-1" SIZE="6171424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T16:23:01" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="bd455c978aae6759c88e11f0e464d09cf4fdbdec" CHECKSUMTYPE="SHA-1" SIZE="6171424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T16:23:30"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="56e388705293f6b3da1e6608be56b8aeb30a862a"
-				CHECKSUMTYPE="SHA-1" SIZE="6265029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T16:23:30" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="56e388705293f6b3da1e6608be56b8aeb30a862a" CHECKSUMTYPE="SHA-1" SIZE="6265029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0034.jp2"/>
 			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T16:24:02"
-				MIMETYPE="image/jp2" SEQ="35" CHECKSUM="e35435d2ec32e86446af43270f39e52d5a2a1dbf"
-				CHECKSUMTYPE="SHA-1" SIZE="6283909">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0035.jp2"
-				/>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T16:24:02" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="e35435d2ec32e86446af43270f39e52d5a2a1dbf" CHECKSUMTYPE="SHA-1" SIZE="6283909">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0035.jp2"/>
 			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T16:24:35"
-				MIMETYPE="image/jp2" SEQ="36" CHECKSUM="ce2fa76cd42772c965484ac9dc88108c5a8a50a7"
-				CHECKSUMTYPE="SHA-1" SIZE="6235328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0036.jp2"
-				/>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T16:24:35" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="ce2fa76cd42772c965484ac9dc88108c5a8a50a7" CHECKSUMTYPE="SHA-1" SIZE="6235328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/delivery/bmtnabf_1898-02_01_0036.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:25:00" MIMETYPE="text/xml"
-				CHECKSUM="9b3fa4ebed627385a51b08eefa74b69dcf742c53" CHECKSUMTYPE="SHA-1" SIZE="9170">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:25:00" MIMETYPE="text/xml" CHECKSUM="9b3fa4ebed627385a51b08eefa74b69dcf742c53" CHECKSUMTYPE="SHA-1" SIZE="9170">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:25:00" MIMETYPE="text/xml"
-				CHECKSUM="ec2911065143528f9aefd998d6ecf99c80f10a80" CHECKSUMTYPE="SHA-1"
-				SIZE="54106">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:25:00" MIMETYPE="text/xml" CHECKSUM="ec2911065143528f9aefd998d6ecf99c80f10a80" CHECKSUMTYPE="SHA-1" SIZE="54106">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:25:01" MIMETYPE="text/xml"
-				CHECKSUM="726d544ebb5fa8e79ed4d8a043cd56ad0f306274" CHECKSUMTYPE="SHA-1" SIZE="5118">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:25:01" MIMETYPE="text/xml" CHECKSUM="726d544ebb5fa8e79ed4d8a043cd56ad0f306274" CHECKSUMTYPE="SHA-1" SIZE="5118">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:25:01" MIMETYPE="text/xml"
-				CHECKSUM="f91c310b4c2e789630da77b2623267beba053e31" CHECKSUMTYPE="SHA-1" SIZE="6124">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:25:01" MIMETYPE="text/xml" CHECKSUM="f91c310b4c2e789630da77b2623267beba053e31" CHECKSUMTYPE="SHA-1" SIZE="6124">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:25:01" MIMETYPE="text/xml"
-				CHECKSUM="51a0ac2c25dedd0b335cd5af08dda115508375c5" CHECKSUMTYPE="SHA-1"
-				SIZE="66322">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:25:01" MIMETYPE="text/xml" CHECKSUM="51a0ac2c25dedd0b335cd5af08dda115508375c5" CHECKSUMTYPE="SHA-1" SIZE="66322">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:25:01" MIMETYPE="text/xml"
-				CHECKSUM="aff6fcd105d747188754461a5358efa708aec68b" CHECKSUMTYPE="SHA-1"
-				SIZE="99506">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:25:01" MIMETYPE="text/xml" CHECKSUM="aff6fcd105d747188754461a5358efa708aec68b" CHECKSUMTYPE="SHA-1" SIZE="99506">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:25:02" MIMETYPE="text/xml"
-				CHECKSUM="bc6ad2d7df6b8868ab87f4b60901e8c3b28948f4" CHECKSUMTYPE="SHA-1"
-				SIZE="154900">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:25:02" MIMETYPE="text/xml" CHECKSUM="bc6ad2d7df6b8868ab87f4b60901e8c3b28948f4" CHECKSUMTYPE="SHA-1" SIZE="154900">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:25:02" MIMETYPE="text/xml"
-				CHECKSUM="de384cafffdb7970ee406493c2a0e755997b0ef7" CHECKSUMTYPE="SHA-1"
-				SIZE="93101">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:25:02" MIMETYPE="text/xml" CHECKSUM="de384cafffdb7970ee406493c2a0e755997b0ef7" CHECKSUMTYPE="SHA-1" SIZE="93101">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:25:03" MIMETYPE="text/xml"
-				CHECKSUM="0482f5583e3c86a1bdc85665a0a326b9f501ec10" CHECKSUMTYPE="SHA-1"
-				SIZE="73934">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:25:03" MIMETYPE="text/xml" CHECKSUM="0482f5583e3c86a1bdc85665a0a326b9f501ec10" CHECKSUMTYPE="SHA-1" SIZE="73934">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:25:03" MIMETYPE="text/xml"
-				CHECKSUM="364119e5c4c409dca73c33a52ad3477313cf4cbf" CHECKSUMTYPE="SHA-1"
-				SIZE="58464">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:25:03" MIMETYPE="text/xml" CHECKSUM="364119e5c4c409dca73c33a52ad3477313cf4cbf" CHECKSUMTYPE="SHA-1" SIZE="58464">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:25:03" MIMETYPE="text/xml"
-				CHECKSUM="b0f4b93236b50db90617e6882cfa06ca2390f402" CHECKSUMTYPE="SHA-1"
-				SIZE="68196">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:25:03" MIMETYPE="text/xml" CHECKSUM="b0f4b93236b50db90617e6882cfa06ca2390f402" CHECKSUMTYPE="SHA-1" SIZE="68196">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:25:04" MIMETYPE="text/xml"
-				CHECKSUM="542a5b09187ae1c45c0987b2b7ecb29ab1a72d9e" CHECKSUMTYPE="SHA-1"
-				SIZE="43556">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:25:04" MIMETYPE="text/xml" CHECKSUM="542a5b09187ae1c45c0987b2b7ecb29ab1a72d9e" CHECKSUMTYPE="SHA-1" SIZE="43556">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:25:04" MIMETYPE="text/xml"
-				CHECKSUM="5d8fc7e53c5ca49b6a0060c99500ece5e0aaf790" CHECKSUMTYPE="SHA-1"
-				SIZE="89112">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:25:04" MIMETYPE="text/xml" CHECKSUM="5d8fc7e53c5ca49b6a0060c99500ece5e0aaf790" CHECKSUMTYPE="SHA-1" SIZE="89112">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:25:04" MIMETYPE="text/xml"
-				CHECKSUM="09d05b0728d48608f37f9ae8109157fc398df41b" CHECKSUMTYPE="SHA-1"
-				SIZE="87111">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:25:04" MIMETYPE="text/xml" CHECKSUM="09d05b0728d48608f37f9ae8109157fc398df41b" CHECKSUMTYPE="SHA-1" SIZE="87111">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:25:04" MIMETYPE="text/xml"
-				CHECKSUM="df70943a795610d3e951a43cc822d63e5f676b9f" CHECKSUMTYPE="SHA-1"
-				SIZE="78272">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:25:04" MIMETYPE="text/xml" CHECKSUM="df70943a795610d3e951a43cc822d63e5f676b9f" CHECKSUMTYPE="SHA-1" SIZE="78272">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:25:05" MIMETYPE="text/xml"
-				CHECKSUM="3e519cd15f262f62d4475201f7497c7a913d9f41" CHECKSUMTYPE="SHA-1"
-				SIZE="108722">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:25:05" MIMETYPE="text/xml" CHECKSUM="3e519cd15f262f62d4475201f7497c7a913d9f41" CHECKSUMTYPE="SHA-1" SIZE="108722">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:25:05" MIMETYPE="text/xml"
-				CHECKSUM="6366d2d88f39668c4831106926c1b7a33058b432" CHECKSUMTYPE="SHA-1" SIZE="6169">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:25:05" MIMETYPE="text/xml" CHECKSUM="6366d2d88f39668c4831106926c1b7a33058b432" CHECKSUMTYPE="SHA-1" SIZE="6169">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:25:05" MIMETYPE="text/xml"
-				CHECKSUM="8639593116234b1d2179c49dfe5bbff1c44f6a80" CHECKSUMTYPE="SHA-1"
-				SIZE="33280">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:25:05" MIMETYPE="text/xml" CHECKSUM="8639593116234b1d2179c49dfe5bbff1c44f6a80" CHECKSUMTYPE="SHA-1" SIZE="33280">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:25:05" MIMETYPE="text/xml"
-				CHECKSUM="1df220e10559b4825079b287118a499de6810bea" CHECKSUMTYPE="SHA-1"
-				SIZE="35650">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:25:05" MIMETYPE="text/xml" CHECKSUM="1df220e10559b4825079b287118a499de6810bea" CHECKSUMTYPE="SHA-1" SIZE="35650">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:25:06" MIMETYPE="text/xml"
-				CHECKSUM="a1c66db3163e2c5cd524e7b1c779c9ffc5ff3fda" CHECKSUMTYPE="SHA-1" SIZE="8338">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:25:06" MIMETYPE="text/xml" CHECKSUM="a1c66db3163e2c5cd524e7b1c779c9ffc5ff3fda" CHECKSUMTYPE="SHA-1" SIZE="8338">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:25:06" MIMETYPE="text/xml"
-				CHECKSUM="e5a6c1d54a266db179deeed04e3ced102c622042" CHECKSUMTYPE="SHA-1"
-				SIZE="42887">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:25:06" MIMETYPE="text/xml" CHECKSUM="e5a6c1d54a266db179deeed04e3ced102c622042" CHECKSUMTYPE="SHA-1" SIZE="42887">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:25:06" MIMETYPE="text/xml"
-				CHECKSUM="4ef0e7ea8382e55e01f90752f6bd39dee4f4dac0" CHECKSUMTYPE="SHA-1"
-				SIZE="84831">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:25:06" MIMETYPE="text/xml" CHECKSUM="4ef0e7ea8382e55e01f90752f6bd39dee4f4dac0" CHECKSUMTYPE="SHA-1" SIZE="84831">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:25:06" MIMETYPE="text/xml"
-				CHECKSUM="d7408c80ca1e664ddc9f99ce85f7043451b4c94b" CHECKSUMTYPE="SHA-1"
-				SIZE="58527">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:25:06" MIMETYPE="text/xml" CHECKSUM="d7408c80ca1e664ddc9f99ce85f7043451b4c94b" CHECKSUMTYPE="SHA-1" SIZE="58527">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:25:07" MIMETYPE="text/xml"
-				CHECKSUM="67cb9ec93e562f8a7d1fccb86924721644bd20ce" CHECKSUMTYPE="SHA-1" SIZE="5743">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:25:07" MIMETYPE="text/xml" CHECKSUM="67cb9ec93e562f8a7d1fccb86924721644bd20ce" CHECKSUMTYPE="SHA-1" SIZE="5743">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:25:08" MIMETYPE="text/xml"
-				CHECKSUM="6d6761d70dacf8784a84d59243a0c56a073b6fd4" CHECKSUMTYPE="SHA-1"
-				SIZE="49618">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:25:08" MIMETYPE="text/xml" CHECKSUM="6d6761d70dacf8784a84d59243a0c56a073b6fd4" CHECKSUMTYPE="SHA-1" SIZE="49618">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:25:09" MIMETYPE="text/xml"
-				CHECKSUM="1229f0152b61596e7e45bbf6e570c9fab9d71ca6" CHECKSUMTYPE="SHA-1"
-				SIZE="43857">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:25:09" MIMETYPE="text/xml" CHECKSUM="1229f0152b61596e7e45bbf6e570c9fab9d71ca6" CHECKSUMTYPE="SHA-1" SIZE="43857">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:25:09" MIMETYPE="text/xml"
-				CHECKSUM="92a2899745c3b0529e0b82a6616c6104b95d3fc8" CHECKSUMTYPE="SHA-1"
-				SIZE="85975">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:25:09" MIMETYPE="text/xml" CHECKSUM="92a2899745c3b0529e0b82a6616c6104b95d3fc8" CHECKSUMTYPE="SHA-1" SIZE="85975">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:25:09" MIMETYPE="text/xml"
-				CHECKSUM="3b0932ca6833bd41ba3fa585be3774bd7fc65d1e" CHECKSUMTYPE="SHA-1"
-				SIZE="89620">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:25:09" MIMETYPE="text/xml" CHECKSUM="3b0932ca6833bd41ba3fa585be3774bd7fc65d1e" CHECKSUMTYPE="SHA-1" SIZE="89620">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:25:10" MIMETYPE="text/xml"
-				CHECKSUM="4ab1e7de2001b7c9d3856427dc272a592f7f5886" CHECKSUMTYPE="SHA-1" SIZE="4992">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:25:10" MIMETYPE="text/xml" CHECKSUM="4ab1e7de2001b7c9d3856427dc272a592f7f5886" CHECKSUMTYPE="SHA-1" SIZE="4992">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:25:10" MIMETYPE="text/xml"
-				CHECKSUM="5a6927f110f3aec44d8a8d67fbaa1b0510d2f155" CHECKSUMTYPE="SHA-1"
-				SIZE="59653">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:25:10" MIMETYPE="text/xml" CHECKSUM="5a6927f110f3aec44d8a8d67fbaa1b0510d2f155" CHECKSUMTYPE="SHA-1" SIZE="59653">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:25:11" MIMETYPE="text/xml"
-				CHECKSUM="e22ab787af8996495df5a55ae266524ae20229e7" CHECKSUMTYPE="SHA-1"
-				SIZE="12247">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:25:11" MIMETYPE="text/xml" CHECKSUM="e22ab787af8996495df5a55ae266524ae20229e7" CHECKSUMTYPE="SHA-1" SIZE="12247">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:25:11" MIMETYPE="text/xml"
-				CHECKSUM="489230a7775dd6c859034ebc1cbf784e1d8b7c21" CHECKSUMTYPE="SHA-1"
-				SIZE="46647">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:25:11" MIMETYPE="text/xml" CHECKSUM="489230a7775dd6c859034ebc1cbf784e1d8b7c21" CHECKSUMTYPE="SHA-1" SIZE="46647">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T16:25:12" MIMETYPE="text/xml"
-				CHECKSUM="8374e1ff52dcb219bf35553642acbc401a8e0aa9" CHECKSUMTYPE="SHA-1"
-				SIZE="19445">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T16:25:12" MIMETYPE="text/xml" CHECKSUM="8374e1ff52dcb219bf35553642acbc401a8e0aa9" CHECKSUMTYPE="SHA-1" SIZE="19445">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T16:25:12" MIMETYPE="text/xml"
-				CHECKSUM="4d032f340bed6a541a09b41afa01cf67229ad8c3" CHECKSUMTYPE="SHA-1" SIZE="2984">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T16:25:12" MIMETYPE="text/xml" CHECKSUM="4d032f340bed6a541a09b41afa01cf67229ad8c3" CHECKSUMTYPE="SHA-1" SIZE="2984">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T16:25:12" MIMETYPE="text/xml"
-				CHECKSUM="8f8e7b5d096a6316eb275ac5c9c500240a901318" CHECKSUMTYPE="SHA-1"
-				SIZE="37773">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T16:25:12" MIMETYPE="text/xml" CHECKSUM="8f8e7b5d096a6316eb275ac5c9c500240a901318" CHECKSUMTYPE="SHA-1" SIZE="37773">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T16:25:13" MIMETYPE="text/xml"
-				CHECKSUM="4fa9eb81827b8d988ad610a9bc10ef8a4b641b28" CHECKSUMTYPE="SHA-1" SIZE="4099">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T16:25:13" MIMETYPE="text/xml" CHECKSUM="4fa9eb81827b8d988ad610a9bc10ef8a4b641b28" CHECKSUMTYPE="SHA-1" SIZE="4099">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-02_01_0036.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:26:00" MIMETYPE="application/pdf"
-				CHECKSUM="525292e4e0406079ef501a0c5ea6d053967b454a" CHECKSUMTYPE="SHA-1"
-				SIZE="11330766">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/bmtnabf_1898-02_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:26:00" MIMETYPE="application/pdf" CHECKSUM="525292e4e0406079ef501a0c5ea6d053967b454a" CHECKSUMTYPE="SHA-1" SIZE="11330766">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/02_01/bmtnabf_1898-02_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -5012,8 +4795,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c005"
-					LABEL="GUTENBERG-DENKMAL">
+				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c005" LABEL="GUTENBERG-DENKMAL">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00005"/>
@@ -5030,18 +4812,15 @@
 								<div ID="L.1.1.6.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00007"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004"
-						LABEL="GUTENBERG-DENKMAL">
+					<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004" LABEL="GUTENBERG-DENKMAL">
 						<div ID="L.1.1.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00003"/>
@@ -5063,8 +4842,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c006"
-						LABEL="Entwurt von O. Schimkowitz">
+					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c006" LABEL="Entwurt von O. Schimkowitz">
 						<div ID="L.1.1.6.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -5091,8 +4869,7 @@
 
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="TextContent" ORDER="5" DMDID="c008"
-					LABEL="WIENER GESCHMACKLOSIGKEITEN">
+				<div ID="L.1.1.7" TYPE="TextContent" ORDER="5" DMDID="c008" LABEL="WIENER GESCHMACKLOSIGKEITEN">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00003"/>
@@ -5109,16 +4886,11 @@
 								<div ID="L.1.1.7.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
@@ -5142,8 +4914,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.5" TYPE="Illustration" ORDER="2" DMDID="c010"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.7.5" TYPE="Illustration" ORDER="2" DMDID="c010" LABEL="Buchschmuck">
 						<div ID="L.1.1.7.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00005"/>
@@ -5172,8 +4943,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.6" TYPE="Illustration" ORDER="3" DMDID="c013"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.7.6" TYPE="Illustration" ORDER="3" DMDID="c013" LABEL="Buchschmuck">
 						<div ID="L.1.1.7.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00007"/>
@@ -5225,26 +4995,19 @@
 								<div ID="L.1.1.8.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.8.4" TYPE="Illustration" ORDER="1" DMDID="c016"
-						LABEL="Zeichnungen">
+					<div ID="L.1.1.8.4" TYPE="Illustration" ORDER="1" DMDID="c016" LABEL="Zeichnungen">
 						<div ID="L.1.1.8.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00006"/>
@@ -5260,8 +5023,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="3" DMDID="c018"
-							LABEL="KOPF: PUTZ">
+						<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="3" DMDID="c018" LABEL="KOPF: PUTZ">
 							<div ID="L.1.1.8.6.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00004"/>
@@ -5280,24 +5042,21 @@
 							</div>
 
 						</div>
-						<div ID="L.1.1.8.6.5" TYPE="Illustration" ORDER="3" DMDID="c020"
-							LABEL="KOPF: ZIER">
+						<div ID="L.1.1.8.6.5" TYPE="Illustration" ORDER="3" DMDID="c020" LABEL="KOPF: ZIER">
 							<div ID="L.1.1.8.6.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.8.6.6" TYPE="Illustration" ORDER="4" DMDID="c021"
-							LABEL="Untitled Image by Kolo Moser">
+						<div ID="L.1.1.8.6.6" TYPE="Illustration" ORDER="4" DMDID="c021" LABEL="Untitled Image by Kolo Moser">
 							<div ID="L.1.1.8.6.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00001"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.8.6.7" TYPE="Illustration" ORDER="5" DMDID="c022"
-							LABEL="ZWEIRLEI AERMEL">
+						<div ID="L.1.1.8.6.7" TYPE="Illustration" ORDER="5" DMDID="c022" LABEL="ZWEIRLEI AERMEL">
 							<div ID="L.1.1.8.6.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00002"/>
@@ -5305,8 +5064,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="2" DMDID="c017"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="2" DMDID="c017" LABEL="Buchschmuck">
 						<div ID="L.1.1.8.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00008"/>
@@ -5323,8 +5081,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.6.4" TYPE="Illustration" ORDER="2" DMDID="c019"
-						LABEL="Untitled Image by Jos. Hoffmann">
+					<div ID="L.1.1.8.6.4" TYPE="Illustration" ORDER="2" DMDID="c019" LABEL="Untitled Image by Jos. Hoffmann">
 						<div ID="L.1.1.8.6.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00002"/>
@@ -5349,32 +5106,22 @@
 								<div ID="L.1.1.9.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="2" DMDID="c025"
-						LABEL="Illustriert">
+					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="2" DMDID="c025" LABEL="Illustriert">
 						<div ID="L.1.1.9.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00005"/>
@@ -5385,40 +5132,35 @@
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00006"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.9.5.3" TYPE="Illustration" ORDER="1"
-							LABEL="Untitled Image by Rud. Bacher">
+						<div ID="L.1.1.9.5.3" TYPE="Illustration" ORDER="1" LABEL="Untitled Image by Rud. Bacher">
 							<div ID="L.1.1.9.5.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00001"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.9.5.4" TYPE="Illustration" ORDER="2" DMDID="c026"
-							LABEL="Untitled Image by Rud. Bacher">
+						<div ID="L.1.1.9.5.4" TYPE="Illustration" ORDER="2" DMDID="c026" LABEL="Untitled Image by Rud. Bacher">
 							<div ID="L.1.1.9.5.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00001"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.9.5.5" TYPE="Illustration" ORDER="3" DMDID="c027"
-							LABEL="Untitled Image by Rud. Bacher">
+						<div ID="L.1.1.9.5.5" TYPE="Illustration" ORDER="3" DMDID="c027" LABEL="Untitled Image by Rud. Bacher">
 							<div ID="L.1.1.9.5.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.9.5.6" TYPE="Illustration" ORDER="4" DMDID="c028"
-							LABEL="Untitled Image by Rud. Bacher">
+						<div ID="L.1.1.9.5.6" TYPE="Illustration" ORDER="4" DMDID="c028" LABEL="Untitled Image by Rud. Bacher">
 							<div ID="L.1.1.9.5.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00001"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.9.5.7" TYPE="Illustration" ORDER="5" DMDID="c029"
-							LABEL="Untitled Image by Rud. Bacher">
+						<div ID="L.1.1.9.5.7" TYPE="Illustration" ORDER="5" DMDID="c029" LABEL="Untitled Image by Rud. Bacher">
 							<div ID="L.1.1.9.5.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00001"/>
@@ -5426,8 +5168,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.9.4" TYPE="Illustration" ORDER="1" DMDID="c024"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.9.4" TYPE="Illustration" ORDER="1" DMDID="c024" LABEL="Buchschmuck">
 						<div ID="L.1.1.9.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00005"/>
@@ -5444,8 +5185,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.6" TYPE="Illustration" ORDER="3" DMDID="c030"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.9.6" TYPE="Illustration" ORDER="3" DMDID="c030" LABEL="Buchschmuck">
 						<div ID="L.1.1.9.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00005"/>
@@ -5485,8 +5225,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="TextContent" ORDER="9" DMDID="c032"
-					LABEL="EINEM UNMODERNEN. EPISTEL">
+				<div ID="L.1.1.11" TYPE="TextContent" ORDER="9" DMDID="c032" LABEL="EINEM UNMODERNEN. EPISTEL">
 					<div ID="L.1.1.11.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
@@ -5502,8 +5241,7 @@
 							<div ID="L.1.1.11.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.11.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
 									</fptr>
 								</div>
 							</div>
@@ -5519,8 +5257,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.11.4" TYPE="Illustration" ORDER="1" DMDID="c033"
-						LABEL="Untitled Image by Jos. Engelhart">
+					<div ID="L.1.1.11.4" TYPE="Illustration" ORDER="1" DMDID="c033" LABEL="Untitled Image by Jos. Engelhart">
 						<div ID="L.1.1.11.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"/>
@@ -5537,8 +5274,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.5" TYPE="Illustration" ORDER="2" DMDID="c034"
-						LABEL="Untitled Image by Jos. Engelhart">
+					<div ID="L.1.1.11.5" TYPE="Illustration" ORDER="2" DMDID="c034" LABEL="Untitled Image by Jos. Engelhart">
 						<div ID="L.1.1.11.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
@@ -5556,8 +5292,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c035"
-					LABEL="Decorative Landschaft">
+				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c035" LABEL="Decorative Landschaft">
 					<div ID="L.1.1.13.3.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00002"/>
@@ -5601,8 +5336,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.14" TYPE="TextContent" ORDER="12" DMDID="c038"
-					LABEL="AUSSTELLUNGSWESEN">
+				<div ID="L.1.1.14" TYPE="TextContent" ORDER="12" DMDID="c038" LABEL="AUSSTELLUNGSWESEN">
 					<div ID="L.1.1.14.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00003"/>
@@ -5619,26 +5353,19 @@
 								<div ID="L.1.1.14.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.14.4" TYPE="Illustration" ORDER="1" DMDID="c039"
-						LABEL="Decorativer Entwurf">
+					<div ID="L.1.1.14.4" TYPE="Illustration" ORDER="1" DMDID="c039" LABEL="Decorativer Entwurf">
 						<div ID="L.1.1.14.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00005"/>
@@ -5655,8 +5382,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.14.5" TYPE="Illustration" ORDER="2" DMDID="c040"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.14.5" TYPE="Illustration" ORDER="2" DMDID="c040" LABEL="Buchschmuck">
 						<div ID="L.1.1.14.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00007"/>
@@ -5673,8 +5399,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.14.6" TYPE="Illustration" ORDER="3" DMDID="c041"
-						LABEL="ÄRZTE UND DER TOD">
+					<div ID="L.1.1.14.6" TYPE="Illustration" ORDER="3" DMDID="c041" LABEL="ÄRZTE UND DER TOD">
 						<div ID="L.1.1.14.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00006"/>
@@ -5691,8 +5416,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.14.7" TYPE="Illustration" ORDER="4" DMDID="c042"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.14.7" TYPE="Illustration" ORDER="4" DMDID="c042" LABEL="Buchschmuck">
 						<div ID="L.1.1.14.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00007"/>
@@ -5709,8 +5433,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.14.8" TYPE="Illustration" ORDER="5" DMDID="c043"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.14.8" TYPE="Illustration" ORDER="5" DMDID="c043" LABEL="Buchschmuck">
 						<div ID="L.1.1.14.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00009"/>
@@ -5761,8 +5484,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.14.11" TYPE="Illustration" ORDER="8" DMDID="c046"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.14.11" TYPE="Illustration" ORDER="8" DMDID="c046" LABEL="Buchschmuck">
 						<div ID="L.1.1.14.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00007"/>
@@ -5780,8 +5502,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c047"
-					LABEL="NÄCHTLICHES ABENTEUER">
+				<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c047" LABEL="NÄCHTLICHES ABENTEUER">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00003"/>
@@ -5803,8 +5524,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.16" TYPE="TextContent" ORDER="14" DMDID="c048"
-					LABEL="IUGENDSCHATZ DEUTSCHER DICHTUNGEN">
+				<div ID="L.1.1.16" TYPE="TextContent" ORDER="14" DMDID="c048" LABEL="IUGENDSCHATZ DEUTSCHER DICHTUNGEN">
 					<div ID="L.1.1.16.1" TYPE="Head">
 						<fptr>
 							<seq>
@@ -5818,8 +5538,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00008"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.16.3" TYPE="Illustration" ORDER="1" DMDID="c049"
-						LABEL="Untitled Image by J. Hoffmann">
+					<div ID="L.1.1.16.3" TYPE="Illustration" ORDER="1" DMDID="c049" LABEL="Untitled Image by J. Hoffmann">
 						<div ID="L.1.1.16.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_CB00003"/>
@@ -5836,8 +5555,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.4" TYPE="Illustration" ORDER="2" DMDID="c050"
-						LABEL="Untitled Image by Jos. Hoffmann">
+					<div ID="L.1.1.16.4" TYPE="Illustration" ORDER="2" DMDID="c050" LABEL="Untitled Image by Jos. Hoffmann">
 						<div ID="L.1.1.16.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_CB00004"/>
@@ -5854,8 +5572,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.5" TYPE="Illustration" ORDER="3" DMDID="c051"
-						LABEL="Untitled Image by Alf. Roller">
+					<div ID="L.1.1.16.5" TYPE="Illustration" ORDER="3" DMDID="c051" LABEL="Untitled Image by Alf. Roller">
 						<div ID="L.1.1.16.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_CB00003"/>
@@ -5878,36 +5595,24 @@
 								<div ID="L.1.1.16.6.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00007"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.16.7" TYPE="Illustration" ORDER="1" DMDID="c052"
-						LABEL="Bucheinband">
+					<div ID="L.1.1.16.7" TYPE="Illustration" ORDER="1" DMDID="c052" LABEL="Bucheinband">
 						<div ID="L.1.1.16.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00007"/>
@@ -5924,8 +5629,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.8" TYPE="Illustration" ORDER="2" DMDID="c053"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.16.8" TYPE="Illustration" ORDER="2" DMDID="c053" LABEL="Buchschmuck">
 						<div ID="L.1.1.16.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00009"/>
@@ -5942,8 +5646,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.9" TYPE="Illustration" ORDER="3" DMDID="c054"
-						LABEL="Gallerie am Meere. Entwurf">
+					<div ID="L.1.1.16.9" TYPE="Illustration" ORDER="3" DMDID="c054" LABEL="Gallerie am Meere. Entwurf">
 						<div ID="L.1.1.16.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00007"/>
@@ -5967,8 +5670,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.10" TYPE="Illustration" ORDER="4" DMDID="c056"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.16.10" TYPE="Illustration" ORDER="4" DMDID="c056" LABEL="Buchschmuck">
 						<div ID="L.1.1.16.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00009"/>
@@ -5985,8 +5687,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.11" TYPE="Illustration" ORDER="5" DMDID="c057"
-						LABEL="Architekturskizze">
+					<div ID="L.1.1.16.11" TYPE="Illustration" ORDER="5" DMDID="c057" LABEL="Architekturskizze">
 						<div ID="L.1.1.16.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00009"/>
@@ -6038,8 +5739,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.18" TYPE="TextContent" ORDER="16" DMDID="c060"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.18" TYPE="TextContent" ORDER="16" DMDID="c060" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.18.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00003"/>
@@ -6050,8 +5750,7 @@
 							<div ID="L.1.1.18.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.18.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00004"/>
 									</fptr>
 								</div>
 							</div>
@@ -6067,8 +5766,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.18.3" TYPE="Illustration" ORDER="1" DMDID="c061"
-						LABEL="Untitled Image by A. Roller">
+					<div ID="L.1.1.18.3" TYPE="Illustration" ORDER="1" DMDID="c061" LABEL="Untitled Image by A. Roller">
 						<div ID="L.1.1.18.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00007"/>
@@ -6085,8 +5783,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18.4" TYPE="Illustration" ORDER="2" DMDID="c062"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.18.4" TYPE="Illustration" ORDER="2" DMDID="c062" LABEL="Buchschmuck">
 						<div ID="L.1.1.18.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00009"/>
@@ -6103,8 +5800,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18.5" TYPE="Illustration" ORDER="3" DMDID="c063"
-						LABEL="Untitled Image by Kolo Moser">
+					<div ID="L.1.1.18.5" TYPE="Illustration" ORDER="3" DMDID="c063" LABEL="Untitled Image by Kolo Moser">
 						<div ID="L.1.1.18.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00011"/>
@@ -6122,8 +5818,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.19" TYPE="TextContent" ORDER="17" DMDID="c064"
-					LABEL="Der Kunstschatz">
+				<div ID="L.1.1.19" TYPE="TextContent" ORDER="17" DMDID="c064" LABEL="Der Kunstschatz">
 					<div ID="L.1.1.19.1" TYPE="HeadingText">
 						<div ID="L.1.1.19.1.1" TYPE="Text">
 							<fptr>
@@ -6134,48 +5829,42 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.19.2" TYPE="Illustration" ORDER="1" DMDID="c065"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.19.2" TYPE="Illustration" ORDER="1" DMDID="c065" LABEL="Untitled Image">
 						<div ID="L.1.1.19.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="2" DMDID="c066"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="2" DMDID="c066" LABEL="Untitled Image">
 						<div ID="L.1.1.19.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.19.4" TYPE="Illustration" ORDER="3" DMDID="c067"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.19.4" TYPE="Illustration" ORDER="3" DMDID="c067" LABEL="Untitled Image">
 						<div ID="L.1.1.19.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.19.5" TYPE="Illustration" ORDER="4" DMDID="c068"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.19.5" TYPE="Illustration" ORDER="4" DMDID="c068" LABEL="Untitled Image">
 						<div ID="L.1.1.19.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.19.6" TYPE="Illustration" ORDER="5" DMDID="c069"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.19.6" TYPE="Illustration" ORDER="5" DMDID="c069" LABEL="Untitled Image">
 						<div ID="L.1.1.19.6.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_CB00003"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.19.7" TYPE="Illustration" ORDER="6" DMDID="c070"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.19.7" TYPE="Illustration" ORDER="6" DMDID="c070" LABEL="Untitled Image">
 						<div ID="L.1.1.19.7.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_CB00004"/>
@@ -6188,12 +5877,9 @@
 								<div ID="L.1.1.19.8.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00032"
-												BEGIN="P32_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00033"
-												BEGIN="P33_TB00001"/>
-											<area BETYPE="IDREF" FILEID="ALTO00033"
-												BEGIN="P33_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_TB00001"/>
+											<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -6201,8 +5887,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.20" TYPE="Illustration" ORDER="18" DMDID="c071"
-					LABEL="GERLACH-SCHENK">
+				<div ID="L.1.1.20" TYPE="Illustration" ORDER="18" DMDID="c071" LABEL="GERLACH-SCHENK">
 					<div ID="L.1.1.20.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00034" BEGIN="P34_TB00001"/>

--- a/metadata/periodicals/bmtnabf/issues/1898/03_01/bmtnabf_1898-03_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1898/03_01/bmtnabf_1898-03_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-03_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-03_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-03_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1898-03_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-03_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2891,342 +2885,180 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:05:28"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="578b0835c89c37f2c8a8c3a5a3deceab5dc36cf0"
-				CHECKSUMTYPE="SHA-1" SIZE="6219099">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:05:28" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="578b0835c89c37f2c8a8c3a5a3deceab5dc36cf0" CHECKSUMTYPE="SHA-1" SIZE="6219099">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:06:07"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="df3f4c1a6fdf3aa706e8c21944008c0adbbf6fef"
-				CHECKSUMTYPE="SHA-1" SIZE="6202021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:06:07" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="df3f4c1a6fdf3aa706e8c21944008c0adbbf6fef" CHECKSUMTYPE="SHA-1" SIZE="6202021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:06:42"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="450fd2606262e471bf1c12e9b6724d53b690090b"
-				CHECKSUMTYPE="SHA-1" SIZE="6226319">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:06:42" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="450fd2606262e471bf1c12e9b6724d53b690090b" CHECKSUMTYPE="SHA-1" SIZE="6226319">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:07:13"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a42c5a197e521a3a4641ecbdc4daf5d18adbd0e0"
-				CHECKSUMTYPE="SHA-1" SIZE="6172318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:07:13" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a42c5a197e521a3a4641ecbdc4daf5d18adbd0e0" CHECKSUMTYPE="SHA-1" SIZE="6172318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:07:43"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="c1526433448aca867fee289b3dc81cf20fbcda46"
-				CHECKSUMTYPE="SHA-1" SIZE="6226320">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:07:43" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="c1526433448aca867fee289b3dc81cf20fbcda46" CHECKSUMTYPE="SHA-1" SIZE="6226320">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:08:13"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="7bd2b5391f71a6b6aded29c2a71b15dcbd07d675"
-				CHECKSUMTYPE="SHA-1" SIZE="6172329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:08:13" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="7bd2b5391f71a6b6aded29c2a71b15dcbd07d675" CHECKSUMTYPE="SHA-1" SIZE="6172329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:08:44"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="bde6a485400a70c02d79f4a427118243383d8827"
-				CHECKSUMTYPE="SHA-1" SIZE="6226327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:08:44" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="bde6a485400a70c02d79f4a427118243383d8827" CHECKSUMTYPE="SHA-1" SIZE="6226327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:09:16"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="cd901c6c8fb19b474cf0e27ab0ba6b7eb0221591"
-				CHECKSUMTYPE="SHA-1" SIZE="6202021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:09:16" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="cd901c6c8fb19b474cf0e27ab0ba6b7eb0221591" CHECKSUMTYPE="SHA-1" SIZE="6202021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:09:47"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="c9e947ed33e456e59cc591951a2f48c199d70a63"
-				CHECKSUMTYPE="SHA-1" SIZE="6226325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:09:47" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="c9e947ed33e456e59cc591951a2f48c199d70a63" CHECKSUMTYPE="SHA-1" SIZE="6226325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:10:18"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="0d0929f4002f30a8d70ccf9ab067558eb99c37ac"
-				CHECKSUMTYPE="SHA-1" SIZE="6187626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:10:18" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="0d0929f4002f30a8d70ccf9ab067558eb99c37ac" CHECKSUMTYPE="SHA-1" SIZE="6187626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:10:50"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="c14396a6fab2e5fd87b7b7a2d6b9452ef026c1f6"
-				CHECKSUMTYPE="SHA-1" SIZE="6217321">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:10:50" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="c14396a6fab2e5fd87b7b7a2d6b9452ef026c1f6" CHECKSUMTYPE="SHA-1" SIZE="6217321">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:11:22"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="70dc9a29a98a8aab147869971e4b8b49b87b4e40"
-				CHECKSUMTYPE="SHA-1" SIZE="6186729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:11:22" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="70dc9a29a98a8aab147869971e4b8b49b87b4e40" CHECKSUMTYPE="SHA-1" SIZE="6186729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:11:54"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="282ac6940e2177db0fba8b3e37241bcf5ab49500"
-				CHECKSUMTYPE="SHA-1" SIZE="6143512">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:11:54" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="282ac6940e2177db0fba8b3e37241bcf5ab49500" CHECKSUMTYPE="SHA-1" SIZE="6143512">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:12:26"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="c401d9a1d405a6f48afb9b4247099a7495d97145"
-				CHECKSUMTYPE="SHA-1" SIZE="6186729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:12:26" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="c401d9a1d405a6f48afb9b4247099a7495d97145" CHECKSUMTYPE="SHA-1" SIZE="6186729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:12:58"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="bcd212412f6e3f1f6a59b35bfc53cea7b729ddbc"
-				CHECKSUMTYPE="SHA-1" SIZE="6195723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:12:58" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="bcd212412f6e3f1f6a59b35bfc53cea7b729ddbc" CHECKSUMTYPE="SHA-1" SIZE="6195723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:13:29"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="c6d3e3c8bca5d86ff892f10b058ff1d489ca6e89"
-				CHECKSUMTYPE="SHA-1" SIZE="6254195">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:13:29" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="c6d3e3c8bca5d86ff892f10b058ff1d489ca6e89" CHECKSUMTYPE="SHA-1" SIZE="6254195">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:14:02"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="91d66e5670da9198b8a244bd59c95e7670743381"
-				CHECKSUMTYPE="SHA-1" SIZE="6150727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:14:02" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="91d66e5670da9198b8a244bd59c95e7670743381" CHECKSUMTYPE="SHA-1" SIZE="6150727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:14:33"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="f1881e6295de786013d7da5987fa76c7a08acac0"
-				CHECKSUMTYPE="SHA-1" SIZE="6221826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:14:33" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="f1881e6295de786013d7da5987fa76c7a08acac0" CHECKSUMTYPE="SHA-1" SIZE="6221826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:15:04"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="88623ff59b6ec86902680c0f5a0544bd171ba0c2"
-				CHECKSUMTYPE="SHA-1" SIZE="6149821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:15:04" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="88623ff59b6ec86902680c0f5a0544bd171ba0c2" CHECKSUMTYPE="SHA-1" SIZE="6149821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:15:36"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="bf97d5e24dd0c1add9384d339b9ee95dd8039723"
-				CHECKSUMTYPE="SHA-1" SIZE="6244329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:15:36" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="bf97d5e24dd0c1add9384d339b9ee95dd8039723" CHECKSUMTYPE="SHA-1" SIZE="6244329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:16:10"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="260af0e0f8a649b280a9789693657828f3010bc6"
-				CHECKSUMTYPE="SHA-1" SIZE="6178618">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:16:10" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="260af0e0f8a649b280a9789693657828f3010bc6" CHECKSUMTYPE="SHA-1" SIZE="6178618">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:16:41"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="5a04568be57f59b144b637ed63259e03bb0111c8"
-				CHECKSUMTYPE="SHA-1" SIZE="6194783">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:16:41" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="5a04568be57f59b144b637ed63259e03bb0111c8" CHECKSUMTYPE="SHA-1" SIZE="6194783">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:17:13"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="4c314de5f17c559aceb1bb6111131d4eca370549"
-				CHECKSUMTYPE="SHA-1" SIZE="6211027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:17:13" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="4c314de5f17c559aceb1bb6111131d4eca370549" CHECKSUMTYPE="SHA-1" SIZE="6211027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:17:44"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="7d285a2e27c1656025366084ef6eee49818b9e17"
-				CHECKSUMTYPE="SHA-1" SIZE="6217318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:17:44" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="7d285a2e27c1656025366084ef6eee49818b9e17" CHECKSUMTYPE="SHA-1" SIZE="6217318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:18:16"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="4322cd73aca7c2290e774bf882fcd30344ef3c3f"
-				CHECKSUMTYPE="SHA-1" SIZE="6211028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:18:16" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="4322cd73aca7c2290e774bf882fcd30344ef3c3f" CHECKSUMTYPE="SHA-1" SIZE="6211028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:18:46"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="dad419813e251e5d717849dfe19a139afd67789c"
-				CHECKSUMTYPE="SHA-1" SIZE="6217328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:18:46" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="dad419813e251e5d717849dfe19a139afd67789c" CHECKSUMTYPE="SHA-1" SIZE="6217328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:19:18"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="e917f3d2a33c4ccb7cfdfab794887bfed2b8ab2a"
-				CHECKSUMTYPE="SHA-1" SIZE="6172326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:19:18" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="e917f3d2a33c4ccb7cfdfab794887bfed2b8ab2a" CHECKSUMTYPE="SHA-1" SIZE="6172326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:19:51"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="f92da16c8ada17559996310ee5783adf30100328"
-				CHECKSUMTYPE="SHA-1" SIZE="6217218">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:19:51" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="f92da16c8ada17559996310ee5783adf30100328" CHECKSUMTYPE="SHA-1" SIZE="6217218">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/delivery/bmtnabf_1898-03_01_0028.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:20:13" MIMETYPE="text/xml"
-				CHECKSUM="da09315bb53e6f2f145747b027d29ed8fbc09e7c" CHECKSUMTYPE="SHA-1" SIZE="6624">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:20:13" MIMETYPE="text/xml" CHECKSUM="da09315bb53e6f2f145747b027d29ed8fbc09e7c" CHECKSUMTYPE="SHA-1" SIZE="6624">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:20:13" MIMETYPE="text/xml"
-				CHECKSUM="ae25c5ba594479221ee5b318b4e493feab460c60" CHECKSUMTYPE="SHA-1"
-				SIZE="60578">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:20:13" MIMETYPE="text/xml" CHECKSUM="ae25c5ba594479221ee5b318b4e493feab460c60" CHECKSUMTYPE="SHA-1" SIZE="60578">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:20:13" MIMETYPE="text/xml"
-				CHECKSUM="f0ff1217b3b5aa1a697d70c4b19f247f95edbf1a" CHECKSUMTYPE="SHA-1"
-				SIZE="28732">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:20:13" MIMETYPE="text/xml" CHECKSUM="f0ff1217b3b5aa1a697d70c4b19f247f95edbf1a" CHECKSUMTYPE="SHA-1" SIZE="28732">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:20:14" MIMETYPE="text/xml"
-				CHECKSUM="75952a05622013fd7c7ef01e8be0d71c3d0ff292" CHECKSUMTYPE="SHA-1" SIZE="4594">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:20:14" MIMETYPE="text/xml" CHECKSUM="75952a05622013fd7c7ef01e8be0d71c3d0ff292" CHECKSUMTYPE="SHA-1" SIZE="4594">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:20:14" MIMETYPE="text/xml"
-				CHECKSUM="a2e9d1ca6505ec40c8835a91cbb2194e84b3961b" CHECKSUMTYPE="SHA-1" SIZE="5300">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:20:14" MIMETYPE="text/xml" CHECKSUM="a2e9d1ca6505ec40c8835a91cbb2194e84b3961b" CHECKSUMTYPE="SHA-1" SIZE="5300">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:20:15" MIMETYPE="text/xml"
-				CHECKSUM="51f81076f6ccbc5e9a24d27b34654eb7683ad98d" CHECKSUMTYPE="SHA-1" SIZE="4122">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:20:15" MIMETYPE="text/xml" CHECKSUM="51f81076f6ccbc5e9a24d27b34654eb7683ad98d" CHECKSUMTYPE="SHA-1" SIZE="4122">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:20:16" MIMETYPE="text/xml"
-				CHECKSUM="73db8c24c20267dcf24a1fb8e24dd16acaffd322" CHECKSUMTYPE="SHA-1" SIZE="5307">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:20:16" MIMETYPE="text/xml" CHECKSUM="73db8c24c20267dcf24a1fb8e24dd16acaffd322" CHECKSUMTYPE="SHA-1" SIZE="5307">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:20:16" MIMETYPE="text/xml"
-				CHECKSUM="56c338ea6481aaef262e9520e4a433ca7fc8fc78" CHECKSUMTYPE="SHA-1" SIZE="5699">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:20:16" MIMETYPE="text/xml" CHECKSUM="56c338ea6481aaef262e9520e4a433ca7fc8fc78" CHECKSUMTYPE="SHA-1" SIZE="5699">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:20:17" MIMETYPE="text/xml"
-				CHECKSUM="fd446d4a74a1715cf5787022d95412babcdff53e" CHECKSUMTYPE="SHA-1"
-				SIZE="71533">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:20:17" MIMETYPE="text/xml" CHECKSUM="fd446d4a74a1715cf5787022d95412babcdff53e" CHECKSUMTYPE="SHA-1" SIZE="71533">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:20:18" MIMETYPE="text/xml"
-				CHECKSUM="047a4132a3a8a008587ab73b5fdacc16a7e8bb71" CHECKSUMTYPE="SHA-1"
-				SIZE="131749">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:20:18" MIMETYPE="text/xml" CHECKSUM="047a4132a3a8a008587ab73b5fdacc16a7e8bb71" CHECKSUMTYPE="SHA-1" SIZE="131749">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:20:19" MIMETYPE="text/xml"
-				CHECKSUM="1b092b985f52676c0627748949d5343ac5342f56" CHECKSUMTYPE="SHA-1"
-				SIZE="69246">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:20:19" MIMETYPE="text/xml" CHECKSUM="1b092b985f52676c0627748949d5343ac5342f56" CHECKSUMTYPE="SHA-1" SIZE="69246">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:20:19" MIMETYPE="text/xml"
-				CHECKSUM="189d3513f58da3a99b0e305bf26f40cc178204f1" CHECKSUMTYPE="SHA-1"
-				SIZE="78013">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:20:19" MIMETYPE="text/xml" CHECKSUM="189d3513f58da3a99b0e305bf26f40cc178204f1" CHECKSUMTYPE="SHA-1" SIZE="78013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:20:19" MIMETYPE="text/xml"
-				CHECKSUM="2bbd79ffb3100c4ec130bb8fc201452835d8249b" CHECKSUMTYPE="SHA-1"
-				SIZE="140028">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:20:19" MIMETYPE="text/xml" CHECKSUM="2bbd79ffb3100c4ec130bb8fc201452835d8249b" CHECKSUMTYPE="SHA-1" SIZE="140028">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:20:20" MIMETYPE="text/xml"
-				CHECKSUM="c74243d883435bbd01da4ec1e6e010e9eed92370" CHECKSUMTYPE="SHA-1"
-				SIZE="82775">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:20:20" MIMETYPE="text/xml" CHECKSUM="c74243d883435bbd01da4ec1e6e010e9eed92370" CHECKSUMTYPE="SHA-1" SIZE="82775">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:20:20" MIMETYPE="text/xml"
-				CHECKSUM="a0e2a6c5e70cd24eab0145231814d6bf0c8c0a26" CHECKSUMTYPE="SHA-1"
-				SIZE="88077">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:20:20" MIMETYPE="text/xml" CHECKSUM="a0e2a6c5e70cd24eab0145231814d6bf0c8c0a26" CHECKSUMTYPE="SHA-1" SIZE="88077">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:20:20" MIMETYPE="text/xml"
-				CHECKSUM="83aab8c9bfd545c19e8f2c89fd3dfb53824fa31b" CHECKSUMTYPE="SHA-1"
-				SIZE="45131">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:20:20" MIMETYPE="text/xml" CHECKSUM="83aab8c9bfd545c19e8f2c89fd3dfb53824fa31b" CHECKSUMTYPE="SHA-1" SIZE="45131">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:20:21" MIMETYPE="text/xml"
-				CHECKSUM="4c15f1115c1c6d8a9978af22aa476e0c4b6deee2" CHECKSUMTYPE="SHA-1"
-				SIZE="47896">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:20:21" MIMETYPE="text/xml" CHECKSUM="4c15f1115c1c6d8a9978af22aa476e0c4b6deee2" CHECKSUMTYPE="SHA-1" SIZE="47896">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:20:21" MIMETYPE="text/xml"
-				CHECKSUM="7632cefb3520ebbeb93ae637abc4f3647c14efe5" CHECKSUMTYPE="SHA-1"
-				SIZE="74698">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:20:21" MIMETYPE="text/xml" CHECKSUM="7632cefb3520ebbeb93ae637abc4f3647c14efe5" CHECKSUMTYPE="SHA-1" SIZE="74698">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:20:21" MIMETYPE="text/xml"
-				CHECKSUM="3d1fde31888a6b57a74c7ea52e86b4fefddf5a10" CHECKSUMTYPE="SHA-1"
-				SIZE="95571">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:20:21" MIMETYPE="text/xml" CHECKSUM="3d1fde31888a6b57a74c7ea52e86b4fefddf5a10" CHECKSUMTYPE="SHA-1" SIZE="95571">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:20:21" MIMETYPE="text/xml"
-				CHECKSUM="70790fe36e2722c5978d3b73da3f712a396f3838" CHECKSUMTYPE="SHA-1"
-				SIZE="104193">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:20:21" MIMETYPE="text/xml" CHECKSUM="70790fe36e2722c5978d3b73da3f712a396f3838" CHECKSUMTYPE="SHA-1" SIZE="104193">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:20:22" MIMETYPE="text/xml"
-				CHECKSUM="b806e312b719a4cb90a6a551adab594a48bf520e" CHECKSUMTYPE="SHA-1"
-				SIZE="15592">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:20:22" MIMETYPE="text/xml" CHECKSUM="b806e312b719a4cb90a6a551adab594a48bf520e" CHECKSUMTYPE="SHA-1" SIZE="15592">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:20:22" MIMETYPE="text/xml"
-				CHECKSUM="6fc1eaa6fdd759d446c8ab7b2c84267380280735" CHECKSUMTYPE="SHA-1" SIZE="6017">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:20:22" MIMETYPE="text/xml" CHECKSUM="6fc1eaa6fdd759d446c8ab7b2c84267380280735" CHECKSUMTYPE="SHA-1" SIZE="6017">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:20:22" MIMETYPE="text/xml"
-				CHECKSUM="3b35dcc306b91b28558054acf2164e94614c6679" CHECKSUMTYPE="SHA-1" SIZE="5697">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:20:22" MIMETYPE="text/xml" CHECKSUM="3b35dcc306b91b28558054acf2164e94614c6679" CHECKSUMTYPE="SHA-1" SIZE="5697">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:20:22" MIMETYPE="text/xml"
-				CHECKSUM="11865c47a8813bd411e705aad7f5be360ca8d642" CHECKSUMTYPE="SHA-1" SIZE="4155">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:20:22" MIMETYPE="text/xml" CHECKSUM="11865c47a8813bd411e705aad7f5be360ca8d642" CHECKSUMTYPE="SHA-1" SIZE="4155">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:20:23" MIMETYPE="text/xml"
-				CHECKSUM="84b7d853227f2aaea7b0f1bdda46b19cba18a177" CHECKSUMTYPE="SHA-1"
-				SIZE="68732">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:20:23" MIMETYPE="text/xml" CHECKSUM="84b7d853227f2aaea7b0f1bdda46b19cba18a177" CHECKSUMTYPE="SHA-1" SIZE="68732">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:20:23" MIMETYPE="text/xml"
-				CHECKSUM="e607a18bb803d38be489ba89126d26d6b0733eb6" CHECKSUMTYPE="SHA-1"
-				SIZE="96856">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:20:23" MIMETYPE="text/xml" CHECKSUM="e607a18bb803d38be489ba89126d26d6b0733eb6" CHECKSUMTYPE="SHA-1" SIZE="96856">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:20:23" MIMETYPE="text/xml"
-				CHECKSUM="e9fbcc1c05dc1dfcfd26df5839b3dba515c391a7" CHECKSUMTYPE="SHA-1"
-				SIZE="17902">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:20:23" MIMETYPE="text/xml" CHECKSUM="e9fbcc1c05dc1dfcfd26df5839b3dba515c391a7" CHECKSUMTYPE="SHA-1" SIZE="17902">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:20:23" MIMETYPE="text/xml"
-				CHECKSUM="f37d0b97b7bcf2fedea3f28ebf1c7a1552bc9fd4" CHECKSUMTYPE="SHA-1" SIZE="6053">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:20:23" MIMETYPE="text/xml" CHECKSUM="f37d0b97b7bcf2fedea3f28ebf1c7a1552bc9fd4" CHECKSUMTYPE="SHA-1" SIZE="6053">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-03_01_0028.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:21:05" MIMETYPE="application/pdf"
-				CHECKSUM="045cb03523602c6befa15e60f00ca389e600bf82" CHECKSUMTYPE="SHA-1"
-				SIZE="6925880">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/bmtnabf_1898-03_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:21:05" MIMETYPE="application/pdf" CHECKSUM="045cb03523602c6befa15e60f00ca389e600bf82" CHECKSUMTYPE="SHA-1" SIZE="6925880">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/03_01/bmtnabf_1898-03_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3461,8 +3293,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 3 03.1898">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by Gustav Klimt">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by Gustav Klimt">
 					<div ID="L.1.1.1.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_TB00001"/>
@@ -3655,8 +3486,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c005"
-						LABEL="Aus &#34;Allegorien, neue Folge&#34;">
+					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c005" LABEL="Aus &#34;Allegorien, neue Folge&#34;">
 						<div ID="L.1.1.5.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00004"/>
@@ -3673,8 +3503,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="2" DMDID="c006"
-						LABEL="Plakat-Entwurf">
+					<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="2" DMDID="c006" LABEL="Plakat-Entwurf">
 						<div ID="L.1.1.5.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00002"/>
@@ -3691,8 +3520,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="3" DMDID="c007"
-						LABEL="Entwurf für ein Deckengemälde &#34;Hygieia&#34;">
+					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="3" DMDID="c007" LABEL="Entwurf für ein Deckengemälde &#34;Hygieia&#34;">
 						<div ID="L.1.1.5.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -3743,8 +3571,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="6" DMDID="c010"
-						LABEL="Porträtskizze">
+					<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="6" DMDID="c010" LABEL="Porträtskizze">
 						<div ID="L.1.1.5.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
@@ -3784,8 +3611,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="TextContent" ORDER="3" DMDID="c012"
-					LABEL="SYMBOLISTIK VOR HUNDERT JAHREN">
+				<div ID="L.1.1.6" TYPE="TextContent" ORDER="3" DMDID="c012" LABEL="SYMBOLISTIK VOR HUNDERT JAHREN">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -3811,56 +3637,31 @@
 								<div ID="L.1.1.6.3.1.3.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3882,8 +3683,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c013"
-						LABEL="Aus &#34;Allegorien&#34;, neue Folge">
+					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c013" LABEL="Aus &#34;Allegorien&#34;, neue Folge">
 						<div ID="L.1.1.6.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00007"/>
@@ -3900,8 +3700,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="2" DMDID="c014"
-						LABEL="Placatskizze">
+					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="2" DMDID="c014" LABEL="Placatskizze">
 						<div ID="L.1.1.6.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00005"/>
@@ -3935,8 +3734,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.7" TYPE="Illustration" ORDER="4" DMDID="c016"
-						LABEL="Gruppenbildnis">
+					<div ID="L.1.1.6.7" TYPE="Illustration" ORDER="4" DMDID="c016" LABEL="Gruppenbildnis">
 						<div ID="L.1.1.6.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00004"/>
@@ -3970,8 +3768,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.9" TYPE="Illustration" ORDER="6" DMDID="c018"
-						LABEL="Gruppenbildnis">
+					<div ID="L.1.1.6.9" TYPE="Illustration" ORDER="6" DMDID="c018" LABEL="Gruppenbildnis">
 						<div ID="L.1.1.6.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00005"/>
@@ -3988,8 +3785,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.10" TYPE="Illustration" ORDER="7" DMDID="c019"
-						LABEL="Nuda Veritas">
+					<div ID="L.1.1.6.10" TYPE="Illustration" ORDER="7" DMDID="c019" LABEL="Nuda Veritas">
 						<div ID="L.1.1.6.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
@@ -4008,16 +3804,14 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.6.10.4" TYPE="Illustration" ORDER="2" DMDID="c020"
-						LABEL="Der Neid">
+					<div ID="L.1.1.6.10.4" TYPE="Illustration" ORDER="2" DMDID="c020" LABEL="Der Neid">
 						<div ID="L.1.1.6.10.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.11" TYPE="Illustration" ORDER="8" DMDID="c021"
-						LABEL="Ver Sacrum">
+					<div ID="L.1.1.6.11" TYPE="Illustration" ORDER="8" DMDID="c021" LABEL="Ver Sacrum">
 						<div ID="L.1.1.6.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
@@ -4036,16 +3830,14 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.6.11.4" TYPE="Illustration" ORDER="2" DMDID="c022"
-						LABEL="Ver Sacrum">
+					<div ID="L.1.1.6.11.4" TYPE="Illustration" ORDER="2" DMDID="c022" LABEL="Ver Sacrum">
 						<div ID="L.1.1.6.11.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.12" TYPE="Illustration" ORDER="9" DMDID="c023"
-						LABEL="Zwickelbilder im Stiegenhause des k. k. kunsthistorischen Hofmuseums zu Wien (1890)">
+					<div ID="L.1.1.6.12" TYPE="Illustration" ORDER="9" DMDID="c023" LABEL="Zwickelbilder im Stiegenhause des k. k. kunsthistorischen Hofmuseums zu Wien (1890)">
 						<div ID="L.1.1.6.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"/>
@@ -4062,8 +3854,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.13" TYPE="Illustration" ORDER="10" DMDID="c024"
-						LABEL="Zwickelbilder im Stiegenhause des k. k. kunsthistorischen Hofmuseums zu Wien ">
+					<div ID="L.1.1.6.13" TYPE="Illustration" ORDER="10" DMDID="c024" LABEL="Zwickelbilder im Stiegenhause des k. k. kunsthistorischen Hofmuseums zu Wien ">
 						<div ID="L.1.1.6.13.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00005"/>
@@ -4080,8 +3871,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.14" TYPE="Illustration" ORDER="11" DMDID="c025"
-						LABEL="Malereien im Stiegenhause des k. k. kunsthistorischen Hofmnseums zu Wien ">
+					<div ID="L.1.1.6.14" TYPE="Illustration" ORDER="11" DMDID="c025" LABEL="Malereien im Stiegenhause des k. k. kunsthistorischen Hofmnseums zu Wien ">
 						<div ID="L.1.1.6.14.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"/>
@@ -4098,8 +3888,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.15" TYPE="Illustration" ORDER="12" DMDID="c026"
-						LABEL="Fragment aus einem Kalender ">
+					<div ID="L.1.1.6.15" TYPE="Illustration" ORDER="12" DMDID="c026" LABEL="Fragment aus einem Kalender ">
 						<div ID="L.1.1.6.15.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00006"/>
@@ -4116,8 +3905,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.16" TYPE="Illustration" ORDER="13" DMDID="c027"
-						LABEL="Damenbildnis ">
+					<div ID="L.1.1.6.16" TYPE="Illustration" ORDER="13" DMDID="c027" LABEL="Damenbildnis ">
 						<div ID="L.1.1.6.16.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00005"/>
@@ -4134,8 +3922,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.17" TYPE="Illustration" ORDER="14" DMDID="c028"
-						LABEL="Studie zu einem Bildnis">
+					<div ID="L.1.1.6.17" TYPE="Illustration" ORDER="14" DMDID="c028" LABEL="Studie zu einem Bildnis">
 						<div ID="L.1.1.6.17.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00004"/>
@@ -4152,8 +3939,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.18" TYPE="Illustration" ORDER="15" DMDID="c029"
-						LABEL="Aus &#34;Advent&#34; Verlag von P. Friesenhahn. Leipzig">
+					<div ID="L.1.1.6.18" TYPE="Illustration" ORDER="15" DMDID="c029" LABEL="Aus &#34;Advent&#34; Verlag von P. Friesenhahn. Leipzig">
 						<div ID="L.1.1.6.18.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00003"/>
@@ -4170,8 +3956,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="MET-GH111-c029a" TYPE="TextContent" ORDER="1" DMDID="c029a"
-						LABEL="Lehnen im Abendgarten beide…">
+					<div ID="MET-GH111-c029a" TYPE="TextContent" ORDER="1" DMDID="c029a" LABEL="Lehnen im Abendgarten beide…">
 						<div ID="L.1.1.6.2" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
@@ -4183,16 +3968,14 @@
 								<div ID="L.1.1.6.3.1.4" TYPE="Paragraph" ORDER="4">
 									<div ID="L.1.1.6.3.1.4.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00001"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00001"/>
 										</fptr>
 									</div>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.19" TYPE="Illustration" ORDER="16" DMDID="c030"
-						LABEL="Porträtskizze">
+					<div ID="L.1.1.6.19" TYPE="Illustration" ORDER="16" DMDID="c030" LABEL="Porträtskizze">
 						<div ID="L.1.1.6.19.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
@@ -4235,8 +4018,7 @@
 							</div>
 						
 					</div>
-					<div ID="L.1.1.6.21" TYPE="Illustration" ORDER="18" DMDID="c033"
-						LABEL="Studie zu einem Porträt des Schauspielers Blasel">
+					<div ID="L.1.1.6.21" TYPE="Illustration" ORDER="18" DMDID="c033" LABEL="Studie zu einem Porträt des Schauspielers Blasel">
 						<div ID="L.1.1.6.21.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
@@ -4271,15 +4053,13 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="TextContent" ORDER="4" DMDID="c035"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.7" TYPE="TextContent" ORDER="4" DMDID="c035" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="3" DMDID="c038"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="3" DMDID="c038" LABEL="Untitled Image">
 						<div ID="L.1.1.7.4.1" TYPE="Image">
 							<fptr>
 								<seq>
@@ -4294,47 +4074,41 @@
 							<div ID="L.1.1.7.5.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.7.5.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.7.5.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.7.5.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.7.5.1.3" TYPE="Paragraph" ORDER="3">
 								<div ID="L.1.1.7.5.1.3.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00005"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00005"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.7.5.1.4" TYPE="Paragraph" ORDER="4">
 								<div ID="L.1.1.7.5.1.4.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00006"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00006"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.7.5.1.5" TYPE="Paragraph" ORDER="5">
 								<div ID="L.1.1.7.5.1.5.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7.6" TYPE="Illustration" ORDER="1" DMDID="c039"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.7.6" TYPE="Illustration" ORDER="1" DMDID="c039" LABEL="Buchschmuck">
 						<div ID="L.1.1.7.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00007"/>
@@ -4351,8 +4125,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.7" TYPE="Illustration" ORDER="2" DMDID="c040"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.7.7" TYPE="Illustration" ORDER="2" DMDID="c040" LABEL="Buchschmuck">
 						<div ID="L.1.1.7.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"/>
@@ -4369,8 +4142,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.8" TYPE="Illustration" ORDER="3" DMDID="c041"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.7.8" TYPE="Illustration" ORDER="3" DMDID="c041" LABEL="Buchschmuck">
 						<div ID="L.1.1.7.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00005"/>

--- a/metadata/periodicals/bmtnabf/issues/1898/04_01/bmtnabf_1898-04_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1898/04_01/bmtnabf_1898-04_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-04_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-04_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-04_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1898-04_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-04_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3621,412 +3615,216 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:05:31"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="876a09f476e45e4f40269eafa595cb48a539d5d8"
-				CHECKSUMTYPE="SHA-1" SIZE="6250628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:05:31" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="876a09f476e45e4f40269eafa595cb48a539d5d8" CHECKSUMTYPE="SHA-1" SIZE="6250628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:06:09"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="5ae4df06ab6f992ec4129e971f564ca95ae50797"
-				CHECKSUMTYPE="SHA-1" SIZE="6110220">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:06:09" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="5ae4df06ab6f992ec4129e971f564ca95ae50797" CHECKSUMTYPE="SHA-1" SIZE="6110220">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:06:47"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="ea752d5bf5ac8cdd68c3063be29601968d763120"
-				CHECKSUMTYPE="SHA-1" SIZE="6173227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:06:47" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="ea752d5bf5ac8cdd68c3063be29601968d763120" CHECKSUMTYPE="SHA-1" SIZE="6173227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:07:22"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="ce3c1f1470656a602de7608b2b61e09152e2d427"
-				CHECKSUMTYPE="SHA-1" SIZE="6028224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:07:22" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="ce3c1f1470656a602de7608b2b61e09152e2d427" CHECKSUMTYPE="SHA-1" SIZE="6028224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:08:00"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="72a270bac411d8b63d65e7019ad0095427093b92"
-				CHECKSUMTYPE="SHA-1" SIZE="6220026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:08:00" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="72a270bac411d8b63d65e7019ad0095427093b92" CHECKSUMTYPE="SHA-1" SIZE="6220026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:08:35"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="34798508e147299dc26e51aaae87b7913a38405f"
-				CHECKSUMTYPE="SHA-1" SIZE="6083229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:08:35" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="34798508e147299dc26e51aaae87b7913a38405f" CHECKSUMTYPE="SHA-1" SIZE="6083229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:09:08"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="9f59dc878a329d0da5f303984587cea6c6e9bb1f"
-				CHECKSUMTYPE="SHA-1" SIZE="6227216">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:09:08" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="9f59dc878a329d0da5f303984587cea6c6e9bb1f" CHECKSUMTYPE="SHA-1" SIZE="6227216">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:09:45"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="3124584aa6d6384ec3c56b84e24dcee51c9bda33"
-				CHECKSUMTYPE="SHA-1" SIZE="6127320">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:09:45" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="3124584aa6d6384ec3c56b84e24dcee51c9bda33" CHECKSUMTYPE="SHA-1" SIZE="6127320">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:10:19"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="3410322fdffa5402ed50f903554022686d00182e"
-				CHECKSUMTYPE="SHA-1" SIZE="6213714">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:10:19" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="3410322fdffa5402ed50f903554022686d00182e" CHECKSUMTYPE="SHA-1" SIZE="6213714">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:10:57"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="833c9821f5801e7127e3a25d56b2583cda0def37"
-				CHECKSUMTYPE="SHA-1" SIZE="6127327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:10:57" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="833c9821f5801e7127e3a25d56b2583cda0def37" CHECKSUMTYPE="SHA-1" SIZE="6127327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:11:33"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="7d99524887b1b1cd44d6e302eccc5bda6e055910"
-				CHECKSUMTYPE="SHA-1" SIZE="6187629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:11:33" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="7d99524887b1b1cd44d6e302eccc5bda6e055910" CHECKSUMTYPE="SHA-1" SIZE="6187629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:12:10"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="51fd7c6699441bd047fa2a08158dfdd82d51bcef"
-				CHECKSUMTYPE="SHA-1" SIZE="6127327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:12:10" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="51fd7c6699441bd047fa2a08158dfdd82d51bcef" CHECKSUMTYPE="SHA-1" SIZE="6127327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:12:49"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="a4a7ce7213673a9c5ebe8a8c72056319df15b644"
-				CHECKSUMTYPE="SHA-1" SIZE="6187619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:12:49" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="a4a7ce7213673a9c5ebe8a8c72056319df15b644" CHECKSUMTYPE="SHA-1" SIZE="6187619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:13:24"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="bbc2547928e35703ed11d6bc56c774cf7ec85652"
-				CHECKSUMTYPE="SHA-1" SIZE="6155228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:13:24" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="bbc2547928e35703ed11d6bc56c774cf7ec85652" CHECKSUMTYPE="SHA-1" SIZE="6155228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:14:00"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="9bd593c23b57fa5886ea15a5d6240c00741b7a91"
-				CHECKSUMTYPE="SHA-1" SIZE="6175927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:14:00" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="9bd593c23b57fa5886ea15a5d6240c00741b7a91" CHECKSUMTYPE="SHA-1" SIZE="6175927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:14:35"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="b905e4b7f5c3f9781c358357e3de9d5410bcc209"
-				CHECKSUMTYPE="SHA-1" SIZE="6151625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:14:35" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="b905e4b7f5c3f9781c358357e3de9d5410bcc209" CHECKSUMTYPE="SHA-1" SIZE="6151625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:15:11"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="573ae8d81873d39fb001bda3b875c081c7bc0e8e"
-				CHECKSUMTYPE="SHA-1" SIZE="6175919">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:15:11" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="573ae8d81873d39fb001bda3b875c081c7bc0e8e" CHECKSUMTYPE="SHA-1" SIZE="6175919">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:15:48"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="3e85af1f828fa8a305f3eedf28779878a206b4f3"
-				CHECKSUMTYPE="SHA-1" SIZE="6180425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:15:48" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="3e85af1f828fa8a305f3eedf28779878a206b4f3" CHECKSUMTYPE="SHA-1" SIZE="6180425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:16:24"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="25f3788b864ca3fdb1e1f974950bf1444c7095ff"
-				CHECKSUMTYPE="SHA-1" SIZE="6138126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:16:24" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="25f3788b864ca3fdb1e1f974950bf1444c7095ff" CHECKSUMTYPE="SHA-1" SIZE="6138126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:16:59"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="391310f8e755f4f1fccf246a192252eb35ccfee2"
-				CHECKSUMTYPE="SHA-1" SIZE="6141708">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:16:59" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="391310f8e755f4f1fccf246a192252eb35ccfee2" CHECKSUMTYPE="SHA-1" SIZE="6141708">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:17:35"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="cf0798f53581f66581869848febc6c1c7e32ed8a"
-				CHECKSUMTYPE="SHA-1" SIZE="6151628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:17:35" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="cf0798f53581f66581869848febc6c1c7e32ed8a" CHECKSUMTYPE="SHA-1" SIZE="6151628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:18:09"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="8cec614fa50ca3a05827cd3c2b3781d4fc281a6e"
-				CHECKSUMTYPE="SHA-1" SIZE="6173223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:18:09" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="8cec614fa50ca3a05827cd3c2b3781d4fc281a6e" CHECKSUMTYPE="SHA-1" SIZE="6173223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:18:42"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="c77e49cf3e296fc4ffc7b21d7b473d31cc7cd941"
-				CHECKSUMTYPE="SHA-1" SIZE="6151623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:18:42" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="c77e49cf3e296fc4ffc7b21d7b473d31cc7cd941" CHECKSUMTYPE="SHA-1" SIZE="6151623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:19:16"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="14cddf94eb76017ca89be54985a7831d018e7bd4"
-				CHECKSUMTYPE="SHA-1" SIZE="6173226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:19:16" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="14cddf94eb76017ca89be54985a7831d018e7bd4" CHECKSUMTYPE="SHA-1" SIZE="6173226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:19:50"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="686b83844180b23e1fd649754f84518ab39967be"
-				CHECKSUMTYPE="SHA-1" SIZE="6151629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:19:50" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="686b83844180b23e1fd649754f84518ab39967be" CHECKSUMTYPE="SHA-1" SIZE="6151629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:20:25"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="acdf9e41eb47ba822dddac3a5409e9b38fe86028"
-				CHECKSUMTYPE="SHA-1" SIZE="6173218">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:20:25" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="acdf9e41eb47ba822dddac3a5409e9b38fe86028" CHECKSUMTYPE="SHA-1" SIZE="6173218">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:21:00"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="eb923b3caf03225b7360455ff6c66644147ba3ce"
-				CHECKSUMTYPE="SHA-1" SIZE="6151585">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:21:00" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="eb923b3caf03225b7360455ff6c66644147ba3ce" CHECKSUMTYPE="SHA-1" SIZE="6151585">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:21:37"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="0f4a2dffd069a0a6b07c3949e83949602328a2c4"
-				CHECKSUMTYPE="SHA-1" SIZE="6199308">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:21:37" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="0f4a2dffd069a0a6b07c3949e83949602328a2c4" CHECKSUMTYPE="SHA-1" SIZE="6199308">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:22:12"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="38c4a454ec2c6bbf89a482003006bd295939405e"
-				CHECKSUMTYPE="SHA-1" SIZE="6151628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:22:12" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="38c4a454ec2c6bbf89a482003006bd295939405e" CHECKSUMTYPE="SHA-1" SIZE="6151628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:22:48"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="84e4e966cbb246f03d59f7b98bdc9f51d9bc3731"
-				CHECKSUMTYPE="SHA-1" SIZE="6278525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:22:48" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="84e4e966cbb246f03d59f7b98bdc9f51d9bc3731" CHECKSUMTYPE="SHA-1" SIZE="6278525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:23:23"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="5ae1f319dba9be88186b3657b0ba74f3e631b410"
-				CHECKSUMTYPE="SHA-1" SIZE="6189429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:23:23" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="5ae1f319dba9be88186b3657b0ba74f3e631b410" CHECKSUMTYPE="SHA-1" SIZE="6189429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:24:01"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="6f419e5f48d7d9642ad1e38d0275219c31c2ac60"
-				CHECKSUMTYPE="SHA-1" SIZE="6213722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:24:01" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="6f419e5f48d7d9642ad1e38d0275219c31c2ac60" CHECKSUMTYPE="SHA-1" SIZE="6213722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T16:24:37"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="1fce0736c9f9f86c6cfdff153aacd197675fb47c"
-				CHECKSUMTYPE="SHA-1" SIZE="6189422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T16:24:37" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="1fce0736c9f9f86c6cfdff153aacd197675fb47c" CHECKSUMTYPE="SHA-1" SIZE="6189422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T16:25:13"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="017e589cf35a8dc1f8dc4e7fca8ee994f9e87428"
-				CHECKSUMTYPE="SHA-1" SIZE="6212802">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T16:25:13" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="017e589cf35a8dc1f8dc4e7fca8ee994f9e87428" CHECKSUMTYPE="SHA-1" SIZE="6212802">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/delivery/bmtnabf_1898-04_01_0034.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:25:38" MIMETYPE="text/xml"
-				CHECKSUM="83c6c5141d98fd1f0211c28004ce64a1eeb57435" CHECKSUMTYPE="SHA-1"
-				SIZE="10529">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:25:38" MIMETYPE="text/xml" CHECKSUM="83c6c5141d98fd1f0211c28004ce64a1eeb57435" CHECKSUMTYPE="SHA-1" SIZE="10529">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:25:38" MIMETYPE="text/xml"
-				CHECKSUM="2106c84e1db5b351d600c6778ce9b9dd8bd6f0a4" CHECKSUMTYPE="SHA-1"
-				SIZE="71209">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:25:38" MIMETYPE="text/xml" CHECKSUM="2106c84e1db5b351d600c6778ce9b9dd8bd6f0a4" CHECKSUMTYPE="SHA-1" SIZE="71209">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:25:38" MIMETYPE="text/xml"
-				CHECKSUM="e509703d125d55df88647cfb82ae87501d47764a" CHECKSUMTYPE="SHA-1" SIZE="7588">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:25:38" MIMETYPE="text/xml" CHECKSUM="e509703d125d55df88647cfb82ae87501d47764a" CHECKSUMTYPE="SHA-1" SIZE="7588">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:25:39" MIMETYPE="text/xml"
-				CHECKSUM="b9cc395e9714a8898f816e32ce283ec660752ce2" CHECKSUMTYPE="SHA-1" SIZE="4368">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:25:39" MIMETYPE="text/xml" CHECKSUM="b9cc395e9714a8898f816e32ce283ec660752ce2" CHECKSUMTYPE="SHA-1" SIZE="4368">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:25:39" MIMETYPE="text/xml"
-				CHECKSUM="8abf606093f93c81113bb56a503b39a9768bcaee" CHECKSUMTYPE="SHA-1"
-				SIZE="79767">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:25:39" MIMETYPE="text/xml" CHECKSUM="8abf606093f93c81113bb56a503b39a9768bcaee" CHECKSUMTYPE="SHA-1" SIZE="79767">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:25:39" MIMETYPE="text/xml"
-				CHECKSUM="25557cbdff483dcad2394508c70436758dbd80cb" CHECKSUMTYPE="SHA-1"
-				SIZE="47664">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:25:39" MIMETYPE="text/xml" CHECKSUM="25557cbdff483dcad2394508c70436758dbd80cb" CHECKSUMTYPE="SHA-1" SIZE="47664">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:25:39" MIMETYPE="text/xml"
-				CHECKSUM="cda5f42e59e84df35773f02364b7f2b179919d03" CHECKSUMTYPE="SHA-1"
-				SIZE="46225">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:25:39" MIMETYPE="text/xml" CHECKSUM="cda5f42e59e84df35773f02364b7f2b179919d03" CHECKSUMTYPE="SHA-1" SIZE="46225">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:25:40" MIMETYPE="text/xml"
-				CHECKSUM="25da62124a7ac1e5ba53ba786bb8171fe04ee356" CHECKSUMTYPE="SHA-1"
-				SIZE="132724">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:25:40" MIMETYPE="text/xml" CHECKSUM="25da62124a7ac1e5ba53ba786bb8171fe04ee356" CHECKSUMTYPE="SHA-1" SIZE="132724">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:25:40" MIMETYPE="text/xml"
-				CHECKSUM="ce71e8f779b93bcd1381252f914a4ba314e166a0" CHECKSUMTYPE="SHA-1"
-				SIZE="52784">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:25:40" MIMETYPE="text/xml" CHECKSUM="ce71e8f779b93bcd1381252f914a4ba314e166a0" CHECKSUMTYPE="SHA-1" SIZE="52784">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:25:40" MIMETYPE="text/xml"
-				CHECKSUM="1ec8572de500aeff2da8df59fba05870d109ee87" CHECKSUMTYPE="SHA-1"
-				SIZE="59546">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:25:40" MIMETYPE="text/xml" CHECKSUM="1ec8572de500aeff2da8df59fba05870d109ee87" CHECKSUMTYPE="SHA-1" SIZE="59546">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:25:40" MIMETYPE="text/xml"
-				CHECKSUM="645240ae7eee1b3398434627d538a0826a489956" CHECKSUMTYPE="SHA-1"
-				SIZE="140574">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:25:40" MIMETYPE="text/xml" CHECKSUM="645240ae7eee1b3398434627d538a0826a489956" CHECKSUMTYPE="SHA-1" SIZE="140574">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:25:41" MIMETYPE="text/xml"
-				CHECKSUM="124a4c6ce0ca940848f6ab4105fdc6f867e3e38d" CHECKSUMTYPE="SHA-1"
-				SIZE="54436">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:25:41" MIMETYPE="text/xml" CHECKSUM="124a4c6ce0ca940848f6ab4105fdc6f867e3e38d" CHECKSUMTYPE="SHA-1" SIZE="54436">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:25:41" MIMETYPE="text/xml"
-				CHECKSUM="2464b6f9949eea8d3794996e7c6f74bc621661e2" CHECKSUMTYPE="SHA-1" SIZE="6317">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:25:41" MIMETYPE="text/xml" CHECKSUM="2464b6f9949eea8d3794996e7c6f74bc621661e2" CHECKSUMTYPE="SHA-1" SIZE="6317">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:25:41" MIMETYPE="text/xml"
-				CHECKSUM="89177a4d445ff86c75847d69d66dd57c043a6082" CHECKSUMTYPE="SHA-1"
-				SIZE="78760">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:25:41" MIMETYPE="text/xml" CHECKSUM="89177a4d445ff86c75847d69d66dd57c043a6082" CHECKSUMTYPE="SHA-1" SIZE="78760">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:25:42" MIMETYPE="text/xml"
-				CHECKSUM="6ff48015b246f5a104fbd061ffda8c973a1b858c" CHECKSUMTYPE="SHA-1"
-				SIZE="90810">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:25:42" MIMETYPE="text/xml" CHECKSUM="6ff48015b246f5a104fbd061ffda8c973a1b858c" CHECKSUMTYPE="SHA-1" SIZE="90810">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:25:42" MIMETYPE="text/xml"
-				CHECKSUM="5db7e6c38f3ca45a879001901402d513a09d40e4" CHECKSUMTYPE="SHA-1" SIZE="4576">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:25:42" MIMETYPE="text/xml" CHECKSUM="5db7e6c38f3ca45a879001901402d513a09d40e4" CHECKSUMTYPE="SHA-1" SIZE="4576">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:25:43" MIMETYPE="text/xml"
-				CHECKSUM="bc6f80270dcc88a687e7502c15be4356557e3736" CHECKSUMTYPE="SHA-1" SIZE="4128">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:25:43" MIMETYPE="text/xml" CHECKSUM="bc6f80270dcc88a687e7502c15be4356557e3736" CHECKSUMTYPE="SHA-1" SIZE="4128">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:25:43" MIMETYPE="text/xml"
-				CHECKSUM="0ca9b16e82bf5b8bea517340799371909e079dd5" CHECKSUMTYPE="SHA-1" SIZE="4906">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:25:43" MIMETYPE="text/xml" CHECKSUM="0ca9b16e82bf5b8bea517340799371909e079dd5" CHECKSUMTYPE="SHA-1" SIZE="4906">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:25:43" MIMETYPE="text/xml"
-				CHECKSUM="41702e1a4e82725a3ddc28498ee185224b802ba6" CHECKSUMTYPE="SHA-1" SIZE="4149">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:25:43" MIMETYPE="text/xml" CHECKSUM="41702e1a4e82725a3ddc28498ee185224b802ba6" CHECKSUMTYPE="SHA-1" SIZE="4149">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:25:43" MIMETYPE="text/xml"
-				CHECKSUM="6366f1975afb6170f996cc42e0b5b385bd29c6e6" CHECKSUMTYPE="SHA-1" SIZE="4130">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:25:43" MIMETYPE="text/xml" CHECKSUM="6366f1975afb6170f996cc42e0b5b385bd29c6e6" CHECKSUMTYPE="SHA-1" SIZE="4130">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:25:44" MIMETYPE="text/xml"
-				CHECKSUM="d42d0caee16caed4c12cfb2fa6b61c465b0d4e65" CHECKSUMTYPE="SHA-1" SIZE="4651">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:25:44" MIMETYPE="text/xml" CHECKSUM="d42d0caee16caed4c12cfb2fa6b61c465b0d4e65" CHECKSUMTYPE="SHA-1" SIZE="4651">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:25:44" MIMETYPE="text/xml"
-				CHECKSUM="0a469e9ed364aa83fce25bc9057f5df30456a60e" CHECKSUMTYPE="SHA-1"
-				SIZE="23260">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:25:44" MIMETYPE="text/xml" CHECKSUM="0a469e9ed364aa83fce25bc9057f5df30456a60e" CHECKSUMTYPE="SHA-1" SIZE="23260">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:25:44" MIMETYPE="text/xml"
-				CHECKSUM="eee38891dd5d8ca9a232ca56f2607d476692b595" CHECKSUMTYPE="SHA-1"
-				SIZE="150232">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:25:44" MIMETYPE="text/xml" CHECKSUM="eee38891dd5d8ca9a232ca56f2607d476692b595" CHECKSUMTYPE="SHA-1" SIZE="150232">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:25:45" MIMETYPE="text/xml"
-				CHECKSUM="b8f51fa4677b190fa07a5094e55ee3af79e9a77c" CHECKSUMTYPE="SHA-1"
-				SIZE="30539">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:25:45" MIMETYPE="text/xml" CHECKSUM="b8f51fa4677b190fa07a5094e55ee3af79e9a77c" CHECKSUMTYPE="SHA-1" SIZE="30539">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:25:45" MIMETYPE="text/xml"
-				CHECKSUM="c15f1f959a415997e3017ae3474de50d30f6687c" CHECKSUMTYPE="SHA-1"
-				SIZE="97906">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:25:45" MIMETYPE="text/xml" CHECKSUM="c15f1f959a415997e3017ae3474de50d30f6687c" CHECKSUMTYPE="SHA-1" SIZE="97906">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:25:46" MIMETYPE="text/xml"
-				CHECKSUM="ec9c0f75f178ae331e18c99b3393a7216c60daaa" CHECKSUMTYPE="SHA-1"
-				SIZE="42054">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:25:46" MIMETYPE="text/xml" CHECKSUM="ec9c0f75f178ae331e18c99b3393a7216c60daaa" CHECKSUMTYPE="SHA-1" SIZE="42054">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:25:46" MIMETYPE="text/xml"
-				CHECKSUM="c795ae82a26e1d5ac04f4a9cf4ae8fae8fd6a672" CHECKSUMTYPE="SHA-1" SIZE="5917">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:25:46" MIMETYPE="text/xml" CHECKSUM="c795ae82a26e1d5ac04f4a9cf4ae8fae8fd6a672" CHECKSUMTYPE="SHA-1" SIZE="5917">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:25:46" MIMETYPE="text/xml"
-				CHECKSUM="c8ddc030d86c12b5435038a1e61edaec9e3dd591" CHECKSUMTYPE="SHA-1"
-				SIZE="38551">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:25:46" MIMETYPE="text/xml" CHECKSUM="c8ddc030d86c12b5435038a1e61edaec9e3dd591" CHECKSUMTYPE="SHA-1" SIZE="38551">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:25:46" MIMETYPE="text/xml"
-				CHECKSUM="ba10eb8372186c2785421163b4fb341fc8e68723" CHECKSUMTYPE="SHA-1" SIZE="5749">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:25:46" MIMETYPE="text/xml" CHECKSUM="ba10eb8372186c2785421163b4fb341fc8e68723" CHECKSUMTYPE="SHA-1" SIZE="5749">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:25:47" MIMETYPE="text/xml"
-				CHECKSUM="3ddec4fc605e025bd03809df5d546dd3431916cb" CHECKSUMTYPE="SHA-1"
-				SIZE="93773">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:25:47" MIMETYPE="text/xml" CHECKSUM="3ddec4fc605e025bd03809df5d546dd3431916cb" CHECKSUMTYPE="SHA-1" SIZE="93773">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:25:47" MIMETYPE="text/xml"
-				CHECKSUM="fbd6ce45e024545a3eecee069469bc9796488dc3" CHECKSUMTYPE="SHA-1"
-				SIZE="61706">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:25:47" MIMETYPE="text/xml" CHECKSUM="fbd6ce45e024545a3eecee069469bc9796488dc3" CHECKSUMTYPE="SHA-1" SIZE="61706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:25:47" MIMETYPE="text/xml"
-				CHECKSUM="0e8a834cb5db12d03cd8887e12636f1f7ef79ed4" CHECKSUMTYPE="SHA-1"
-				SIZE="79788">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:25:47" MIMETYPE="text/xml" CHECKSUM="0e8a834cb5db12d03cd8887e12636f1f7ef79ed4" CHECKSUMTYPE="SHA-1" SIZE="79788">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T16:25:47" MIMETYPE="text/xml"
-				CHECKSUM="89fb43be21f1d5f86f06f1e4c2f598ab6ff4f503" CHECKSUMTYPE="SHA-1"
-				SIZE="22792">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T16:25:47" MIMETYPE="text/xml" CHECKSUM="89fb43be21f1d5f86f06f1e4c2f598ab6ff4f503" CHECKSUMTYPE="SHA-1" SIZE="22792">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T16:25:48" MIMETYPE="text/xml"
-				CHECKSUM="38d14cdc74f2b663fad19ee7edba67eda0b3eda7" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T16:25:48" MIMETYPE="text/xml" CHECKSUM="38d14cdc74f2b663fad19ee7edba67eda0b3eda7" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-04_01_0034.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:26:37" MIMETYPE="application/pdf"
-				CHECKSUM="05ab7b25ccb8aa9d032d0ef5d625afe36d92bdd4" CHECKSUMTYPE="SHA-1"
-				SIZE="10710777">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/bmtnabf_1898-04_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:26:37" MIMETYPE="application/pdf" CHECKSUM="05ab7b25ccb8aa9d032d0ef5d625afe36d92bdd4" CHECKSUMTYPE="SHA-1" SIZE="10710777">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/04_01/bmtnabf_1898-04_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -4316,8 +4114,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.2" TYPE="TextContent" ORDER="2" DMDID="c002"
-					LABEL="TEXTLICHER INHALT">
+				<div ID="L.1.1.2" TYPE="TextContent" ORDER="2" DMDID="c002" LABEL="TEXTLICHER INHALT">
 					<div ID="L.1.1.2.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00002" BEGIN="P2_TB00001"/>
@@ -4644,40 +4441,23 @@
 								<div ID="L.1.1.9.3.1.4.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4821,8 +4601,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="6" DMDID="c017"
-					LABEL="Allerlei Gethier">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="6" DMDID="c017" LABEL="Allerlei Gethier">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
@@ -4840,40 +4619,35 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="2" DMDID="c018"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="2" DMDID="c018" LABEL="Untitled Image">
 						<div ID="L.1.1.10.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.5" TYPE="Illustration" ORDER="3" DMDID="c019"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.10.5" TYPE="Illustration" ORDER="3" DMDID="c019" LABEL="Untitled Image">
 						<div ID="L.1.1.10.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00003"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.6" TYPE="Illustration" ORDER="4" DMDID="c020"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.10.6" TYPE="Illustration" ORDER="4" DMDID="c020" LABEL="Untitled Image">
 						<div ID="L.1.1.10.6.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00004"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.7" TYPE="Illustration" ORDER="5" DMDID="c021"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.10.7" TYPE="Illustration" ORDER="5" DMDID="c021" LABEL="Untitled Image">
 						<div ID="L.1.1.10.7.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00005"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.8" TYPE="Illustration" ORDER="6" DMDID="c022"
-						LABEL="No 18396 DAX EIX DEX XEL">
+					<div ID="L.1.1.10.8" TYPE="Illustration" ORDER="6" DMDID="c022" LABEL="No 18396 DAX EIX DEX XEL">
 						<div ID="L.1.1.10.8.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00006"/>
@@ -4898,18 +4672,15 @@
 								<div ID="L.1.1.11.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.11.4" TYPE="Illustration" ORDER="1" DMDID="c024"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.11.4" TYPE="Illustration" ORDER="1" DMDID="c024" LABEL="Buchschmuck">
 						<div ID="L.1.1.11.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00005"/>
@@ -4933,8 +4704,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.5" TYPE="Illustration" ORDER="2" DMDID="c026"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.11.5" TYPE="Illustration" ORDER="2" DMDID="c026" LABEL="Buchschmuck">
 						<div ID="L.1.1.11.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00005"/>
@@ -4993,8 +4763,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.14" TYPE="Illustration" ORDER="10" DMDID="c030"
-					LABEL="Untitled Image by Felician v. Myrbach">
+				<div ID="L.1.1.14" TYPE="Illustration" ORDER="10" DMDID="c030" LABEL="Untitled Image by Felician v. Myrbach">
 					<div ID="L.1.1.14.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
@@ -5078,23 +4847,20 @@
 							<div ID="L.1.1.18.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.18.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00005"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00005"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.18.3.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.18.3.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00006"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00006"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.18.4" TYPE="Illustration" ORDER="1" DMDID="c035"
-						LABEL="Untitled Image by J. Engelhart">
+					<div ID="L.1.1.18.4" TYPE="Illustration" ORDER="1" DMDID="c035" LABEL="Untitled Image by J. Engelhart">
 						<div ID="L.1.1.18.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00007"/>
@@ -5112,8 +4878,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.19" TYPE="TextContent" ORDER="15" DMDID="c036"
-					LABEL="MARIA THERESIEN–SAAL IN DER NEUEN HOFBURG">
+				<div ID="L.1.1.19" TYPE="TextContent" ORDER="15" DMDID="c036" LABEL="MARIA THERESIEN–SAAL IN DER NEUEN HOFBURG">
 					<div ID="L.1.1.19.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
@@ -5124,8 +4889,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00006"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="1" DMDID="c037"
-						LABEL="Untitled Image by O. Friedrich">
+					<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="1" DMDID="c037" LABEL="Untitled Image by O. Friedrich">
 						<div ID="L.1.1.19.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_CB00002"/>
@@ -5142,23 +4906,20 @@
 							<div ID="L.1.1.19.4.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.19.4.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.19.4.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.19.4.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00005"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00005"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.19.5" TYPE="Illustration" ORDER="1" DMDID="c038"
-						LABEL="Untitled Image by Jos. Hoffmann">
+					<div ID="L.1.1.19.5" TYPE="Illustration" ORDER="1" DMDID="c038" LABEL="Untitled Image by Jos. Hoffmann">
 						<div ID="L.1.1.19.5.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00007"/>
@@ -5182,8 +4943,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00006"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.20.3" TYPE="Illustration" ORDER="1" DMDID="c040"
-						LABEL="Untitled Image by Alf. Roller">
+					<div ID="L.1.1.20.3" TYPE="Illustration" ORDER="1" DMDID="c040" LABEL="Untitled Image by Alf. Roller">
 						<div ID="L.1.1.20.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_CB00002"/>
@@ -5201,18 +4961,15 @@
 								<div ID="L.1.1.20.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00005"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.20.5" TYPE="Illustration" ORDER="1" DMDID="c041"
-						LABEL="Im Mondenscheine">
+					<div ID="L.1.1.20.5" TYPE="Illustration" ORDER="1" DMDID="c041" LABEL="Im Mondenscheine">
 						<div ID="L.1.1.20.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00007"/>
@@ -5246,8 +5003,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00005"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.21.3" TYPE="Illustration" ORDER="1" DMDID="c043"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.21.3" TYPE="Illustration" ORDER="1" DMDID="c043" LABEL="Untitled Image">
 						<div ID="L.1.1.21.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_CB00003"/>
@@ -5259,8 +5015,7 @@
 							<div ID="L.1.1.21.4.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.21.4.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00004"/>
 									</fptr>
 								</div>
 							</div>
@@ -5268,20 +5023,16 @@
 								<div ID="L.1.1.21.4.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.21.5" TYPE="Illustration" ORDER="1" DMDID="c044"
-						LABEL="Buchstaben u. Schmuckleiste">
+					<div ID="L.1.1.21.5" TYPE="Illustration" ORDER="1" DMDID="c044" LABEL="Buchstaben u. Schmuckleiste">
 						<div ID="L.1.1.21.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00006"/>
@@ -5315,8 +5066,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.21.6" TYPE="Illustration" ORDER="2" DMDID="c048"
-						LABEL="Böllerschiessen. ">
+					<div ID="L.1.1.21.6" TYPE="Illustration" ORDER="2" DMDID="c048" LABEL="Böllerschiessen. ">
 						<div ID="L.1.1.21.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00006"/>
@@ -5333,8 +5083,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.21.7" TYPE="Illustration" ORDER="3" DMDID="c049"
-						LABEL="Gezeichnet">
+					<div ID="L.1.1.21.7" TYPE="Illustration" ORDER="3" DMDID="c049" LABEL="Gezeichnet">
 						<div ID="L.1.1.21.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00008"/>
@@ -5353,15 +5102,13 @@
 					</div>
 				</div>
 
-				<div ID="L.1.1.24" TYPE="TextContent" ORDER="20" DMDID="c053"
-					LABEL="AUS DEM WIENER CAMERA-CLUB">
+				<div ID="L.1.1.24" TYPE="TextContent" ORDER="20" DMDID="c053" LABEL="AUS DEM WIENER CAMERA-CLUB">
 					<div ID="L.1.1.24.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00003"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.22" TYPE="Illustration" ORDER="18" DMDID="c050"
-						LABEL="Deutsches Städtchen">
+					<div ID="L.1.1.22" TYPE="Illustration" ORDER="18" DMDID="c050" LABEL="Deutsches Städtchen">
 						<div ID="L.1.1.22.1" TYPE="Head">
 							<fptr>
 								<seq>
@@ -5381,8 +5128,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.23.4" TYPE="Illustration" ORDER="1" DMDID="c052"
-						LABEL="Südliche Landschaft">
+					<div ID="L.1.1.23.4" TYPE="Illustration" ORDER="1" DMDID="c052" LABEL="Südliche Landschaft">
 						<div ID="L.1.1.23.4.1" TYPE="Head">
 							<fptr>
 								<seq>
@@ -5412,10 +5158,8 @@
 									<div ID="L.1.1.23.3.1.1.1" TYPE="Text">
 										<fptr>
 											<seq>
-												<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00004"/>
-												<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00005"/>
+												<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00004"/>
+												<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00005"/>
 											</seq>
 										</fptr>
 									</div>
@@ -5428,8 +5172,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.24.4" TYPE="Illustration" ORDER="1" DMDID="c054"
-						LABEL="Wiesenblumen">
+					<div ID="L.1.1.24.4" TYPE="Illustration" ORDER="1" DMDID="c054" LABEL="Wiesenblumen">
 						<div ID="L.1.1.24.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00004"/>
@@ -5447,8 +5190,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="MET-GH117-c053a" TYPE="TextContent" ORDER="1" DMDID="c053a"
-					LABEL="DER AUSSCHUSS FÜR KUNST IM HANDWERK">
+				<div ID="MET-GH117-c053a" TYPE="TextContent" ORDER="1" DMDID="c053a" LABEL="DER AUSSCHUSS FÜR KUNST IM HANDWERK">
 					<div ID="L.1.1.24.2" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00006"/>
@@ -5459,8 +5201,7 @@
 							<div ID="L.1.1.24.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.24.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00003"/>
 									</fptr>
 								</div>
 							</div>
@@ -5468,14 +5209,10 @@
 								<div ID="L.1.1.24.3.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00031"
-												BEGIN="P31_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00031"
-												BEGIN="P31_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00031"
-												BEGIN="P31_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00005"/>
 										</seq>
 									</fptr>
 								</div>
@@ -5499,8 +5236,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.24.6" TYPE="Illustration" ORDER="3" DMDID="c056"
-						LABEL="Entwurf zu einem Bilderrahmen">
+					<div ID="L.1.1.24.6" TYPE="Illustration" ORDER="3" DMDID="c056" LABEL="Entwurf zu einem Bilderrahmen">
 						<div ID="L.1.1.24.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00007"/>
@@ -5517,8 +5253,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.24.7" TYPE="Illustration" ORDER="4" DMDID="c057"
-						LABEL="Studie zu einem einfachen Wohnzimmer">
+					<div ID="L.1.1.24.7" TYPE="Illustration" ORDER="4" DMDID="c057" LABEL="Studie zu einem einfachen Wohnzimmer">
 						<div ID="L.1.1.24.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00007"/>
@@ -5561,8 +5296,7 @@
 					</div>
 				</div>
 
-				<div ID="L.1.1.25" TYPE="TextContent" ORDER="21" DMDID="c060"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.25" TYPE="TextContent" ORDER="21" DMDID="c060" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.25.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00003"/>
@@ -5573,23 +5307,20 @@
 							<div ID="L.1.1.25.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.25.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.25.2.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.25.2.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00005"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00005"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.25.3" TYPE="Illustration" ORDER="1" DMDID="c061"
-						LABEL="Untitled Image by J. Engelhart">
+					<div ID="L.1.1.25.3" TYPE="Illustration" ORDER="1" DMDID="c061" LABEL="Untitled Image by J. Engelhart">
 						<div ID="L.1.1.25.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00006"/>

--- a/metadata/periodicals/bmtnabf/issues/1898/07_01/bmtnabf_1898-07_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1898/07_01/bmtnabf_1898-07_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-07_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-07_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-07_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1898-07_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-07_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -4455,464 +4449,240 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:06:23"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="c0b2ab7ece14c001dced414b70d32d0941a04562"
-				CHECKSUMTYPE="SHA-1" SIZE="6257747">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:06:23" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="c0b2ab7ece14c001dced414b70d32d0941a04562" CHECKSUMTYPE="SHA-1" SIZE="6257747">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:06:58"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="143d404da21ae47e40a16d6aa757020bf1feccc3"
-				CHECKSUMTYPE="SHA-1" SIZE="6237116">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:06:58" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="143d404da21ae47e40a16d6aa757020bf1feccc3" CHECKSUMTYPE="SHA-1" SIZE="6237116">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:07:33"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="0f43b46e090c78f125fade6b74aa4af83bd8bf44"
-				CHECKSUMTYPE="SHA-1" SIZE="6209227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:07:33" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="0f43b46e090c78f125fade6b74aa4af83bd8bf44" CHECKSUMTYPE="SHA-1" SIZE="6209227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:08:09"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="e57a0d936ef9f97035a1cee849f074677855ee0b"
-				CHECKSUMTYPE="SHA-1" SIZE="6352323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:08:09" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="e57a0d936ef9f97035a1cee849f074677855ee0b" CHECKSUMTYPE="SHA-1" SIZE="6352323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:08:46"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="5ee13e96babe561f8d028358e551ad7a93adb89a"
-				CHECKSUMTYPE="SHA-1" SIZE="6222704">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:08:46" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="5ee13e96babe561f8d028358e551ad7a93adb89a" CHECKSUMTYPE="SHA-1" SIZE="6222704">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:09:19"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="1359cf07ccc69b276dbd5265f0f40b6094685ff5"
-				CHECKSUMTYPE="SHA-1" SIZE="6190298">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:09:19" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="1359cf07ccc69b276dbd5265f0f40b6094685ff5" CHECKSUMTYPE="SHA-1" SIZE="6190298">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:09:52"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="ff20827c20926d302402eb8c6d486b13e3248420"
-				CHECKSUMTYPE="SHA-1" SIZE="6219126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:09:52" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="ff20827c20926d302402eb8c6d486b13e3248420" CHECKSUMTYPE="SHA-1" SIZE="6219126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:10:24"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="c9b7f747ace6716233fb8c20a1eddc70959be629"
-				CHECKSUMTYPE="SHA-1" SIZE="6190325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:10:24" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="c9b7f747ace6716233fb8c20a1eddc70959be629" CHECKSUMTYPE="SHA-1" SIZE="6190325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:10:57"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="0074c491061ed7010aea1e11b0b50729349d3934"
-				CHECKSUMTYPE="SHA-1" SIZE="6219127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:10:57" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="0074c491061ed7010aea1e11b0b50729349d3934" CHECKSUMTYPE="SHA-1" SIZE="6219127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:11:28"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="e642e18d0cd94265e3f6700fe4a05d8cd34c3655"
-				CHECKSUMTYPE="SHA-1" SIZE="6190320">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:11:28" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="e642e18d0cd94265e3f6700fe4a05d8cd34c3655" CHECKSUMTYPE="SHA-1" SIZE="6190320">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:12:02"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f488fccdc2872c3dd0fe6ef1173fc90af3e78db6"
-				CHECKSUMTYPE="SHA-1" SIZE="6219127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:12:02" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f488fccdc2872c3dd0fe6ef1173fc90af3e78db6" CHECKSUMTYPE="SHA-1" SIZE="6219127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:12:34"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="d55c3aae6155cee8981c7448e67fb5218efc8330"
-				CHECKSUMTYPE="SHA-1" SIZE="6190306">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:12:34" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="d55c3aae6155cee8981c7448e67fb5218efc8330" CHECKSUMTYPE="SHA-1" SIZE="6190306">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:13:07"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="ab40c228bea804421275aec39348c97e311b82c5"
-				CHECKSUMTYPE="SHA-1" SIZE="6219122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:13:07" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="ab40c228bea804421275aec39348c97e311b82c5" CHECKSUMTYPE="SHA-1" SIZE="6219122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:13:40"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="8760ef4986da8bc506e5f8674d96b09c257c6fc9"
-				CHECKSUMTYPE="SHA-1" SIZE="6216423">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:13:40" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="8760ef4986da8bc506e5f8674d96b09c257c6fc9" CHECKSUMTYPE="SHA-1" SIZE="6216423">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:14:13"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="dcdc40262c4ac8d618163a25f773997dc57909db"
-				CHECKSUMTYPE="SHA-1" SIZE="6193926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:14:13" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="dcdc40262c4ac8d618163a25f773997dc57909db" CHECKSUMTYPE="SHA-1" SIZE="6193926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:14:47"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="dd0e25af6ef9f98f1736f0c3a0bc0296d1e816cc"
-				CHECKSUMTYPE="SHA-1" SIZE="6193022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:14:47" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="dd0e25af6ef9f98f1736f0c3a0bc0296d1e816cc" CHECKSUMTYPE="SHA-1" SIZE="6193022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:15:20"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="29f3863e5a8a79f10b93b26215ec81d42f0efd5a"
-				CHECKSUMTYPE="SHA-1" SIZE="6174126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:15:20" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="29f3863e5a8a79f10b93b26215ec81d42f0efd5a" CHECKSUMTYPE="SHA-1" SIZE="6174126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:15:50"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="e79244bc29cbdb1a2400313d5d989050c949b075"
-				CHECKSUMTYPE="SHA-1" SIZE="6216425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:15:50" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="e79244bc29cbdb1a2400313d5d989050c949b075" CHECKSUMTYPE="SHA-1" SIZE="6216425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:16:20"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="b56ab14eecccabaa29e7fd2c928a797fc59e30f6"
-				CHECKSUMTYPE="SHA-1" SIZE="6193905">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:16:20" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="b56ab14eecccabaa29e7fd2c928a797fc59e30f6" CHECKSUMTYPE="SHA-1" SIZE="6193905">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:16:53"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="a3e4e06f6f8244e2b2319436d8e92066e38f7260"
-				CHECKSUMTYPE="SHA-1" SIZE="6216422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:16:53" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="a3e4e06f6f8244e2b2319436d8e92066e38f7260" CHECKSUMTYPE="SHA-1" SIZE="6216422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:17:24"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="2c2d70b79be714326f60c48bf5e7b8a6a654007e"
-				CHECKSUMTYPE="SHA-1" SIZE="6194814">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:17:24" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="2c2d70b79be714326f60c48bf5e7b8a6a654007e" CHECKSUMTYPE="SHA-1" SIZE="6194814">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:17:57"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="bcc583507c18f3069912a83ec2172e380e1646f1"
-				CHECKSUMTYPE="SHA-1" SIZE="6249718">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:17:57" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="bcc583507c18f3069912a83ec2172e380e1646f1" CHECKSUMTYPE="SHA-1" SIZE="6249718">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:18:31"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="de4e85ec22a7a3a43b0f4687bc182642f7930159"
-				CHECKSUMTYPE="SHA-1" SIZE="6131822">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:18:31" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="de4e85ec22a7a3a43b0f4687bc182642f7930159" CHECKSUMTYPE="SHA-1" SIZE="6131822">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:19:02"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="9b4c5bc43cb4c7fc0b48909049ac639c00f694b0"
-				CHECKSUMTYPE="SHA-1" SIZE="6249729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:19:02" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="9b4c5bc43cb4c7fc0b48909049ac639c00f694b0" CHECKSUMTYPE="SHA-1" SIZE="6249729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:19:35"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="9b6b7fa325a0f660db3b86286b70e4801f58f7f9"
-				CHECKSUMTYPE="SHA-1" SIZE="6131829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:19:35" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="9b6b7fa325a0f660db3b86286b70e4801f58f7f9" CHECKSUMTYPE="SHA-1" SIZE="6131829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:20:10"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="a1b3d382e61e93ad241d1f5204b6ed0dd39ac841"
-				CHECKSUMTYPE="SHA-1" SIZE="6244324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:20:10" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="a1b3d382e61e93ad241d1f5204b6ed0dd39ac841" CHECKSUMTYPE="SHA-1" SIZE="6244324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:20:41"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="b92cde2505079dc8cef64425b03479776f9473d9"
-				CHECKSUMTYPE="SHA-1" SIZE="6119216">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:20:41" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="b92cde2505079dc8cef64425b03479776f9473d9" CHECKSUMTYPE="SHA-1" SIZE="6119216">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:21:14"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="d67640e648f0ad51faf853d30e452a5bf062de29"
-				CHECKSUMTYPE="SHA-1" SIZE="6244327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:21:14" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="d67640e648f0ad51faf853d30e452a5bf062de29" CHECKSUMTYPE="SHA-1" SIZE="6244327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:21:45"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="629ea83483d18e11e6fc6a3db7c6f511a3655bad"
-				CHECKSUMTYPE="SHA-1" SIZE="6083229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:21:45" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="629ea83483d18e11e6fc6a3db7c6f511a3655bad" CHECKSUMTYPE="SHA-1" SIZE="6083229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:22:17"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="02c2e5be2da61a3acfe8df8bd8fd0ea6997b0bc4"
-				CHECKSUMTYPE="SHA-1" SIZE="6230828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:22:17" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="02c2e5be2da61a3acfe8df8bd8fd0ea6997b0bc4" CHECKSUMTYPE="SHA-1" SIZE="6230828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:22:49"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="e8c8c80abe6774e0673e01f2655a315111604c52"
-				CHECKSUMTYPE="SHA-1" SIZE="6090422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:22:49" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="e8c8c80abe6774e0673e01f2655a315111604c52" CHECKSUMTYPE="SHA-1" SIZE="6090422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:23:20"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="7dfd4ce1bfc350974f7f9f92b777c7053f147615"
-				CHECKSUMTYPE="SHA-1" SIZE="6230827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:23:20" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="7dfd4ce1bfc350974f7f9f92b777c7053f147615" CHECKSUMTYPE="SHA-1" SIZE="6230827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T16:23:52"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="39af9b5bf1c79a019e311513bb8a6f2e94709a58"
-				CHECKSUMTYPE="SHA-1" SIZE="6090428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T16:23:52" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="39af9b5bf1c79a019e311513bb8a6f2e94709a58" CHECKSUMTYPE="SHA-1" SIZE="6090428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T16:24:23"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="3a0c142055771315cc2cce26cb13daaad9ad42d5"
-				CHECKSUMTYPE="SHA-1" SIZE="6230793">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T16:24:23" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="3a0c142055771315cc2cce26cb13daaad9ad42d5" CHECKSUMTYPE="SHA-1" SIZE="6230793">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0034.jp2"/>
 			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T16:24:56"
-				MIMETYPE="image/jp2" SEQ="35" CHECKSUM="963041dd57b08ada03a1e9f38c6200ab987709d2"
-				CHECKSUMTYPE="SHA-1" SIZE="6090429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0035.jp2"
-				/>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T16:24:56" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="963041dd57b08ada03a1e9f38c6200ab987709d2" CHECKSUMTYPE="SHA-1" SIZE="6090429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0035.jp2"/>
 			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T16:25:28"
-				MIMETYPE="image/jp2" SEQ="36" CHECKSUM="9d55fd8b4b5f979052bee88ac1d3432201ea616d"
-				CHECKSUMTYPE="SHA-1" SIZE="6212793">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0036.jp2"
-				/>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T16:25:28" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="9d55fd8b4b5f979052bee88ac1d3432201ea616d" CHECKSUMTYPE="SHA-1" SIZE="6212793">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0036.jp2"/>
 			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T16:25:58"
-				MIMETYPE="image/jp2" SEQ="37" CHECKSUM="2ff7fe781a6d528ddb715c4f820b00ba607cf643"
-				CHECKSUMTYPE="SHA-1" SIZE="6090424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0037.jp2"
-				/>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T16:25:58" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="2ff7fe781a6d528ddb715c4f820b00ba607cf643" CHECKSUMTYPE="SHA-1" SIZE="6090424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0037.jp2"/>
 			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T16:26:31"
-				MIMETYPE="image/jp2" SEQ="38" CHECKSUM="53c386a4f46491503ff2fbde13f319a1235d7dc6"
-				CHECKSUMTYPE="SHA-1" SIZE="6212826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0038.jp2"
-				/>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T16:26:31" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="53c386a4f46491503ff2fbde13f319a1235d7dc6" CHECKSUMTYPE="SHA-1" SIZE="6212826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/delivery/bmtnabf_1898-07_01_0038.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:26:51" MIMETYPE="text/xml"
-				CHECKSUM="ad36b57edba5e07f8e7b3be992a7704c82be0874" CHECKSUMTYPE="SHA-1" SIZE="6159">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:26:51" MIMETYPE="text/xml" CHECKSUM="ad36b57edba5e07f8e7b3be992a7704c82be0874" CHECKSUMTYPE="SHA-1" SIZE="6159">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:26:51" MIMETYPE="text/xml"
-				CHECKSUM="f876fb55080a9dd93a1f1bb8b89df147105c0b19" CHECKSUMTYPE="SHA-1"
-				SIZE="86037">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:26:51" MIMETYPE="text/xml" CHECKSUM="f876fb55080a9dd93a1f1bb8b89df147105c0b19" CHECKSUMTYPE="SHA-1" SIZE="86037">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:26:52" MIMETYPE="text/xml"
-				CHECKSUM="ea60686611d20544092d84eca7c434a37a385397" CHECKSUMTYPE="SHA-1"
-				SIZE="15786">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:26:52" MIMETYPE="text/xml" CHECKSUM="ea60686611d20544092d84eca7c434a37a385397" CHECKSUMTYPE="SHA-1" SIZE="15786">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:26:52" MIMETYPE="text/xml"
-				CHECKSUM="1d2f1d9b324cfe70d488aec935356261b56113b3" CHECKSUMTYPE="SHA-1" SIZE="1706">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:26:52" MIMETYPE="text/xml" CHECKSUM="1d2f1d9b324cfe70d488aec935356261b56113b3" CHECKSUMTYPE="SHA-1" SIZE="1706">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:26:52" MIMETYPE="text/xml"
-				CHECKSUM="0314c28bc794fd1a219e1f5114197016479437ab" CHECKSUMTYPE="SHA-1" SIZE="8557">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:26:52" MIMETYPE="text/xml" CHECKSUM="0314c28bc794fd1a219e1f5114197016479437ab" CHECKSUMTYPE="SHA-1" SIZE="8557">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:26:52" MIMETYPE="text/xml"
-				CHECKSUM="313c19090068948210d6bfa9553bc1718a0fd3e5" CHECKSUMTYPE="SHA-1" SIZE="9001">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:26:52" MIMETYPE="text/xml" CHECKSUM="313c19090068948210d6bfa9553bc1718a0fd3e5" CHECKSUMTYPE="SHA-1" SIZE="9001">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:26:53" MIMETYPE="text/xml"
-				CHECKSUM="a0fa0fbbb845041c1f67e739f03bdc5676239a68" CHECKSUMTYPE="SHA-1"
-				SIZE="129374">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:26:53" MIMETYPE="text/xml" CHECKSUM="a0fa0fbbb845041c1f67e739f03bdc5676239a68" CHECKSUMTYPE="SHA-1" SIZE="129374">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:26:53" MIMETYPE="text/xml"
-				CHECKSUM="bc0bab6bbe4832ebefa234643de2f99fe3641fd7" CHECKSUMTYPE="SHA-1"
-				SIZE="96041">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:26:53" MIMETYPE="text/xml" CHECKSUM="bc0bab6bbe4832ebefa234643de2f99fe3641fd7" CHECKSUMTYPE="SHA-1" SIZE="96041">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:26:54" MIMETYPE="text/xml"
-				CHECKSUM="8c9c3adbdb098715c351515600a622bca0e5ac28" CHECKSUMTYPE="SHA-1"
-				SIZE="53231">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:26:54" MIMETYPE="text/xml" CHECKSUM="8c9c3adbdb098715c351515600a622bca0e5ac28" CHECKSUMTYPE="SHA-1" SIZE="53231">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:26:54" MIMETYPE="text/xml"
-				CHECKSUM="dcd43411b4782daaf7db5d2fd6227bd54eba93e1" CHECKSUMTYPE="SHA-1"
-				SIZE="79826">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:26:54" MIMETYPE="text/xml" CHECKSUM="dcd43411b4782daaf7db5d2fd6227bd54eba93e1" CHECKSUMTYPE="SHA-1" SIZE="79826">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:26:54" MIMETYPE="text/xml"
-				CHECKSUM="4c39b0fc1d2d7a728957387a26f75d2491129b2a" CHECKSUMTYPE="SHA-1"
-				SIZE="101550">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:26:54" MIMETYPE="text/xml" CHECKSUM="4c39b0fc1d2d7a728957387a26f75d2491129b2a" CHECKSUMTYPE="SHA-1" SIZE="101550">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:26:55" MIMETYPE="text/xml"
-				CHECKSUM="4dbda262d0785b3449d009d2e8f3221a229a2320" CHECKSUMTYPE="SHA-1"
-				SIZE="37945">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:26:55" MIMETYPE="text/xml" CHECKSUM="4dbda262d0785b3449d009d2e8f3221a229a2320" CHECKSUMTYPE="SHA-1" SIZE="37945">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:26:55" MIMETYPE="text/xml"
-				CHECKSUM="7abe9a9e1e06807c8bae1860d612f0411bd502d1" CHECKSUMTYPE="SHA-1"
-				SIZE="129904">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:26:55" MIMETYPE="text/xml" CHECKSUM="7abe9a9e1e06807c8bae1860d612f0411bd502d1" CHECKSUMTYPE="SHA-1" SIZE="129904">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:26:55" MIMETYPE="text/xml"
-				CHECKSUM="a7d3362ea7906df7414c8cc3a035c8d85edf73f7" CHECKSUMTYPE="SHA-1"
-				SIZE="92228">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:26:55" MIMETYPE="text/xml" CHECKSUM="a7d3362ea7906df7414c8cc3a035c8d85edf73f7" CHECKSUMTYPE="SHA-1" SIZE="92228">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:26:56" MIMETYPE="text/xml"
-				CHECKSUM="e40b9c1084e38d31c6051d2d4c3fbf3537e8a714" CHECKSUMTYPE="SHA-1"
-				SIZE="114755">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:26:56" MIMETYPE="text/xml" CHECKSUM="e40b9c1084e38d31c6051d2d4c3fbf3537e8a714" CHECKSUMTYPE="SHA-1" SIZE="114755">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:26:56" MIMETYPE="text/xml"
-				CHECKSUM="f9e3b98371108d0f96be3338aaaf1112c1cc96b3" CHECKSUMTYPE="SHA-1"
-				SIZE="111139">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:26:56" MIMETYPE="text/xml" CHECKSUM="f9e3b98371108d0f96be3338aaaf1112c1cc96b3" CHECKSUMTYPE="SHA-1" SIZE="111139">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:26:56" MIMETYPE="text/xml"
-				CHECKSUM="44d2334d5ac59bd26e862ad96ebae924aa1bc7e4" CHECKSUMTYPE="SHA-1"
-				SIZE="134457">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:26:56" MIMETYPE="text/xml" CHECKSUM="44d2334d5ac59bd26e862ad96ebae924aa1bc7e4" CHECKSUMTYPE="SHA-1" SIZE="134457">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:26:56" MIMETYPE="text/xml"
-				CHECKSUM="a9f6aabccd7579ca6f78d22da571c12142d2c952" CHECKSUMTYPE="SHA-1"
-				SIZE="32087">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:26:56" MIMETYPE="text/xml" CHECKSUM="a9f6aabccd7579ca6f78d22da571c12142d2c952" CHECKSUMTYPE="SHA-1" SIZE="32087">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:26:57" MIMETYPE="text/xml"
-				CHECKSUM="01a31a6c2e5fe0ad63ae997b07aeeb63db7df362" CHECKSUMTYPE="SHA-1"
-				SIZE="50327">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:26:57" MIMETYPE="text/xml" CHECKSUM="01a31a6c2e5fe0ad63ae997b07aeeb63db7df362" CHECKSUMTYPE="SHA-1" SIZE="50327">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:26:57" MIMETYPE="text/xml"
-				CHECKSUM="e6a6bbd4221a59af727732075970d5aa964678d9" CHECKSUMTYPE="SHA-1"
-				SIZE="142790">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:26:57" MIMETYPE="text/xml" CHECKSUM="e6a6bbd4221a59af727732075970d5aa964678d9" CHECKSUMTYPE="SHA-1" SIZE="142790">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:26:57" MIMETYPE="text/xml"
-				CHECKSUM="dd72882b815367151048ad2d172feb8203f865cc" CHECKSUMTYPE="SHA-1"
-				SIZE="26336">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:26:57" MIMETYPE="text/xml" CHECKSUM="dd72882b815367151048ad2d172feb8203f865cc" CHECKSUMTYPE="SHA-1" SIZE="26336">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:26:58" MIMETYPE="text/xml"
-				CHECKSUM="0ac374d1ea6c856fdf7da2415d52ccffc3d3b0b2" CHECKSUMTYPE="SHA-1" SIZE="7436">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:26:58" MIMETYPE="text/xml" CHECKSUM="0ac374d1ea6c856fdf7da2415d52ccffc3d3b0b2" CHECKSUMTYPE="SHA-1" SIZE="7436">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:26:58" MIMETYPE="text/xml"
-				CHECKSUM="d50123bbb9e6d224cceeced9a44907cee1d6fd89" CHECKSUMTYPE="SHA-1"
-				SIZE="59180">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:26:58" MIMETYPE="text/xml" CHECKSUM="d50123bbb9e6d224cceeced9a44907cee1d6fd89" CHECKSUMTYPE="SHA-1" SIZE="59180">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:26:58" MIMETYPE="text/xml"
-				CHECKSUM="c3814046d8fae5caa33d96337a07dab66ed2e4a8" CHECKSUMTYPE="SHA-1"
-				SIZE="40660">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:26:58" MIMETYPE="text/xml" CHECKSUM="c3814046d8fae5caa33d96337a07dab66ed2e4a8" CHECKSUMTYPE="SHA-1" SIZE="40660">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:26:58" MIMETYPE="text/xml"
-				CHECKSUM="9e980f1d7931a80702a46003e5a64f17620bc1f6" CHECKSUMTYPE="SHA-1"
-				SIZE="37302">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:26:58" MIMETYPE="text/xml" CHECKSUM="9e980f1d7931a80702a46003e5a64f17620bc1f6" CHECKSUMTYPE="SHA-1" SIZE="37302">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:26:59" MIMETYPE="text/xml"
-				CHECKSUM="dc3f0494347edeac818e272f7f3d03e1de38f61a" CHECKSUMTYPE="SHA-1"
-				SIZE="37591">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:26:59" MIMETYPE="text/xml" CHECKSUM="dc3f0494347edeac818e272f7f3d03e1de38f61a" CHECKSUMTYPE="SHA-1" SIZE="37591">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:26:59" MIMETYPE="text/xml"
-				CHECKSUM="629038f8b4051fb765352e1bfca88899a3c0dd69" CHECKSUMTYPE="SHA-1" SIZE="9334">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:26:59" MIMETYPE="text/xml" CHECKSUM="629038f8b4051fb765352e1bfca88899a3c0dd69" CHECKSUMTYPE="SHA-1" SIZE="9334">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:26:59" MIMETYPE="text/xml"
-				CHECKSUM="d21b09faaad7e59fa015476f1c77bbf905ca76ac" CHECKSUMTYPE="SHA-1"
-				SIZE="70483">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:26:59" MIMETYPE="text/xml" CHECKSUM="d21b09faaad7e59fa015476f1c77bbf905ca76ac" CHECKSUMTYPE="SHA-1" SIZE="70483">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:27:00" MIMETYPE="text/xml"
-				CHECKSUM="01209744917ec54ab1d6a5b80b87db4f4bbe1e16" CHECKSUMTYPE="SHA-1" SIZE="5228">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:27:00" MIMETYPE="text/xml" CHECKSUM="01209744917ec54ab1d6a5b80b87db4f4bbe1e16" CHECKSUMTYPE="SHA-1" SIZE="5228">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:27:00" MIMETYPE="text/xml"
-				CHECKSUM="8cc898b6054074a6beaf49dd60486f08b777b274" CHECKSUMTYPE="SHA-1"
-				SIZE="84762">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:27:00" MIMETYPE="text/xml" CHECKSUM="8cc898b6054074a6beaf49dd60486f08b777b274" CHECKSUMTYPE="SHA-1" SIZE="84762">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:27:00" MIMETYPE="text/xml"
-				CHECKSUM="deb399122445604c54d6c25b7274a9b3eeea6672" CHECKSUMTYPE="SHA-1"
-				SIZE="79358">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:27:00" MIMETYPE="text/xml" CHECKSUM="deb399122445604c54d6c25b7274a9b3eeea6672" CHECKSUMTYPE="SHA-1" SIZE="79358">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:27:00" MIMETYPE="text/xml"
-				CHECKSUM="83350228bf7d4ad53aa66da7b57160551e10d3e8" CHECKSUMTYPE="SHA-1"
-				SIZE="21177">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:27:00" MIMETYPE="text/xml" CHECKSUM="83350228bf7d4ad53aa66da7b57160551e10d3e8" CHECKSUMTYPE="SHA-1" SIZE="21177">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T16:27:01" MIMETYPE="text/xml"
-				CHECKSUM="d9f6bb497a3b4fff5eada74360d1cb8c9592b32d" CHECKSUMTYPE="SHA-1"
-				SIZE="21822">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T16:27:01" MIMETYPE="text/xml" CHECKSUM="d9f6bb497a3b4fff5eada74360d1cb8c9592b32d" CHECKSUMTYPE="SHA-1" SIZE="21822">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T16:27:01" MIMETYPE="text/xml"
-				CHECKSUM="ad2c1583d2c6946d2d5544dab364f51127c2991c" CHECKSUMTYPE="SHA-1"
-				SIZE="53640">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T16:27:01" MIMETYPE="text/xml" CHECKSUM="ad2c1583d2c6946d2d5544dab364f51127c2991c" CHECKSUMTYPE="SHA-1" SIZE="53640">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T16:27:01" MIMETYPE="text/xml"
-				CHECKSUM="2cc1f0a8c459513e5ca16c1b6069ebd7455db0ed" CHECKSUMTYPE="SHA-1"
-				SIZE="33677">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T16:27:01" MIMETYPE="text/xml" CHECKSUM="2cc1f0a8c459513e5ca16c1b6069ebd7455db0ed" CHECKSUMTYPE="SHA-1" SIZE="33677">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T16:27:01" MIMETYPE="text/xml"
-				CHECKSUM="e1124ad050b1c5489b6bea51a718f778277ad5a9" CHECKSUMTYPE="SHA-1"
-				SIZE="33328">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T16:27:01" MIMETYPE="text/xml" CHECKSUM="e1124ad050b1c5489b6bea51a718f778277ad5a9" CHECKSUMTYPE="SHA-1" SIZE="33328">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T16:27:02" MIMETYPE="text/xml"
-				CHECKSUM="b9e4793ffd33e353e848b52b803cca2cd46812e1" CHECKSUMTYPE="SHA-1"
-				SIZE="74865">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T16:27:02" MIMETYPE="text/xml" CHECKSUM="b9e4793ffd33e353e848b52b803cca2cd46812e1" CHECKSUMTYPE="SHA-1" SIZE="74865">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T16:27:02" MIMETYPE="text/xml"
-				CHECKSUM="c5e96fcb672b2f73bb5f677dc7dd611b9cea9dd0" CHECKSUMTYPE="SHA-1" SIZE="2402">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T16:27:02" MIMETYPE="text/xml" CHECKSUM="c5e96fcb672b2f73bb5f677dc7dd611b9cea9dd0" CHECKSUMTYPE="SHA-1" SIZE="2402">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-07_01_0038.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:28:02" MIMETYPE="application/pdf"
-				CHECKSUM="13921625fc91d24a90bfa5e050e0c9ac047d69a7" CHECKSUMTYPE="SHA-1"
-				SIZE="13994217">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/bmtnabf_1898-07_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:28:02" MIMETYPE="application/pdf" CHECKSUM="13921625fc91d24a90bfa5e050e0c9ac047d69a7" CHECKSUMTYPE="SHA-1" SIZE="13994217">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/07_01/bmtnabf_1898-07_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -5426,8 +5196,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="TextContent" ORDER="2" DMDID="c007"
-					LABEL="Untitled text by GUSTAV KLIMT">
+				<div ID="L.1.1.4" TYPE="TextContent" ORDER="2" DMDID="c007" LABEL="Untitled text by GUSTAV KLIMT">
 					<div ID="L.1.1.4.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00001"/>
@@ -5462,15 +5231,13 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c009"
-					LABEL="Verziertes Notenmanuscript">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c009" LABEL="Verziertes Notenmanuscript">
 					<div ID="L.1.1.6.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00005"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.6.2" TYPE="Music" ORDER="1"
-						LABEL="Verziertes Notenmanuscript. Gedicht">
+					<div ID="L.1.1.6.2" TYPE="Music" ORDER="1" LABEL="Verziertes Notenmanuscript. Gedicht">
 						<div ID="L.1.1.6.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00002"/>
@@ -5483,8 +5250,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c010"
-					LABEL="Entwurf zu einem Glasgemälde">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c010" LABEL="Entwurf zu einem Glasgemälde">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
@@ -5501,8 +5267,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c011"
-					LABEL="Entwurf für Flächendecoration">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c011" LABEL="Entwurf für Flächendecoration">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00004"/>
@@ -5543,20 +5308,16 @@
 								<div ID="L.1.1.9.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.9.4" TYPE="Illustration" ORDER="1" DMDID="c014"
-						LABEL="Tigerfries Entwurf">
+					<div ID="L.1.1.9.4" TYPE="Illustration" ORDER="1" DMDID="c014" LABEL="Tigerfries Entwurf">
 						<div ID="L.1.1.9.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00006"/>
@@ -5573,8 +5334,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="2" DMDID="c015"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="2" DMDID="c015" LABEL="Buchschmuck">
 						<div ID="L.1.1.9.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00004"/>
@@ -5599,8 +5359,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="TextContent" ORDER="8" DMDID="c017"
-					LABEL="DILETTANTISMUS DIE NEUE VOLKSKUNST">
+				<div ID="L.1.1.10" TYPE="TextContent" ORDER="8" DMDID="c017" LABEL="DILETTANTISMUS DIE NEUE VOLKSKUNST">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<seq>
@@ -5634,28 +5393,20 @@
 								<div ID="L.1.1.10.3.1.3.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00007"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="1" DMDID="c018"
-						LABEL="Gartenmauer. ">
+					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="1" DMDID="c018" LABEL="Gartenmauer. ">
 						<div ID="L.1.1.10.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00008"/>
@@ -5672,8 +5423,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.5" TYPE="Illustration" ORDER="2" DMDID="c019"
-						LABEL="Zwei Bilderrahmen Entworfen von J. Hoffman">
+					<div ID="L.1.1.10.5" TYPE="Illustration" ORDER="2" DMDID="c019" LABEL="Zwei Bilderrahmen Entworfen von J. Hoffman">
 						<div ID="L.1.1.10.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00004"/>
@@ -5684,8 +5434,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00005"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.10.5.3" TYPE="Illustration" ORDER="1"
-							LABEL="Zwei Bilderrahmen Entworfen von J. Hoffman">
+						<div ID="L.1.1.10.5.3" TYPE="Illustration" ORDER="1" LABEL="Zwei Bilderrahmen Entworfen von J. Hoffman">
 							<div ID="L.1.1.10.5.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00001"/>
@@ -5698,8 +5447,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.6" TYPE="Illustration" ORDER="3" DMDID="c021"
-						LABEL="Spiegel und Möbel für ein Ankleidezimmer">
+					<div ID="L.1.1.10.6" TYPE="Illustration" ORDER="3" DMDID="c021" LABEL="Spiegel und Möbel für ein Ankleidezimmer">
 						<div ID="L.1.1.10.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00005"/>
@@ -5716,8 +5464,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.7" TYPE="Illustration" ORDER="4" DMDID="c022"
-						LABEL="Einfagie Möbel">
+					<div ID="L.1.1.10.7" TYPE="Illustration" ORDER="4" DMDID="c022" LABEL="Einfagie Möbel">
 						<div ID="L.1.1.10.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00006"/>
@@ -5734,8 +5481,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.8" TYPE="Illustration" ORDER="5" DMDID="c023"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.10.8" TYPE="Illustration" ORDER="5" DMDID="c023" LABEL="Buchschmuck">
 						<div ID="L.1.1.10.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00008"/>
@@ -5791,8 +5537,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00005"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.11.3" TYPE="Illustration" ORDER="1" DMDID="c030"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.11.3" TYPE="Illustration" ORDER="1" DMDID="c030" LABEL="Buchschmuck">
 						<div ID="L.1.1.11.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00003"/>
@@ -5814,8 +5559,7 @@
 							<div ID="L.1.1.11.4.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.11.4.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
 									</fptr>
 								</div>
 							</div>
@@ -5823,38 +5567,25 @@
 								<div ID="L.1.1.11.4.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00007"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00006"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.11.5" TYPE="Illustration" ORDER="1" DMDID="c031"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.11.5" TYPE="Illustration" ORDER="1" DMDID="c031" LABEL="Buchschmuck">
 						<div ID="L.1.1.11.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00008"/>
@@ -5871,8 +5602,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.6" TYPE="Illustration" ORDER="2" DMDID="c032"
-						LABEL="Blumengestell">
+					<div ID="L.1.1.11.6" TYPE="Illustration" ORDER="2" DMDID="c032" LABEL="Blumengestell">
 						<div ID="L.1.1.11.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00010"/>
@@ -5889,8 +5619,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.7" TYPE="Illustration" ORDER="3" DMDID="c033"
-						LABEL="Haus an der Landstrasse">
+					<div ID="L.1.1.11.7" TYPE="Illustration" ORDER="3" DMDID="c033" LABEL="Haus an der Landstrasse">
 						<div ID="L.1.1.11.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
@@ -5907,8 +5636,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.8" TYPE="Illustration" ORDER="4" DMDID="c034"
-						LABEL="DAS HAUS AVE DER LANDSTRASSE">
+					<div ID="L.1.1.11.8" TYPE="Illustration" ORDER="4" DMDID="c034" LABEL="DAS HAUS AVE DER LANDSTRASSE">
 						<div ID="L.1.1.11.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00007"/>
@@ -5925,8 +5653,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.9" TYPE="Illustration" ORDER="5" DMDID="c035"
-						LABEL="Decoratives Gefäss. ">
+					<div ID="L.1.1.11.9" TYPE="Illustration" ORDER="5" DMDID="c035" LABEL="Decoratives Gefäss. ">
 						<div ID="L.1.1.11.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00009"/>
@@ -5943,8 +5670,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.10" TYPE="Illustration" ORDER="6" DMDID="c036"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.11.10" TYPE="Illustration" ORDER="6" DMDID="c036" LABEL="Buchschmuck">
 						<div ID="L.1.1.11.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00007"/>
@@ -5961,8 +5687,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.11" TYPE="Illustration" ORDER="7" DMDID="c037"
-						LABEL="Decoratives Gefäss">
+					<div ID="L.1.1.11.11" TYPE="Illustration" ORDER="7" DMDID="c037" LABEL="Decoratives Gefäss">
 						<div ID="L.1.1.11.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00009"/>
@@ -5991,8 +5716,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00004"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.12.3" TYPE="Illustration" ORDER="1" DMDID="c039"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.12.3" TYPE="Illustration" ORDER="1" DMDID="c039" LABEL="Buchschmuck">
 						<div ID="L.1.1.12.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_CB00002"/>
@@ -6015,26 +5739,19 @@
 								<div ID="L.1.1.12.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00007"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00008"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00009"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00008"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00009"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.12.5" TYPE="Illustration" ORDER="1" DMDID="c040"
-						LABEL="Decoratives Gefäss. ">
+					<div ID="L.1.1.12.5" TYPE="Illustration" ORDER="1" DMDID="c040" LABEL="Decoratives Gefäss. ">
 						<div ID="L.1.1.12.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00010"/>
@@ -6051,8 +5768,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12.6" TYPE="Illustration" ORDER="2" DMDID="c041"
-						LABEL="STUDIEN ZUR DECORATIVEN AUSGESTALTUNG EINES HAUSEINGANGES">
+					<div ID="L.1.1.12.6" TYPE="Illustration" ORDER="2" DMDID="c041" LABEL="STUDIEN ZUR DECORATIVEN AUSGESTALTUNG EINES HAUSEINGANGES">
 						<div ID="L.1.1.12.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
@@ -6063,24 +5779,21 @@
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.12.6.3" TYPE="Illustration" ORDER="1"
-							LABEL="Studien von Josef Hoffmann">
+						<div ID="L.1.1.12.6.3" TYPE="Illustration" ORDER="1" LABEL="Studien von Josef Hoffmann">
 							<div ID="L.1.1.12.6.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00001"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.12.6.4" TYPE="Illustration" ORDER="2" DMDID="c042"
-							LABEL="Untitled Image by JOSEF HOFFMANN">
+						<div ID="L.1.1.12.6.4" TYPE="Illustration" ORDER="2" DMDID="c042" LABEL="Untitled Image by JOSEF HOFFMANN">
 							<div ID="L.1.1.12.6.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.12.6.5" TYPE="Illustration" ORDER="3" DMDID="c043"
-							LABEL="Untitled Image by JOSEF HOFFMANN">
+						<div ID="L.1.1.12.6.5" TYPE="Illustration" ORDER="3" DMDID="c043" LABEL="Untitled Image by JOSEF HOFFMANN">
 							<div ID="L.1.1.12.6.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00003"/>
@@ -6089,8 +5802,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="TextContent" ORDER="11" DMDID="c044"
-					LABEL="POTEMKIN’SCHE STADT">
+				<div ID="L.1.1.13" TYPE="TextContent" ORDER="11" DMDID="c044" LABEL="POTEMKIN’SCHE STADT">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
@@ -6107,28 +5819,20 @@
 								<div ID="L.1.1.13.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00005"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.13.4" TYPE="Illustration" ORDER="1" DMDID="c045"
-						LABEL="Architektonische Studie">
+					<div ID="L.1.1.13.4" TYPE="Illustration" ORDER="1" DMDID="c045" LABEL="Architektonische Studie">
 						<div ID="L.1.1.13.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00005"/>
@@ -6145,8 +5849,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13.5" TYPE="Illustration" ORDER="2" DMDID="c046"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.13.5" TYPE="Illustration" ORDER="2" DMDID="c046" LABEL="Buchschmuck">
 						<div ID="L.1.1.13.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00007"/>
@@ -6163,8 +5866,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13.6" TYPE="Illustration" ORDER="3" DMDID="c047"
-						LABEL="Entwurf für Seidenstickerei">
+					<div ID="L.1.1.13.6" TYPE="Illustration" ORDER="3" DMDID="c047" LABEL="Entwurf für Seidenstickerei">
 						<div ID="L.1.1.13.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00004"/>
@@ -6181,8 +5883,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13.7" TYPE="Illustration" ORDER="4" DMDID="c048"
-						LABEL="DECORATIVE LANDSCHAFT">
+					<div ID="L.1.1.13.7" TYPE="Illustration" ORDER="4" DMDID="c048" LABEL="DECORATIVE LANDSCHAFT">
 						<div ID="L.1.1.13.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00007"/>
@@ -6199,8 +5900,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13.8" TYPE="Illustration" ORDER="5" DMDID="c049"
-						LABEL="BUCHSCHMUCK">
+					<div ID="L.1.1.13.8" TYPE="Illustration" ORDER="5" DMDID="c049" LABEL="BUCHSCHMUCK">
 						<div ID="L.1.1.13.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00009"/>
@@ -6242,8 +5942,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c052"
-					LABEL="ARCHITEKTONISCHE STUDIE">
+				<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c052" LABEL="ARCHITEKTONISCHE STUDIE">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00005"/>
@@ -6260,8 +5959,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.16" TYPE="TextContent" ORDER="14" DMDID="c053"
-					LABEL="UNSEREN JUNGEN ARCHITEKTEN">
+				<div ID="L.1.1.16" TYPE="TextContent" ORDER="14" DMDID="c053" LABEL="UNSEREN JUNGEN ARCHITEKTEN">
 					<div ID="L.1.1.16.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
@@ -6278,22 +5976,17 @@
 								<div ID="L.1.1.16.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.16.4" TYPE="Illustration" ORDER="1" DMDID="c054"
-						LABEL="Architektonische Studien">
+					<div ID="L.1.1.16.4" TYPE="Illustration" ORDER="1" DMDID="c054" LABEL="Architektonische Studien">
 						<div ID="L.1.1.16.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00007"/>
@@ -6304,8 +5997,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00008"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.16.4.3" TYPE="Illustration" ORDER="1"
-							LABEL="Aus „Der Architekt“. Verlag von Ant. Schroll &amp; Co.">
+						<div ID="L.1.1.16.4.3" TYPE="Illustration" ORDER="1" LABEL="Aus „Der Architekt“. Verlag von Ant. Schroll &amp; Co.">
 							<div ID="L.1.1.16.4.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_CB00001"/>
@@ -6317,8 +6009,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.16.4.4" TYPE="Illustration" ORDER="2" DMDID="c055"
-							LABEL="Architektonische Studien">
+						<div ID="L.1.1.16.4.4" TYPE="Illustration" ORDER="2" DMDID="c055" LABEL="Architektonische Studien">
 							<div ID="L.1.1.16.4.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_CB00002"/>
@@ -6326,8 +6017,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.16.5" TYPE="Illustration" ORDER="2" DMDID="c056"
-						LABEL="ENTWURF FÜR GLASMOSAIK">
+					<div ID="L.1.1.16.5" TYPE="Illustration" ORDER="2" DMDID="c056" LABEL="ENTWURF FÜR GLASMOSAIK">
 						<div ID="L.1.1.16.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00004"/>
@@ -6344,8 +6034,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.6" TYPE="Illustration" ORDER="3" DMDID="c057"
-						LABEL="ENTWURF FÜR LEDERMOSAIK">
+					<div ID="L.1.1.16.6" TYPE="Illustration" ORDER="3" DMDID="c057" LABEL="ENTWURF FÜR LEDERMOSAIK">
 						<div ID="L.1.1.16.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"/>
@@ -6363,8 +6052,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.17" TYPE="TextContent" ORDER="15" DMDID="c058"
-					LABEL="OESTERREICHISCHE KÜNSTLER-BIOGRAPHIEN">
+				<div ID="L.1.1.17" TYPE="TextContent" ORDER="15" DMDID="c058" LABEL="OESTERREICHISCHE KÜNSTLER-BIOGRAPHIEN">
 					<div ID="L.1.1.17.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
@@ -6375,8 +6063,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00005"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.17.3" TYPE="Illustration" ORDER="1" DMDID="c059"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.17.3" TYPE="Illustration" ORDER="1" DMDID="c059" LABEL="Buchschmuck">
 						<div ID="L.1.1.17.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_CB00002"/>
@@ -6399,10 +6086,8 @@
 								<div ID="L.1.1.17.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
@@ -6427,8 +6112,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.18" TYPE="Illustration" ORDER="16" DMDID="c061"
-					LABEL="ARCHITEKTONISCHE STUDIE">
+				<div ID="L.1.1.18" TYPE="Illustration" ORDER="16" DMDID="c061" LABEL="ARCHITEKTONISCHE STUDIE">
 					<div ID="L.1.1.18.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00003"/>
@@ -6479,8 +6163,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.21" TYPE="TextContent" ORDER="19" DMDID="c064"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.21" TYPE="TextContent" ORDER="19" DMDID="c064" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.21.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00002"/>
@@ -6491,15 +6174,13 @@
 							<div ID="L.1.1.21.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.21.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.21.3" TYPE="Illustration" ORDER="1" DMDID="c065"
-						LABEL="Initial und Zierleiste">
+					<div ID="L.1.1.21.3" TYPE="Illustration" ORDER="1" DMDID="c065" LABEL="Initial und Zierleiste">
 						<div ID="L.1.1.21.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00004"/>
@@ -6517,8 +6198,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.21.3.4" TYPE="Illustration" ORDER="2" DMDID="c066"
-							LABEL="VER SACRVM">
+						<div ID="L.1.1.21.3.4" TYPE="Illustration" ORDER="2" DMDID="c066" LABEL="VER SACRVM">
 							<div ID="L.1.1.21.3.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_CB00002"/>
@@ -6526,8 +6206,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.21.4" TYPE="Illustration" ORDER="2" DMDID="c067"
-						LABEL="Blumenvase mit Stielstützen ">
+					<div ID="L.1.1.21.4" TYPE="Illustration" ORDER="2" DMDID="c067" LABEL="Blumenvase mit Stielstützen ">
 						<div ID="L.1.1.21.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00006"/>
@@ -6545,8 +6224,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.22" TYPE="Illustration" ORDER="20" DMDID="c068"
-					LABEL="Studie für Fresco">
+				<div ID="L.1.1.22" TYPE="Illustration" ORDER="20" DMDID="c068" LABEL="Studie für Fresco">
 					<div ID="L.1.1.22.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00003"/>
@@ -6580,18 +6258,15 @@
 								<div ID="L.1.1.23.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00031"
-												BEGIN="P31_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.23.4" TYPE="Illustration" ORDER="1" DMDID="c070"
-						LABEL="Credenzdecke">
+					<div ID="L.1.1.23.4" TYPE="Illustration" ORDER="1" DMDID="c070" LABEL="Credenzdecke">
 						<div ID="L.1.1.23.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00005"/>
@@ -6615,16 +6290,14 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.23.5" TYPE="Illustration" ORDER="1" DMDID="c072"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.23.5" TYPE="Illustration" ORDER="1" DMDID="c072" LABEL="Untitled Image">
 						<div ID="L.1.1.23.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.23.6" TYPE="Illustration" ORDER="2" DMDID="c073"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.23.6" TYPE="Illustration" ORDER="2" DMDID="c073" LABEL="Untitled Image">
 						<div ID="L.1.1.23.6.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_CB00003"/>
@@ -6632,8 +6305,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.24" TYPE="TextContent" ORDER="22" DMDID="c074"
-					LABEL="ARCHITEKTONISCHEN SKIZZEN DIESES HEFTES">
+				<div ID="L.1.1.24" TYPE="TextContent" ORDER="22" DMDID="c074" LABEL="ARCHITEKTONISCHEN SKIZZEN DIESES HEFTES">
 					<div ID="L.1.1.24.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00005"/>
@@ -6649,23 +6321,20 @@
 							<div ID="L.1.1.24.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.24.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00006"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00006"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.24.4" TYPE="Illustration" ORDER="1" DMDID="c075"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.24.4" TYPE="Illustration" ORDER="1" DMDID="c075" LABEL="Untitled Image">
 						<div ID="L.1.1.24.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.24.5" TYPE="Illustration" ORDER="2" DMDID="c076"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.24.5" TYPE="Illustration" ORDER="2" DMDID="c076" LABEL="Untitled Image">
 						<div ID="L.1.1.24.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_CB00003"/>
@@ -6689,23 +6358,20 @@
 							<div ID="L.1.1.25.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.25.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.25.3.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.25.3.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.25.4" TYPE="Illustration" ORDER="1" DMDID="c078"
-						LABEL="Untitled Image by Jos. Auchentaller">
+					<div ID="L.1.1.25.4" TYPE="Illustration" ORDER="1" DMDID="c078" LABEL="Untitled Image by Jos. Auchentaller">
 						<div ID="L.1.1.25.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00005"/>
@@ -6722,8 +6388,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.25.5" TYPE="Illustration" ORDER="2" DMDID="c079"
-						LABEL="Untitled Image by Jos. Auchentaller">
+					<div ID="L.1.1.25.5" TYPE="Illustration" ORDER="2" DMDID="c079" LABEL="Untitled Image by Jos. Auchentaller">
 						<div ID="L.1.1.25.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_TB00005"/>
@@ -6741,8 +6406,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.26" TYPE="TextContent" ORDER="24" DMDID="c080"
-					LABEL="MALEREI MIT DER PLATTE">
+				<div ID="L.1.1.26" TYPE="TextContent" ORDER="24" DMDID="c080" LABEL="MALEREI MIT DER PLATTE">
 					<div ID="L.1.1.26.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00034" BEGIN="P34_TB00002"/>
@@ -6759,24 +6423,18 @@
 								<div ID="L.1.1.26.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00034"
-												BEGIN="P34_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00034"
-												BEGIN="P34_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00035"
-												BEGIN="P35_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00036"
-												BEGIN="P36_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00036"
-												BEGIN="P36_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00034" BEGIN="P34_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00034" BEGIN="P34_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00035" BEGIN="P35_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.26.4" TYPE="Illustration" ORDER="1" DMDID="c081"
-						LABEL="Weiden am Wasser">
+					<div ID="L.1.1.26.4" TYPE="Illustration" ORDER="1" DMDID="c081" LABEL="Weiden am Wasser">
 						<div ID="L.1.1.26.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00034" BEGIN="P34_TB00006"/>
@@ -6793,8 +6451,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.26.5" TYPE="Illustration" ORDER="2" DMDID="c082"
-						LABEL="Grietje und Tryntje">
+					<div ID="L.1.1.26.5" TYPE="Illustration" ORDER="2" DMDID="c082" LABEL="Grietje und Tryntje">
 						<div ID="L.1.1.26.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00035" BEGIN="P35_TB00003"/>
@@ -6811,8 +6468,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.26.6" TYPE="Illustration" ORDER="3" DMDID="c083"
-						LABEL="Ital. Villa im Herbst">
+					<div ID="L.1.1.26.6" TYPE="Illustration" ORDER="3" DMDID="c083" LABEL="Ital. Villa im Herbst">
 						<div ID="L.1.1.26.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00004"/>

--- a/metadata/periodicals/bmtnabf/issues/1898/08_01/bmtnabf_1898-08_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1898/08_01/bmtnabf_1898-08_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-08_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-08_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-08_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1898-08_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-08_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -4556,477 +4550,252 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:08:46"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a044984dfc580c1da3ee09f0c296a761b4c6baba"
-				CHECKSUMTYPE="SHA-1" SIZE="6305528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:08:46" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a044984dfc580c1da3ee09f0c296a761b4c6baba" CHECKSUMTYPE="SHA-1" SIZE="6305528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:09:24"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="ecc9d50dba4beeb90d2f2a2ad907b00a37dfac77"
-				CHECKSUMTYPE="SHA-1" SIZE="6257828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:09:24" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="ecc9d50dba4beeb90d2f2a2ad907b00a37dfac77" CHECKSUMTYPE="SHA-1" SIZE="6257828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:10:02"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="1704e2697c206d8d5b97a10561233d13a26173aa"
-				CHECKSUMTYPE="SHA-1" SIZE="6252429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:10:02" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="1704e2697c206d8d5b97a10561233d13a26173aa" CHECKSUMTYPE="SHA-1" SIZE="6252429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:10:38"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="e3b436bc5116df4832e65514a5f63687066003a6"
-				CHECKSUMTYPE="SHA-1" SIZE="6258717">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:10:38" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="e3b436bc5116df4832e65514a5f63687066003a6" CHECKSUMTYPE="SHA-1" SIZE="6258717">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:11:14"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="f894c1c21f800d60448e35dbedf7171dcd1c456e"
-				CHECKSUMTYPE="SHA-1" SIZE="6252426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:11:14" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="f894c1c21f800d60448e35dbedf7171dcd1c456e" CHECKSUMTYPE="SHA-1" SIZE="6252426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:11:50"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="41f611753a1345b1468508db019018043324b785"
-				CHECKSUMTYPE="SHA-1" SIZE="6258713">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:11:50" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="41f611753a1345b1468508db019018043324b785" CHECKSUMTYPE="SHA-1" SIZE="6258713">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:12:28"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="360be9cace0b01a761cbc99e38f730ff65389a14"
-				CHECKSUMTYPE="SHA-1" SIZE="6283925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:12:28" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="360be9cace0b01a761cbc99e38f730ff65389a14" CHECKSUMTYPE="SHA-1" SIZE="6283925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:13:04"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="defd40d8a748b79d550817778e4a2d3c849e2f2d"
-				CHECKSUMTYPE="SHA-1" SIZE="6253317">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:13:04" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="defd40d8a748b79d550817778e4a2d3c849e2f2d" CHECKSUMTYPE="SHA-1" SIZE="6253317">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:13:39"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="50adf01b012ba3858486998d19fbf7b5f099adad"
-				CHECKSUMTYPE="SHA-1" SIZE="6283916">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:13:39" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="50adf01b012ba3858486998d19fbf7b5f099adad" CHECKSUMTYPE="SHA-1" SIZE="6283916">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:14:17"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="f73f2bfcc4591db7e0e934afcd12c08093c8fe80"
-				CHECKSUMTYPE="SHA-1" SIZE="6253312">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:14:17" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="f73f2bfcc4591db7e0e934afcd12c08093c8fe80" CHECKSUMTYPE="SHA-1" SIZE="6253312">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:14:56"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="95d9fb44435fced541bc4d584e95dc4a4c319525"
-				CHECKSUMTYPE="SHA-1" SIZE="6283925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:14:56" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="95d9fb44435fced541bc4d584e95dc4a4c319525" CHECKSUMTYPE="SHA-1" SIZE="6283925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:15:33"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="d7388c43a1e7fbb667680ed0b356640358a3ab91"
-				CHECKSUMTYPE="SHA-1" SIZE="6232622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:15:33" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="d7388c43a1e7fbb667680ed0b356640358a3ab91" CHECKSUMTYPE="SHA-1" SIZE="6232622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:16:11"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="c2aa9607190a9c8f636e4979b10f28b7a44f15d6"
-				CHECKSUMTYPE="SHA-1" SIZE="6356758">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:16:11" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="c2aa9607190a9c8f636e4979b10f28b7a44f15d6" CHECKSUMTYPE="SHA-1" SIZE="6356758">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:16:48"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="0ea936a60a28d3cf86af21604b52e4dc4b4ae6ef"
-				CHECKSUMTYPE="SHA-1" SIZE="6233500">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:16:48" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="0ea936a60a28d3cf86af21604b52e4dc4b4ae6ef" CHECKSUMTYPE="SHA-1" SIZE="6233500">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:17:25"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="ca78525ef39f2045c8b6fc214cb8dc5d4631a929"
-				CHECKSUMTYPE="SHA-1" SIZE="6356806">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:17:25" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="ca78525ef39f2045c8b6fc214cb8dc5d4631a929" CHECKSUMTYPE="SHA-1" SIZE="6356806">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:18:02"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d73ee0ea7614a2ceea47864535027bc81e330c8b"
-				CHECKSUMTYPE="SHA-1" SIZE="6258723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:18:02" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d73ee0ea7614a2ceea47864535027bc81e330c8b" CHECKSUMTYPE="SHA-1" SIZE="6258723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:18:39"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="a43e0dee26600b086ba96cb2fcb1d5b9f8f4d862"
-				CHECKSUMTYPE="SHA-1" SIZE="6356805">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:18:39" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="a43e0dee26600b086ba96cb2fcb1d5b9f8f4d862" CHECKSUMTYPE="SHA-1" SIZE="6356805">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:19:15"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="ad0f0c2b36938bf9f48ab09c82a107edf82aff31"
-				CHECKSUMTYPE="SHA-1" SIZE="6258694">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:19:15" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="ad0f0c2b36938bf9f48ab09c82a107edf82aff31" CHECKSUMTYPE="SHA-1" SIZE="6258694">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:19:55"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="c7daee73c42b791249828cdb97d0f1e7253f09f1"
-				CHECKSUMTYPE="SHA-1" SIZE="6356825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:19:55" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="c7daee73c42b791249828cdb97d0f1e7253f09f1" CHECKSUMTYPE="SHA-1" SIZE="6356825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:20:35"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="8f032affc6dfc47761c82d6ad1d351fab01e51e9"
-				CHECKSUMTYPE="SHA-1" SIZE="6336122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:20:35" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="8f032affc6dfc47761c82d6ad1d351fab01e51e9" CHECKSUMTYPE="SHA-1" SIZE="6336122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:21:09"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="6ece558b2d6ff3124bd480a2dfa20cb9f55a4cff"
-				CHECKSUMTYPE="SHA-1" SIZE="6343305">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:21:09" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="6ece558b2d6ff3124bd480a2dfa20cb9f55a4cff" CHECKSUMTYPE="SHA-1" SIZE="6343305">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:21:45"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="8264be7a7a44b95b0e8083fa1f3ac2e430f2ef06"
-				CHECKSUMTYPE="SHA-1" SIZE="6355022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:21:45" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="8264be7a7a44b95b0e8083fa1f3ac2e430f2ef06" CHECKSUMTYPE="SHA-1" SIZE="6355022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:22:22"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="4e9604b5288b3ac41bb40d9adaf65a5257270815"
-				CHECKSUMTYPE="SHA-1" SIZE="6276686">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:22:22" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="4e9604b5288b3ac41bb40d9adaf65a5257270815" CHECKSUMTYPE="SHA-1" SIZE="6276686">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:22:59"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="de93fcfc5e49b52c72cd6b1a3fac1f5421640922"
-				CHECKSUMTYPE="SHA-1" SIZE="6355929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:22:59" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="de93fcfc5e49b52c72cd6b1a3fac1f5421640922" CHECKSUMTYPE="SHA-1" SIZE="6355929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:23:38"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="65ef43a007d7e553835257ef0b20a8d7319d3e1a"
-				CHECKSUMTYPE="SHA-1" SIZE="6276557">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:23:38" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="65ef43a007d7e553835257ef0b20a8d7319d3e1a" CHECKSUMTYPE="SHA-1" SIZE="6276557">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:24:14"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="6d8340655b970e1bf1537542d7736ac1bc8c828a"
-				CHECKSUMTYPE="SHA-1" SIZE="6355929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:24:14" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="6d8340655b970e1bf1537542d7736ac1bc8c828a" CHECKSUMTYPE="SHA-1" SIZE="6355929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:24:52"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="ea3a739523860ba63b808e4d2a2a59fa002f13fb"
-				CHECKSUMTYPE="SHA-1" SIZE="6195725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:24:52" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="ea3a739523860ba63b808e4d2a2a59fa002f13fb" CHECKSUMTYPE="SHA-1" SIZE="6195725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:25:25"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="dd10a65bdf4b6319372ed7aad5276709c79fc649"
-				CHECKSUMTYPE="SHA-1" SIZE="6355926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:25:25" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="dd10a65bdf4b6319372ed7aad5276709c79fc649" CHECKSUMTYPE="SHA-1" SIZE="6355926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:26:01"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="9a4fd046e69a5d03990f96dcf108c5aecf46ab9e"
-				CHECKSUMTYPE="SHA-1" SIZE="6195727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:26:01" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="9a4fd046e69a5d03990f96dcf108c5aecf46ab9e" CHECKSUMTYPE="SHA-1" SIZE="6195727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:26:36"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="6531150bc4e86f81c186bc7806fc73bd3a3f56d2"
-				CHECKSUMTYPE="SHA-1" SIZE="6355917">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:26:36" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="6531150bc4e86f81c186bc7806fc73bd3a3f56d2" CHECKSUMTYPE="SHA-1" SIZE="6355917">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:27:13"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="ea6e10f6492d82117ab3e1213255e538ad1c5334"
-				CHECKSUMTYPE="SHA-1" SIZE="6195717">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:27:13" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="ea6e10f6492d82117ab3e1213255e538ad1c5334" CHECKSUMTYPE="SHA-1" SIZE="6195717">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:27:51"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="61b31a3bb9f8b7b411c0531a2593254003df5de3"
-				CHECKSUMTYPE="SHA-1" SIZE="6355929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:27:51" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="61b31a3bb9f8b7b411c0531a2593254003df5de3" CHECKSUMTYPE="SHA-1" SIZE="6355929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T16:28:26"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="7f4bad3804a4bbcb85a12d2434cc271ea378e940"
-				CHECKSUMTYPE="SHA-1" SIZE="6153417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T16:28:26" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="7f4bad3804a4bbcb85a12d2434cc271ea378e940" CHECKSUMTYPE="SHA-1" SIZE="6153417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T16:29:01"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="17fc2dca18c62725a6b87cd3f456f7f9662cbc2e"
-				CHECKSUMTYPE="SHA-1" SIZE="6355858">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T16:29:01" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="17fc2dca18c62725a6b87cd3f456f7f9662cbc2e" CHECKSUMTYPE="SHA-1" SIZE="6355858">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0034.jp2"/>
 			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T16:29:36"
-				MIMETYPE="image/jp2" SEQ="35" CHECKSUM="c2f6b91ba847f8d0ea53dfab0997e5078f89bd70"
-				CHECKSUMTYPE="SHA-1" SIZE="6180428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0035.jp2"
-				/>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T16:29:36" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="c2f6b91ba847f8d0ea53dfab0997e5078f89bd70" CHECKSUMTYPE="SHA-1" SIZE="6180428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0035.jp2"/>
 			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T16:30:15"
-				MIMETYPE="image/jp2" SEQ="36" CHECKSUM="bf89a731c45b32f4a7c44e7530866a8bc3667a37"
-				CHECKSUMTYPE="SHA-1" SIZE="6355901">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0036.jp2"
-				/>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T16:30:15" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="bf89a731c45b32f4a7c44e7530866a8bc3667a37" CHECKSUMTYPE="SHA-1" SIZE="6355901">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0036.jp2"/>
 			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T16:30:53"
-				MIMETYPE="image/jp2" SEQ="37" CHECKSUM="a1934ebcf3c0403aea1cc59a534daf1abda7f1ab"
-				CHECKSUMTYPE="SHA-1" SIZE="6180344">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0037.jp2"
-				/>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T16:30:53" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="a1934ebcf3c0403aea1cc59a534daf1abda7f1ab" CHECKSUMTYPE="SHA-1" SIZE="6180344">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0037.jp2"/>
 			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T16:31:31"
-				MIMETYPE="image/jp2" SEQ="38" CHECKSUM="4f7e0bdd74e52986d2967aef91642af7916623ba"
-				CHECKSUMTYPE="SHA-1" SIZE="6343329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0038.jp2"
-				/>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T16:31:31" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="4f7e0bdd74e52986d2967aef91642af7916623ba" CHECKSUMTYPE="SHA-1" SIZE="6343329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0038.jp2"/>
 			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-10-09T16:32:07"
-				MIMETYPE="image/jp2" SEQ="39" CHECKSUM="fec8c4cbfdf42411533fdd69fc29d7f7ec0324cd"
-				CHECKSUMTYPE="SHA-1" SIZE="6180429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0039.jp2"
-				/>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-10-09T16:32:07" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="fec8c4cbfdf42411533fdd69fc29d7f7ec0324cd" CHECKSUMTYPE="SHA-1" SIZE="6180429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0039.jp2"/>
 			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-10-09T16:32:47"
-				MIMETYPE="image/jp2" SEQ="40" CHECKSUM="0a1227d4587e1f20c5cbd9f6fbfaacee9feff8d5"
-				CHECKSUMTYPE="SHA-1" SIZE="6382922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0040.jp2"
-				/>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-10-09T16:32:47" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="0a1227d4587e1f20c5cbd9f6fbfaacee9feff8d5" CHECKSUMTYPE="SHA-1" SIZE="6382922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/delivery/bmtnabf_1898-08_01_0040.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:33:08" MIMETYPE="text/xml"
-				CHECKSUM="7564c8a9cd93ff15772f999ea88f9bfff0e2e5e0" CHECKSUMTYPE="SHA-1" SIZE="6190">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:33:08" MIMETYPE="text/xml" CHECKSUM="7564c8a9cd93ff15772f999ea88f9bfff0e2e5e0" CHECKSUMTYPE="SHA-1" SIZE="6190">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:33:09" MIMETYPE="text/xml"
-				CHECKSUM="515314af640c7d28d8ec4a1da6dcde9d6a689226" CHECKSUMTYPE="SHA-1"
-				SIZE="114326">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:33:09" MIMETYPE="text/xml" CHECKSUM="515314af640c7d28d8ec4a1da6dcde9d6a689226" CHECKSUMTYPE="SHA-1" SIZE="114326">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:33:10" MIMETYPE="text/xml"
-				CHECKSUM="ab84eaab8c1c9fd48b7c5f3c7811be5528d3f280" CHECKSUMTYPE="SHA-1"
-				SIZE="19006">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:33:10" MIMETYPE="text/xml" CHECKSUM="ab84eaab8c1c9fd48b7c5f3c7811be5528d3f280" CHECKSUMTYPE="SHA-1" SIZE="19006">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:33:10" MIMETYPE="text/xml"
-				CHECKSUM="d495a43fbe3bf94092b7ae9e1b8fafbd7384f33e" CHECKSUMTYPE="SHA-1" SIZE="6678">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:33:10" MIMETYPE="text/xml" CHECKSUM="d495a43fbe3bf94092b7ae9e1b8fafbd7384f33e" CHECKSUMTYPE="SHA-1" SIZE="6678">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:33:10" MIMETYPE="text/xml"
-				CHECKSUM="e310189588c67d35281c7e66b87d394781c47cc5" CHECKSUMTYPE="SHA-1" SIZE="4770">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:33:10" MIMETYPE="text/xml" CHECKSUM="e310189588c67d35281c7e66b87d394781c47cc5" CHECKSUMTYPE="SHA-1" SIZE="4770">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:33:11" MIMETYPE="text/xml"
-				CHECKSUM="cc6269bf600698061ff88d2d61571b0650e1e10b" CHECKSUMTYPE="SHA-1" SIZE="4429">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:33:11" MIMETYPE="text/xml" CHECKSUM="cc6269bf600698061ff88d2d61571b0650e1e10b" CHECKSUMTYPE="SHA-1" SIZE="4429">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:33:11" MIMETYPE="text/xml"
-				CHECKSUM="9712c2f24ccf8d298fdf440840ace7d34ddbe6fe" CHECKSUMTYPE="SHA-1" SIZE="8752">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:33:11" MIMETYPE="text/xml" CHECKSUM="9712c2f24ccf8d298fdf440840ace7d34ddbe6fe" CHECKSUMTYPE="SHA-1" SIZE="8752">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:33:11" MIMETYPE="text/xml"
-				CHECKSUM="aee1cb278185c55c3e41bdd1fe33e92723751325" CHECKSUMTYPE="SHA-1" SIZE="6567">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:33:11" MIMETYPE="text/xml" CHECKSUM="aee1cb278185c55c3e41bdd1fe33e92723751325" CHECKSUMTYPE="SHA-1" SIZE="6567">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:33:11" MIMETYPE="text/xml"
-				CHECKSUM="c610f637ba803fcf0aedfae12c1ab384b852e0a6" CHECKSUMTYPE="SHA-1" SIZE="8857">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:33:11" MIMETYPE="text/xml" CHECKSUM="c610f637ba803fcf0aedfae12c1ab384b852e0a6" CHECKSUMTYPE="SHA-1" SIZE="8857">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:33:12" MIMETYPE="text/xml"
-				CHECKSUM="265c8d31b1f163bbbe4e9b8574c5f02a6b1db6be" CHECKSUMTYPE="SHA-1" SIZE="8385">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:33:12" MIMETYPE="text/xml" CHECKSUM="265c8d31b1f163bbbe4e9b8574c5f02a6b1db6be" CHECKSUMTYPE="SHA-1" SIZE="8385">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:33:12" MIMETYPE="text/xml"
-				CHECKSUM="0df93d5c1f79efb54b6d39a0fab8ef2a019b546e" CHECKSUMTYPE="SHA-1" SIZE="4587">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:33:12" MIMETYPE="text/xml" CHECKSUM="0df93d5c1f79efb54b6d39a0fab8ef2a019b546e" CHECKSUMTYPE="SHA-1" SIZE="4587">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:33:12" MIMETYPE="text/xml"
-				CHECKSUM="5cb377109fc363a83377d8affafb2070a52da9bd" CHECKSUMTYPE="SHA-1" SIZE="4266">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:33:12" MIMETYPE="text/xml" CHECKSUM="5cb377109fc363a83377d8affafb2070a52da9bd" CHECKSUMTYPE="SHA-1" SIZE="4266">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:33:12" MIMETYPE="text/xml"
-				CHECKSUM="7042e05c20952e82d037e65e0499d3671aa976c2" CHECKSUMTYPE="SHA-1"
-				SIZE="89193">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:33:12" MIMETYPE="text/xml" CHECKSUM="7042e05c20952e82d037e65e0499d3671aa976c2" CHECKSUMTYPE="SHA-1" SIZE="89193">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:33:13" MIMETYPE="text/xml"
-				CHECKSUM="c02d26095f2478534d4c2b8c6f34c26cfbbfe614" CHECKSUMTYPE="SHA-1"
-				SIZE="134947">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:33:13" MIMETYPE="text/xml" CHECKSUM="c02d26095f2478534d4c2b8c6f34c26cfbbfe614" CHECKSUMTYPE="SHA-1" SIZE="134947">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:33:13" MIMETYPE="text/xml"
-				CHECKSUM="3759c5233682c77f1b0eaceb155f462cd5332191" CHECKSUMTYPE="SHA-1"
-				SIZE="117506">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:33:13" MIMETYPE="text/xml" CHECKSUM="3759c5233682c77f1b0eaceb155f462cd5332191" CHECKSUMTYPE="SHA-1" SIZE="117506">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:33:13" MIMETYPE="text/xml"
-				CHECKSUM="46d082ff226c80ff25aec62644cd9abb5ff0e739" CHECKSUMTYPE="SHA-1"
-				SIZE="66021">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:33:13" MIMETYPE="text/xml" CHECKSUM="46d082ff226c80ff25aec62644cd9abb5ff0e739" CHECKSUMTYPE="SHA-1" SIZE="66021">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:33:14" MIMETYPE="text/xml"
-				CHECKSUM="819861f05a40cec3472dffb8bf816d37f385b85c" CHECKSUMTYPE="SHA-1"
-				SIZE="88054">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:33:14" MIMETYPE="text/xml" CHECKSUM="819861f05a40cec3472dffb8bf816d37f385b85c" CHECKSUMTYPE="SHA-1" SIZE="88054">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:33:14" MIMETYPE="text/xml"
-				CHECKSUM="67ffd3176e2dd6e7b691739517afdec80dd60a3c" CHECKSUMTYPE="SHA-1"
-				SIZE="68148">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:33:14" MIMETYPE="text/xml" CHECKSUM="67ffd3176e2dd6e7b691739517afdec80dd60a3c" CHECKSUMTYPE="SHA-1" SIZE="68148">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:33:14" MIMETYPE="text/xml"
-				CHECKSUM="c6fa6e70811aa9ec524953dd244ea34b1e3f5863" CHECKSUMTYPE="SHA-1"
-				SIZE="87700">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:33:14" MIMETYPE="text/xml" CHECKSUM="c6fa6e70811aa9ec524953dd244ea34b1e3f5863" CHECKSUMTYPE="SHA-1" SIZE="87700">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:33:14" MIMETYPE="text/xml"
-				CHECKSUM="4f8063fc4f9a8c92a3d78c097d16980bfa917e0b" CHECKSUMTYPE="SHA-1" SIZE="4776">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:33:14" MIMETYPE="text/xml" CHECKSUM="4f8063fc4f9a8c92a3d78c097d16980bfa917e0b" CHECKSUMTYPE="SHA-1" SIZE="4776">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:33:15" MIMETYPE="text/xml"
-				CHECKSUM="75a46166b4dc20a074622b5eb1bbbac8b91d87b1" CHECKSUMTYPE="SHA-1"
-				SIZE="50477">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:33:15" MIMETYPE="text/xml" CHECKSUM="75a46166b4dc20a074622b5eb1bbbac8b91d87b1" CHECKSUMTYPE="SHA-1" SIZE="50477">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:33:15" MIMETYPE="text/xml"
-				CHECKSUM="5cdbf170774c1d5179bbb3a47b3ee8935c4fc9ef" CHECKSUMTYPE="SHA-1"
-				SIZE="117860">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:33:15" MIMETYPE="text/xml" CHECKSUM="5cdbf170774c1d5179bbb3a47b3ee8935c4fc9ef" CHECKSUMTYPE="SHA-1" SIZE="117860">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:33:15" MIMETYPE="text/xml"
-				CHECKSUM="8360da4e979079b5f97aac55ff1ab90f77a20c9a" CHECKSUMTYPE="SHA-1"
-				SIZE="127942">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:33:15" MIMETYPE="text/xml" CHECKSUM="8360da4e979079b5f97aac55ff1ab90f77a20c9a" CHECKSUMTYPE="SHA-1" SIZE="127942">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:33:16" MIMETYPE="text/xml"
-				CHECKSUM="1645a3835109f574e76c1bd71cc49aab2b672b1a" CHECKSUMTYPE="SHA-1" SIZE="6812">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:33:16" MIMETYPE="text/xml" CHECKSUM="1645a3835109f574e76c1bd71cc49aab2b672b1a" CHECKSUMTYPE="SHA-1" SIZE="6812">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:33:16" MIMETYPE="text/xml"
-				CHECKSUM="63f862683a85fac5dd761baff293752bad411852" CHECKSUMTYPE="SHA-1"
-				SIZE="127645">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:33:16" MIMETYPE="text/xml" CHECKSUM="63f862683a85fac5dd761baff293752bad411852" CHECKSUMTYPE="SHA-1" SIZE="127645">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:33:16" MIMETYPE="text/xml"
-				CHECKSUM="52e851adf82936e3dec1781168c27ac44159af3c" CHECKSUMTYPE="SHA-1"
-				SIZE="89336">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:33:16" MIMETYPE="text/xml" CHECKSUM="52e851adf82936e3dec1781168c27ac44159af3c" CHECKSUMTYPE="SHA-1" SIZE="89336">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:33:17" MIMETYPE="text/xml"
-				CHECKSUM="8dda93c643a2a34d8dd2507ed58c3dab981983f0" CHECKSUMTYPE="SHA-1" SIZE="6368">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:33:17" MIMETYPE="text/xml" CHECKSUM="8dda93c643a2a34d8dd2507ed58c3dab981983f0" CHECKSUMTYPE="SHA-1" SIZE="6368">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:33:17" MIMETYPE="text/xml"
-				CHECKSUM="932fafc9eb87088da3077e1cfc62076064ff27d4" CHECKSUMTYPE="SHA-1"
-				SIZE="11465">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:33:17" MIMETYPE="text/xml" CHECKSUM="932fafc9eb87088da3077e1cfc62076064ff27d4" CHECKSUMTYPE="SHA-1" SIZE="11465">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:33:17" MIMETYPE="text/xml"
-				CHECKSUM="9146dc5ec27f8eaee869b91929a4e85140ad9e68" CHECKSUMTYPE="SHA-1" SIZE="9851">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:33:17" MIMETYPE="text/xml" CHECKSUM="9146dc5ec27f8eaee869b91929a4e85140ad9e68" CHECKSUMTYPE="SHA-1" SIZE="9851">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:33:18" MIMETYPE="text/xml"
-				CHECKSUM="728dca4d592106c53bc0d6f1a5eb12c78a3abf77" CHECKSUMTYPE="SHA-1" SIZE="6475">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:33:18" MIMETYPE="text/xml" CHECKSUM="728dca4d592106c53bc0d6f1a5eb12c78a3abf77" CHECKSUMTYPE="SHA-1" SIZE="6475">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:33:18" MIMETYPE="text/xml"
-				CHECKSUM="9ea5d01051904ec8923506fcc5351f1bfdfca937" CHECKSUMTYPE="SHA-1"
-				SIZE="11368">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:33:18" MIMETYPE="text/xml" CHECKSUM="9ea5d01051904ec8923506fcc5351f1bfdfca937" CHECKSUMTYPE="SHA-1" SIZE="11368">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:33:18" MIMETYPE="text/xml"
-				CHECKSUM="8a32e41ee44d8827f75c36bdf823dcd6060a545d" CHECKSUMTYPE="SHA-1" SIZE="7634">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:33:18" MIMETYPE="text/xml" CHECKSUM="8a32e41ee44d8827f75c36bdf823dcd6060a545d" CHECKSUMTYPE="SHA-1" SIZE="7634">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T16:33:18" MIMETYPE="text/xml"
-				CHECKSUM="444389704290409e8f2048332860501afe5a7d59" CHECKSUMTYPE="SHA-1" SIZE="7505">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T16:33:18" MIMETYPE="text/xml" CHECKSUM="444389704290409e8f2048332860501afe5a7d59" CHECKSUMTYPE="SHA-1" SIZE="7505">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T16:33:19" MIMETYPE="text/xml"
-				CHECKSUM="e458f5337cae4a878a5edb0c077f49286a5d4206" CHECKSUMTYPE="SHA-1"
-				SIZE="10897">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T16:33:19" MIMETYPE="text/xml" CHECKSUM="e458f5337cae4a878a5edb0c077f49286a5d4206" CHECKSUMTYPE="SHA-1" SIZE="10897">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T16:33:19" MIMETYPE="text/xml"
-				CHECKSUM="8d422d7ab3882aaf32c12a59a9908ab5bf6e2969" CHECKSUMTYPE="SHA-1"
-				SIZE="11301">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T16:33:19" MIMETYPE="text/xml" CHECKSUM="8d422d7ab3882aaf32c12a59a9908ab5bf6e2969" CHECKSUMTYPE="SHA-1" SIZE="11301">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T16:33:19" MIMETYPE="text/xml"
-				CHECKSUM="faadbb23a424aa3297e36abbadaf77a2fd942a19" CHECKSUMTYPE="SHA-1" SIZE="7177">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T16:33:19" MIMETYPE="text/xml" CHECKSUM="faadbb23a424aa3297e36abbadaf77a2fd942a19" CHECKSUMTYPE="SHA-1" SIZE="7177">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T16:33:19" MIMETYPE="text/xml"
-				CHECKSUM="48122e14565fc2479bf4d71d58db6298479e6995" CHECKSUMTYPE="SHA-1"
-				SIZE="12575">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T16:33:19" MIMETYPE="text/xml" CHECKSUM="48122e14565fc2479bf4d71d58db6298479e6995" CHECKSUMTYPE="SHA-1" SIZE="12575">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T16:33:20" MIMETYPE="text/xml"
-				CHECKSUM="c9ff601547d0b205514c54824479dd51ac97bd17" CHECKSUMTYPE="SHA-1" SIZE="8771">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T16:33:20" MIMETYPE="text/xml" CHECKSUM="c9ff601547d0b205514c54824479dd51ac97bd17" CHECKSUMTYPE="SHA-1" SIZE="8771">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-10-09T16:33:20" MIMETYPE="text/xml"
-				CHECKSUM="7e40607f51c31d423b0080d29f1f28d210e881ab" CHECKSUMTYPE="SHA-1"
-				SIZE="67963">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-10-09T16:33:20" MIMETYPE="text/xml" CHECKSUM="7e40607f51c31d423b0080d29f1f28d210e881ab" CHECKSUMTYPE="SHA-1" SIZE="67963">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-10-09T16:33:20" MIMETYPE="text/xml"
-				CHECKSUM="23f0e2e08ff1e0e01d44116a4bca6c2d27f7d34b" CHECKSUMTYPE="SHA-1"
-				SIZE="15937">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-10-09T16:33:20" MIMETYPE="text/xml" CHECKSUM="23f0e2e08ff1e0e01d44116a4bca6c2d27f7d34b" CHECKSUMTYPE="SHA-1" SIZE="15937">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-08_01_0040.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:34:12" MIMETYPE="application/pdf"
-				CHECKSUM="dcf8c81b3f51292ba2d1e62d102dccbfef8da68d" CHECKSUMTYPE="SHA-1"
-				SIZE="12380171">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/bmtnabf_1898-08_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:34:12" MIMETYPE="application/pdf" CHECKSUM="dcf8c81b3f51292ba2d1e62d102dccbfef8da68d" CHECKSUMTYPE="SHA-1" SIZE="12380171">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/08_01/bmtnabf_1898-08_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -5566,8 +5335,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="TextContent" ORDER="2" DMDID="c004"
-					LABEL="INHALTSVERZEICHNIS">
+				<div ID="L.1.1.4" TYPE="TextContent" ORDER="2" DMDID="c004" LABEL="INHALTSVERZEICHNIS">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00002" BEGIN="P2_TB00001"/>
@@ -5585,8 +5353,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c005"
-					LABEL="SIR EDWARD BÜRNE JONES">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c005" LABEL="SIR EDWARD BÜRNE JONES">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00002"/>
@@ -5611,8 +5378,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c006"
-					LABEL="IGEL ALS BRÄUTIGAM">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c006" LABEL="IGEL ALS BRÄUTIGAM">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00002"/>
@@ -5634,8 +5400,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c007"
-					LABEL="STUDIEN VON H. SCHWAIGER">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c007" LABEL="STUDIEN VON H. SCHWAIGER">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00001"/>
@@ -5682,8 +5447,7 @@
 					</div>
 				</div>
 
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c011"
-					LABEL="LANGE, DER DICKE U. D. SCHARFSICHTIGE">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c011" LABEL="LANGE, DER DICKE U. D. SCHARFSICHTIGE">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -5708,8 +5472,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c012"
-					LABEL="GEISTERBESCHWÖRER">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c012" LABEL="GEISTERBESCHWÖRER">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
@@ -5731,8 +5494,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c013"
-					LABEL="EINER, DER DAS GRUSELN LERNEN WILL">
+				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c013" LABEL="EINER, DER DAS GRUSELN LERNEN WILL">
 					<div ID="L.1.1.11.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -5771,8 +5533,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c015"
-					LABEL="MENSCH IST DA!">
+				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c015" LABEL="MENSCH IST DA!">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -5794,8 +5555,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c016"
-					LABEL="STUDIE ZU DEM BILDE">
+				<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c016" LABEL="STUDIE ZU DEM BILDE">
 					<div ID="L.1.1.14.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00005"/>
@@ -5807,8 +5567,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c017"
-					LABEL="HÖHLE VON STEENFOOL">
+				<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c017" LABEL="HÖHLE VON STEENFOOL">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00001"/>
@@ -5853,8 +5612,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00005"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.17.3" TYPE="Illustration" ORDER="1" DMDID="c020"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.17.3" TYPE="Illustration" ORDER="1" DMDID="c020" LABEL="Untitled Image">
 						<div ID="L.1.1.17.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00002"/>
@@ -5867,36 +5625,24 @@
 								<div ID="L.1.1.17.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.17.5" TYPE="Illustration" ORDER="1" DMDID="c021"
-						LABEL="Slovakisches Kinderspielseug">
+					<div ID="L.1.1.17.5" TYPE="Illustration" ORDER="1" DMDID="c021" LABEL="Slovakisches Kinderspielseug">
 						<div ID="L.1.1.17.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00005"/>
@@ -5918,8 +5664,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17.6" TYPE="Illustration" ORDER="2" DMDID="c022"
-						LABEL="Zierleiste">
+					<div ID="L.1.1.17.6" TYPE="Illustration" ORDER="2" DMDID="c022" LABEL="Zierleiste">
 						<div ID="L.1.1.17.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
@@ -5941,8 +5686,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17.7" TYPE="Illustration" ORDER="3" DMDID="c023"
-						LABEL="Taschenfeitel – Fries">
+					<div ID="L.1.1.17.7" TYPE="Illustration" ORDER="3" DMDID="c023" LABEL="Taschenfeitel – Fries">
 						<div ID="L.1.1.17.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00007"/>
@@ -5986,8 +5730,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17.9" TYPE="Illustration" ORDER="5" DMDID="c025"
-						LABEL="Fragmente aus dem Rahmen der Illustrationen zu Canterburytales">
+					<div ID="L.1.1.17.9" TYPE="Illustration" ORDER="5" DMDID="c025" LABEL="Fragmente aus dem Rahmen der Illustrationen zu Canterburytales">
 						<div ID="L.1.1.17.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00007"/>
@@ -6031,8 +5774,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17.10" TYPE="Illustration" ORDER="6" DMDID="c031"
-						LABEL="Wohnhaus in den Karpathen">
+					<div ID="L.1.1.17.10" TYPE="Illustration" ORDER="6" DMDID="c031" LABEL="Wohnhaus in den Karpathen">
 						<div ID="L.1.1.17.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00005"/>
@@ -6054,8 +5796,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17.11" TYPE="Illustration" ORDER="7" DMDID="c032"
-						LABEL="Wallachisehe St. Nicolaus-Semmel">
+					<div ID="L.1.1.17.11" TYPE="Illustration" ORDER="7" DMDID="c032" LABEL="Wallachisehe St. Nicolaus-Semmel">
 						<div ID="L.1.1.17.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00008"/>
@@ -6077,8 +5818,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17.12" TYPE="Illustration" ORDER="8" DMDID="c033"
-						LABEL="Teufelsmaske">
+					<div ID="L.1.1.17.12" TYPE="Illustration" ORDER="8" DMDID="c033" LABEL="Teufelsmaske">
 						<div ID="L.1.1.17.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00006"/>
@@ -6100,8 +5840,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17.13" TYPE="Illustration" ORDER="9" DMDID="c034"
-						LABEL="Zierleiste">
+					<div ID="L.1.1.17.13" TYPE="Illustration" ORDER="9" DMDID="c034" LABEL="Zierleiste">
 						<div ID="L.1.1.17.13.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00009"/>
@@ -6135,8 +5874,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.18.3" TYPE="TextContent" ORDER="1" DMDID="c036"
-						LABEL="KLEINE SÜNDER">
+					<div ID="L.1.1.18.3" TYPE="TextContent" ORDER="1" DMDID="c036" LABEL="KLEINE SÜNDER">
 						<div ID="L.1.1.18.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"/>
@@ -6146,15 +5884,13 @@
 							<div ID="L.1.1.18.3.2.1" TYPE="BodyContent">
 								<div ID="L.1.1.18.3.2.1.1" TYPE="Text" ORDER="1">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00005"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00005"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.18.4" TYPE="TextContent" ORDER="2" DMDID="c037"
-						LABEL="FRAGEFRITZE UND DIE PLAPPERTASCHE">
+					<div ID="L.1.1.18.4" TYPE="TextContent" ORDER="2" DMDID="c037" LABEL="FRAGEFRITZE UND DIE PLAPPERTASCHE">
 						<div ID="L.1.1.18.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00006"/>
@@ -6165,16 +5901,14 @@
 								<div ID="L.1.1.18.4.2.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.18.4.2.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00007"/>
 										</fptr>
 									</div>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.18.5" TYPE="TextContent" ORDER="3" DMDID="c038"
-						LABEL="TINTENHEINZ UND PLÄTSCHERLOTTCHEN">
+					<div ID="L.1.1.18.5" TYPE="TextContent" ORDER="3" DMDID="c038" LABEL="TINTENHEINZ UND PLÄTSCHERLOTTCHEN">
 						<div ID="L.1.1.18.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00008"/>
@@ -6186,10 +5920,8 @@
 									<div ID="L.1.1.18.5.2.1.1.1" TYPE="Text">
 										<fptr>
 											<seq>
-												<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00009"/>
-												<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00010"/>
+												<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00009"/>
+												<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00010"/>
 											</seq>
 										</fptr>
 									</div>
@@ -6197,8 +5929,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.18.6" TYPE="Illustration" ORDER="4" DMDID="c039"
-						LABEL="Slovak. Kinderspielzeug: Nussknacker">
+					<div ID="L.1.1.18.6" TYPE="Illustration" ORDER="4" DMDID="c039" LABEL="Slovak. Kinderspielzeug: Nussknacker">
 						<div ID="L.1.1.18.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00011"/>
@@ -6220,8 +5951,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18.7" TYPE="Illustration" ORDER="5" DMDID="c040"
-						LABEL="Zwiegespräch">
+					<div ID="L.1.1.18.7" TYPE="Illustration" ORDER="5" DMDID="c040" LABEL="Zwiegespräch">
 						<div ID="L.1.1.18.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00014"/>
@@ -6244,8 +5974,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.19" TYPE="TextContent" ORDER="17" DMDID="c041"
-					LABEL="BEMERKUNGEN ZU DEN REPRODUCTIONEN NACH HANS SCHWAIGERS BILDERN">
+				<div ID="L.1.1.19" TYPE="TextContent" ORDER="17" DMDID="c041" LABEL="BEMERKUNGEN ZU DEN REPRODUCTIONEN NACH HANS SCHWAIGERS BILDERN">
 					<div ID="L.1.1.19.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
@@ -6257,24 +5986,18 @@
 								<div ID="L.1.1.19.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00007"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="1" DMDID="c042"
-						LABEL="Slovak. Kinderspielzeug: Nussknacker">
+					<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="1" DMDID="c042" LABEL="Slovak. Kinderspielzeug: Nussknacker">
 						<div ID="L.1.1.19.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00008"/>
@@ -6303,8 +6026,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.19.4" TYPE="Illustration" ORDER="2" DMDID="c044"
-						LABEL="Schreiballons">
+					<div ID="L.1.1.19.4" TYPE="Illustration" ORDER="2" DMDID="c044" LABEL="Schreiballons">
 						<div ID="L.1.1.19.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00011"/>
@@ -6344,8 +6066,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.21" TYPE="TextContent" ORDER="19" DMDID="c046"
-					LABEL="WAS IST ZEITGEMÄSS?">
+				<div ID="L.1.1.21" TYPE="TextContent" ORDER="19" DMDID="c046" LABEL="WAS IST ZEITGEMÄSS?">
 					<div ID="L.1.1.21.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
@@ -6362,30 +6083,18 @@
 								<div ID="L.1.1.21.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00007"/>
 										</seq>
 									</fptr>
 								</div>
@@ -6406,8 +6115,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.21.4" TYPE="Illustration" ORDER="1" DMDID="c047"
-						LABEL="Schloss Neuhaus in Böhmen">
+					<div ID="L.1.1.21.4" TYPE="Illustration" ORDER="1" DMDID="c047" LABEL="Schloss Neuhaus in Böhmen">
 						<div ID="L.1.1.21.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00005"/>
@@ -6429,8 +6137,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.21.5" TYPE="Illustration" ORDER="2" DMDID="c048"
-						LABEL="STUDIEN AUS KUTTENBERG IN BÖHMEN">
+					<div ID="L.1.1.21.5" TYPE="Illustration" ORDER="2" DMDID="c048" LABEL="STUDIEN AUS KUTTENBERG IN BÖHMEN">
 						<div ID="L.1.1.21.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00004"/>
@@ -6453,8 +6160,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.21.5.4" TYPE="Illustration" ORDER="2" DMDID="c049"
-							LABEL="Untitled Image by HANS SCHWAIGER">
+						<div ID="L.1.1.21.5.4" TYPE="Illustration" ORDER="2" DMDID="c049" LABEL="Untitled Image by HANS SCHWAIGER">
 							<div ID="L.1.1.21.5.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_CB00002"/>
@@ -6462,8 +6168,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.21.6" TYPE="Illustration" ORDER="3" DMDID="c050"
-						LABEL="STUDIEN AUS KUTTENBERG IN BÖHMEN">
+					<div ID="L.1.1.21.6" TYPE="Illustration" ORDER="3" DMDID="c050" LABEL="STUDIEN AUS KUTTENBERG IN BÖHMEN">
 						<div ID="L.1.1.21.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
@@ -6486,8 +6191,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.21.6.4" TYPE="Illustration" ORDER="2" DMDID="c051"
-							LABEL="Untitled Image by H. SCHWAIGER">
+						<div ID="L.1.1.21.6.4" TYPE="Illustration" ORDER="2" DMDID="c051" LABEL="Untitled Image by H. SCHWAIGER">
 							<div ID="L.1.1.21.6.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_CB00002"/>
@@ -6495,8 +6199,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.21.7" TYPE="Illustration" ORDER="4" DMDID="c052"
-						LABEL="Illustration">
+					<div ID="L.1.1.21.7" TYPE="Illustration" ORDER="4" DMDID="c052" LABEL="Illustration">
 						<div ID="L.1.1.21.7.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00009"/>
@@ -6508,8 +6211,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.23" TYPE="TextContent" ORDER="21" DMDID="c054"
-						LABEL="Bleiern liegt Gewitterschwüle">
+					<div ID="L.1.1.23" TYPE="TextContent" ORDER="21" DMDID="c054" LABEL="Bleiern liegt Gewitterschwüle">
 						<div ID="L.1.1.23.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00011"/>
@@ -6520,8 +6222,7 @@
 								<div ID="L.1.1.23.2.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.23.2.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00010"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00010"/>
 										</fptr>
 									</div>
 								</div>
@@ -6551,8 +6252,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.24" TYPE="TextContent" ORDER="22" DMDID="c055"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.24" TYPE="TextContent" ORDER="22" DMDID="c055" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.24.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
@@ -6564,12 +6264,9 @@
 								<div ID="L.1.1.24.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00005"/>
 										</seq>
 									</fptr>
 								</div>
@@ -6588,8 +6285,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.24.4" TYPE="Illustration" ORDER="2" DMDID="c057"
-						LABEL="Heimkehr von der Kirmess">
+					<div ID="L.1.1.24.4" TYPE="Illustration" ORDER="2" DMDID="c057" LABEL="Heimkehr von der Kirmess">
 						<div ID="L.1.1.24.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00007"/>
@@ -6673,8 +6369,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.28" TYPE="Illustration" ORDER="26" DMDID="c061"
-					LABEL="SPIELER UND DER TEUFEL">
+				<div ID="L.1.1.28" TYPE="Illustration" ORDER="26" DMDID="c061" LABEL="SPIELER UND DER TEUFEL">
 					<div ID="L.1.1.28.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00002"/>
@@ -6696,8 +6391,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.29" TYPE="Illustration" ORDER="27" DMDID="c062"
-					LABEL="STREIT UM DEN RICHTIGEN GLAUBEN">
+				<div ID="L.1.1.29" TYPE="Illustration" ORDER="27" DMDID="c062" LABEL="STREIT UM DEN RICHTIGEN GLAUBEN">
 					<div ID="L.1.1.29.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00005"/>
@@ -6741,8 +6435,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.31" TYPE="Illustration" ORDER="29" DMDID="c064"
-					LABEL="ILLUSTRATION ZUR LEGENDE V. BETTELMÖNCH GRAMSALBUS">
+				<div ID="L.1.1.31" TYPE="Illustration" ORDER="29" DMDID="c064" LABEL="ILLUSTRATION ZUR LEGENDE V. BETTELMÖNCH GRAMSALBUS">
 					<div ID="L.1.1.31.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00002"/>
@@ -6767,15 +6460,13 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="GH-135-1" TYPE="TextContent" ORDER="1" DMDID="c065a"
-					LABEL="ILLUSTRATIONEN ZU CHAUCERS CANTERBURYTALES">
+				<div ID="GH-135-1" TYPE="TextContent" ORDER="1" DMDID="c065a" LABEL="ILLUSTRATIONEN ZU CHAUCERS CANTERBURYTALES">
 					<div ID="L.1.1.34.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_TB00002"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.32" TYPE="Illustration" ORDER="30" DMDID="c065"
-						LABEL="EINLEITUNGSBILD ZU CHAUCERS CANTERBURYTALES">
+					<div ID="L.1.1.32" TYPE="Illustration" ORDER="30" DMDID="c065" LABEL="EINLEITUNGSBILD ZU CHAUCERS CANTERBURYTALES">
 						<div ID="L.1.1.32.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00006"/>
@@ -6797,8 +6488,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.33" TYPE="Illustration" ORDER="31" DMDID="c066"
-						LABEL="ILLUSTRATIONEN ZU CHAUCERS CANTERBURYTALES">
+					<div ID="L.1.1.33" TYPE="Illustration" ORDER="31" DMDID="c066" LABEL="ILLUSTRATIONEN ZU CHAUCERS CANTERBURYTALES">
 						<div ID="L.1.1.33.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00002"/>
@@ -6809,8 +6499,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.33.3" TYPE="Illustration" ORDER="1"
-							LABEL="1882. IM BESITZE D. GRÄFIN SIZZO-NORIS, WIEN.">
+						<div ID="L.1.1.33.3" TYPE="Illustration" ORDER="1" LABEL="1882. IM BESITZE D. GRÄFIN SIZZO-NORIS, WIEN.">
 							<div ID="L.1.1.33.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_CB00001"/>
@@ -6823,23 +6512,20 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.33.4" TYPE="Illustration" ORDER="2" DMDID="c067"
-						LABEL="ILLUSTRATIONEN ZU CHAUCERS CANTERBURYTALES">
+					<div ID="L.1.1.33.4" TYPE="Illustration" ORDER="2" DMDID="c067" LABEL="ILLUSTRATIONEN ZU CHAUCERS CANTERBURYTALES">
 						<div ID="L.1.1.33.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.34" TYPE="Illustration" ORDER="32" DMDID="c068"
-						LABEL="ILLUSTRATIONEN ZU CHAUCERS CANTERBURYTALES">
+					<div ID="L.1.1.34" TYPE="Illustration" ORDER="32" DMDID="c068" LABEL="ILLUSTRATIONEN ZU CHAUCERS CANTERBURYTALES">
 						<div ID="L.1.1.34.2" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.34.3" TYPE="Illustration" ORDER="1"
-							LABEL="1882. IM BESITZE D. GRÄFIN SIZZO-NORIS, WIEN.">
+						<div ID="L.1.1.34.3" TYPE="Illustration" ORDER="1" LABEL="1882. IM BESITZE D. GRÄFIN SIZZO-NORIS, WIEN.">
 							<div ID="L.1.1.34.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_CB00001"/>
@@ -6852,8 +6538,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.34.4" TYPE="Illustration" ORDER="2" DMDID="c069"
-						LABEL="ILLUSTRATIONEN ZU CHAUCERS CANTERBURYTALES">
+					<div ID="L.1.1.34.4" TYPE="Illustration" ORDER="2" DMDID="c069" LABEL="ILLUSTRATIONEN ZU CHAUCERS CANTERBURYTALES">
 						<div ID="L.1.1.34.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_CB00002"/>
@@ -6861,8 +6546,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.35" TYPE="Illustration" ORDER="33" DMDID="c070"
-					LABEL="SCHMUGGLER UND DAS GALGENMÄNNLEIN">
+				<div ID="L.1.1.35" TYPE="Illustration" ORDER="33" DMDID="c070" LABEL="SCHMUGGLER UND DAS GALGENMÄNNLEIN">
 					<div ID="L.1.1.35.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00034" BEGIN="P34_TB00002"/>
@@ -6884,8 +6568,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.36" TYPE="Illustration" ORDER="34" DMDID="c071"
-					LABEL="GALGENWURZZIEHEN">
+				<div ID="L.1.1.36" TYPE="Illustration" ORDER="34" DMDID="c071" LABEL="GALGENWURZZIEHEN">
 					<div ID="L.1.1.36.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00034" BEGIN="P34_TB00005"/>
@@ -6929,8 +6612,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.38" TYPE="Illustration" ORDER="36" DMDID="c073"
-					LABEL="KINDER VOR DER HÖHLE RÜBEZAHLS">
+				<div ID="L.1.1.38" TYPE="Illustration" ORDER="36" DMDID="c073" LABEL="KINDER VOR DER HÖHLE RÜBEZAHLS">
 					<div ID="L.1.1.38.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00035" BEGIN="P35_TB00005"/>
@@ -6952,8 +6634,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.39" TYPE="Illustration" ORDER="37" DMDID="c074"
-					LABEL="AUS EINEM RATTENFÄNGER-ALBUM">
+				<div ID="L.1.1.39" TYPE="Illustration" ORDER="37" DMDID="c074" LABEL="AUS EINEM RATTENFÄNGER-ALBUM">
 					<div ID="L.1.1.39.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00002"/>
@@ -6964,8 +6645,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00003"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.39.3" TYPE="Illustration" ORDER="1"
-						LABEL="1882. BESITZER: S. EXC. GRAF HANS WILCZEK.">
+					<div ID="L.1.1.39.3" TYPE="Illustration" ORDER="1" LABEL="1882. BESITZER: S. EXC. GRAF HANS WILCZEK.">
 						<div ID="L.1.1.39.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_CB00001"/>
@@ -6977,8 +6657,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.39.4" TYPE="Illustration" ORDER="2" DMDID="c075"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.39.4" TYPE="Illustration" ORDER="2" DMDID="c075" LABEL="Untitled Image">
 						<div ID="L.1.1.39.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_CB00002"/>
@@ -7003,8 +6682,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.41" TYPE="Illustration" ORDER="39" DMDID="c077"
-					LABEL="STEINERNES THÜRFUTTER VON EINEM BADERHAUSE A. D. J. 1556 ZU NEUHAUS IN BÖHMEN">
+				<div ID="L.1.1.41" TYPE="Illustration" ORDER="39" DMDID="c077" LABEL="STEINERNES THÜRFUTTER VON EINEM BADERHAUSE A. D. J. 1556 ZU NEUHAUS IN BÖHMEN">
 					<div ID="L.1.1.41.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00037" BEGIN="P37_TB00004"/>
@@ -7026,8 +6704,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.42" TYPE="Illustration" ORDER="40" DMDID="c078"
-					LABEL="AUS E. RATTENFÄNGER-ALBUM">
+				<div ID="L.1.1.42" TYPE="Illustration" ORDER="40" DMDID="c078" LABEL="AUS E. RATTENFÄNGER-ALBUM">
 					<div ID="L.1.1.42.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00037" BEGIN="P37_TB00007"/>
@@ -7049,8 +6726,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.43" TYPE="Illustration" ORDER="41" DMDID="c079"
-					LABEL="AUS EINEM RATTENFÄNGER-ALBUM">
+				<div ID="L.1.1.43" TYPE="Illustration" ORDER="41" DMDID="c079" LABEL="AUS EINEM RATTENFÄNGER-ALBUM">
 					<div ID="L.1.1.43.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_TB00002"/>
@@ -7072,8 +6748,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.44" TYPE="Illustration" ORDER="42" DMDID="c080"
-					LABEL="PORTRATSKIZZE VON HANS SCHWAIGER">
+				<div ID="L.1.1.44" TYPE="Illustration" ORDER="42" DMDID="c080" LABEL="PORTRATSKIZZE VON HANS SCHWAIGER">
 					<div ID="L.1.1.44.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_TB00005"/>
@@ -7091,8 +6766,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.44.3" TYPE="Illustration" ORDER="2" DMDID="c081"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.44.3" TYPE="Illustration" ORDER="2" DMDID="c081" LABEL="Untitled Image">
 						<div ID="L.1.1.44.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_CB00003"/>

--- a/metadata/periodicals/bmtnabf/issues/1898/09_01/bmtnabf_1898-09_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1898/09_01/bmtnabf_1898-09_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-09_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-09_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-09_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1898-09_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-09_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3510,390 +3504,204 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:22:35"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="b60d87d4359202bc6d0469aa1eaa6e81258376d4"
-				CHECKSUMTYPE="SHA-1" SIZE="6253182">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:22:35" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="b60d87d4359202bc6d0469aa1eaa6e81258376d4" CHECKSUMTYPE="SHA-1" SIZE="6253182">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:23:07"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="bc88174eeafcc3c11ac1e6d1526eedf1b043d14d"
-				CHECKSUMTYPE="SHA-1" SIZE="6241626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:23:07" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="bc88174eeafcc3c11ac1e6d1526eedf1b043d14d" CHECKSUMTYPE="SHA-1" SIZE="6241626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:23:39"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="4012443aa081741b593884cd2d4994b89412107f"
-				CHECKSUMTYPE="SHA-1" SIZE="6203829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:23:39" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="4012443aa081741b593884cd2d4994b89412107f" CHECKSUMTYPE="SHA-1" SIZE="6203829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:24:10"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="d96be9f0b0b611e5e92928d968cb0fdd8b72d249"
-				CHECKSUMTYPE="SHA-1" SIZE="6241610">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:24:10" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="d96be9f0b0b611e5e92928d968cb0fdd8b72d249" CHECKSUMTYPE="SHA-1" SIZE="6241610">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:24:42"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="b5c7551ef5bb788f6d6ec1ae061957786d6d1afe"
-				CHECKSUMTYPE="SHA-1" SIZE="6265016">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:24:42" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="b5c7551ef5bb788f6d6ec1ae061957786d6d1afe" CHECKSUMTYPE="SHA-1" SIZE="6265016">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:25:14"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="afb8ba6618b5152d7e8f3854f84bad952a155aa9"
-				CHECKSUMTYPE="SHA-1" SIZE="6241604">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:25:14" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="afb8ba6618b5152d7e8f3854f84bad952a155aa9" CHECKSUMTYPE="SHA-1" SIZE="6241604">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:25:46"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="941a4b938d6be192ddce7660df6b7910261385e6"
-				CHECKSUMTYPE="SHA-1" SIZE="6242510">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:25:46" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="941a4b938d6be192ddce7660df6b7910261385e6" CHECKSUMTYPE="SHA-1" SIZE="6242510">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:26:18"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="ac5231fe70ec4c7c46bf8a3e8183076c427d9004"
-				CHECKSUMTYPE="SHA-1" SIZE="6279407">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:26:18" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="ac5231fe70ec4c7c46bf8a3e8183076c427d9004" CHECKSUMTYPE="SHA-1" SIZE="6279407">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:26:48"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f5fe46427eb848763d307ea2185b69e10072ca77"
-				CHECKSUMTYPE="SHA-1" SIZE="6166926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:26:48" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f5fe46427eb848763d307ea2185b69e10072ca77" CHECKSUMTYPE="SHA-1" SIZE="6166926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:27:18"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="3f49f10aee0c7ab34ec25aae2907b63bb8cf32d1"
-				CHECKSUMTYPE="SHA-1" SIZE="6239817">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:27:18" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="3f49f10aee0c7ab34ec25aae2907b63bb8cf32d1" CHECKSUMTYPE="SHA-1" SIZE="6239817">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:27:55"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="20d3ee133ecbd1fa957ee38f8c0efdb2ce77d76f"
-				CHECKSUMTYPE="SHA-1" SIZE="6210122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:27:55" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="20d3ee133ecbd1fa957ee38f8c0efdb2ce77d76f" CHECKSUMTYPE="SHA-1" SIZE="6210122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:28:28"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="c34ddb8564bb1fedba7d145cd8773f1c5a8f41e9"
-				CHECKSUMTYPE="SHA-1" SIZE="6226320">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:28:28" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="c34ddb8564bb1fedba7d145cd8773f1c5a8f41e9" CHECKSUMTYPE="SHA-1" SIZE="6226320">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:29:01"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="2bc3cc1268bec28f52f548118c5da43679f0d428"
-				CHECKSUMTYPE="SHA-1" SIZE="6229924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:29:01" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="2bc3cc1268bec28f52f548118c5da43679f0d428" CHECKSUMTYPE="SHA-1" SIZE="6229924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:29:34"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="02aa375698f95c8e394f6b1b27ddf616e0cc8173"
-				CHECKSUMTYPE="SHA-1" SIZE="6193025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:29:34" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="02aa375698f95c8e394f6b1b27ddf616e0cc8173" CHECKSUMTYPE="SHA-1" SIZE="6193025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:30:08"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="31d87534ff91a13f3bae5acbc894de8c1fd27b12"
-				CHECKSUMTYPE="SHA-1" SIZE="6213722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:30:08" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="31d87534ff91a13f3bae5acbc894de8c1fd27b12" CHECKSUMTYPE="SHA-1" SIZE="6213722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:30:39"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d4dcbf9a042b07474fdf036e1a90ba4b6599c68d"
-				CHECKSUMTYPE="SHA-1" SIZE="6253305">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:30:39" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d4dcbf9a042b07474fdf036e1a90ba4b6599c68d" CHECKSUMTYPE="SHA-1" SIZE="6253305">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:31:12"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7d67f0e30c4f214579ef0a9a67a8695e23260596"
-				CHECKSUMTYPE="SHA-1" SIZE="6208325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:31:12" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7d67f0e30c4f214579ef0a9a67a8695e23260596" CHECKSUMTYPE="SHA-1" SIZE="6208325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:31:45"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="3844d11812ff3b8ec56a3f72fff3125da5120c05"
-				CHECKSUMTYPE="SHA-1" SIZE="6265926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:31:45" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="3844d11812ff3b8ec56a3f72fff3125da5120c05" CHECKSUMTYPE="SHA-1" SIZE="6265926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:32:18"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="e6f5bf673c818572084a8071e32545277bdc3371"
-				CHECKSUMTYPE="SHA-1" SIZE="6174110">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:32:18" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="e6f5bf673c818572084a8071e32545277bdc3371" CHECKSUMTYPE="SHA-1" SIZE="6174110">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:32:50"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="6141833e6c1449737fffa502f4c335359e39bae8"
-				CHECKSUMTYPE="SHA-1" SIZE="6250625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:32:50" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="6141833e6c1449737fffa502f4c335359e39bae8" CHECKSUMTYPE="SHA-1" SIZE="6250625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:33:23"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="0f2b7ee3d6b340b58181b6d0af5d4340a293ed09"
-				CHECKSUMTYPE="SHA-1" SIZE="6159722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:33:23" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="0f2b7ee3d6b340b58181b6d0af5d4340a293ed09" CHECKSUMTYPE="SHA-1" SIZE="6159722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:33:56"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="cb19ce6a4b5b1d8084c465ee3c3d0849e865538f"
-				CHECKSUMTYPE="SHA-1" SIZE="6255111">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:33:56" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="cb19ce6a4b5b1d8084c465ee3c3d0849e865538f" CHECKSUMTYPE="SHA-1" SIZE="6255111">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:34:29"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="36adc48317b57eb60ee6647bc9716e46c2e4da9b"
-				CHECKSUMTYPE="SHA-1" SIZE="6175027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:34:29" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="36adc48317b57eb60ee6647bc9716e46c2e4da9b" CHECKSUMTYPE="SHA-1" SIZE="6175027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:35:02"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f6faee0d4d88957cb9b8dba46cf912d31d6356e5"
-				CHECKSUMTYPE="SHA-1" SIZE="6228090">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:35:02" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f6faee0d4d88957cb9b8dba46cf912d31d6356e5" CHECKSUMTYPE="SHA-1" SIZE="6228090">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:35:33"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="29e170c95fbbc18dcf5b04d5878990cd62589e29"
-				CHECKSUMTYPE="SHA-1" SIZE="6174089">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:35:33" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="29e170c95fbbc18dcf5b04d5878990cd62589e29" CHECKSUMTYPE="SHA-1" SIZE="6174089">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:36:06"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="114ea32b4b98f3f654ae7f73539dabc208329234"
-				CHECKSUMTYPE="SHA-1" SIZE="6270404">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:36:06" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="114ea32b4b98f3f654ae7f73539dabc208329234" CHECKSUMTYPE="SHA-1" SIZE="6270404">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:36:37"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="37baa178aa6dfcf7c34bfbae85dcaa181bd61a32"
-				CHECKSUMTYPE="SHA-1" SIZE="6174996">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:36:37" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="37baa178aa6dfcf7c34bfbae85dcaa181bd61a32" CHECKSUMTYPE="SHA-1" SIZE="6174996">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:37:10"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="b6defae00b299e15724b2414d24f7da6cfb6d9aa"
-				CHECKSUMTYPE="SHA-1" SIZE="6272206">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:37:10" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="b6defae00b299e15724b2414d24f7da6cfb6d9aa" CHECKSUMTYPE="SHA-1" SIZE="6272206">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:37:42"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="da7e4daa0be3774bb514eddb57d9aba62eedcbea"
-				CHECKSUMTYPE="SHA-1" SIZE="6166918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:37:42" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="da7e4daa0be3774bb514eddb57d9aba62eedcbea" CHECKSUMTYPE="SHA-1" SIZE="6166918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:38:16"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="8c8ff225a418f0df57faf233155d6a8546aabcb4"
-				CHECKSUMTYPE="SHA-1" SIZE="6246110">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:38:16" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="8c8ff225a418f0df57faf233155d6a8546aabcb4" CHECKSUMTYPE="SHA-1" SIZE="6246110">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:38:47"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="8187c34599ec05e0f06d4b54d3d8e58976b7fd2f"
-				CHECKSUMTYPE="SHA-1" SIZE="6166927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:38:47" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="8187c34599ec05e0f06d4b54d3d8e58976b7fd2f" CHECKSUMTYPE="SHA-1" SIZE="6166927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:39:19"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="887603ca71f5d9d5c714f778d977a718dab9275b"
-				CHECKSUMTYPE="SHA-1" SIZE="6246106">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:39:19" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="887603ca71f5d9d5c714f778d977a718dab9275b" CHECKSUMTYPE="SHA-1" SIZE="6246106">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/delivery/bmtnabf_1898-09_01_0032.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:39:38" MIMETYPE="text/xml"
-				CHECKSUM="1fef594c9e5b27ffb4086940acd525e99069e29d" CHECKSUMTYPE="SHA-1"
-				SIZE="20944">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:39:38" MIMETYPE="text/xml" CHECKSUM="1fef594c9e5b27ffb4086940acd525e99069e29d" CHECKSUMTYPE="SHA-1" SIZE="20944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:39:39" MIMETYPE="text/xml"
-				CHECKSUM="73a85654cf40bbd244021f33a3b5f76e31cb94cc" CHECKSUMTYPE="SHA-1"
-				SIZE="101691">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:39:39" MIMETYPE="text/xml" CHECKSUM="73a85654cf40bbd244021f33a3b5f76e31cb94cc" CHECKSUMTYPE="SHA-1" SIZE="101691">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:39:39" MIMETYPE="text/xml"
-				CHECKSUM="32bd168d54403c0376ab1cf23c6d14d0452fb422" CHECKSUMTYPE="SHA-1" SIZE="6011">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:39:39" MIMETYPE="text/xml" CHECKSUM="32bd168d54403c0376ab1cf23c6d14d0452fb422" CHECKSUMTYPE="SHA-1" SIZE="6011">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:39:39" MIMETYPE="text/xml"
-				CHECKSUM="3f90103348e0ec14168837c54d06cb92eb962a4c" CHECKSUMTYPE="SHA-1"
-				SIZE="26460">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:39:39" MIMETYPE="text/xml" CHECKSUM="3f90103348e0ec14168837c54d06cb92eb962a4c" CHECKSUMTYPE="SHA-1" SIZE="26460">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:39:39" MIMETYPE="text/xml"
-				CHECKSUM="859a4d9ab1d09a7baeaa0980fa56bb8e5ff5271f" CHECKSUMTYPE="SHA-1"
-				SIZE="100708">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:39:39" MIMETYPE="text/xml" CHECKSUM="859a4d9ab1d09a7baeaa0980fa56bb8e5ff5271f" CHECKSUMTYPE="SHA-1" SIZE="100708">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:39:40" MIMETYPE="text/xml"
-				CHECKSUM="3fc03a956b8849e4ecc5e134df7f70f3f9bfe0df" CHECKSUMTYPE="SHA-1"
-				SIZE="51965">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:39:40" MIMETYPE="text/xml" CHECKSUM="3fc03a956b8849e4ecc5e134df7f70f3f9bfe0df" CHECKSUMTYPE="SHA-1" SIZE="51965">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:39:40" MIMETYPE="text/xml"
-				CHECKSUM="7f51f2dd62c07562c1ce901db89b4460cd90475b" CHECKSUMTYPE="SHA-1"
-				SIZE="48342">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:39:40" MIMETYPE="text/xml" CHECKSUM="7f51f2dd62c07562c1ce901db89b4460cd90475b" CHECKSUMTYPE="SHA-1" SIZE="48342">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:39:40" MIMETYPE="text/xml"
-				CHECKSUM="0116b27b47ef349bed2c619bb70acd701dbf0d00" CHECKSUMTYPE="SHA-1"
-				SIZE="47692">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:39:40" MIMETYPE="text/xml" CHECKSUM="0116b27b47ef349bed2c619bb70acd701dbf0d00" CHECKSUMTYPE="SHA-1" SIZE="47692">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:39:40" MIMETYPE="text/xml"
-				CHECKSUM="2353543ba3e1a46f03fbb837771a26bb3907ff44" CHECKSUMTYPE="SHA-1" SIZE="8157">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:39:40" MIMETYPE="text/xml" CHECKSUM="2353543ba3e1a46f03fbb837771a26bb3907ff44" CHECKSUMTYPE="SHA-1" SIZE="8157">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:39:41" MIMETYPE="text/xml"
-				CHECKSUM="0b6b0d010a26567dc7dd1f43de9ea0358a903114" CHECKSUMTYPE="SHA-1" SIZE="8094">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:39:41" MIMETYPE="text/xml" CHECKSUM="0b6b0d010a26567dc7dd1f43de9ea0358a903114" CHECKSUMTYPE="SHA-1" SIZE="8094">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:39:41" MIMETYPE="text/xml"
-				CHECKSUM="637f4d216a704712a4c6c6927944d2aba092d1eb" CHECKSUMTYPE="SHA-1"
-				SIZE="106011">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:39:41" MIMETYPE="text/xml" CHECKSUM="637f4d216a704712a4c6c6927944d2aba092d1eb" CHECKSUMTYPE="SHA-1" SIZE="106011">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:39:41" MIMETYPE="text/xml"
-				CHECKSUM="13962179dc43685c727f4f61ae837a289416162d" CHECKSUMTYPE="SHA-1"
-				SIZE="160290">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:39:41" MIMETYPE="text/xml" CHECKSUM="13962179dc43685c727f4f61ae837a289416162d" CHECKSUMTYPE="SHA-1" SIZE="160290">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:39:42" MIMETYPE="text/xml"
-				CHECKSUM="683e4c50e35c4bf7d9603fb77a510a71693376eb" CHECKSUMTYPE="SHA-1" SIZE="6529">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:39:42" MIMETYPE="text/xml" CHECKSUM="683e4c50e35c4bf7d9603fb77a510a71693376eb" CHECKSUMTYPE="SHA-1" SIZE="6529">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:39:42" MIMETYPE="text/xml"
-				CHECKSUM="44e592c448c19bf9818449c5ee1f3ac59a9284da" CHECKSUMTYPE="SHA-1" SIZE="6318">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:39:42" MIMETYPE="text/xml" CHECKSUM="44e592c448c19bf9818449c5ee1f3ac59a9284da" CHECKSUMTYPE="SHA-1" SIZE="6318">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:39:42" MIMETYPE="text/xml"
-				CHECKSUM="86852557dc99b2a1b9994b4382865a99ca0ebffd" CHECKSUMTYPE="SHA-1" SIZE="6268">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:39:42" MIMETYPE="text/xml" CHECKSUM="86852557dc99b2a1b9994b4382865a99ca0ebffd" CHECKSUMTYPE="SHA-1" SIZE="6268">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:39:42" MIMETYPE="text/xml"
-				CHECKSUM="ea3ab621a191368475ed806b7a9ba521aaa092b2" CHECKSUMTYPE="SHA-1" SIZE="4854">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:39:42" MIMETYPE="text/xml" CHECKSUM="ea3ab621a191368475ed806b7a9ba521aaa092b2" CHECKSUMTYPE="SHA-1" SIZE="4854">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:39:42" MIMETYPE="text/xml"
-				CHECKSUM="35542f27f3df7ae5528795ee043cd403ea1c9e17" CHECKSUMTYPE="SHA-1"
-				SIZE="57599">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:39:42" MIMETYPE="text/xml" CHECKSUM="35542f27f3df7ae5528795ee043cd403ea1c9e17" CHECKSUMTYPE="SHA-1" SIZE="57599">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:39:43" MIMETYPE="text/xml"
-				CHECKSUM="ca3f7e88a26de7e48b9339be0adebd0aa252ae1d" CHECKSUMTYPE="SHA-1"
-				SIZE="120477">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:39:43" MIMETYPE="text/xml" CHECKSUM="ca3f7e88a26de7e48b9339be0adebd0aa252ae1d" CHECKSUMTYPE="SHA-1" SIZE="120477">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:39:43" MIMETYPE="text/xml"
-				CHECKSUM="fd00fccf64045bf07c197a5f08364f1f48df2410" CHECKSUMTYPE="SHA-1"
-				SIZE="114111">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:39:43" MIMETYPE="text/xml" CHECKSUM="fd00fccf64045bf07c197a5f08364f1f48df2410" CHECKSUMTYPE="SHA-1" SIZE="114111">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:39:43" MIMETYPE="text/xml"
-				CHECKSUM="670780cb999d1db97b192bd7e9f1b4dd9488cb17" CHECKSUMTYPE="SHA-1" SIZE="7044">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:39:43" MIMETYPE="text/xml" CHECKSUM="670780cb999d1db97b192bd7e9f1b4dd9488cb17" CHECKSUMTYPE="SHA-1" SIZE="7044">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:39:44" MIMETYPE="text/xml"
-				CHECKSUM="c14c88ecc92b1c0b8da69c15b5b8dee9816eeb62" CHECKSUMTYPE="SHA-1"
-				SIZE="50991">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:39:44" MIMETYPE="text/xml" CHECKSUM="c14c88ecc92b1c0b8da69c15b5b8dee9816eeb62" CHECKSUMTYPE="SHA-1" SIZE="50991">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:39:44" MIMETYPE="text/xml"
-				CHECKSUM="cb4b768dc4fd8b358a6ab7d5eb4312d49c62ac9d" CHECKSUMTYPE="SHA-1"
-				SIZE="100939">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:39:44" MIMETYPE="text/xml" CHECKSUM="cb4b768dc4fd8b358a6ab7d5eb4312d49c62ac9d" CHECKSUMTYPE="SHA-1" SIZE="100939">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:39:44" MIMETYPE="text/xml"
-				CHECKSUM="02ad6f30b7ad60142b0d3800f179609e619422eb" CHECKSUMTYPE="SHA-1"
-				SIZE="102424">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:39:44" MIMETYPE="text/xml" CHECKSUM="02ad6f30b7ad60142b0d3800f179609e619422eb" CHECKSUMTYPE="SHA-1" SIZE="102424">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:39:44" MIMETYPE="text/xml"
-				CHECKSUM="b125253b9e5f1288a5576d77733903853ba1e3e3" CHECKSUMTYPE="SHA-1"
-				SIZE="117566">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:39:44" MIMETYPE="text/xml" CHECKSUM="b125253b9e5f1288a5576d77733903853ba1e3e3" CHECKSUMTYPE="SHA-1" SIZE="117566">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:39:45" MIMETYPE="text/xml"
-				CHECKSUM="e3e725746bae7019538f1d6aab236a40934e91ec" CHECKSUMTYPE="SHA-1"
-				SIZE="13500">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:39:45" MIMETYPE="text/xml" CHECKSUM="e3e725746bae7019538f1d6aab236a40934e91ec" CHECKSUMTYPE="SHA-1" SIZE="13500">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:39:45" MIMETYPE="text/xml"
-				CHECKSUM="ad2b803ed4351bf09d7ce776bfc71014b2e7ff61" CHECKSUMTYPE="SHA-1"
-				SIZE="115942">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:39:45" MIMETYPE="text/xml" CHECKSUM="ad2b803ed4351bf09d7ce776bfc71014b2e7ff61" CHECKSUMTYPE="SHA-1" SIZE="115942">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:39:46" MIMETYPE="text/xml"
-				CHECKSUM="aa222ce702bf3d5fa7631c149afc7c0e7b48f410" CHECKSUMTYPE="SHA-1"
-				SIZE="113199">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:39:46" MIMETYPE="text/xml" CHECKSUM="aa222ce702bf3d5fa7631c149afc7c0e7b48f410" CHECKSUMTYPE="SHA-1" SIZE="113199">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:39:46" MIMETYPE="text/xml"
-				CHECKSUM="981d7ad4c3de4295dda5f8f426f6f745f428cd48" CHECKSUMTYPE="SHA-1"
-				SIZE="126417">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:39:46" MIMETYPE="text/xml" CHECKSUM="981d7ad4c3de4295dda5f8f426f6f745f428cd48" CHECKSUMTYPE="SHA-1" SIZE="126417">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:39:47" MIMETYPE="text/xml"
-				CHECKSUM="f5cb57faa236654849508cf79c5655aab359d863" CHECKSUMTYPE="SHA-1" SIZE="5269">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:39:47" MIMETYPE="text/xml" CHECKSUM="f5cb57faa236654849508cf79c5655aab359d863" CHECKSUMTYPE="SHA-1" SIZE="5269">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:39:47" MIMETYPE="text/xml"
-				CHECKSUM="72a26f2306479a64b3c13c55461a3f14cbf7569f" CHECKSUMTYPE="SHA-1"
-				SIZE="88314">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:39:47" MIMETYPE="text/xml" CHECKSUM="72a26f2306479a64b3c13c55461a3f14cbf7569f" CHECKSUMTYPE="SHA-1" SIZE="88314">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:39:48" MIMETYPE="text/xml"
-				CHECKSUM="6907330a1ad0880c28faab3ee6745e796073c1ac" CHECKSUMTYPE="SHA-1"
-				SIZE="58811">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:39:48" MIMETYPE="text/xml" CHECKSUM="6907330a1ad0880c28faab3ee6745e796073c1ac" CHECKSUMTYPE="SHA-1" SIZE="58811">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:39:48" MIMETYPE="text/xml"
-				CHECKSUM="60c444f9cf4eebdf50668c92e35311f914922cb0" CHECKSUMTYPE="SHA-1" SIZE="2401">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:39:48" MIMETYPE="text/xml" CHECKSUM="60c444f9cf4eebdf50668c92e35311f914922cb0" CHECKSUMTYPE="SHA-1" SIZE="2401">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-09_01_0032.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:40:40" MIMETYPE="application/pdf"
-				CHECKSUM="4043163b2573f626d07fb926428b34976ef88f1d" CHECKSUMTYPE="SHA-1"
-				SIZE="12002217">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/bmtnabf_1898-09_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:40:40" MIMETYPE="application/pdf" CHECKSUM="4043163b2573f626d07fb926428b34976ef88f1d" CHECKSUMTYPE="SHA-1" SIZE="12002217">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/09_01/bmtnabf_1898-09_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -4349,8 +4157,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="TextContent" ORDER="2" DMDID="c004"
-					LABEL="INHALTSVERZEICHNIS">
+				<div ID="L.1.1.4" TYPE="TextContent" ORDER="2" DMDID="c004" LABEL="INHALTSVERZEICHNIS">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00002" BEGIN="P2_TB00001"/>
@@ -4374,8 +4181,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_CB00002"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="1" DMDID="c007"
-						LABEL="LIEDV. L. STÖHR">
+					<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="1" DMDID="c007" LABEL="LIEDV. L. STÖHR">
 						<div ID="L.1.1.5.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00004"/>
@@ -4417,8 +4223,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="2" DMDID="c008"
-						LABEL="ZIERLEISTE">
+					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="2" DMDID="c008" LABEL="ZIERLEISTE">
 						<div ID="L.1.1.5.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00005"/>
@@ -4435,8 +4240,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="3" DMDID="c009"
-						LABEL="VIERTHEILIGER PARAVENT">
+					<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="3" DMDID="c009" LABEL="VIERTHEILIGER PARAVENT">
 						<div ID="L.1.1.5.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00007"/>
@@ -4466,8 +4270,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c011"
-					LABEL="KÜNSTLER-LITHOGRAPHIEN">
+				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c011" LABEL="KÜNSTLER-LITHOGRAPHIEN">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00003"/>
@@ -4498,14 +4301,10 @@
 								<div ID="L.1.1.6.3.1.3.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00006"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4514,14 +4313,10 @@
 								<div ID="L.1.1.6.3.1.4.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00005"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4530,14 +4325,10 @@
 								<div ID="L.1.1.6.3.1.5.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00006"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4546,14 +4337,10 @@
 								<div ID="L.1.1.6.3.1.6.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00006"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4562,18 +4349,15 @@
 								<div ID="L.1.1.6.3.1.7.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c012"
-						LABEL="Studie für d. Holzeinlegearbeit zum Paravent">
+					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c012" LABEL="Studie für d. Holzeinlegearbeit zum Paravent">
 						<div ID="L.1.1.6.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00007"/>
@@ -4590,8 +4374,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="2" DMDID="c013"
-						LABEL="Studie für die Schnitzarbeit in den unteren Feldern des Paravents">
+					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="2" DMDID="c013" LABEL="Studie für die Schnitzarbeit in den unteren Feldern des Paravents">
 						<div ID="L.1.1.6.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00007"/>
@@ -4608,8 +4391,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.6" TYPE="Illustration" ORDER="3" DMDID="c014"
-						LABEL="Studie für die Schnitzarbeit in den unteren Feldern des Paravents">
+					<div ID="L.1.1.6.6" TYPE="Illustration" ORDER="3" DMDID="c014" LABEL="Studie für die Schnitzarbeit in den unteren Feldern des Paravents">
 						<div ID="L.1.1.6.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00006"/>
@@ -4626,8 +4408,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.7" TYPE="Illustration" ORDER="4" DMDID="c015"
-						LABEL="Studie für die Schnitzarbeit in den unteren Feldern des Paravents">
+					<div ID="L.1.1.6.7" TYPE="Illustration" ORDER="4" DMDID="c015" LABEL="Studie für die Schnitzarbeit in den unteren Feldern des Paravents">
 						<div ID="L.1.1.6.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00007"/>
@@ -4644,8 +4425,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c018"
-						LABEL="HOLZEINLEGEARBEIT V. ERSTEN FELDE DES PARAVENTS">
+					<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c018" LABEL="HOLZEINLEGEARBEIT V. ERSTEN FELDE DES PARAVENTS">
 						<div ID="L.1.1.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
@@ -4662,8 +4442,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c019"
-						LABEL="HOLZEINLEGEARBEIT V. VIERTEN FELDE DES PARAVENTS">
+					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c019" LABEL="HOLZEINLEGEARBEIT V. VIERTEN FELDE DES PARAVENTS">
 						<div ID="L.1.1.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00005"/>
@@ -4680,8 +4459,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c020"
-						LABEL="SCHNITZARBEIT V. ERSTEN FELDE D. PARAVENTS">
+					<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c020" LABEL="SCHNITZARBEIT V. ERSTEN FELDE D. PARAVENTS">
 						<div ID="L.1.1.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -4698,8 +4476,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c021"
-						LABEL="SCHNITZARBEIT V. ZWEITEN FELDE D. PARAVENTS">
+					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c021" LABEL="SCHNITZARBEIT V. ZWEITEN FELDE D. PARAVENTS">
 						<div ID="L.1.1.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00004"/>
@@ -4716,8 +4493,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.8" TYPE="Illustration" ORDER="5" DMDID="c016"
-						LABEL="Studie für d. Holzeinlegearbeit zum Paravent">
+					<div ID="L.1.1.6.8" TYPE="Illustration" ORDER="5" DMDID="c016" LABEL="Studie für d. Holzeinlegearbeit zum Paravent">
 						<div ID="L.1.1.6.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00007"/>
@@ -4734,8 +4510,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.9" TYPE="Illustration" ORDER="6" DMDID="c017"
-						LABEL="Selbstgenügsamkeit">
+					<div ID="L.1.1.6.9" TYPE="Illustration" ORDER="6" DMDID="c017" LABEL="Selbstgenügsamkeit">
 						<div ID="L.1.1.6.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00004"/>
@@ -4877,8 +4652,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.18" TYPE="TextContent" ORDER="16" DMDID="c030"
-					LABEL="ÜBER MODERNE POESIE UND MALEREI">
+				<div ID="L.1.1.18" TYPE="TextContent" ORDER="16" DMDID="c030" LABEL="ÜBER MODERNE POESIE UND MALEREI">
 					<div ID="L.1.1.18.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
@@ -4894,47 +4668,41 @@
 							<div ID="L.1.1.18.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.18.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.18.3.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.18.3.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.18.3.1.3" TYPE="Paragraph" ORDER="3">
 								<div ID="L.1.1.18.3.1.3.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.18.3.1.4" TYPE="Paragraph" ORDER="4">
 								<div ID="L.1.1.18.3.1.4.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.18.3.1.5" TYPE="Paragraph" ORDER="5">
 								<div ID="L.1.1.18.3.1.5.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.18.4" TYPE="Illustration" ORDER="1" DMDID="c031"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.18.4" TYPE="Illustration" ORDER="1" DMDID="c031" LABEL="Buchschmuck">
 						<div ID="L.1.1.18.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00005"/>
@@ -4951,8 +4719,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18.5" TYPE="Illustration" ORDER="2" DMDID="c032"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.18.5" TYPE="Illustration" ORDER="2" DMDID="c032" LABEL="Buchschmuck">
 						<div ID="L.1.1.18.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00007"/>
@@ -4969,8 +4736,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18.6" TYPE="Illustration" ORDER="3" DMDID="c033"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.18.6" TYPE="Illustration" ORDER="3" DMDID="c033" LABEL="Buchschmuck">
 						<div ID="L.1.1.18.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00005"/>
@@ -4994,8 +4760,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18.7" TYPE="Illustration" ORDER="4" DMDID="c035"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.18.7" TYPE="Illustration" ORDER="4" DMDID="c035" LABEL="Buchschmuck">
 						<div ID="L.1.1.18.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00007"/>
@@ -5012,8 +4777,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18.8" TYPE="Illustration" ORDER="5" DMDID="c036"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.18.8" TYPE="Illustration" ORDER="5" DMDID="c036" LABEL="Buchschmuck">
 						<div ID="L.1.1.18.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00006"/>
@@ -5037,8 +4801,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18.9" TYPE="Illustration" ORDER="6" DMDID="c038"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.18.9" TYPE="Illustration" ORDER="6" DMDID="c038" LABEL="Buchschmuck">
 						<div ID="L.1.1.18.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00008"/>
@@ -5126,28 +4889,20 @@
 								<div ID="L.1.1.21.5.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.21.6" TYPE="Illustration" ORDER="1" DMDID="c044"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.21.6" TYPE="Illustration" ORDER="1" DMDID="c044" LABEL="Buchschmuck">
 						<div ID="L.1.1.21.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00005"/>
@@ -5164,8 +4919,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.21.7" TYPE="Illustration" ORDER="2" DMDID="c045"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.21.7" TYPE="Illustration" ORDER="2" DMDID="c045" LABEL="Buchschmuck">
 						<div ID="L.1.1.21.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00005"/>
@@ -5189,8 +4943,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.21.8" TYPE="Illustration" ORDER="3" DMDID="c047"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.21.8" TYPE="Illustration" ORDER="3" DMDID="c047" LABEL="Buchschmuck">
 						<div ID="L.1.1.21.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
@@ -5214,8 +4967,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.21.9" TYPE="Illustration" ORDER="4" DMDID="c049"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.21.9" TYPE="Illustration" ORDER="4" DMDID="c049" LABEL="Buchschmuck">
 						<div ID="L.1.1.21.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00005"/>
@@ -5245,8 +4997,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.22" TYPE="TextContent" ORDER="20" DMDID="c052"
-					LABEL="Untitled Poem by RAINER MARIA RILKE">
+				<div ID="L.1.1.22" TYPE="TextContent" ORDER="20" DMDID="c052" LABEL="Untitled Poem by RAINER MARIA RILKE">
 					<div ID="L.1.1.22.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00004"/>
@@ -5257,15 +5008,13 @@
 							<div ID="L.1.1.22.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.22.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.22.3" TYPE="Illustration" ORDER="1" DMDID="c053"
-						LABEL="Aus &#34;Advent&#34;">
+					<div ID="L.1.1.22.3" TYPE="Illustration" ORDER="1" DMDID="c053" LABEL="Aus &#34;Advent&#34;">
 						<div ID="L.1.1.22.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00005"/>
@@ -5299,16 +5048,14 @@
 							<div ID="L.1.1.23.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.23.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.23.3.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.23.3.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00004"/>
 									</fptr>
 								</div>
 							</div>
@@ -5316,22 +5063,17 @@
 								<div ID="L.1.1.23.3.1.3.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.23.4" TYPE="Illustration" ORDER="1" DMDID="c055"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.23.4" TYPE="Illustration" ORDER="1" DMDID="c055" LABEL="Buchschmuck">
 						<div ID="L.1.1.23.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00005"/>
@@ -5348,8 +5090,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.23.5" TYPE="Illustration" ORDER="2" DMDID="c056"
-						LABEL="FLOXBLÜTEN">
+					<div ID="L.1.1.23.5" TYPE="Illustration" ORDER="2" DMDID="c056" LABEL="FLOXBLÜTEN">
 						<div ID="L.1.1.23.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00007"/>
@@ -5366,8 +5107,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.23.6" TYPE="Illustration" ORDER="3" DMDID="c057"
-						LABEL="LETZTE SONNENSTRAHLEN">
+					<div ID="L.1.1.23.6" TYPE="Illustration" ORDER="3" DMDID="c057" LABEL="LETZTE SONNENSTRAHLEN">
 						<div ID="L.1.1.23.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00004"/>
@@ -5384,8 +5124,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.23.7" TYPE="Illustration" ORDER="4" DMDID="c058"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.23.7" TYPE="Illustration" ORDER="4" DMDID="c058" LABEL="Buchschmuck">
 						<div ID="L.1.1.23.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00006"/>
@@ -5402,8 +5141,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.23.8" TYPE="Illustration" ORDER="5" DMDID="c059"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.23.8" TYPE="Illustration" ORDER="5" DMDID="c059" LABEL="Buchschmuck">
 						<div ID="L.1.1.23.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00006"/>
@@ -5421,8 +5159,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.24" TYPE="Illustration" ORDER="22" DMDID="c060"
-					LABEL="Untitled Image by ALOIS HÄNISCH">
+				<div ID="L.1.1.24" TYPE="Illustration" ORDER="22" DMDID="c060" LABEL="Untitled Image by ALOIS HÄNISCH">
 					<div ID="L.1.1.24.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00003"/>
@@ -5439,8 +5176,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.25" TYPE="TextContent" ORDER="23" DMDID="c061"
-					LABEL="Schulausstellung der Akademie der bildenden Künste in Wien">
+				<div ID="L.1.1.25" TYPE="TextContent" ORDER="23" DMDID="c061" LABEL="Schulausstellung der Akademie der bildenden Künste in Wien">
 					<div ID="L.1.1.25.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00002"/>
@@ -5456,15 +5192,13 @@
 							<div ID="L.1.1.25.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.25.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.25.4" TYPE="Illustration" ORDER="1" DMDID="c062"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.25.4" TYPE="Illustration" ORDER="1" DMDID="c062" LABEL="Buchschmuck">
 						<div ID="L.1.1.25.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00005"/>

--- a/metadata/periodicals/bmtnabf/issues/1898/10_01/bmtnabf_1898-10_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1898/10_01/bmtnabf_1898-10_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1900-01-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1900-01-15_01">
 
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
@@ -20,9 +15,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-10_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1898-10_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -51,10 +46,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-10_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -4115,483 +4109,252 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:23:49"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="cff209dc6e963527b7a043034c0129cd69dc0722"
-				CHECKSUMTYPE="SHA-1" SIZE="6237125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:23:49" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="cff209dc6e963527b7a043034c0129cd69dc0722" CHECKSUMTYPE="SHA-1" SIZE="6237125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:24:27"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="ec5f20e893093a5064182143d8d53751d7adea7c"
-				CHECKSUMTYPE="SHA-1" SIZE="6250619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:24:27" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="ec5f20e893093a5064182143d8d53751d7adea7c" CHECKSUMTYPE="SHA-1" SIZE="6250619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:25:09"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="9c2595dca7761f0fd8b647a8c45da3de77526198"
-				CHECKSUMTYPE="SHA-1" SIZE="6203821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:25:09" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="9c2595dca7761f0fd8b647a8c45da3de77526198" CHECKSUMTYPE="SHA-1" SIZE="6203821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:25:45"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a6624a9194907abcd8e9db2addf14b93f7d7307b"
-				CHECKSUMTYPE="SHA-1" SIZE="6264129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:25:45" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a6624a9194907abcd8e9db2addf14b93f7d7307b" CHECKSUMTYPE="SHA-1" SIZE="6264129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:26:24"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="dfe9a96a8120d9b779eb2512cfae3bf1508154c6"
-				CHECKSUMTYPE="SHA-1" SIZE="6235327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:26:24" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="dfe9a96a8120d9b779eb2512cfae3bf1508154c6" CHECKSUMTYPE="SHA-1" SIZE="6235327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:27:02"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="feff4d4dfba0e95303b62fde8ea28c3433d8777c"
-				CHECKSUMTYPE="SHA-1" SIZE="6232629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:27:02" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="feff4d4dfba0e95303b62fde8ea28c3433d8777c" CHECKSUMTYPE="SHA-1" SIZE="6232629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:27:40"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="0cc854e112145cf23dda82f5fad38f2f4f4efdd2"
-				CHECKSUMTYPE="SHA-1" SIZE="6229896">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:27:40" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="0cc854e112145cf23dda82f5fad38f2f4f4efdd2" CHECKSUMTYPE="SHA-1" SIZE="6229896">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:28:19"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="8642969b066045ed1c2e52304e451fa1f5029d69"
-				CHECKSUMTYPE="SHA-1" SIZE="6253309">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:28:19" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="8642969b066045ed1c2e52304e451fa1f5029d69" CHECKSUMTYPE="SHA-1" SIZE="6253309">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:28:53"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="3fd911ca41350143107d8cfe79f40daf98bd8142"
-				CHECKSUMTYPE="SHA-1" SIZE="6229911">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:28:53" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="3fd911ca41350143107d8cfe79f40daf98bd8142" CHECKSUMTYPE="SHA-1" SIZE="6229911">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:29:28"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="009856a7420609fabbad3ed3f4136bfec8aecae2"
-				CHECKSUMTYPE="SHA-1" SIZE="6224529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:29:28" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="009856a7420609fabbad3ed3f4136bfec8aecae2" CHECKSUMTYPE="SHA-1" SIZE="6224529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:30:03"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="843c71e03ffcbf326ad894aad1db6f8e9067871c"
-				CHECKSUMTYPE="SHA-1" SIZE="6180403">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:30:03" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="843c71e03ffcbf326ad894aad1db6f8e9067871c" CHECKSUMTYPE="SHA-1" SIZE="6180403">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:30:42"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="22c7195dffd02dfc83e1e4d9ac6f3fc0a7bebe25"
-				CHECKSUMTYPE="SHA-1" SIZE="6288397">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:30:42" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="22c7195dffd02dfc83e1e4d9ac6f3fc0a7bebe25" CHECKSUMTYPE="SHA-1" SIZE="6288397">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:31:19"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="fc2760cf9bdbbe5811ec77dee2d95c50a858e4b5"
-				CHECKSUMTYPE="SHA-1" SIZE="6133629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:31:19" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="fc2760cf9bdbbe5811ec77dee2d95c50a858e4b5" CHECKSUMTYPE="SHA-1" SIZE="6133629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:31:54"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="3cba5a0241aa5e85bd11b27a3dd43a169012f6b3"
-				CHECKSUMTYPE="SHA-1" SIZE="6230798">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:31:54" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="3cba5a0241aa5e85bd11b27a3dd43a169012f6b3" CHECKSUMTYPE="SHA-1" SIZE="6230798">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:32:33"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="fc21dd82904fb487c82551730ad9230f01993779"
-				CHECKSUMTYPE="SHA-1" SIZE="6138128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:32:33" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="fc21dd82904fb487c82551730ad9230f01993779" CHECKSUMTYPE="SHA-1" SIZE="6138128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:33:12"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="b5c5c0c2a4e081a07769c2e53ffd1f8c8ba0100c"
-				CHECKSUMTYPE="SHA-1" SIZE="6220029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:33:12" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="b5c5c0c2a4e081a07769c2e53ffd1f8c8ba0100c" CHECKSUMTYPE="SHA-1" SIZE="6220029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:33:50"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="16f2c23faceade5add90b49654ae11b18f9ed0c9"
-				CHECKSUMTYPE="SHA-1" SIZE="6217318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:33:50" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="16f2c23faceade5add90b49654ae11b18f9ed0c9" CHECKSUMTYPE="SHA-1" SIZE="6217318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:34:26"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="98d061344d78a24280036d3a4e7e21f1d466500b"
-				CHECKSUMTYPE="SHA-1" SIZE="6286618">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:34:26" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="98d061344d78a24280036d3a4e7e21f1d466500b" CHECKSUMTYPE="SHA-1" SIZE="6286618">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:35:00"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7e9ec2399023a82aec0d867c0c0e6d3abe1bc56b"
-				CHECKSUMTYPE="SHA-1" SIZE="6186724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:35:00" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7e9ec2399023a82aec0d867c0c0e6d3abe1bc56b" CHECKSUMTYPE="SHA-1" SIZE="6186724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:35:37"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="f0e595e2109c3304a24470758ca2b455d0a4435d"
-				CHECKSUMTYPE="SHA-1" SIZE="6246105">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:35:37" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="f0e595e2109c3304a24470758ca2b455d0a4435d" CHECKSUMTYPE="SHA-1" SIZE="6246105">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:36:14"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="6ce03a5c7ace5e41c1698f592b760104d142ff31"
-				CHECKSUMTYPE="SHA-1" SIZE="6271324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:36:14" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="6ce03a5c7ace5e41c1698f592b760104d142ff31" CHECKSUMTYPE="SHA-1" SIZE="6271324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:36:49"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="ede951cf01bb95e4876f77b49a4a64c966fdd939"
-				CHECKSUMTYPE="SHA-1" SIZE="6223629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:36:49" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="ede951cf01bb95e4876f77b49a4a64c966fdd939" CHECKSUMTYPE="SHA-1" SIZE="6223629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:37:27"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="55176f9846ab14fde50d161e6c07749e9e4a5689"
-				CHECKSUMTYPE="SHA-1" SIZE="6275827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:37:27" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="55176f9846ab14fde50d161e6c07749e9e4a5689" CHECKSUMTYPE="SHA-1" SIZE="6275827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:38:04"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="031449227b04dccf872eb33d3bcb2ad0bd6b9236"
-				CHECKSUMTYPE="SHA-1" SIZE="6136279">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:38:04" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="031449227b04dccf872eb33d3bcb2ad0bd6b9236" CHECKSUMTYPE="SHA-1" SIZE="6136279">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:38:39"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="67b3623e0dbbaa74268b2176c230b994502a1965"
-				CHECKSUMTYPE="SHA-1" SIZE="6240726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:38:39" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="67b3623e0dbbaa74268b2176c230b994502a1965" CHECKSUMTYPE="SHA-1" SIZE="6240726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:39:14"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="306b1ccfefacfc5d22057a92cd04e59aa309e1c7"
-				CHECKSUMTYPE="SHA-1" SIZE="6274029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:39:14" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="306b1ccfefacfc5d22057a92cd04e59aa309e1c7" CHECKSUMTYPE="SHA-1" SIZE="6274029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:39:53"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="171bdc32583d027b7908300cd3e1110877ad1411"
-				CHECKSUMTYPE="SHA-1" SIZE="6294712">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:39:53" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="171bdc32583d027b7908300cd3e1110877ad1411" CHECKSUMTYPE="SHA-1" SIZE="6294712">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:40:31"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="23331a5af9ebd77b22c457ed3f9d04f6f6077921"
-				CHECKSUMTYPE="SHA-1" SIZE="6241605">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:40:31" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="23331a5af9ebd77b22c457ed3f9d04f6f6077921" CHECKSUMTYPE="SHA-1" SIZE="6241605">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:41:05"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="b8afb675699804dc28a0a69cafbd195f0df2256d"
-				CHECKSUMTYPE="SHA-1" SIZE="6260527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:41:05" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="b8afb675699804dc28a0a69cafbd195f0df2256d" CHECKSUMTYPE="SHA-1" SIZE="6260527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:41:45"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="c393883c650d97e925defc99b6a027e5a8137a13"
-				CHECKSUMTYPE="SHA-1" SIZE="6241628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:41:45" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="c393883c650d97e925defc99b6a027e5a8137a13" CHECKSUMTYPE="SHA-1" SIZE="6241628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:42:21"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="2837e4eca3895445baf42946ee041041ffe2f310"
-				CHECKSUMTYPE="SHA-1" SIZE="6260508">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:42:21" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="2837e4eca3895445baf42946ee041041ffe2f310" CHECKSUMTYPE="SHA-1" SIZE="6260508">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:42:59"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="747e6f5516f34d14a18b5a75b6288eedb573f23e"
-				CHECKSUMTYPE="SHA-1" SIZE="6257827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:42:59" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="747e6f5516f34d14a18b5a75b6288eedb573f23e" CHECKSUMTYPE="SHA-1" SIZE="6257827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T16:43:37"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="896989478b0366756d528948d568ec4ceb205c2b"
-				CHECKSUMTYPE="SHA-1" SIZE="6211929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T16:43:37" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="896989478b0366756d528948d568ec4ceb205c2b" CHECKSUMTYPE="SHA-1" SIZE="6211929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T16:44:12"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="fb7e4fe59a305638d9e214512bf456e68b9dd087"
-				CHECKSUMTYPE="SHA-1" SIZE="6257795">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T16:44:12" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="fb7e4fe59a305638d9e214512bf456e68b9dd087" CHECKSUMTYPE="SHA-1" SIZE="6257795">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0034.jp2"/>
 			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T16:44:46"
-				MIMETYPE="image/jp2" SEQ="35" CHECKSUM="3ef01b61f596a360a8f25bfd666df9fed6877736"
-				CHECKSUMTYPE="SHA-1" SIZE="6211924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0035.jp2"
-				/>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T16:44:46" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="3ef01b61f596a360a8f25bfd666df9fed6877736" CHECKSUMTYPE="SHA-1" SIZE="6211924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0035.jp2"/>
 			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T16:45:21"
-				MIMETYPE="image/jp2" SEQ="36" CHECKSUM="2698baea71f70fc4062e6f3c148d383b5683e1be"
-				CHECKSUMTYPE="SHA-1" SIZE="6273104">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0036.jp2"
-				/>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T16:45:21" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="2698baea71f70fc4062e6f3c148d383b5683e1be" CHECKSUMTYPE="SHA-1" SIZE="6273104">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0036.jp2"/>
 			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T16:45:57"
-				MIMETYPE="image/jp2" SEQ="37" CHECKSUM="efe652ce5cc70ca9cf7bfd87d3102abef76856c9"
-				CHECKSUMTYPE="SHA-1" SIZE="6185828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0037.jp2"
-				/>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T16:45:57" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="efe652ce5cc70ca9cf7bfd87d3102abef76856c9" CHECKSUMTYPE="SHA-1" SIZE="6185828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0037.jp2"/>
 			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T16:46:36"
-				MIMETYPE="image/jp2" SEQ="38" CHECKSUM="1cb0184307690a10db8a2f774bc79c14d7fa7590"
-				CHECKSUMTYPE="SHA-1" SIZE="6273127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0038.jp2"
-				/>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T16:46:36" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="1cb0184307690a10db8a2f774bc79c14d7fa7590" CHECKSUMTYPE="SHA-1" SIZE="6273127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0038.jp2"/>
 			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-10-09T16:47:10"
-				MIMETYPE="image/jp2" SEQ="39" CHECKSUM="d22a5c22a2078188bb47ed734f550d904b8758f6"
-				CHECKSUMTYPE="SHA-1" SIZE="6185813">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0039.jp2"
-				/>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-10-09T16:47:10" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="d22a5c22a2078188bb47ed734f550d904b8758f6" CHECKSUMTYPE="SHA-1" SIZE="6185813">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0039.jp2"/>
 			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-10-09T16:47:45"
-				MIMETYPE="image/jp2" SEQ="40" CHECKSUM="6727afa8d668cd563ce61eb6fb106b6b3de39729"
-				CHECKSUMTYPE="SHA-1" SIZE="6303688">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0040.jp2"
-				/>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-10-09T16:47:45" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="6727afa8d668cd563ce61eb6fb106b6b3de39729" CHECKSUMTYPE="SHA-1" SIZE="6303688">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/delivery/bmtnabf_1898-10_01_0040.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:48:09" MIMETYPE="text/xml"
-				CHECKSUM="ee3bd8a63d60377f6b4a2b8b2f2e85028ab7c509" CHECKSUMTYPE="SHA-1"
-				SIZE="11569">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:48:09" MIMETYPE="text/xml" CHECKSUM="ee3bd8a63d60377f6b4a2b8b2f2e85028ab7c509" CHECKSUMTYPE="SHA-1" SIZE="11569">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:48:09" MIMETYPE="text/xml"
-				CHECKSUM="04b4ecf3f293ddb5f385cdcfaa1b35a1f8c207d6" CHECKSUMTYPE="SHA-1"
-				SIZE="73647">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:48:09" MIMETYPE="text/xml" CHECKSUM="04b4ecf3f293ddb5f385cdcfaa1b35a1f8c207d6" CHECKSUMTYPE="SHA-1" SIZE="73647">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:48:09" MIMETYPE="text/xml"
-				CHECKSUM="dbf4270c424dce15027035472a8691d5cfaa30db" CHECKSUMTYPE="SHA-1"
-				SIZE="17155">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:48:09" MIMETYPE="text/xml" CHECKSUM="dbf4270c424dce15027035472a8691d5cfaa30db" CHECKSUMTYPE="SHA-1" SIZE="17155">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:48:09" MIMETYPE="text/xml"
-				CHECKSUM="c91c772cc0a8afa07063bb8b422f1a871c0bb832" CHECKSUMTYPE="SHA-1"
-				SIZE="120268">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:48:09" MIMETYPE="text/xml" CHECKSUM="c91c772cc0a8afa07063bb8b422f1a871c0bb832" CHECKSUMTYPE="SHA-1" SIZE="120268">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:48:10" MIMETYPE="text/xml"
-				CHECKSUM="3b78e887626a59b9abf9e6824b1ec608b02f3dcc" CHECKSUMTYPE="SHA-1" SIZE="7392">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:48:10" MIMETYPE="text/xml" CHECKSUM="3b78e887626a59b9abf9e6824b1ec608b02f3dcc" CHECKSUMTYPE="SHA-1" SIZE="7392">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:48:10" MIMETYPE="text/xml"
-				CHECKSUM="b92d40c988bd6c272a2ee51c9731555de89ae48f" CHECKSUMTYPE="SHA-1" SIZE="6391">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:48:10" MIMETYPE="text/xml" CHECKSUM="b92d40c988bd6c272a2ee51c9731555de89ae48f" CHECKSUMTYPE="SHA-1" SIZE="6391">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:48:10" MIMETYPE="text/xml"
-				CHECKSUM="743b3f0d42f3ca9396d96b461b4034956c3f21a3" CHECKSUMTYPE="SHA-1"
-				SIZE="91365">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:48:10" MIMETYPE="text/xml" CHECKSUM="743b3f0d42f3ca9396d96b461b4034956c3f21a3" CHECKSUMTYPE="SHA-1" SIZE="91365">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:48:10" MIMETYPE="text/xml"
-				CHECKSUM="9688549920294783b8ddd20c0d796629c569fad9" CHECKSUMTYPE="SHA-1"
-				SIZE="129633">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:48:10" MIMETYPE="text/xml" CHECKSUM="9688549920294783b8ddd20c0d796629c569fad9" CHECKSUMTYPE="SHA-1" SIZE="129633">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:48:11" MIMETYPE="text/xml"
-				CHECKSUM="70c06dc29af5257ef67f57ad5f7d3e744acf323f" CHECKSUMTYPE="SHA-1"
-				SIZE="130464">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:48:11" MIMETYPE="text/xml" CHECKSUM="70c06dc29af5257ef67f57ad5f7d3e744acf323f" CHECKSUMTYPE="SHA-1" SIZE="130464">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:48:11" MIMETYPE="text/xml"
-				CHECKSUM="6eaabc64718236bf98314a017b449b2d10f5903c" CHECKSUMTYPE="SHA-1"
-				SIZE="117702">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:48:11" MIMETYPE="text/xml" CHECKSUM="6eaabc64718236bf98314a017b449b2d10f5903c" CHECKSUMTYPE="SHA-1" SIZE="117702">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:48:12" MIMETYPE="text/xml"
-				CHECKSUM="ca28f28b6e0fa1951648db49040f863f42b7930b" CHECKSUMTYPE="SHA-1"
-				SIZE="10608">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:48:12" MIMETYPE="text/xml" CHECKSUM="ca28f28b6e0fa1951648db49040f863f42b7930b" CHECKSUMTYPE="SHA-1" SIZE="10608">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:48:12" MIMETYPE="text/xml"
-				CHECKSUM="348b95d0d4c4cfb38e3ea695a3ffd26c26d4d021" CHECKSUMTYPE="SHA-1" SIZE="9926">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:48:12" MIMETYPE="text/xml" CHECKSUM="348b95d0d4c4cfb38e3ea695a3ffd26c26d4d021" CHECKSUMTYPE="SHA-1" SIZE="9926">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:48:12" MIMETYPE="text/xml"
-				CHECKSUM="0467e7c0a37f4706b13794cf4ef23c5183199b13" CHECKSUMTYPE="SHA-1"
-				SIZE="70984">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:48:12" MIMETYPE="text/xml" CHECKSUM="0467e7c0a37f4706b13794cf4ef23c5183199b13" CHECKSUMTYPE="SHA-1" SIZE="70984">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:48:12" MIMETYPE="text/xml"
-				CHECKSUM="b46bfad9334d4c75f9b18239437e1636bdfe1dea" CHECKSUMTYPE="SHA-1"
-				SIZE="82019">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:48:12" MIMETYPE="text/xml" CHECKSUM="b46bfad9334d4c75f9b18239437e1636bdfe1dea" CHECKSUMTYPE="SHA-1" SIZE="82019">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:48:13" MIMETYPE="text/xml"
-				CHECKSUM="914cff642bb5f297f1a7769ebf7b086bd483c899" CHECKSUMTYPE="SHA-1"
-				SIZE="93402">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:48:13" MIMETYPE="text/xml" CHECKSUM="914cff642bb5f297f1a7769ebf7b086bd483c899" CHECKSUMTYPE="SHA-1" SIZE="93402">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:48:13" MIMETYPE="text/xml"
-				CHECKSUM="bcd8ddf47e3af9f5249292bf68cb4835582c6e3e" CHECKSUMTYPE="SHA-1"
-				SIZE="136344">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:48:13" MIMETYPE="text/xml" CHECKSUM="bcd8ddf47e3af9f5249292bf68cb4835582c6e3e" CHECKSUMTYPE="SHA-1" SIZE="136344">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:48:14" MIMETYPE="text/xml"
-				CHECKSUM="d772c295eaf3c2d26a4eeb2522660425a8eb35c9" CHECKSUMTYPE="SHA-1" SIZE="6570">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:48:14" MIMETYPE="text/xml" CHECKSUM="d772c295eaf3c2d26a4eeb2522660425a8eb35c9" CHECKSUMTYPE="SHA-1" SIZE="6570">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:48:14" MIMETYPE="text/xml"
-				CHECKSUM="b98ea70f77a3c0400051ffef8fd9ec8f300b8c83" CHECKSUMTYPE="SHA-1" SIZE="6638">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:48:14" MIMETYPE="text/xml" CHECKSUM="b98ea70f77a3c0400051ffef8fd9ec8f300b8c83" CHECKSUMTYPE="SHA-1" SIZE="6638">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:48:14" MIMETYPE="text/xml"
-				CHECKSUM="7e533c8738e7a51c81ed67eeb422588ac108f989" CHECKSUMTYPE="SHA-1"
-				SIZE="147298">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:48:14" MIMETYPE="text/xml" CHECKSUM="7e533c8738e7a51c81ed67eeb422588ac108f989" CHECKSUMTYPE="SHA-1" SIZE="147298">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:48:15" MIMETYPE="text/xml"
-				CHECKSUM="160720d6d8126bcf12ebd254d98ed798a91951ff" CHECKSUMTYPE="SHA-1"
-				SIZE="102046">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:48:15" MIMETYPE="text/xml" CHECKSUM="160720d6d8126bcf12ebd254d98ed798a91951ff" CHECKSUMTYPE="SHA-1" SIZE="102046">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:48:15" MIMETYPE="text/xml"
-				CHECKSUM="08236c167e819ea40b7033d659226c085ed66de6" CHECKSUMTYPE="SHA-1"
-				SIZE="104446">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:48:15" MIMETYPE="text/xml" CHECKSUM="08236c167e819ea40b7033d659226c085ed66de6" CHECKSUMTYPE="SHA-1" SIZE="104446">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:48:15" MIMETYPE="text/xml"
-				CHECKSUM="91de106e6609fa2464768d744aed2f909706b70a" CHECKSUMTYPE="SHA-1"
-				SIZE="160770">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:48:15" MIMETYPE="text/xml" CHECKSUM="91de106e6609fa2464768d744aed2f909706b70a" CHECKSUMTYPE="SHA-1" SIZE="160770">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:48:16" MIMETYPE="text/xml"
-				CHECKSUM="ca7396f5dce9fb9a0cb64fb3d9684ecbbc5c9db6" CHECKSUMTYPE="SHA-1" SIZE="9094">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:48:16" MIMETYPE="text/xml" CHECKSUM="ca7396f5dce9fb9a0cb64fb3d9684ecbbc5c9db6" CHECKSUMTYPE="SHA-1" SIZE="9094">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:48:16" MIMETYPE="text/xml"
-				CHECKSUM="8576d4ee301095e4a26c4b000b7488c75716c952" CHECKSUMTYPE="SHA-1" SIZE="4597">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:48:16" MIMETYPE="text/xml" CHECKSUM="8576d4ee301095e4a26c4b000b7488c75716c952" CHECKSUMTYPE="SHA-1" SIZE="4597">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:48:16" MIMETYPE="text/xml"
-				CHECKSUM="7e84983241ab5a85939ec7a623e911a397c38cc8" CHECKSUMTYPE="SHA-1"
-				SIZE="97664">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:48:16" MIMETYPE="text/xml" CHECKSUM="7e84983241ab5a85939ec7a623e911a397c38cc8" CHECKSUMTYPE="SHA-1" SIZE="97664">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:48:17" MIMETYPE="text/xml"
-				CHECKSUM="2b3a89bd961bcc6f91c229b3106d914e6b13bd6d" CHECKSUMTYPE="SHA-1"
-				SIZE="168530">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:48:17" MIMETYPE="text/xml" CHECKSUM="2b3a89bd961bcc6f91c229b3106d914e6b13bd6d" CHECKSUMTYPE="SHA-1" SIZE="168530">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:48:17" MIMETYPE="text/xml"
-				CHECKSUM="ca99d3573292d892176cacbcf19a64e63af3ace1" CHECKSUMTYPE="SHA-1"
-				SIZE="91924">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:48:17" MIMETYPE="text/xml" CHECKSUM="ca99d3573292d892176cacbcf19a64e63af3ace1" CHECKSUMTYPE="SHA-1" SIZE="91924">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:48:17" MIMETYPE="text/xml"
-				CHECKSUM="2e31f4b26fc1e09c0e38a087bb66a6c572d42953" CHECKSUMTYPE="SHA-1"
-				SIZE="153039">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:48:17" MIMETYPE="text/xml" CHECKSUM="2e31f4b26fc1e09c0e38a087bb66a6c572d42953" CHECKSUMTYPE="SHA-1" SIZE="153039">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:48:19" MIMETYPE="text/xml"
-				CHECKSUM="0b8809fdf6c8b7e25289318958d8eed5dedf0b54" CHECKSUMTYPE="SHA-1" SIZE="4564">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:48:19" MIMETYPE="text/xml" CHECKSUM="0b8809fdf6c8b7e25289318958d8eed5dedf0b54" CHECKSUMTYPE="SHA-1" SIZE="4564">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:48:20" MIMETYPE="text/xml"
-				CHECKSUM="15c4113186e7d161efca13a2b807c0b2a74e160f" CHECKSUMTYPE="SHA-1"
-				SIZE="68261">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:48:20" MIMETYPE="text/xml" CHECKSUM="15c4113186e7d161efca13a2b807c0b2a74e160f" CHECKSUMTYPE="SHA-1" SIZE="68261">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:48:20" MIMETYPE="text/xml"
-				CHECKSUM="c6ee3eb2a1b342e224c8c1e8e59e3675fb4ccd60" CHECKSUMTYPE="SHA-1" SIZE="4614">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:48:20" MIMETYPE="text/xml" CHECKSUM="c6ee3eb2a1b342e224c8c1e8e59e3675fb4ccd60" CHECKSUMTYPE="SHA-1" SIZE="4614">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:48:20" MIMETYPE="text/xml"
-				CHECKSUM="ee0e70a668e5df97695a87ecb758cf81a752851c" CHECKSUMTYPE="SHA-1" SIZE="5013">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:48:20" MIMETYPE="text/xml" CHECKSUM="ee0e70a668e5df97695a87ecb758cf81a752851c" CHECKSUMTYPE="SHA-1" SIZE="5013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T16:48:20" MIMETYPE="text/xml"
-				CHECKSUM="6181e7989ce851242d63223b2aa6e8d0d755b7fd" CHECKSUMTYPE="SHA-1" SIZE="7275">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T16:48:20" MIMETYPE="text/xml" CHECKSUM="6181e7989ce851242d63223b2aa6e8d0d755b7fd" CHECKSUMTYPE="SHA-1" SIZE="7275">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T16:48:21" MIMETYPE="text/xml"
-				CHECKSUM="275d29bd13c4238662c6d0b63fe589e10962ce3c" CHECKSUMTYPE="SHA-1" SIZE="6245">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T16:48:21" MIMETYPE="text/xml" CHECKSUM="275d29bd13c4238662c6d0b63fe589e10962ce3c" CHECKSUMTYPE="SHA-1" SIZE="6245">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T16:48:21" MIMETYPE="text/xml"
-				CHECKSUM="9d554c2840fa1d349080a31b76c3ad9ba94b8ea5" CHECKSUMTYPE="SHA-1"
-				SIZE="71043">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T16:48:21" MIMETYPE="text/xml" CHECKSUM="9d554c2840fa1d349080a31b76c3ad9ba94b8ea5" CHECKSUMTYPE="SHA-1" SIZE="71043">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T16:48:21" MIMETYPE="text/xml"
-				CHECKSUM="602e8fcd2a65d4d17a543b8055da064ed1c4695a" CHECKSUMTYPE="SHA-1"
-				SIZE="44566">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T16:48:21" MIMETYPE="text/xml" CHECKSUM="602e8fcd2a65d4d17a543b8055da064ed1c4695a" CHECKSUMTYPE="SHA-1" SIZE="44566">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T16:48:22" MIMETYPE="text/xml"
-				CHECKSUM="31674c8c92ed4b8336bafe0b9e1007887036602a" CHECKSUMTYPE="SHA-1"
-				SIZE="76537">
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T16:48:22" MIMETYPE="text/xml" CHECKSUM="31674c8c92ed4b8336bafe0b9e1007887036602a" CHECKSUMTYPE="SHA-1" SIZE="76537">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T16:48:22" MIMETYPE="text/xml"
-				CHECKSUM="18fc7f5bdf7e884adeda2707e1254f23a34ae5b6" CHECKSUMTYPE="SHA-1"
-				SIZE="83790">
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T16:48:22" MIMETYPE="text/xml" CHECKSUM="18fc7f5bdf7e884adeda2707e1254f23a34ae5b6" CHECKSUMTYPE="SHA-1" SIZE="83790">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-10-09T16:48:22" MIMETYPE="text/xml"
-				CHECKSUM="55704ef623602cfddae91deefbead4496fed32d8" CHECKSUMTYPE="SHA-1"
-				SIZE="61016">
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-10-09T16:48:22" MIMETYPE="text/xml" CHECKSUM="55704ef623602cfddae91deefbead4496fed32d8" CHECKSUMTYPE="SHA-1" SIZE="61016">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-10-09T16:48:22" MIMETYPE="text/xml"
-				CHECKSUM="5c28376be24ab71d0a3352cf59c91960a66f4ead" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-10-09T16:48:22" MIMETYPE="text/xml" CHECKSUM="5c28376be24ab71d0a3352cf59c91960a66f4ead" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-10_01_0040.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:49:27" MIMETYPE="application/pdf"
-				CHECKSUM="d5f7986b53b3f961571e8ab40bcb7095eb4c2994" CHECKSUMTYPE="SHA-1"
-				SIZE="15062402">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/bmtnabf_1898-10_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:49:27" MIMETYPE="application/pdf" CHECKSUM="d5f7986b53b3f961571e8ab40bcb7095eb4c2994" CHECKSUMTYPE="SHA-1" SIZE="15062402">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/10_01/bmtnabf_1898-10_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -5136,8 +4899,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="TextContent" ORDER="2" DMDID="c004"
-					LABEL="INHALTSVERZEICHNIS">
+				<div ID="L.1.1.4" TYPE="TextContent" ORDER="2" DMDID="c004" LABEL="INHALTSVERZEICHNIS">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00002" BEGIN="P2_TB00001"/>
@@ -5155,8 +4917,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c005"
-					LABEL="C. M FELICIAN ROPS">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c005" LABEL="C. M FELICIAN ROPS">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<seq>
@@ -5179,8 +4940,7 @@
 					</div>
 				</div>
 				<!-- edits Ticket 148 -->
-				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c006"
-					LABEL="JUBILÄUMS-AUSSTELLUNG IN WIEN 1898">
+				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c006" LABEL="JUBILÄUMS-AUSSTELLUNG IN WIEN 1898">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00002"/>
@@ -5197,18 +4957,15 @@
 								<div ID="L.1.1.6.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00004"
-												BEGIN="P4_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00004"
-												BEGIN="P4_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c007"
-						LABEL="Gemaltes Velumornament aus dem Ausstellungsräume der Militär-Tuchfabriken">
+					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c007" LABEL="Gemaltes Velumornament aus dem Ausstellungsräume der Militär-Tuchfabriken">
 						<div ID="L.1.1.6.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00006"/>
@@ -5225,8 +4982,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.2" TYPE="Illustration" ORDER="1" DMDID="c009"
-						LABEL="VITRINE AUS GLAS UND MATTIERTEM SILBER">
+					<div ID="L.1.1.7.2" TYPE="Illustration" ORDER="1" DMDID="c009" LABEL="VITRINE AUS GLAS UND MATTIERTEM SILBER">
 						<div ID="L.1.1.7.2.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00004"/>
@@ -5243,8 +4999,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="2" DMDID="c010"
-						LABEL="GESTICKTE BEHÄNGE">
+					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="2" DMDID="c010" LABEL="GESTICKTE BEHÄNGE">
 						<div ID="L.1.1.7.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00006"/>
@@ -5268,8 +5023,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c012"
-						LABEL="DECORATIVE ARCHITEKTUR D. CENTRALRAUMES DER KUNSTGEWERBE-ABTHEILUNG">
+					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c012" LABEL="DECORATIVE ARCHITEKTUR D. CENTRALRAUMES DER KUNSTGEWERBE-ABTHEILUNG">
 						<div ID="L.1.1.8.1" TYPE="Head">
 							<fptr>
 								<seq>
@@ -5289,8 +5043,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.2" TYPE="Illustration" ORDER="1" DMDID="c021"
-						LABEL="BALLUSTRADE">
+					<div ID="L.1.1.10.2" TYPE="Illustration" ORDER="1" DMDID="c021" LABEL="BALLUSTRADE">
 						<div ID="L.1.1.10.2.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
@@ -5307,8 +5060,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.3" TYPE="Illustration" ORDER="2" DMDID="c022"
-						LABEL="MÖBEL AUS EINEM SCHLAFUND EINEM BADEZIMMER">
+					<div ID="L.1.1.10.3" TYPE="Illustration" ORDER="2" DMDID="c022" LABEL="MÖBEL AUS EINEM SCHLAFUND EINEM BADEZIMMER">
 						<div ID="L.1.1.10.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00006"/>
@@ -5325,8 +5077,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="3" DMDID="c023"
-						LABEL="KRIEGERGRUPPE UND REITERSTANDBILD AUS DER AUSSTELLUNG DER MILITÄRTUCHFABRIKEN">
+					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="3" DMDID="c023" LABEL="KRIEGERGRUPPE UND REITERSTANDBILD AUS DER AUSSTELLUNG DER MILITÄRTUCHFABRIKEN">
 						<div ID="L.1.1.10.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00009"/>
@@ -5350,8 +5101,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.2" TYPE="Illustration" ORDER="1" DMDID="c026"
-						LABEL="AUS DER AUSSTELLUNG DER MILITÄRTUCHFABRIKEN">
+					<div ID="L.1.1.11.2" TYPE="Illustration" ORDER="1" DMDID="c026" LABEL="AUS DER AUSSTELLUNG DER MILITÄRTUCHFABRIKEN">
 						<div ID="L.1.1.11.2.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
@@ -5375,8 +5125,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.3" TYPE="Illustration" ORDER="2" DMDID="c028"
-						LABEL="GEMALTER FRIES V. D. D. URANIA-THATERS">
+					<div ID="L.1.1.11.3" TYPE="Illustration" ORDER="2" DMDID="c028" LABEL="GEMALTER FRIES V. D. D. URANIA-THATERS">
 						<div ID="L.1.1.11.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00006"/>
@@ -5393,8 +5142,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.15.2" TYPE="Illustration" ORDER="1" DMDID="c040"
-						LABEL="GEMALTER FRIES VON DER FAÇADE DES URANIA – THEATERS">
+					<div ID="L.1.1.15.2" TYPE="Illustration" ORDER="1" DMDID="c040" LABEL="GEMALTER FRIES VON DER FAÇADE DES URANIA – THEATERS">
 						<div ID="L.1.1.15.2.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
@@ -5411,8 +5159,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.15.3" TYPE="Illustration" ORDER="2" DMDID="c041"
-						LABEL="CENTRALRAUM D. KUNSTGEWER – BE – ABTHEILUNG">
+					<div ID="L.1.1.15.3" TYPE="Illustration" ORDER="2" DMDID="c041" LABEL="CENTRALRAUM D. KUNSTGEWER – BE – ABTHEILUNG">
 						<div ID="L.1.1.15.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00006"/>
@@ -5432,8 +5179,7 @@
 				</div>
 				<!-- edits Ticket 148 -->
 
-				<div ID="L.1.1.9" TYPE="TextContent" ORDER="7" DMDID="c013"
-					LABEL="MODERNE HOLZSCHNITTE">
+				<div ID="L.1.1.9" TYPE="TextContent" ORDER="7" DMDID="c013" LABEL="MODERNE HOLZSCHNITTE">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -5450,22 +5196,14 @@
 								<div ID="L.1.1.9.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
@@ -5479,8 +5217,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.9.4" TYPE="Illustration" ORDER="1" DMDID="c014"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.9.4" TYPE="Illustration" ORDER="1" DMDID="c014" LABEL="Buchschmuck">
 						<div ID="L.1.1.9.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00006"/>
@@ -5497,8 +5234,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="2" DMDID="c015"
-						LABEL="Schutzstangenhälter aus Messing">
+					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="2" DMDID="c015" LABEL="Schutzstangenhälter aus Messing">
 						<div ID="L.1.1.9.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00008"/>
@@ -5515,8 +5251,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.6" TYPE="Illustration" ORDER="3" DMDID="c016"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.9.6" TYPE="Illustration" ORDER="3" DMDID="c016" LABEL="Buchschmuck">
 						<div ID="L.1.1.9.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00004"/>
@@ -5533,8 +5268,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.7" TYPE="Illustration" ORDER="4" DMDID="c017"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.9.7" TYPE="Illustration" ORDER="4" DMDID="c017" LABEL="Buchschmuck">
 						<div ID="L.1.1.9.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
@@ -5588,8 +5322,7 @@
 				</div>
 
 
-				<div ID="L.1.1.12" TYPE="TextContent" ORDER="10" DMDID="c029"
-					LABEL="WAHRHEIT UND SCHÖNHEIT IN DER MODERNEN MALEREI">
+				<div ID="L.1.1.12" TYPE="TextContent" ORDER="10" DMDID="c029" LABEL="WAHRHEIT UND SCHÖNHEIT IN DER MODERNEN MALEREI">
 					<div ID="L.1.1.12.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
@@ -5606,48 +5339,30 @@
 								<div ID="L.1.1.12.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.12.4" TYPE="Illustration" ORDER="1" DMDID="c030"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.12.4" TYPE="Illustration" ORDER="1" DMDID="c030" LABEL="Buchschmuck">
 						<div ID="L.1.1.12.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00006"/>
@@ -5664,8 +5379,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12.5" TYPE="Illustration" ORDER="2" DMDID="c031"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.12.5" TYPE="Illustration" ORDER="2" DMDID="c031" LABEL="Buchschmuck">
 						<div ID="L.1.1.12.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"/>
@@ -5682,8 +5396,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12.6" TYPE="Illustration" ORDER="3" DMDID="c032"
-						LABEL="Decorativer Entwurf">
+					<div ID="L.1.1.12.6" TYPE="Illustration" ORDER="3" DMDID="c032" LABEL="Decorativer Entwurf">
 						<div ID="L.1.1.12.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00005"/>
@@ -5700,8 +5413,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12.7" TYPE="Illustration" ORDER="4" DMDID="c033"
-						LABEL="Decorativer Entwurf v">
+					<div ID="L.1.1.12.7" TYPE="Illustration" ORDER="4" DMDID="c033" LABEL="Decorativer Entwurf v">
 						<div ID="L.1.1.12.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00006"/>
@@ -5752,8 +5464,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12.10" TYPE="Illustration" ORDER="7" DMDID="c036"
-						LABEL="Vignette">
+					<div ID="L.1.1.12.10" TYPE="Illustration" ORDER="7" DMDID="c036" LABEL="Vignette">
 						<div ID="L.1.1.12.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00004"/>
@@ -5839,8 +5550,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.17" TYPE="TextContent" ORDER="15" DMDID="c043"
-					LABEL="STIL UND INDIVIDUALITÄT">
+				<div ID="L.1.1.17" TYPE="TextContent" ORDER="15" DMDID="c043" LABEL="STIL UND INDIVIDUALITÄT">
 					<div ID="L.1.1.17.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
@@ -5857,32 +5567,22 @@
 								<div ID="L.1.1.17.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.17.4" TYPE="Illustration" ORDER="1" DMDID="c044"
-						LABEL="Decorativer Entwurf">
+					<div ID="L.1.1.17.4" TYPE="Illustration" ORDER="1" DMDID="c044" LABEL="Decorativer Entwurf">
 						<div ID="L.1.1.17.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00006"/>
@@ -5916,8 +5616,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17.6" TYPE="Illustration" ORDER="3" DMDID="c046"
-						LABEL="Decorativer Entwurf">
+					<div ID="L.1.1.17.6" TYPE="Illustration" ORDER="3" DMDID="c046" LABEL="Decorativer Entwurf">
 						<div ID="L.1.1.17.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00004"/>
@@ -5934,8 +5633,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17.7" TYPE="Illustration" ORDER="4" DMDID="c047"
-						LABEL="Decorativer Entwurf">
+					<div ID="L.1.1.17.7" TYPE="Illustration" ORDER="4" DMDID="c047" LABEL="Decorativer Entwurf">
 						<div ID="L.1.1.17.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00004"/>
@@ -5970,8 +5668,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.19" TYPE="TextContent" ORDER="17" DMDID="c049"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.19" TYPE="TextContent" ORDER="17" DMDID="c049" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.19.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00006"/>
@@ -5982,15 +5679,13 @@
 							<div ID="L.1.1.19.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.19.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00007"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00007"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="1" DMDID="c050"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="1" DMDID="c050" LABEL="Untitled Image">
 						<div ID="L.1.1.19.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_CB00002"/>
@@ -6015,8 +5710,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.21" TYPE="Illustration" ORDER="19" DMDID="c052"
-					LABEL="WANDERUNG DER SLAVEN">
+				<div ID="L.1.1.21" TYPE="Illustration" ORDER="19" DMDID="c052" LABEL="WANDERUNG DER SLAVEN">
 					<div ID="L.1.1.21.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00002"/>
@@ -6033,8 +5727,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.22" TYPE="TextContent" ORDER="20" DMDID="c053"
-					LABEL="AUS DEM WIENER CAMERA – CLUB">
+				<div ID="L.1.1.22" TYPE="TextContent" ORDER="20" DMDID="c053" LABEL="AUS DEM WIENER CAMERA – CLUB">
 					<div ID="L.1.1.22.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_TB00003"/>
@@ -6057,8 +5750,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.22.3" TYPE="Illustration" ORDER="2" DMDID="c055"
-						LABEL="WIESENBACH">
+					<div ID="L.1.1.22.3" TYPE="Illustration" ORDER="2" DMDID="c055" LABEL="WIESENBACH">
 						<div ID="L.1.1.22.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_TB00006"/>
@@ -6101,15 +5793,13 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.24" TYPE="TextContent" ORDER="22" DMDID="c057"
-					LABEL="VERLAG für Kunst und Gewerbe">
+				<div ID="L.1.1.24" TYPE="TextContent" ORDER="22" DMDID="c057" LABEL="VERLAG für Kunst und Gewerbe">
 					<div ID="L.1.1.24.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00035" BEGIN="P35_TB00001"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.24.2" TYPE="Illustration" ORDER="1" DMDID="c058"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.24.2" TYPE="Illustration" ORDER="1" DMDID="c058" LABEL="Untitled Image">
 						<div ID="L.1.1.24.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00035" BEGIN="P35_CB00001"/>
@@ -6122,12 +5812,9 @@
 								<div ID="L.1.1.24.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00035"
-												BEGIN="P35_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00035"
-												BEGIN="P35_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00035"
-												BEGIN="P35_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00035" BEGIN="P35_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00035" BEGIN="P35_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00035" BEGIN="P35_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
@@ -6135,8 +5822,7 @@
 							<div ID="L.1.1.24.3.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.24.3.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00035" BEGIN="P35_TB00005"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00035" BEGIN="P35_TB00005"/>
 									</fptr>
 								</div>
 							</div>
@@ -6149,56 +5835,49 @@
 							<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00001"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.25.2" TYPE="Illustration" ORDER="1" DMDID="c060"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.25.2" TYPE="Illustration" ORDER="1" DMDID="c060" LABEL="Untitled Image">
 						<div ID="L.1.1.25.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.25.3" TYPE="Illustration" ORDER="2" DMDID="c061"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.25.3" TYPE="Illustration" ORDER="2" DMDID="c061" LABEL="Untitled Image">
 						<div ID="L.1.1.25.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.25.4" TYPE="Illustration" ORDER="3" DMDID="c062"
-						LABEL="POSTKARTEN">
+					<div ID="L.1.1.25.4" TYPE="Illustration" ORDER="3" DMDID="c062" LABEL="POSTKARTEN">
 						<div ID="L.1.1.25.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00037" BEGIN="P37_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.25.5" TYPE="Illustration" ORDER="4" DMDID="c063"
-						LABEL="Gerlach &amp; Schenk">
+					<div ID="L.1.1.25.5" TYPE="Illustration" ORDER="4" DMDID="c063" LABEL="Gerlach &amp; Schenk">
 						<div ID="L.1.1.25.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00037" BEGIN="P37_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.25.6" TYPE="Illustration" ORDER="5" DMDID="c064"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.25.6" TYPE="Illustration" ORDER="5" DMDID="c064" LABEL="Untitled Image">
 						<div ID="L.1.1.25.6.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.25.7" TYPE="Illustration" ORDER="6" DMDID="c065"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.25.7" TYPE="Illustration" ORDER="6" DMDID="c065" LABEL="Untitled Image">
 						<div ID="L.1.1.25.7.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.25.8" TYPE="Illustration" ORDER="7" DMDID="c066"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.25.8" TYPE="Illustration" ORDER="7" DMDID="c066" LABEL="Untitled Image">
 						<div ID="L.1.1.25.8.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_CB00003"/>
@@ -6211,34 +5890,20 @@
 								<div ID="L.1.1.25.9.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00036"
-												BEGIN="P36_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00036"
-												BEGIN="P36_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00036"
-												BEGIN="P36_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00036"
-												BEGIN="P36_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00037"
-												BEGIN="P37_TB00001"/>
-											<area BETYPE="IDREF" FILEID="ALTO00037"
-												BEGIN="P37_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00037"
-												BEGIN="P37_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00037"
-												BEGIN="P37_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00038"
-												BEGIN="P38_TB00001"/>
-											<area BETYPE="IDREF" FILEID="ALTO00038"
-												BEGIN="P38_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00038"
-												BEGIN="P38_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00038"
-												BEGIN="P38_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00038"
-												BEGIN="P38_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00038"
-												BEGIN="P38_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00037" BEGIN="P37_TB00001"/>
+											<area BETYPE="IDREF" FILEID="ALTO00037" BEGIN="P37_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00037" BEGIN="P37_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00037" BEGIN="P37_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_TB00001"/>
+											<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00038" BEGIN="P38_TB00006"/>
 										</seq>
 									</fptr>
 								</div>

--- a/metadata/periodicals/bmtnabf/issues/1898/11_01/bmtnabf_1898-11_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1898/11_01/bmtnabf_1898-11_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-11_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1898-11_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-11_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1898-11_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-11_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3159,368 +3153,192 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:26:24"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="97f8b37fd30d783f8c6eb64613774302841dcc25"
-				CHECKSUMTYPE="SHA-1" SIZE="6257803">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:26:24" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="97f8b37fd30d783f8c6eb64613774302841dcc25" CHECKSUMTYPE="SHA-1" SIZE="6257803">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:26:59"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="0a318a2b38145de60881e1ca26e5adc4d6e7d254"
-				CHECKSUMTYPE="SHA-1" SIZE="6138842">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:26:59" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="0a318a2b38145de60881e1ca26e5adc4d6e7d254" CHECKSUMTYPE="SHA-1" SIZE="6138842">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:27:36"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="801f8125f9f6198c362cee5b0342a536cbb7f007"
-				CHECKSUMTYPE="SHA-1" SIZE="6251529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:27:36" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="801f8125f9f6198c362cee5b0342a536cbb7f007" CHECKSUMTYPE="SHA-1" SIZE="6251529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:28:14"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="8a3ff605cf06d10f38cefc955010bc339c1b6260"
-				CHECKSUMTYPE="SHA-1" SIZE="6139024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:28:14" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="8a3ff605cf06d10f38cefc955010bc339c1b6260" CHECKSUMTYPE="SHA-1" SIZE="6139024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:28:51"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="5ad8e6c668e28e558512c3392deed87d74b50d9b"
-				CHECKSUMTYPE="SHA-1" SIZE="6199327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:28:51" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="5ad8e6c668e28e558512c3392deed87d74b50d9b" CHECKSUMTYPE="SHA-1" SIZE="6199327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:29:29"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="5ef59afc19f937e9b95692cdd2e57a5f62119711"
-				CHECKSUMTYPE="SHA-1" SIZE="6160613">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:29:29" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="5ef59afc19f937e9b95692cdd2e57a5f62119711" CHECKSUMTYPE="SHA-1" SIZE="6160613">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:30:06"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="0a3d42580f3d3c69f91e0a12300bc568cdc14e87"
-				CHECKSUMTYPE="SHA-1" SIZE="6215528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:30:06" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="0a3d42580f3d3c69f91e0a12300bc568cdc14e87" CHECKSUMTYPE="SHA-1" SIZE="6215528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:30:42"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="f2c4182a7f0570bb941e8c8b2bfe449ca8d224f2"
-				CHECKSUMTYPE="SHA-1" SIZE="6179529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:30:42" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="f2c4182a7f0570bb941e8c8b2bfe449ca8d224f2" CHECKSUMTYPE="SHA-1" SIZE="6179529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:31:16"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="2edf1985a9a7a0d83f268cef4ecfb6a688b8d7e3"
-				CHECKSUMTYPE="SHA-1" SIZE="6231722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:31:16" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="2edf1985a9a7a0d83f268cef4ecfb6a688b8d7e3" CHECKSUMTYPE="SHA-1" SIZE="6231722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:31:55"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="7b8d74320d29f370be2d081988d1d7dd68a3e8ca"
-				CHECKSUMTYPE="SHA-1" SIZE="6166927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:31:55" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="7b8d74320d29f370be2d081988d1d7dd68a3e8ca" CHECKSUMTYPE="SHA-1" SIZE="6166927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:32:33"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="6ddb2a3fe8072647eb5eba9fe4893002371d75bf"
-				CHECKSUMTYPE="SHA-1" SIZE="6228120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:32:33" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="6ddb2a3fe8072647eb5eba9fe4893002371d75bf" CHECKSUMTYPE="SHA-1" SIZE="6228120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:33:08"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="4a7d7de842a8c876d59b80ef0d17795214e46f76"
-				CHECKSUMTYPE="SHA-1" SIZE="6166024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:33:08" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="4a7d7de842a8c876d59b80ef0d17795214e46f76" CHECKSUMTYPE="SHA-1" SIZE="6166024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:33:46"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="de5bab90cdadb32c2bb1c2260a9b915d95c847f2"
-				CHECKSUMTYPE="SHA-1" SIZE="6228124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:33:46" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="de5bab90cdadb32c2bb1c2260a9b915d95c847f2" CHECKSUMTYPE="SHA-1" SIZE="6228124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:34:24"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="7853944d326131ae72e8abe31199619a0d24bbd2"
-				CHECKSUMTYPE="SHA-1" SIZE="6158793">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:34:24" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="7853944d326131ae72e8abe31199619a0d24bbd2" CHECKSUMTYPE="SHA-1" SIZE="6158793">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:34:58"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="3c9cf1e24b3884b64d8698bb4211425083e55de0"
-				CHECKSUMTYPE="SHA-1" SIZE="6228103">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:34:58" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="3c9cf1e24b3884b64d8698bb4211425083e55de0" CHECKSUMTYPE="SHA-1" SIZE="6228103">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:35:36"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="91712b0b8445ef0550ebb333732ed6a3f8f64399"
-				CHECKSUMTYPE="SHA-1" SIZE="6175924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:35:36" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="91712b0b8445ef0550ebb333732ed6a3f8f64399" CHECKSUMTYPE="SHA-1" SIZE="6175924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:36:14"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7a4187e656b90b7145729b9a5dac7e552ab7c29b"
-				CHECKSUMTYPE="SHA-1" SIZE="6209228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:36:14" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7a4187e656b90b7145729b9a5dac7e552ab7c29b" CHECKSUMTYPE="SHA-1" SIZE="6209228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:36:49"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="e7c331c525a9bbc71f7bc459c7377002b88da74c"
-				CHECKSUMTYPE="SHA-1" SIZE="6203820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:36:49" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="e7c331c525a9bbc71f7bc459c7377002b88da74c" CHECKSUMTYPE="SHA-1" SIZE="6203820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:37:28"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7d089ae25bbc0953376fb42c031c3840337d8277"
-				CHECKSUMTYPE="SHA-1" SIZE="6187628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:37:28" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7d089ae25bbc0953376fb42c031c3840337d8277" CHECKSUMTYPE="SHA-1" SIZE="6187628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:38:05"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="244eaac76aa3c3e50e0c8f0312df99596b5cd9d6"
-				CHECKSUMTYPE="SHA-1" SIZE="6213729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:38:05" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="244eaac76aa3c3e50e0c8f0312df99596b5cd9d6" CHECKSUMTYPE="SHA-1" SIZE="6213729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:38:42"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="8237fcf0786c7979bc01592817446ccae81bac16"
-				CHECKSUMTYPE="SHA-1" SIZE="6187629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:38:42" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="8237fcf0786c7979bc01592817446ccae81bac16" CHECKSUMTYPE="SHA-1" SIZE="6187629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:39:20"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="138d63d44857ec82879f155668e29a33a70fcf20"
-				CHECKSUMTYPE="SHA-1" SIZE="6203806">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:39:20" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="138d63d44857ec82879f155668e29a33a70fcf20" CHECKSUMTYPE="SHA-1" SIZE="6203806">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:39:54"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="26f285b862c146baa6eb1f60fbf238edf5f451f2"
-				CHECKSUMTYPE="SHA-1" SIZE="6173201">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:39:54" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="26f285b862c146baa6eb1f60fbf238edf5f451f2" CHECKSUMTYPE="SHA-1" SIZE="6173201">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:40:30"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="1fc72c625074e0476d648dc8539edb4167ee9359"
-				CHECKSUMTYPE="SHA-1" SIZE="6210121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:40:30" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="1fc72c625074e0476d648dc8539edb4167ee9359" CHECKSUMTYPE="SHA-1" SIZE="6210121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:41:07"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="ac80f151775397d4783e53ce02618d90f0c284ba"
-				CHECKSUMTYPE="SHA-1" SIZE="6187627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:41:07" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="ac80f151775397d4783e53ce02618d90f0c284ba" CHECKSUMTYPE="SHA-1" SIZE="6187627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:41:41"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="6d3fc34768c8dec1d293bf2787dd13a78c0dbe61"
-				CHECKSUMTYPE="SHA-1" SIZE="6220022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:41:41" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="6d3fc34768c8dec1d293bf2787dd13a78c0dbe61" CHECKSUMTYPE="SHA-1" SIZE="6220022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:42:19"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="9e5510d70d74f5d1566c9b33613b3252fa478aeb"
-				CHECKSUMTYPE="SHA-1" SIZE="6124628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:42:19" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="9e5510d70d74f5d1566c9b33613b3252fa478aeb" CHECKSUMTYPE="SHA-1" SIZE="6124628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:42:58"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="b64d5a6ceef0bedfd069d9b744af44bb5a3988f1"
-				CHECKSUMTYPE="SHA-1" SIZE="6228114">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:42:58" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="b64d5a6ceef0bedfd069d9b744af44bb5a3988f1" CHECKSUMTYPE="SHA-1" SIZE="6228114">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:43:31"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="8a2617c5b32dcfcce0e7656f24cb9b9192335f1e"
-				CHECKSUMTYPE="SHA-1" SIZE="6121921">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:43:31" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="8a2617c5b32dcfcce0e7656f24cb9b9192335f1e" CHECKSUMTYPE="SHA-1" SIZE="6121921">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:44:06"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="d1b468dc17628604351b0a1ada9320fda0f65866"
-				CHECKSUMTYPE="SHA-1" SIZE="6234425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:44:06" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="d1b468dc17628604351b0a1ada9320fda0f65866" CHECKSUMTYPE="SHA-1" SIZE="6234425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/delivery/bmtnabf_1898-11_01_0030.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:44:30" MIMETYPE="text/xml"
-				CHECKSUM="fac427d95040427f5836a8f3d1dc269b9c7b9895" CHECKSUMTYPE="SHA-1"
-				SIZE="11406">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:44:30" MIMETYPE="text/xml" CHECKSUM="fac427d95040427f5836a8f3d1dc269b9c7b9895" CHECKSUMTYPE="SHA-1" SIZE="11406">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:44:30" MIMETYPE="text/xml"
-				CHECKSUM="99def74678da489a9049873022ca295f71ee184e" CHECKSUMTYPE="SHA-1"
-				SIZE="46283">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:44:30" MIMETYPE="text/xml" CHECKSUM="99def74678da489a9049873022ca295f71ee184e" CHECKSUMTYPE="SHA-1" SIZE="46283">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:44:30" MIMETYPE="text/xml"
-				CHECKSUM="ab203ba7c0c50602b08a89f6f1b59979acee4c96" CHECKSUMTYPE="SHA-1" SIZE="5914">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:44:30" MIMETYPE="text/xml" CHECKSUM="ab203ba7c0c50602b08a89f6f1b59979acee4c96" CHECKSUMTYPE="SHA-1" SIZE="5914">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:44:31" MIMETYPE="text/xml"
-				CHECKSUM="e2f12902d3375efb534f03efef44f871ee5f8e36" CHECKSUMTYPE="SHA-1" SIZE="9443">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:44:31" MIMETYPE="text/xml" CHECKSUM="e2f12902d3375efb534f03efef44f871ee5f8e36" CHECKSUMTYPE="SHA-1" SIZE="9443">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:44:31" MIMETYPE="text/xml"
-				CHECKSUM="d47929181a194fff2be4d7e420551a77823d00b5" CHECKSUMTYPE="SHA-1"
-				SIZE="12312">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:44:31" MIMETYPE="text/xml" CHECKSUM="d47929181a194fff2be4d7e420551a77823d00b5" CHECKSUMTYPE="SHA-1" SIZE="12312">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:44:31" MIMETYPE="text/xml"
-				CHECKSUM="2759ad0255352291b49842d871a82e43fcb0d377" CHECKSUMTYPE="SHA-1"
-				SIZE="11473">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:44:31" MIMETYPE="text/xml" CHECKSUM="2759ad0255352291b49842d871a82e43fcb0d377" CHECKSUMTYPE="SHA-1" SIZE="11473">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:44:31" MIMETYPE="text/xml"
-				CHECKSUM="9ccfa2c1cdf374989bf240fe84461c7fe8bca713" CHECKSUMTYPE="SHA-1"
-				SIZE="14830">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:44:31" MIMETYPE="text/xml" CHECKSUM="9ccfa2c1cdf374989bf240fe84461c7fe8bca713" CHECKSUMTYPE="SHA-1" SIZE="14830">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:44:32" MIMETYPE="text/xml"
-				CHECKSUM="beb30e5904a61e6bae6964ae080ea9c35185cae8" CHECKSUMTYPE="SHA-1"
-				SIZE="20010">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:44:32" MIMETYPE="text/xml" CHECKSUM="beb30e5904a61e6bae6964ae080ea9c35185cae8" CHECKSUMTYPE="SHA-1" SIZE="20010">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:44:32" MIMETYPE="text/xml"
-				CHECKSUM="89fa321f49bbe4c18af8cdd943d079685ae6cb9a" CHECKSUMTYPE="SHA-1"
-				SIZE="18657">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:44:32" MIMETYPE="text/xml" CHECKSUM="89fa321f49bbe4c18af8cdd943d079685ae6cb9a" CHECKSUMTYPE="SHA-1" SIZE="18657">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:44:32" MIMETYPE="text/xml"
-				CHECKSUM="c4184cb81d40fd37b0d3fcfc5aa9e0806d4480ba" CHECKSUMTYPE="SHA-1"
-				SIZE="14615">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:44:32" MIMETYPE="text/xml" CHECKSUM="c4184cb81d40fd37b0d3fcfc5aa9e0806d4480ba" CHECKSUMTYPE="SHA-1" SIZE="14615">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:44:33" MIMETYPE="text/xml"
-				CHECKSUM="b7c4e02c4e802e4c6109d7c8d782366e340d6991" CHECKSUMTYPE="SHA-1" SIZE="9826">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:44:33" MIMETYPE="text/xml" CHECKSUM="b7c4e02c4e802e4c6109d7c8d782366e340d6991" CHECKSUMTYPE="SHA-1" SIZE="9826">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:44:33" MIMETYPE="text/xml"
-				CHECKSUM="83fc840240744519636970cf04393751b2f6b5a6" CHECKSUMTYPE="SHA-1"
-				SIZE="17852">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:44:33" MIMETYPE="text/xml" CHECKSUM="83fc840240744519636970cf04393751b2f6b5a6" CHECKSUMTYPE="SHA-1" SIZE="17852">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:44:33" MIMETYPE="text/xml"
-				CHECKSUM="e3c76ca0a0296dcc3ce09e01ae1bb05911b96509" CHECKSUMTYPE="SHA-1"
-				SIZE="13654">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:44:33" MIMETYPE="text/xml" CHECKSUM="e3c76ca0a0296dcc3ce09e01ae1bb05911b96509" CHECKSUMTYPE="SHA-1" SIZE="13654">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:44:33" MIMETYPE="text/xml"
-				CHECKSUM="108f653efac8f3d6b3a73bcbe172f136c0659eea" CHECKSUMTYPE="SHA-1" SIZE="7384">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:44:33" MIMETYPE="text/xml" CHECKSUM="108f653efac8f3d6b3a73bcbe172f136c0659eea" CHECKSUMTYPE="SHA-1" SIZE="7384">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:44:34" MIMETYPE="text/xml"
-				CHECKSUM="4ac4c1d2a83d7c6386b0849ca64503f66f8d43be" CHECKSUMTYPE="SHA-1"
-				SIZE="126127">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:44:34" MIMETYPE="text/xml" CHECKSUM="4ac4c1d2a83d7c6386b0849ca64503f66f8d43be" CHECKSUMTYPE="SHA-1" SIZE="126127">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:44:34" MIMETYPE="text/xml"
-				CHECKSUM="dcc8039f5ee899301e315631bd87f09cd0873c9a" CHECKSUMTYPE="SHA-1"
-				SIZE="81050">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:44:34" MIMETYPE="text/xml" CHECKSUM="dcc8039f5ee899301e315631bd87f09cd0873c9a" CHECKSUMTYPE="SHA-1" SIZE="81050">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:44:34" MIMETYPE="text/xml"
-				CHECKSUM="0f3df47087214646af73576ea68e837ef0237ce5" CHECKSUMTYPE="SHA-1" SIZE="5454">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:44:34" MIMETYPE="text/xml" CHECKSUM="0f3df47087214646af73576ea68e837ef0237ce5" CHECKSUMTYPE="SHA-1" SIZE="5454">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:44:35" MIMETYPE="text/xml"
-				CHECKSUM="148425d83109d2a0db25f5dda2f9c998139593e9" CHECKSUMTYPE="SHA-1"
-				SIZE="38308">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:44:35" MIMETYPE="text/xml" CHECKSUM="148425d83109d2a0db25f5dda2f9c998139593e9" CHECKSUMTYPE="SHA-1" SIZE="38308">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:44:35" MIMETYPE="text/xml"
-				CHECKSUM="938b518d0c4578c33bef99f5e1f45d4334bc760a" CHECKSUMTYPE="SHA-1"
-				SIZE="39936">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:44:35" MIMETYPE="text/xml" CHECKSUM="938b518d0c4578c33bef99f5e1f45d4334bc760a" CHECKSUMTYPE="SHA-1" SIZE="39936">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:44:35" MIMETYPE="text/xml"
-				CHECKSUM="3ddf361286356fea307011f3693b05836b0fff53" CHECKSUMTYPE="SHA-1"
-				SIZE="86336">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:44:35" MIMETYPE="text/xml" CHECKSUM="3ddf361286356fea307011f3693b05836b0fff53" CHECKSUMTYPE="SHA-1" SIZE="86336">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:44:35" MIMETYPE="text/xml"
-				CHECKSUM="a3e9cd5fa3a1edd31a905c289e7f59320590a35b" CHECKSUMTYPE="SHA-1"
-				SIZE="64619">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:44:35" MIMETYPE="text/xml" CHECKSUM="a3e9cd5fa3a1edd31a905c289e7f59320590a35b" CHECKSUMTYPE="SHA-1" SIZE="64619">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:44:36" MIMETYPE="text/xml"
-				CHECKSUM="007d7a53ba38423ca77fb7ebfa064c65655140d1" CHECKSUMTYPE="SHA-1"
-				SIZE="76328">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:44:36" MIMETYPE="text/xml" CHECKSUM="007d7a53ba38423ca77fb7ebfa064c65655140d1" CHECKSUMTYPE="SHA-1" SIZE="76328">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:44:36" MIMETYPE="text/xml"
-				CHECKSUM="c931f3d5b137d43c6ec828cc0ece99b7881c25e3" CHECKSUMTYPE="SHA-1"
-				SIZE="90886">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:44:36" MIMETYPE="text/xml" CHECKSUM="c931f3d5b137d43c6ec828cc0ece99b7881c25e3" CHECKSUMTYPE="SHA-1" SIZE="90886">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:44:36" MIMETYPE="text/xml"
-				CHECKSUM="f2c02bb8f04710a6da2bc36d4598ff565c25dcac" CHECKSUMTYPE="SHA-1"
-				SIZE="22348">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:44:36" MIMETYPE="text/xml" CHECKSUM="f2c02bb8f04710a6da2bc36d4598ff565c25dcac" CHECKSUMTYPE="SHA-1" SIZE="22348">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:44:36" MIMETYPE="text/xml"
-				CHECKSUM="5a57ed4ac847251a681a4feb599416e3380ee310" CHECKSUMTYPE="SHA-1"
-				SIZE="113919">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:44:36" MIMETYPE="text/xml" CHECKSUM="5a57ed4ac847251a681a4feb599416e3380ee310" CHECKSUMTYPE="SHA-1" SIZE="113919">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:44:37" MIMETYPE="text/xml"
-				CHECKSUM="04671323fc520501da33888584f5b38cf822e78a" CHECKSUMTYPE="SHA-1"
-				SIZE="35947">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:44:37" MIMETYPE="text/xml" CHECKSUM="04671323fc520501da33888584f5b38cf822e78a" CHECKSUMTYPE="SHA-1" SIZE="35947">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:44:37" MIMETYPE="text/xml"
-				CHECKSUM="e98c2d09f6bb1b9b61de30a878e0aa0377102826" CHECKSUMTYPE="SHA-1" SIZE="4479">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:44:37" MIMETYPE="text/xml" CHECKSUM="e98c2d09f6bb1b9b61de30a878e0aa0377102826" CHECKSUMTYPE="SHA-1" SIZE="4479">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:44:37" MIMETYPE="text/xml"
-				CHECKSUM="23a30f97f54a2409e85dad91bd63a2feaf9c569b" CHECKSUMTYPE="SHA-1" SIZE="4392">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:44:37" MIMETYPE="text/xml" CHECKSUM="23a30f97f54a2409e85dad91bd63a2feaf9c569b" CHECKSUMTYPE="SHA-1" SIZE="4392">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:44:37" MIMETYPE="text/xml"
-				CHECKSUM="ebe941eac923dfdae205f6fc7b9855a85ba7278c" CHECKSUMTYPE="SHA-1"
-				SIZE="23258">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:44:37" MIMETYPE="text/xml" CHECKSUM="ebe941eac923dfdae205f6fc7b9855a85ba7278c" CHECKSUMTYPE="SHA-1" SIZE="23258">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:44:38" MIMETYPE="text/xml"
-				CHECKSUM="033c05e3bbc34be6b1c9d3de71402a7965a12220" CHECKSUMTYPE="SHA-1" SIZE="2013">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:44:38" MIMETYPE="text/xml" CHECKSUM="033c05e3bbc34be6b1c9d3de71402a7965a12220" CHECKSUMTYPE="SHA-1" SIZE="2013">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1898-11_01_0030.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:45:21" MIMETYPE="application/pdf"
-				CHECKSUM="554f9f521ae9ea29715a0998cdb5dc8403342318" CHECKSUMTYPE="SHA-1"
-				SIZE="11251045">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/bmtnabf_1898-11_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:45:21" MIMETYPE="application/pdf" CHECKSUM="554f9f521ae9ea29715a0998cdb5dc8403342318" CHECKSUMTYPE="SHA-1" SIZE="11251045">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1898/11_01/bmtnabf_1898-11_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3935,8 +3753,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="TextContent" ORDER="2" DMDID="c004"
-					LABEL="INHALTSVERZEICHNIS">
+				<div ID="L.1.1.4" TYPE="TextContent" ORDER="2" DMDID="c004" LABEL="INHALTSVERZEICHNIS">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00002" BEGIN="P2_TB00001"/>
@@ -3963,8 +3780,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00004"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="2" DMDID="c007"
-						LABEL="Untitled Image by Josef Hoffmann">
+					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="2" DMDID="c007" LABEL="Untitled Image by Josef Hoffmann">
 						<div ID="L.1.1.5.5.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00005"/>
@@ -3976,8 +3792,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="GH-151-c005a" TYPE="TextContent" ORDER="1" DMDID="c005a"
-						LABEL="Sieben Billionen Jahre vor meiner Geburt…">
+					<div ID="GH-151-c005a" TYPE="TextContent" ORDER="1" DMDID="c005a" LABEL="Sieben Billionen Jahre vor meiner Geburt…">
 						<div ID="GH-151-c005a.c" TYPE="Copy">
 							<div ID="GH-151-c005a.c.b" TYPE="BodyContent">
 								<!-- Paragraphs  -->
@@ -3988,8 +3803,7 @@
 								</div>
 							</div>
 						</div>
-						<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="1" DMDID="c006"
-							LABEL="Untitled image by Kolo Moser">
+						<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="1" DMDID="c006" LABEL="Untitled image by Kolo Moser">
 							<div ID="L.1.1.5.4.1" TYPE="Byline">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00003"/>
@@ -4002,8 +3816,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="GH-151-c005b" TYPE="TextContent" ORDER="2" DMDID="c005b"
-						LABEL="Alle tausent Jahre…">
+					<div ID="GH-151-c005b" TYPE="TextContent" ORDER="2" DMDID="c005b" LABEL="Alle tausent Jahre…">
 						<div ID="GH-151-c005b.c" TYPE="Copy">
 							<div ID="GH-151-c005b.c.b" TYPE="BodyContent">
 								<!-- Paragraphs  -->
@@ -4014,8 +3827,7 @@
 								</div>
 							</div>
 						</div>
-						<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="3" DMDID="c008"
-							LABEL="Untitled Image by Kolo Moser">
+						<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="3" DMDID="c008" LABEL="Untitled Image by Kolo Moser">
 							<div ID="L.1.1.5.6.1" TYPE="Byline">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00004"/>
@@ -4028,8 +3840,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="GH-151-c005c" TYPE="TextContent" ORDER="3" DMDID="c005c"
-						LABEL="Rothe Rosen…">
+					<div ID="GH-151-c005c" TYPE="TextContent" ORDER="3" DMDID="c005c" LABEL="Rothe Rosen…">
 						<div ID="GH-151-c005c.c" TYPE="Copy">
 							<div ID="GH-151-c005c.c.b" TYPE="BodyContent">
 								<!-- Paragraphs  -->
@@ -4041,8 +3852,7 @@
 								</div>
 							</div>
 						</div>
-						<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="4" DMDID="c009"
-							LABEL="Untitled image by Alfred Roller">
+						<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="4" DMDID="c009" LABEL="Untitled image by Alfred Roller">
 							<div ID="L.1.1.5.7.1" TYPE="Byline">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00003"/>
@@ -4055,8 +3865,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="GH-151-c005d" TYPE="TextContent" ORDER="4" DMDID="c005d"
-						LABEL="Unter Blumen nach meiner Flöte tanzt eine nackte Circassierin…">
+					<div ID="GH-151-c005d" TYPE="TextContent" ORDER="4" DMDID="c005d" LABEL="Unter Blumen nach meiner Flöte tanzt eine nackte Circassierin…">
 						<div ID="GH-151-c005d.c" TYPE="Copy">
 							<div ID="GH-151-c005d.c.b" TYPE="BodyContent">
 								<!-- Paragraphs  -->
@@ -4067,8 +3876,7 @@
 								</div>
 							</div>
 						</div>
-						<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="5" DMDID="c010"
-							LABEL="Untitled image by Alfred Roller">
+						<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="5" DMDID="c010" LABEL="Untitled image by Alfred Roller">
 							<div ID="L.1.1.5.8.1" TYPE="Byline">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
@@ -4081,8 +3889,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="GH-151-c005e" TYPE="TextContent" ORDER="5" DMDID="c005e"
-						LABEL="Oben, im siebenten Sommerhimel, angenehm nackt…">
+					<div ID="GH-151-c005e" TYPE="TextContent" ORDER="5" DMDID="c005e" LABEL="Oben, im siebenten Sommerhimel, angenehm nackt…">
 						<div ID="GH-151-c005e.c" TYPE="Copy">
 							<div ID="GH-151-c005e.c.b" TYPE="BodyContent">
 								<!-- Paragraphs  -->
@@ -4093,8 +3900,7 @@
 								</div>
 							</div>
 						</div>
-						<div ID="L.1.1.5.9" TYPE="Illustration" ORDER="6" DMDID="c011"
-							LABEL="Untitled image by Rudolf Jettmar">
+						<div ID="L.1.1.5.9" TYPE="Illustration" ORDER="6" DMDID="c011" LABEL="Untitled image by Rudolf Jettmar">
 							<div ID="L.1.1.5.9.1" TYPE="Byline">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00003"/>
@@ -4107,8 +3913,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="GH-151-c005f" TYPE="TextContent" ORDER="6" DMDID="c005f"
-						LABEL="Unter weissen Sommerwolken…">
+					<div ID="GH-151-c005f" TYPE="TextContent" ORDER="6" DMDID="c005f" LABEL="Unter weissen Sommerwolken…">
 						<div ID="GH-151-c005f.c" TYPE="Copy">
 							<div ID="GH-151-c005f.c.b" TYPE="BodyContent">
 								<!-- Paragraphs  -->
@@ -4119,8 +3924,7 @@
 								</div>
 							</div>
 						</div>
-						<div ID="L.1.1.5.10" TYPE="Illustration" ORDER="7" DMDID="c012"
-							LABEL="Untitled image by Rudolf Jettmar">
+						<div ID="L.1.1.5.10" TYPE="Illustration" ORDER="7" DMDID="c012" LABEL="Untitled image by Rudolf Jettmar">
 							<div ID="L.1.1.5.10.1" TYPE="Byline">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00004"/>
@@ -4133,21 +3937,18 @@
 							</div>
 						</div>
 					</div>
-					<div ID="GH-151-c005g" TYPE="TextContent" ORDER="7" DMDID="c005g"
-						LABEL="Das alte Nest, die alten Dächer!...">
+					<div ID="GH-151-c005g" TYPE="TextContent" ORDER="7" DMDID="c005g" LABEL="Das alte Nest, die alten Dächer!...">
 						<div ID="GH-151-c005g.c" TYPE="Copy">
 							<div ID="GH-151-c005g.c.b" TYPE="BodyContent">
 								<!-- Paragraphs  -->
 								<div ID="GH-151-c005g.p" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
-						<div ID="L.1.1.5.11" TYPE="Illustration" ORDER="8" DMDID="c013"
-							LABEL="Untitled image by Adolf Böhm">
+						<div ID="L.1.1.5.11" TYPE="Illustration" ORDER="8" DMDID="c013" LABEL="Untitled image by Adolf Böhm">
 							<div ID="L.1.1.5.11.1" TYPE="Byline">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
@@ -4160,21 +3961,18 @@
 							</div>
 						</div>
 					</div>
-					<div ID="GH-151-c005h" TYPE="TextContent" ORDER="8" DMDID="c005h"
-						LABEL="In welken Kronen…">
+					<div ID="GH-151-c005h" TYPE="TextContent" ORDER="8" DMDID="c005h" LABEL="In welken Kronen…">
 						<div ID="GH-151-c005h.c" TYPE="Copy">
 							<div ID="GH-151-c005h.c.b" TYPE="BodyContent">
 								<!-- Paragraphs  -->
 								<div ID="GH-151-c005h.p" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
-						<div ID="L.1.1.5.12" TYPE="Illustration" ORDER="9" DMDID="c014"
-							LABEL="Untitled image by Adolf Böhm">
+						<div ID="L.1.1.5.12" TYPE="Illustration" ORDER="9" DMDID="c014" LABEL="Untitled image by Adolf Böhm">
 							<div ID="L.1.1.5.12.1" TYPE="Byline">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
@@ -4187,21 +3985,18 @@
 							</div>
 						</div>
 					</div>
-					<div ID="GH-151-c005i" TYPE="TextContent" ORDER="9" DMDID="c005i"
-						LABEL="Auf einem Berg aus Zuckerkant…">
+					<div ID="GH-151-c005i" TYPE="TextContent" ORDER="9" DMDID="c005i" LABEL="Auf einem Berg aus Zuckerkant…">
 						<div ID="GH-151-c005i.c" TYPE="Copy">
 							<div ID="GH-151-c005i.c.b" TYPE="BodyContent">
 								<!-- Paragraphs  -->
 								<div ID="GH-151-c005i.p" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
-						<div ID="L.1.1.5.13" TYPE="Illustration" ORDER="10" DMDID="c015"
-							LABEL="Untitled image by Friedrich König">
+						<div ID="L.1.1.5.13" TYPE="Illustration" ORDER="10" DMDID="c015" LABEL="Untitled image by Friedrich König">
 							<div ID="L.1.1.5.13.1" TYPE="Byline">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
@@ -4214,21 +4009,18 @@
 							</div>
 						</div>
 					</div>
-					<div ID="GH-151-c005j" TYPE="TextContent" ORDER="10" DMDID="c005j"
-						LABEL="Zwölf!...">
+					<div ID="GH-151-c005j" TYPE="TextContent" ORDER="10" DMDID="c005j" LABEL="Zwölf!...">
 						<div ID="GH-151-c005j.c" TYPE="Copy">
 							<div ID="GH-151-c005j.c.b" TYPE="BodyContent">
 								<!-- Paragraphs  -->
 								<div ID="GH-151-c005j.p" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
-						<div ID="L.1.1.5.14" TYPE="Illustration" ORDER="11" DMDID="c016"
-							LABEL="Untitled Image by Friedrich König">
+						<div ID="L.1.1.5.14" TYPE="Illustration" ORDER="11" DMDID="c016" LABEL="Untitled Image by Friedrich König">
 							<div ID="L.1.1.5.14.1" TYPE="Byline">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
@@ -4262,30 +4054,21 @@
 								<div ID="L.1.1.6.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c018"
-						LABEL="Placatskizze">
+					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="1" DMDID="c018" LABEL="Placatskizze">
 						<div ID="L.1.1.6.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
@@ -4307,8 +4090,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="2" DMDID="c019"
-						LABEL="Placatskizze">
+					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="2" DMDID="c019" LABEL="Placatskizze">
 						<div ID="L.1.1.6.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00006"/>
@@ -4325,8 +4107,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.6" TYPE="Illustration" ORDER="3" DMDID="c020"
-						LABEL="ENTWURF ZU EINEM SCHÜTZENFEST-PLACAT. ">
+					<div ID="L.1.1.6.6" TYPE="Illustration" ORDER="3" DMDID="c020" LABEL="ENTWURF ZU EINEM SCHÜTZENFEST-PLACAT. ">
 						<div ID="L.1.1.6.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
@@ -4343,8 +4124,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.7" TYPE="Illustration" ORDER="4" DMDID="c021"
-						LABEL="ENTWURF ZU EINEM KALENDERBLATT">
+					<div ID="L.1.1.6.7" TYPE="Illustration" ORDER="4" DMDID="c021" LABEL="ENTWURF ZU EINEM KALENDERBLATT">
 						<div ID="L.1.1.6.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
@@ -4361,8 +4141,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.8" TYPE="Illustration" ORDER="5" DMDID="c022"
-						LABEL="ENTWURF ZU EINEM KALENDERBLATT">
+					<div ID="L.1.1.6.8" TYPE="Illustration" ORDER="5" DMDID="c022" LABEL="ENTWURF ZU EINEM KALENDERBLATT">
 						<div ID="L.1.1.6.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
@@ -4379,8 +4158,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.9" TYPE="Illustration" ORDER="6" DMDID="c023"
-						LABEL="Untitled Image by Alois Hänisch">
+					<div ID="L.1.1.6.9" TYPE="Illustration" ORDER="6" DMDID="c023" LABEL="Untitled Image by Alois Hänisch">
 						<div ID="L.1.1.6.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00003"/>
@@ -4418,8 +4196,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="TextContent" ORDER="6" DMDID="c025"
-					LABEL="FARBIGE LITHOGRAPHIEN FÜR DIE SCHULE">
+				<div ID="L.1.1.8" TYPE="TextContent" ORDER="6" DMDID="c025" LABEL="FARBIGE LITHOGRAPHIEN FÜR DIE SCHULE">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00005"/>
@@ -4436,22 +4213,14 @@
 								<div ID="L.1.1.8.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00007"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4475,8 +4244,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="2" DMDID="c027"
-						LABEL="Untitled Image by Alois Hänisch">
+					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="2" DMDID="c027" LABEL="Untitled Image by Alois Hänisch">
 						<div ID="L.1.1.8.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00006"/>
@@ -4493,8 +4261,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="1" DMDID="c028"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="1" DMDID="c028" LABEL="Untitled Image">
 						<div ID="L.1.1.8.6.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_CB00002"/>
@@ -4523,8 +4290,7 @@
 							<div ID="L.1.1.9.3.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.9.3.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00004"/>
 									</fptr>
 								</div>
 							</div>
@@ -4532,18 +4298,15 @@
 								<div ID="L.1.1.9.3.1.3.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.9.4" TYPE="Illustration" ORDER="1" DMDID="c030"
-						LABEL="frischer Wind">
+					<div ID="L.1.1.9.4" TYPE="Illustration" ORDER="1" DMDID="c030" LABEL="frischer Wind">
 						<div ID="L.1.1.9.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00005"/>
@@ -4578,8 +4341,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="TextContent" ORDER="8" DMDID="c032"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.10" TYPE="TextContent" ORDER="8" DMDID="c032" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00001"/>
@@ -4590,15 +4352,13 @@
 							<div ID="L.1.1.10.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.10.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.10.3" TYPE="Illustration" ORDER="1" DMDID="c033"
-						LABEL="Untitled Image by Alois Hänisch">
+					<div ID="L.1.1.10.3" TYPE="Illustration" ORDER="1" DMDID="c033" LABEL="Untitled Image by Alois Hänisch">
 						<div ID="L.1.1.10.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"/>
@@ -4615,8 +4375,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="2" DMDID="c034"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="2" DMDID="c034" LABEL="Buchschmuck">
 						<div ID="L.1.1.10.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00005"/>

--- a/metadata/periodicals/bmtnabf/issues/1898/12_01/bmtnabf_1898-12_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1898/12_01/bmtnabf_1898-12_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-12_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1898-12_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1898-12_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1899/02_01/bmtnabf_1899-02_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1899/02_01/bmtnabf_1899-02_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-02_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1899-02_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-02_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1899/03_01/bmtnabf_1899-03_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1899/03_01/bmtnabf_1899-03_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-03_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1899-03_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-03_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1899/04_01/bmtnabf_1899-04_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1899/04_01/bmtnabf_1899-04_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-   xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-   xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-   TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-04_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-04_01">
    <metsHdr>
       <agent ROLE="CREATOR" TYPE="ORGANIZATION">
          <name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
          <xmlData>
             <mods xmlns="http://www.loc.gov/mods/v3">
                <recordInfo>
-                  <recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+                  <mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-04_01</mods:recordIdentifier>
                </recordInfo>
-               <identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+               <mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1899-04_01</mods:identifier>
                <typeOfResource>text</typeOfResource>
                <genre>Periodicals-Issue</genre>
                <titleInfo>
@@ -50,10 +45,9 @@
                      </copyInformation>
                   </holdingSimple>
                </location>
-               <relatedItem type="host" xlink:type="simple"
-                  xlink:href="urn:PUL:bluemountain:bmtnabf">
+               <relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
                   <recordInfo>
-                     <recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+                     <mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-04_01</mods:recordIdentifier>
                   </recordInfo>
                </relatedItem>
                <relatedItem type="constituent" ID="c001">
@@ -3054,367 +3048,204 @@
    </amdSec>
    <fileSec>
       <fileGrp ID="IMGGRP" USE="Images">
-         <file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:37:36"
-            MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a265122ac045999f9ce6cf24fb2a97c4b1825684"
-            CHECKSUMTYPE="SHA-1" SIZE="6275828">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0001.jp2"
-            />
+         <file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:37:36" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a265122ac045999f9ce6cf24fb2a97c4b1825684" CHECKSUMTYPE="SHA-1" SIZE="6275828">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0001.jp2"/>
          </file>
-         <file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:38:12"
-            MIMETYPE="image/jp2" SEQ="2" CHECKSUM="f1dcdb4159f85cf9e210bd1e45af83f4289b32a9"
-            CHECKSUMTYPE="SHA-1" SIZE="6268625">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0002.jp2"
-            />
+         <file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:38:12" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="f1dcdb4159f85cf9e210bd1e45af83f4289b32a9" CHECKSUMTYPE="SHA-1" SIZE="6268625">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0002.jp2"/>
          </file>
-         <file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:38:48"
-            MIMETYPE="image/jp2" SEQ="3" CHECKSUM="6020b1f0908f2dedf8d8e7a2cedf4edf37134328"
-            CHECKSUMTYPE="SHA-1" SIZE="6274927">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0003.jp2"
-            />
+         <file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:38:48" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="6020b1f0908f2dedf8d8e7a2cedf4edf37134328" CHECKSUMTYPE="SHA-1" SIZE="6274927">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0003.jp2"/>
          </file>
-         <file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:39:20"
-            MIMETYPE="image/jp2" SEQ="4" CHECKSUM="2f7c471c41eb4829aa413972cdcfa30ea46b5214"
-            CHECKSUMTYPE="SHA-1" SIZE="6268622">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0004.jp2"
-            />
+         <file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:39:20" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="2f7c471c41eb4829aa413972cdcfa30ea46b5214" CHECKSUMTYPE="SHA-1" SIZE="6268622">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0004.jp2"/>
          </file>
-         <file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:39:53"
-            MIMETYPE="image/jp2" SEQ="5" CHECKSUM="4c6315175d342ca5ff62f8b81ee2db64b93a67aa"
-            CHECKSUMTYPE="SHA-1" SIZE="6247919">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0005.jp2"
-            />
+         <file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:39:53" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="4c6315175d342ca5ff62f8b81ee2db64b93a67aa" CHECKSUMTYPE="SHA-1" SIZE="6247919">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0005.jp2"/>
          </file>
-         <file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:40:27"
-            MIMETYPE="image/jp2" SEQ="6" CHECKSUM="27dff23646401baafa62b2e300753fa4d1fbeb44"
-            CHECKSUMTYPE="SHA-1" SIZE="6292929">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0006.jp2"
-            />
+         <file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:40:27" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="27dff23646401baafa62b2e300753fa4d1fbeb44" CHECKSUMTYPE="SHA-1" SIZE="6292929">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0006.jp2"/>
          </file>
-         <file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:41:04"
-            MIMETYPE="image/jp2" SEQ="7" CHECKSUM="01b2e436f54da1add470194a7620a8512bd7937d"
-            CHECKSUMTYPE="SHA-1" SIZE="6247899">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0007.jp2"
-            />
+         <file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:41:04" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="01b2e436f54da1add470194a7620a8512bd7937d" CHECKSUMTYPE="SHA-1" SIZE="6247899">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0007.jp2"/>
          </file>
-         <file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:41:45"
-            MIMETYPE="image/jp2" SEQ="8" CHECKSUM="58032988a5ab22441b70e8d276c0f29463277cc1"
-            CHECKSUMTYPE="SHA-1" SIZE="6328920">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0008.jp2"
-            />
+         <file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:41:45" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="58032988a5ab22441b70e8d276c0f29463277cc1" CHECKSUMTYPE="SHA-1" SIZE="6328920">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0008.jp2"/>
          </file>
-         <file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:42:23"
-            MIMETYPE="image/jp2" SEQ="9" CHECKSUM="1e240eb14f82fd2381df182bbb06205c7a3e248e"
-            CHECKSUMTYPE="SHA-1" SIZE="6247927">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0009.jp2"
-            />
+         <file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:42:23" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="1e240eb14f82fd2381df182bbb06205c7a3e248e" CHECKSUMTYPE="SHA-1" SIZE="6247927">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0009.jp2"/>
          </file>
-         <file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:42:59"
-            MIMETYPE="image/jp2" SEQ="10" CHECKSUM="abe326f6bb121b5ba650a4a63696a62d28fdfa2c"
-            CHECKSUMTYPE="SHA-1" SIZE="6342420">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0010.jp2"
-            />
+         <file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:42:59" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="abe326f6bb121b5ba650a4a63696a62d28fdfa2c" CHECKSUMTYPE="SHA-1" SIZE="6342420">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0010.jp2"/>
          </file>
-         <file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:43:35"
-            MIMETYPE="image/jp2" SEQ="11" CHECKSUM="ba9c4e0bf0f2a8acbd7e093524df11c95934a7fb"
-            CHECKSUMTYPE="SHA-1" SIZE="6292010">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0011.jp2"
-            />
+         <file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:43:35" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="ba9c4e0bf0f2a8acbd7e093524df11c95934a7fb" CHECKSUMTYPE="SHA-1" SIZE="6292010">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0011.jp2"/>
          </file>
-         <file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:44:11"
-            MIMETYPE="image/jp2" SEQ="12" CHECKSUM="e78c6a480e60b58861cd6fb3ca149663ecbeb51a"
-            CHECKSUMTYPE="SHA-1" SIZE="6342429">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0012.jp2"
-            />
+         <file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:44:11" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="e78c6a480e60b58861cd6fb3ca149663ecbeb51a" CHECKSUMTYPE="SHA-1" SIZE="6342429">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0012.jp2"/>
          </file>
-         <file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:44:47"
-            MIMETYPE="image/jp2" SEQ="13" CHECKSUM="73c22bb258d026b900f98671d2cc7bf2d83e66c8"
-            CHECKSUMTYPE="SHA-1" SIZE="6292028">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0013.jp2"
-            />
+         <file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:44:47" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="73c22bb258d026b900f98671d2cc7bf2d83e66c8" CHECKSUMTYPE="SHA-1" SIZE="6292028">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0013.jp2"/>
          </file>
-         <file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:45:21"
-            MIMETYPE="image/jp2" SEQ="14" CHECKSUM="43091f5772503b439763be1c2deca911a8b62128"
-            CHECKSUMTYPE="SHA-1" SIZE="6341526">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0014.jp2"
-            />
+         <file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:45:21" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="43091f5772503b439763be1c2deca911a8b62128" CHECKSUMTYPE="SHA-1" SIZE="6341526">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0014.jp2"/>
          </file>
-         <file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:45:58"
-            MIMETYPE="image/jp2" SEQ="15" CHECKSUM="dfb8ef113df4aecb439dadba31f59aa67aca95fb"
-            CHECKSUMTYPE="SHA-1" SIZE="6292028">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0015.jp2"
-            />
+         <file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:45:58" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="dfb8ef113df4aecb439dadba31f59aa67aca95fb" CHECKSUMTYPE="SHA-1" SIZE="6292028">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0015.jp2"/>
          </file>
-         <file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:46:36"
-            MIMETYPE="image/jp2" SEQ="16" CHECKSUM="f742ff7f05ebfc0f9f25db136a3ac8f820842006"
-            CHECKSUMTYPE="SHA-1" SIZE="6342429">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0016.jp2"
-            />
+         <file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:46:36" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="f742ff7f05ebfc0f9f25db136a3ac8f820842006" CHECKSUMTYPE="SHA-1" SIZE="6342429">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0016.jp2"/>
          </file>
-         <file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:47:07"
-            MIMETYPE="image/jp2" SEQ="17" CHECKSUM="a11c91d5c4ea4f0691215f719459211d53991580"
-            CHECKSUMTYPE="SHA-1" SIZE="6292020">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0017.jp2"
-            />
+         <file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:47:07" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="a11c91d5c4ea4f0691215f719459211d53991580" CHECKSUMTYPE="SHA-1" SIZE="6292020">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0017.jp2"/>
          </file>
-         <file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:47:45"
-            MIMETYPE="image/jp2" SEQ="18" CHECKSUM="25a7a8aad786113b426f80640c260a56d59b6378"
-            CHECKSUMTYPE="SHA-1" SIZE="6372120">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0018.jp2"
-            />
+         <file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:47:45" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="25a7a8aad786113b426f80640c260a56d59b6378" CHECKSUMTYPE="SHA-1" SIZE="6372120">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0018.jp2"/>
          </file>
-         <file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:48:21"
-            MIMETYPE="image/jp2" SEQ="19" CHECKSUM="5ee506c94448a206d34807487c263d81a7a880e1"
-            CHECKSUMTYPE="SHA-1" SIZE="6292024">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0019.jp2"
-            />
+         <file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:48:21" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="5ee506c94448a206d34807487c263d81a7a880e1" CHECKSUMTYPE="SHA-1" SIZE="6292024">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0019.jp2"/>
          </file>
-         <file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:48:59"
-            MIMETYPE="image/jp2" SEQ="20" CHECKSUM="2634014f9f6705c0aae666256878b6a44d4a41f1"
-            CHECKSUMTYPE="SHA-1" SIZE="6372127">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0020.jp2"
-            />
+         <file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:48:59" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="2634014f9f6705c0aae666256878b6a44d4a41f1" CHECKSUMTYPE="SHA-1" SIZE="6372127">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0020.jp2"/>
          </file>
-         <file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:49:34"
-            MIMETYPE="image/jp2" SEQ="21" CHECKSUM="2f37eb56f106c3bed05bb18ad187ca3ce6d4f880"
-            CHECKSUMTYPE="SHA-1" SIZE="6292023">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0021.jp2"
-            />
+         <file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:49:34" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="2f37eb56f106c3bed05bb18ad187ca3ce6d4f880" CHECKSUMTYPE="SHA-1" SIZE="6292023">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0021.jp2"/>
          </file>
-         <file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:50:10"
-            MIMETYPE="image/jp2" SEQ="22" CHECKSUM="2b7ee44c3e8f2e23202e6c85f70dc87c0abc8dd8"
-            CHECKSUMTYPE="SHA-1" SIZE="6372126">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0022.jp2"
-            />
+         <file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:50:10" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="2b7ee44c3e8f2e23202e6c85f70dc87c0abc8dd8" CHECKSUMTYPE="SHA-1" SIZE="6372126">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0022.jp2"/>
          </file>
-         <file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:50:43"
-            MIMETYPE="image/jp2" SEQ="23" CHECKSUM="c7aa1000f38fc4443f9fd502e7f49af2f5a1db67"
-            CHECKSUMTYPE="SHA-1" SIZE="6310929">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0023.jp2"
-            />
+         <file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:50:43" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="c7aa1000f38fc4443f9fd502e7f49af2f5a1db67" CHECKSUMTYPE="SHA-1" SIZE="6310929">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0023.jp2"/>
          </file>
-         <file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:51:21"
-            MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f2d2dea9bfda2463182b6a9d872a2947b81c0dd1"
-            CHECKSUMTYPE="SHA-1" SIZE="6372128">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0024.jp2"
-            />
+         <file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:51:21" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f2d2dea9bfda2463182b6a9d872a2947b81c0dd1" CHECKSUMTYPE="SHA-1" SIZE="6372128">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0024.jp2"/>
          </file>
-         <file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:51:58"
-            MIMETYPE="image/jp2" SEQ="25" CHECKSUM="0eb11d8daffefac16f08b8b62204a1ec1c1e4346"
-            CHECKSUMTYPE="SHA-1" SIZE="6310917">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0025.jp2"
-            />
+         <file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:51:58" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="0eb11d8daffefac16f08b8b62204a1ec1c1e4346" CHECKSUMTYPE="SHA-1" SIZE="6310917">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0025.jp2"/>
          </file>
-         <file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:52:35"
-            MIMETYPE="image/jp2" SEQ="26" CHECKSUM="7b2d1cf30b8fa5fe349f1294c6248f40018aceeb"
-            CHECKSUMTYPE="SHA-1" SIZE="6372127">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0026.jp2"
-            />
+         <file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:52:35" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="7b2d1cf30b8fa5fe349f1294c6248f40018aceeb" CHECKSUMTYPE="SHA-1" SIZE="6372127">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0026.jp2"/>
          </file>
-         <file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:53:10"
-            MIMETYPE="image/jp2" SEQ="27" CHECKSUM="de9f3a450decc8bc44afa008af4abfaa9582b04d"
-            CHECKSUMTYPE="SHA-1" SIZE="6310927">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0027.jp2"
-            />
+         <file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:53:10" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="de9f3a450decc8bc44afa008af4abfaa9582b04d" CHECKSUMTYPE="SHA-1" SIZE="6310927">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0027.jp2"/>
          </file>
-         <file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:53:45"
-            MIMETYPE="image/jp2" SEQ="28" CHECKSUM="ff073f89ee91b64bd512b0e633ec021f1f0afb3d"
-            CHECKSUMTYPE="SHA-1" SIZE="6371217">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0028.jp2"
-            />
+         <file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:53:45" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="ff073f89ee91b64bd512b0e633ec021f1f0afb3d" CHECKSUMTYPE="SHA-1" SIZE="6371217">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0028.jp2"/>
          </file>
-         <file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:54:21"
-            MIMETYPE="image/jp2" SEQ="29" CHECKSUM="d97f807fd1376fec809de3c6dac846b599a89819"
-            CHECKSUMTYPE="SHA-1" SIZE="6310029">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0029.jp2"
-            />
+         <file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:54:21" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="d97f807fd1376fec809de3c6dac846b599a89819" CHECKSUMTYPE="SHA-1" SIZE="6310029">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0029.jp2"/>
          </file>
-         <file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:54:57"
-            MIMETYPE="image/jp2" SEQ="30" CHECKSUM="254033487f291962ff53c2e07329f388d747ba0d"
-            CHECKSUMTYPE="SHA-1" SIZE="6371229">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0030.jp2"
-            />
+         <file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:54:57" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="254033487f291962ff53c2e07329f388d747ba0d" CHECKSUMTYPE="SHA-1" SIZE="6371229">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0030.jp2"/>
          </file>
-         <file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:55:32"
-            MIMETYPE="image/jp2" SEQ="31" CHECKSUM="9f06a174ecd1999d50a1f1afbb658842ada9c4c4"
-            CHECKSUMTYPE="SHA-1" SIZE="6310006">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0031.jp2"
-            />
+         <file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:55:32" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="9f06a174ecd1999d50a1f1afbb658842ada9c4c4" CHECKSUMTYPE="SHA-1" SIZE="6310006">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0031.jp2"/>
          </file>
-         <file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:56:09"
-            MIMETYPE="image/jp2" SEQ="32" CHECKSUM="7d1592e8a6194cbfd31c829c87ad3376c6017b11"
-            CHECKSUMTYPE="SHA-1" SIZE="6370327">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0032.jp2"
-            />
+         <file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:56:09" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="7d1592e8a6194cbfd31c829c87ad3376c6017b11" CHECKSUMTYPE="SHA-1" SIZE="6370327">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/delivery/bmtnabf_1899-04_01_0032.jp2"/>
          </file>
       </fileGrp>
       <fileGrp ID="ALTOGRP" USE="OCR">
-         <file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:56:30" MIMETYPE="text/xml"
-            CHECKSUM="5529049986a0273858582ee0bea0b6ae1ed9c63c" CHECKSUMTYPE="SHA-1" SIZE="8214">
+         <file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:56:30" MIMETYPE="text/xml" CHECKSUM="5529049986a0273858582ee0bea0b6ae1ed9c63c" CHECKSUMTYPE="SHA-1" SIZE="8214">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0001.alto.xml"/>
          </file>
-         <file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:56:30" MIMETYPE="text/xml"
-            CHECKSUM="c00d23caba0d3fc4b5af9dab659f6c34d32f047c" CHECKSUMTYPE="SHA-1" SIZE="8774">
+         <file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:56:30" MIMETYPE="text/xml" CHECKSUM="c00d23caba0d3fc4b5af9dab659f6c34d32f047c" CHECKSUMTYPE="SHA-1" SIZE="8774">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0002.alto.xml"/>
          </file>
-         <file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:56:31" MIMETYPE="text/xml"
-            CHECKSUM="328f142830f4a68ced9b8359161b061e09254b99" CHECKSUMTYPE="SHA-1" SIZE="20649">
+         <file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:56:31" MIMETYPE="text/xml" CHECKSUM="328f142830f4a68ced9b8359161b061e09254b99" CHECKSUMTYPE="SHA-1" SIZE="20649">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0003.alto.xml"/>
          </file>
-         <file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:56:31" MIMETYPE="text/xml"
-            CHECKSUM="5fe7a2482cf4339b18254a168ce7ead7cff09321" CHECKSUMTYPE="SHA-1" SIZE="4702">
+         <file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:56:31" MIMETYPE="text/xml" CHECKSUM="5fe7a2482cf4339b18254a168ce7ead7cff09321" CHECKSUMTYPE="SHA-1" SIZE="4702">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0004.alto.xml"/>
          </file>
-         <file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:56:31" MIMETYPE="text/xml"
-            CHECKSUM="af600dda0f2f24bb559da516adbc4ff9379de0c3" CHECKSUMTYPE="SHA-1" SIZE="47758">
+         <file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:56:31" MIMETYPE="text/xml" CHECKSUM="af600dda0f2f24bb559da516adbc4ff9379de0c3" CHECKSUMTYPE="SHA-1" SIZE="47758">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0005.alto.xml"/>
          </file>
-         <file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:56:32" MIMETYPE="text/xml"
-            CHECKSUM="89ff12fb25d47f8ab5024533d508e206cd268767" CHECKSUMTYPE="SHA-1" SIZE="108324">
+         <file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:56:32" MIMETYPE="text/xml" CHECKSUM="89ff12fb25d47f8ab5024533d508e206cd268767" CHECKSUMTYPE="SHA-1" SIZE="108324">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0006.alto.xml"/>
          </file>
-         <file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:56:32" MIMETYPE="text/xml"
-            CHECKSUM="0087b22519988631063dc46def2f7dec0fdd6c86" CHECKSUMTYPE="SHA-1" SIZE="5539">
+         <file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:56:32" MIMETYPE="text/xml" CHECKSUM="0087b22519988631063dc46def2f7dec0fdd6c86" CHECKSUMTYPE="SHA-1" SIZE="5539">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0007.alto.xml"/>
          </file>
-         <file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:56:32" MIMETYPE="text/xml"
-            CHECKSUM="2e5c48a8d7764767c4f61ed035fbff1ab8f00c3e" CHECKSUMTYPE="SHA-1" SIZE="78868">
+         <file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:56:32" MIMETYPE="text/xml" CHECKSUM="2e5c48a8d7764767c4f61ed035fbff1ab8f00c3e" CHECKSUMTYPE="SHA-1" SIZE="78868">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0008.alto.xml"/>
          </file>
-         <file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:56:32" MIMETYPE="text/xml"
-            CHECKSUM="af3ec637f45f5f2ca070b40a1b8b3b3d6f346c68" CHECKSUMTYPE="SHA-1" SIZE="79546">
+         <file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:56:32" MIMETYPE="text/xml" CHECKSUM="af3ec637f45f5f2ca070b40a1b8b3b3d6f346c68" CHECKSUMTYPE="SHA-1" SIZE="79546">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0009.alto.xml"/>
          </file>
-         <file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:56:33" MIMETYPE="text/xml"
-            CHECKSUM="426ddcd261d983b67cb8f44cbaeb994ff58afc8a" CHECKSUMTYPE="SHA-1" SIZE="5076">
+         <file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:56:33" MIMETYPE="text/xml" CHECKSUM="426ddcd261d983b67cb8f44cbaeb994ff58afc8a" CHECKSUMTYPE="SHA-1" SIZE="5076">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0010.alto.xml"/>
          </file>
-         <file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:56:33" MIMETYPE="text/xml"
-            CHECKSUM="8ceee813c0a3555e3082904a2adbc417df2436e2" CHECKSUMTYPE="SHA-1" SIZE="129422">
+         <file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:56:33" MIMETYPE="text/xml" CHECKSUM="8ceee813c0a3555e3082904a2adbc417df2436e2" CHECKSUMTYPE="SHA-1" SIZE="129422">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0011.alto.xml"/>
          </file>
-         <file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:56:33" MIMETYPE="text/xml"
-            CHECKSUM="fe3144564b0cd13742683febb7137f27697e0090" CHECKSUMTYPE="SHA-1" SIZE="58621">
+         <file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:56:33" MIMETYPE="text/xml" CHECKSUM="fe3144564b0cd13742683febb7137f27697e0090" CHECKSUMTYPE="SHA-1" SIZE="58621">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0012.alto.xml"/>
          </file>
-         <file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:56:34" MIMETYPE="text/xml"
-            CHECKSUM="5f23fc3289fc30e0799f74dba18f40b9b73c2b41" CHECKSUMTYPE="SHA-1" SIZE="92761">
+         <file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:56:34" MIMETYPE="text/xml" CHECKSUM="5f23fc3289fc30e0799f74dba18f40b9b73c2b41" CHECKSUMTYPE="SHA-1" SIZE="92761">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0013.alto.xml"/>
          </file>
-         <file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:56:34" MIMETYPE="text/xml"
-            CHECKSUM="e6e50907ee54b7491bb3cf3624f59019f5e14997" CHECKSUMTYPE="SHA-1" SIZE="92208">
+         <file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:56:34" MIMETYPE="text/xml" CHECKSUM="e6e50907ee54b7491bb3cf3624f59019f5e14997" CHECKSUMTYPE="SHA-1" SIZE="92208">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0014.alto.xml"/>
          </file>
-         <file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:56:34" MIMETYPE="text/xml"
-            CHECKSUM="b89fd4d0aa9aa321d4a13e3d9806cdce45a05667" CHECKSUMTYPE="SHA-1" SIZE="7655">
+         <file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:56:34" MIMETYPE="text/xml" CHECKSUM="b89fd4d0aa9aa321d4a13e3d9806cdce45a05667" CHECKSUMTYPE="SHA-1" SIZE="7655">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0015.alto.xml"/>
          </file>
-         <file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:56:34" MIMETYPE="text/xml"
-            CHECKSUM="52cbe4f140701e09c39defdd359711e79c32ffbc" CHECKSUMTYPE="SHA-1" SIZE="2403">
+         <file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:56:34" MIMETYPE="text/xml" CHECKSUM="52cbe4f140701e09c39defdd359711e79c32ffbc" CHECKSUMTYPE="SHA-1" SIZE="2403">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0016.alto.xml"/>
          </file>
-         <file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:56:35" MIMETYPE="text/xml"
-            CHECKSUM="5a3a485f6f925d1dfe228541a0839e0876d2e624" CHECKSUMTYPE="SHA-1" SIZE="59801">
+         <file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:56:35" MIMETYPE="text/xml" CHECKSUM="5a3a485f6f925d1dfe228541a0839e0876d2e624" CHECKSUMTYPE="SHA-1" SIZE="59801">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0017.alto.xml"/>
          </file>
-         <file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:56:35" MIMETYPE="text/xml"
-            CHECKSUM="182c5d7f3770890506cdc1650c46b56adca7e51e" CHECKSUMTYPE="SHA-1" SIZE="117957">
+         <file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:56:35" MIMETYPE="text/xml" CHECKSUM="182c5d7f3770890506cdc1650c46b56adca7e51e" CHECKSUMTYPE="SHA-1" SIZE="117957">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0018.alto.xml"/>
          </file>
-         <file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:56:35" MIMETYPE="text/xml"
-            CHECKSUM="34df0ca34bfe82b7134db7403de5aee55a9c4b98" CHECKSUMTYPE="SHA-1" SIZE="4565">
+         <file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:56:35" MIMETYPE="text/xml" CHECKSUM="34df0ca34bfe82b7134db7403de5aee55a9c4b98" CHECKSUMTYPE="SHA-1" SIZE="4565">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0019.alto.xml"/>
          </file>
-         <file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:56:35" MIMETYPE="text/xml"
-            CHECKSUM="d529678383e57d9d57ca2ade63f1eafbde92992d" CHECKSUMTYPE="SHA-1" SIZE="131028">
+         <file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:56:35" MIMETYPE="text/xml" CHECKSUM="d529678383e57d9d57ca2ade63f1eafbde92992d" CHECKSUMTYPE="SHA-1" SIZE="131028">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0020.alto.xml"/>
          </file>
-         <file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:56:36" MIMETYPE="text/xml"
-            CHECKSUM="50782abfef82dfa9fa377f040546e74e63143944" CHECKSUMTYPE="SHA-1" SIZE="14356">
+         <file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:56:36" MIMETYPE="text/xml" CHECKSUM="50782abfef82dfa9fa377f040546e74e63143944" CHECKSUMTYPE="SHA-1" SIZE="14356">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0021.alto.xml"/>
          </file>
-         <file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:56:36" MIMETYPE="text/xml"
-            CHECKSUM="77808f1b3da7120b73210356c5a020bb925cdf0e" CHECKSUMTYPE="SHA-1" SIZE="2403">
+         <file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:56:36" MIMETYPE="text/xml" CHECKSUM="77808f1b3da7120b73210356c5a020bb925cdf0e" CHECKSUMTYPE="SHA-1" SIZE="2403">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0022.alto.xml"/>
          </file>
-         <file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:56:36" MIMETYPE="text/xml"
-            CHECKSUM="9d3949c6ae4248b8469a51370992eaf30f0927ec" CHECKSUMTYPE="SHA-1" SIZE="32252">
+         <file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:56:36" MIMETYPE="text/xml" CHECKSUM="9d3949c6ae4248b8469a51370992eaf30f0927ec" CHECKSUMTYPE="SHA-1" SIZE="32252">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0023.alto.xml"/>
          </file>
-         <file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:56:37" MIMETYPE="text/xml"
-            CHECKSUM="1686bc6260ccc1913d7e0efc142db90759c9d1b8" CHECKSUMTYPE="SHA-1" SIZE="141512">
+         <file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:56:37" MIMETYPE="text/xml" CHECKSUM="1686bc6260ccc1913d7e0efc142db90759c9d1b8" CHECKSUMTYPE="SHA-1" SIZE="141512">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0024.alto.xml"/>
          </file>
-         <file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:56:37" MIMETYPE="text/xml"
-            CHECKSUM="ab4a8b40194a70e042993b86668362ef440c9736" CHECKSUMTYPE="SHA-1" SIZE="102706">
+         <file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:56:37" MIMETYPE="text/xml" CHECKSUM="ab4a8b40194a70e042993b86668362ef440c9736" CHECKSUMTYPE="SHA-1" SIZE="102706">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0025.alto.xml"/>
          </file>
-         <file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:56:37" MIMETYPE="text/xml"
-            CHECKSUM="37abe8b8fdb496c6e9b2724123ad5df77edfb4c2" CHECKSUMTYPE="SHA-1" SIZE="120170">
+         <file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:56:37" MIMETYPE="text/xml" CHECKSUM="37abe8b8fdb496c6e9b2724123ad5df77edfb4c2" CHECKSUMTYPE="SHA-1" SIZE="120170">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0026.alto.xml"/>
          </file>
-         <file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:56:38" MIMETYPE="text/xml"
-            CHECKSUM="68518e7e918456615661828001b788af9b640d34" CHECKSUMTYPE="SHA-1" SIZE="2401">
+         <file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:56:38" MIMETYPE="text/xml" CHECKSUM="68518e7e918456615661828001b788af9b640d34" CHECKSUMTYPE="SHA-1" SIZE="2401">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0027.alto.xml"/>
          </file>
-         <file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:56:38" MIMETYPE="text/xml"
-            CHECKSUM="5969b98652d905c7457677c3ad4c0aaa185e32a9" CHECKSUMTYPE="SHA-1" SIZE="6485">
+         <file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:56:38" MIMETYPE="text/xml" CHECKSUM="5969b98652d905c7457677c3ad4c0aaa185e32a9" CHECKSUMTYPE="SHA-1" SIZE="6485">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0028.alto.xml"/>
          </file>
-         <file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:56:38" MIMETYPE="text/xml"
-            CHECKSUM="b527367c429cf4236654e92d7d390cb4d554dd7f" CHECKSUMTYPE="SHA-1" SIZE="33464">
+         <file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:56:38" MIMETYPE="text/xml" CHECKSUM="b527367c429cf4236654e92d7d390cb4d554dd7f" CHECKSUMTYPE="SHA-1" SIZE="33464">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0029.alto.xml"/>
          </file>
-         <file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:56:39" MIMETYPE="text/xml"
-            CHECKSUM="7696f0661d5d409bafb06fc7e4e0bd74cd5fe504" CHECKSUMTYPE="SHA-1" SIZE="36901">
+         <file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:56:39" MIMETYPE="text/xml" CHECKSUM="7696f0661d5d409bafb06fc7e4e0bd74cd5fe504" CHECKSUMTYPE="SHA-1" SIZE="36901">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0030.alto.xml"/>
          </file>
-         <file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:56:39" MIMETYPE="text/xml"
-            CHECKSUM="51fb9818347519126f14b6b80a33259b46479c54" CHECKSUMTYPE="SHA-1" SIZE="6017">
+         <file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:56:39" MIMETYPE="text/xml" CHECKSUM="51fb9818347519126f14b6b80a33259b46479c54" CHECKSUMTYPE="SHA-1" SIZE="6017">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0031.alto.xml"/>
          </file>
-         <file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:56:39" MIMETYPE="text/xml"
-            CHECKSUM="f84c17fab9a0e1e8e7ab357bcb251b8337dce1bb" CHECKSUMTYPE="SHA-1" SIZE="3983">
+         <file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:56:39" MIMETYPE="text/xml" CHECKSUM="f84c17fab9a0e1e8e7ab357bcb251b8337dce1bb" CHECKSUMTYPE="SHA-1" SIZE="3983">
             <FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-04_01_0032.alto.xml"/>
          </file>
       </fileGrp>
       <fileGrp ID="PDFGRP" USE="PDF">
-         <file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:57:26" MIMETYPE="application/pdf"
-            CHECKSUM="9845ea7195bae0ae29ad79b10b5e3b31bbe1449d" CHECKSUMTYPE="SHA-1" SIZE="10236512">
-            <FLocat LOCTYPE="URL"
-               xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/bmtnabf_1899-04_01.pdf"
-            />
+         <file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:57:26" MIMETYPE="application/pdf" CHECKSUM="9845ea7195bae0ae29ad79b10b5e3b31bbe1449d" CHECKSUMTYPE="SHA-1" SIZE="10236512">
+            <FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/04_01/bmtnabf_1899-04_01.pdf"/>
          </file>
       </fileGrp>
    </fileSec>
@@ -3726,8 +3557,7 @@
 
             <!-- edits GH-157 -->
             <!--MET-157-start-->
-            <div ID="GH-157-c003a" TYPE="TextContent" ORDER="1" DMDID="c003a"
-               LABEL="IV. AUSSTELLUNG DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+            <div ID="GH-157-c003a" TYPE="TextContent" ORDER="1" DMDID="c003a" LABEL="IV. AUSSTELLUNG DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
                <div ID="L.1.1.4.1" TYPE="Head">
                   <fptr>
                      <area BETYPE="IDREF" FILEID="ALTO00002" BEGIN="P2_TB00001"/>
@@ -3767,8 +3597,7 @@
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.13" TYPE="Illustration" ORDER="13" DMDID="c030"
-                  LABEL="TEIL EINER SAALWAND">
+               <div ID="L.1.1.13" TYPE="Illustration" ORDER="13" DMDID="c030" LABEL="TEIL EINER SAALWAND">
                   <div ID="L.1.1.13.1" TYPE="Head">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00001"/>
@@ -3790,8 +3619,7 @@
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.17" TYPE="Illustration" ORDER="17" DMDID="c038"
-                  LABEL=" AUSGESTALTUNG DES GRAUEN SAALES">
+               <div ID="L.1.1.17" TYPE="Illustration" ORDER="17" DMDID="c038" LABEL=" AUSGESTALTUNG DES GRAUEN SAALES">
                   <div ID="L.1.1.17.1" TYPE="Head">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00001"/>
@@ -3837,8 +3665,7 @@
 
             <!--MET-157-end-->
 
-            <div ID="L.1.1.5" TYPE="Illustration" ORDER="1" DMDID="c004"
-               LABEL="Untitled Image by KOLOMAN MOSER">
+            <div ID="L.1.1.5" TYPE="Illustration" ORDER="1" DMDID="c004" LABEL="Untitled Image by KOLOMAN MOSER">
                <div ID="L.1.1.5.1" TYPE="Image">
                   <fptr>
                      <area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_CB00001"/>
@@ -3862,8 +3689,7 @@
                   </fptr>
                </div>
             </div>
-            <div ID="L.1.1.7" TYPE="TextContent" ORDER="7" DMDID="c006"
-               LABEL="DER GEIST DER JAPANISCHEN KUNST">
+            <div ID="L.1.1.7" TYPE="TextContent" ORDER="7" DMDID="c006" LABEL="DER GEIST DER JAPANISCHEN KUNST">
                <div ID="L.1.1.7.1" TYPE="Head">
                   <fptr>
                      <area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -3948,15 +3774,13 @@
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.7.6" TYPE="Illustration" ORDER="2" DMDID="c009"
-                  LABEL="DER VOGEL BÜLOW">
+               <div ID="L.1.1.7.6" TYPE="Illustration" ORDER="2" DMDID="c009" LABEL="DER VOGEL BÜLOW">
                   <div ID="L.1.1.7.6.1" TYPE="Head">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00004"/>
                      </fptr>
                   </div>
-                  <div ID="L.1.1.7.6.2" TYPE="Illustration" ORDER="1"
-                     LABEL="ENTWURF FÜR WEBEREI. ZWEIFARBIG.">
+                  <div ID="L.1.1.7.6.2" TYPE="Illustration" ORDER="1" LABEL="ENTWURF FÜR WEBEREI. ZWEIFARBIG.">
                      <div ID="L.1.1.7.6.2.1" TYPE="Image">
                         <fptr>
                            <area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_CB00001"/>
@@ -3974,15 +3798,13 @@
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.7.7" TYPE="Illustration" ORDER="3" DMDID="c011"
-                  LABEL="DIE SCHWARZEN TULPEN">
+               <div ID="L.1.1.7.7" TYPE="Illustration" ORDER="3" DMDID="c011" LABEL="DIE SCHWARZEN TULPEN">
                   <div ID="L.1.1.7.7.1" TYPE="Head">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00004"/>
                      </fptr>
                   </div>
-                  <div ID="L.1.1.7.7.2" TYPE="Illustration" ORDER="1"
-                     LABEL="ENTWURF FÜR WEBEREI. VIERFARBIG.">
+                  <div ID="L.1.1.7.7.2" TYPE="Illustration" ORDER="1" LABEL="ENTWURF FÜR WEBEREI. VIERFARBIG.">
                      <div ID="L.1.1.7.7.2.1" TYPE="Image">
                         <fptr>
                            <area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00001"/>
@@ -4000,15 +3822,13 @@
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.7.8" TYPE="Illustration" ORDER="4" DMDID="c013"
-                  LABEL="DIE ZERSCHNITTENEN BLÄTTER">
+               <div ID="L.1.1.7.8" TYPE="Illustration" ORDER="4" DMDID="c013" LABEL="DIE ZERSCHNITTENEN BLÄTTER">
                   <div ID="L.1.1.7.8.1" TYPE="Head">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00004"/>
                      </fptr>
                   </div>
-                  <div ID="L.1.1.7.8.2" TYPE="Illustration" ORDER="1"
-                     LABEL="ENTWURF FÜR WEBEREI. VIERFARBIG.">
+                  <div ID="L.1.1.7.8.2" TYPE="Illustration" ORDER="1" LABEL="ENTWURF FÜR WEBEREI. VIERFARBIG.">
                      <div ID="L.1.1.7.8.2.1" TYPE="Image">
                         <fptr>
                            <area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00001"/>
@@ -4020,8 +3840,7 @@
                         </fptr>
                      </div>
                   </div>
-                  <div ID="L.1.1.7.8.3" TYPE="Illustration" ORDER="2" DMDID="c014"
-                     LABEL="Untitled Image">
+                  <div ID="L.1.1.7.8.3" TYPE="Illustration" ORDER="2" DMDID="c014" LABEL="Untitled Image">
                      <div ID="L.1.1.7.8.3.1" TYPE="Image">
                         <fptr>
                            <area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00002"/>
@@ -4029,8 +3848,7 @@
                      </div>
                   </div>
                </div>
-               <div ID="L.1.1.7.9" TYPE="Illustration" ORDER="1" DMDID="c015"
-                  LABEL="ENTWURF FÜR BODEN – BELAG IN MEAU – QUETTES – WEBEREI">
+               <div ID="L.1.1.7.9" TYPE="Illustration" ORDER="1" DMDID="c015" LABEL="ENTWURF FÜR BODEN – BELAG IN MEAU – QUETTES – WEBEREI">
                   <div ID="L.1.1.7.9.1" TYPE="Image">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00001"/>
@@ -4042,16 +3860,14 @@
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.7.10" TYPE="Illustration" ORDER="2" DMDID="c016"
-                  LABEL="Untitled Image">
+               <div ID="L.1.1.7.10" TYPE="Illustration" ORDER="2" DMDID="c016" LABEL="Untitled Image">
                   <div ID="L.1.1.7.10.1" TYPE="Image">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00002"/>
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.7.11" TYPE="Illustration" ORDER="6" DMDID="c017"
-                  LABEL="HORTENSIENLAUBE">
+               <div ID="L.1.1.7.11" TYPE="Illustration" ORDER="6" DMDID="c017" LABEL="HORTENSIENLAUBE">
                   <div ID="L.1.1.7.11.1" TYPE="Head">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00006"/>
@@ -4068,8 +3884,7 @@
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.7.12" TYPE="Illustration" ORDER="7" DMDID="c018"
-                  LABEL="BLUMEN-ERWACHEN">
+               <div ID="L.1.1.7.12" TYPE="Illustration" ORDER="7" DMDID="c018" LABEL="BLUMEN-ERWACHEN">
                   <div ID="L.1.1.7.12.1" TYPE="Head">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00007"/>
@@ -4082,8 +3897,7 @@
                         </fptr>
                      </div>
                   </div>
-                  <div ID="L.1.1.7.12.3" TYPE="Illustration" ORDER="2" DMDID="c019"
-                     LABEL="Untitled Image">
+                  <div ID="L.1.1.7.12.3" TYPE="Illustration" ORDER="2" DMDID="c019" LABEL="Untitled Image">
                      <div ID="L.1.1.7.12.3.1" TYPE="Image">
                         <fptr>
                            <area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00002"/>
@@ -4109,8 +3923,7 @@
                         </fptr>
                      </div>
                   </div>
-                  <div ID="L.1.1.7.13.3" TYPE="Illustration" ORDER="2" DMDID="c021"
-                     LABEL="Untitled Image">
+                  <div ID="L.1.1.7.13.3" TYPE="Illustration" ORDER="2" DMDID="c021" LABEL="Untitled Image">
                      <div ID="L.1.1.7.13.3.1" TYPE="Image">
                         <fptr>
                            <area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00002"/>
@@ -4140,8 +3953,7 @@
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.7.15" TYPE="Illustration" ORDER="1" DMDID="c023"
-                  LABEL="ENTWURF FÜR VORSATZPAPIER.">
+               <div ID="L.1.1.7.15" TYPE="Illustration" ORDER="1" DMDID="c023" LABEL="ENTWURF FÜR VORSATZPAPIER.">
                   <div ID="L.1.1.7.15.1" TYPE="Image">
                      <fptr>
                         <seq>
@@ -4156,8 +3968,7 @@
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.7.16" TYPE="Illustration" ORDER="1" DMDID="c024"
-                  LABEL="Untitled Image">
+               <div ID="L.1.1.7.16" TYPE="Illustration" ORDER="1" DMDID="c024" LABEL="Untitled Image">
                   <div ID="L.1.1.7.16.1" TYPE="Image">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00001"/>
@@ -4182,8 +3993,7 @@
                   </fptr>
                </div>
             </div>
-            <div ID="L.1.1.9" TYPE="Illustration" ORDER="9" DMDID="c026"
-               LABEL="DAS SCHWEIGEN DES ABENDS">
+            <div ID="L.1.1.9" TYPE="Illustration" ORDER="9" DMDID="c026" LABEL="DAS SCHWEIGEN DES ABENDS">
                <div ID="L.1.1.9.1" TYPE="Head">
                   <fptr>
                      <area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -4290,24 +4100,21 @@
                      </div>
                   </div>
                </div>
-               <div ID="L.1.1.15.4" TYPE="Illustration" ORDER="1" DMDID="c033"
-                  LABEL="Untitled Image">
+               <div ID="L.1.1.15.4" TYPE="Illustration" ORDER="1" DMDID="c033" LABEL="Untitled Image">
                   <div ID="L.1.1.15.4.1" TYPE="Image">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_CB00001"/>
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.15.5" TYPE="Illustration" ORDER="1" DMDID="c034"
-                  LABEL="Untitled Image">
+               <div ID="L.1.1.15.5" TYPE="Illustration" ORDER="1" DMDID="c034" LABEL="Untitled Image">
                   <div ID="L.1.1.15.5.1" TYPE="Image">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_CB00001"/>
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.15.6" TYPE="Illustration" ORDER="3" DMDID="c035"
-                  LABEL="TEIL EINER SAALAUSSCHMÜCKUNG">
+               <div ID="L.1.1.15.6" TYPE="Illustration" ORDER="3" DMDID="c035" LABEL="TEIL EINER SAALAUSSCHMÜCKUNG">
                   <div ID="L.1.1.15.6.1" TYPE="Head">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00004"/>
@@ -4324,8 +4131,7 @@
                      </fptr>
                   </div>
                </div>
-               <div ID="L.1.1.15.7" TYPE="Illustration" ORDER="1" DMDID="c036"
-                  LABEL="ENTWURF ZU EINER PATRONE">
+               <div ID="L.1.1.15.7" TYPE="Illustration" ORDER="1" DMDID="c036" LABEL="ENTWURF ZU EINER PATRONE">
                   <div ID="L.1.1.15.7.1" TYPE="Image">
                      <fptr>
                         <seq>
@@ -4348,8 +4154,7 @@
                   </fptr>
                </div>
             </div>
-            <div ID="L.1.1.18" TYPE="TextContent" ORDER="18" DMDID="c039"
-               LABEL="MITTEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+            <div ID="L.1.1.18" TYPE="TextContent" ORDER="18" DMDID="c039" LABEL="MITTEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
                <div ID="L.1.1.18.1" TYPE="Head">
                   <fptr>
                      <area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00002"/>
@@ -4372,8 +4177,7 @@
                      </div>
                   </div>
                </div>
-               <div ID="L.1.1.18.3" TYPE="Illustration" ORDER="1" DMDID="c040"
-                  LABEL="ENTWURF FÜR WANDVERKLEIDUNGSFLIESEN.">
+               <div ID="L.1.1.18.3" TYPE="Illustration" ORDER="1" DMDID="c040" LABEL="ENTWURF FÜR WANDVERKLEIDUNGSFLIESEN.">
                   <div ID="L.1.1.18.3.1" TYPE="Image">
                      <fptr>
                         <area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_CB00001"/>
@@ -4403,8 +4207,7 @@
                   </div>
                </div>
             </div>
-            <div ID="L.1.1.20" TYPE="Illustration" ORDER="1" DMDID="c043"
-               LABEL="WANDDEKOR FÜR EIN MÄDCHENZIMMER.">
+            <div ID="L.1.1.20" TYPE="Illustration" ORDER="1" DMDID="c043" LABEL="WANDDEKOR FÜR EIN MÄDCHENZIMMER.">
                <div ID="L.1.1.20.1" TYPE="Image">
                   <fptr>
                      <area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_CB00001"/>

--- a/metadata/periodicals/bmtnabf/issues/1899/05_01/bmtnabf_1899-05_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1899/05_01/bmtnabf_1899-05_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-05_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1899-05_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-05_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1899/06_01/bmtnabf_1899-06_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1899/06_01/bmtnabf_1899-06_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-06_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-06_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-06_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1899-06_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-06_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3057,388 +3051,204 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:45:29"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="0d4a75cb3528f58daf36846871f770560b62ae15"
-				CHECKSUMTYPE="SHA-1" SIZE="6283016">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:45:29" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="0d4a75cb3528f58daf36846871f770560b62ae15" CHECKSUMTYPE="SHA-1" SIZE="6283016">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:46:01"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="ce1164dee2a738246c000b0568088bff273aab76"
-				CHECKSUMTYPE="SHA-1" SIZE="6354128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:46:01" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="ce1164dee2a738246c000b0568088bff273aab76" CHECKSUMTYPE="SHA-1" SIZE="6354128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:46:34"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="6ee530587d395566d9deaf4f2ac5c4c11eedef11"
-				CHECKSUMTYPE="SHA-1" SIZE="6319028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:46:34" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="6ee530587d395566d9deaf4f2ac5c4c11eedef11" CHECKSUMTYPE="SHA-1" SIZE="6319028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:47:07"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="73fba4b5f00c003616974591a4b7e976d2cbea13"
-				CHECKSUMTYPE="SHA-1" SIZE="6354112">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:47:07" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="73fba4b5f00c003616974591a4b7e976d2cbea13" CHECKSUMTYPE="SHA-1" SIZE="6354112">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:47:38"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="8f91d6a7266f0f329e378b5026a02ebf16a2cb78"
-				CHECKSUMTYPE="SHA-1" SIZE="6319026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:47:38" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="8f91d6a7266f0f329e378b5026a02ebf16a2cb78" CHECKSUMTYPE="SHA-1" SIZE="6319026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:48:09"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="71a134fde186536122247a6471cbfdb52c39173e"
-				CHECKSUMTYPE="SHA-1" SIZE="6354113">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:48:09" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="71a134fde186536122247a6471cbfdb52c39173e" CHECKSUMTYPE="SHA-1" SIZE="6354113">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:48:40"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="fae486134cf63bec674f4d3abdedc7c3aa51f5a9"
-				CHECKSUMTYPE="SHA-1" SIZE="6363119">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:48:40" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="fae486134cf63bec674f4d3abdedc7c3aa51f5a9" CHECKSUMTYPE="SHA-1" SIZE="6363119">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:49:12"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="aa33c7190924cb4fb3b53c1ccf1fb94a7702b312"
-				CHECKSUMTYPE="SHA-1" SIZE="6354117">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:49:12" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="aa33c7190924cb4fb3b53c1ccf1fb94a7702b312" CHECKSUMTYPE="SHA-1" SIZE="6354117">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:49:43"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="bbd608de62111b14fa0bc8b4f93c6501a2fcb6d8"
-				CHECKSUMTYPE="SHA-1" SIZE="6363127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:49:43" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="bbd608de62111b14fa0bc8b4f93c6501a2fcb6d8" CHECKSUMTYPE="SHA-1" SIZE="6363127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:50:14"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="4f406ef04f2d9b6a2a5098710fecd528c8848204"
-				CHECKSUMTYPE="SHA-1" SIZE="6354127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:50:14" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="4f406ef04f2d9b6a2a5098710fecd528c8848204" CHECKSUMTYPE="SHA-1" SIZE="6354127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:50:44"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="6f954f2eef5de59af923ce34a61043b58c420134"
-				CHECKSUMTYPE="SHA-1" SIZE="6363128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:50:44" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="6f954f2eef5de59af923ce34a61043b58c420134" CHECKSUMTYPE="SHA-1" SIZE="6363128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:51:16"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="6b3b4d00a48234e29824edcf11a5d251d520d88d"
-				CHECKSUMTYPE="SHA-1" SIZE="6354127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:51:16" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="6b3b4d00a48234e29824edcf11a5d251d520d88d" CHECKSUMTYPE="SHA-1" SIZE="6354127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:51:47"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="02c1da1d501ce76adb64085389edfff08f9ced3c"
-				CHECKSUMTYPE="SHA-1" SIZE="6363124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:51:47" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="02c1da1d501ce76adb64085389edfff08f9ced3c" CHECKSUMTYPE="SHA-1" SIZE="6363124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:52:25"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="140c8fc2a89f0ed79fa8481cc94016a3a9958844"
-				CHECKSUMTYPE="SHA-1" SIZE="6354119">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:52:25" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="140c8fc2a89f0ed79fa8481cc94016a3a9958844" CHECKSUMTYPE="SHA-1" SIZE="6354119">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:52:59"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="d17e777fe20745aab27941df8a7c834c1b934bad"
-				CHECKSUMTYPE="SHA-1" SIZE="6363106">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:52:59" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="d17e777fe20745aab27941df8a7c834c1b934bad" CHECKSUMTYPE="SHA-1" SIZE="6363106">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:53:30"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ad69a00d477ea1e0a1bc053e0dfe3766da0c8e72"
-				CHECKSUMTYPE="SHA-1" SIZE="6354111">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:53:30" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ad69a00d477ea1e0a1bc053e0dfe3766da0c8e72" CHECKSUMTYPE="SHA-1" SIZE="6354111">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:54:03"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e0f61fd7f217de1fe935f3991f3326ba862031e6"
-				CHECKSUMTYPE="SHA-1" SIZE="6363104">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:54:03" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e0f61fd7f217de1fe935f3991f3326ba862031e6" CHECKSUMTYPE="SHA-1" SIZE="6363104">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:54:33"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="1b15104888aa890118f157bceb8dbf731bc3f455"
-				CHECKSUMTYPE="SHA-1" SIZE="6354115">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:54:33" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="1b15104888aa890118f157bceb8dbf731bc3f455" CHECKSUMTYPE="SHA-1" SIZE="6354115">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:55:04"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="163265c5c8216f112aa07e0d46398ebcc2919f95"
-				CHECKSUMTYPE="SHA-1" SIZE="6363122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:55:04" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="163265c5c8216f112aa07e0d46398ebcc2919f95" CHECKSUMTYPE="SHA-1" SIZE="6363122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:55:35"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="50adbcdf84f4a5b92b2d2c438b2dc0a102b1a81b"
-				CHECKSUMTYPE="SHA-1" SIZE="6353225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:55:35" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="50adbcdf84f4a5b92b2d2c438b2dc0a102b1a81b" CHECKSUMTYPE="SHA-1" SIZE="6353225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:56:07"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="11fcbf771df05bc5b46fb939f86d6dd41a3e8b5a"
-				CHECKSUMTYPE="SHA-1" SIZE="6363126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:56:07" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="11fcbf771df05bc5b46fb939f86d6dd41a3e8b5a" CHECKSUMTYPE="SHA-1" SIZE="6363126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:56:39"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="821729b6431216cb2dba8793f9422736dcfb5acf"
-				CHECKSUMTYPE="SHA-1" SIZE="6353227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:56:39" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="821729b6431216cb2dba8793f9422736dcfb5acf" CHECKSUMTYPE="SHA-1" SIZE="6353227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:57:12"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="d83115ccaa0de106aeddf1fcb9bc7d21954f2897"
-				CHECKSUMTYPE="SHA-1" SIZE="6363125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:57:12" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="d83115ccaa0de106aeddf1fcb9bc7d21954f2897" CHECKSUMTYPE="SHA-1" SIZE="6363125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:57:45"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f5d5c20baeafc9974f09d2f4f0eb884740bad451"
-				CHECKSUMTYPE="SHA-1" SIZE="6353218">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:57:45" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f5d5c20baeafc9974f09d2f4f0eb884740bad451" CHECKSUMTYPE="SHA-1" SIZE="6353218">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:58:17"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="431cfa5bbbaaf3c902c475347821516164cc59d6"
-				CHECKSUMTYPE="SHA-1" SIZE="6363122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:58:17" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="431cfa5bbbaaf3c902c475347821516164cc59d6" CHECKSUMTYPE="SHA-1" SIZE="6363122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:58:49"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="060b52006b63c3272bbfa2637c2e1370ad13e472"
-				CHECKSUMTYPE="SHA-1" SIZE="6353226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:58:49" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="060b52006b63c3272bbfa2637c2e1370ad13e472" CHECKSUMTYPE="SHA-1" SIZE="6353226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:59:21"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="f53fa75c834a2168eb0730fef3efd7900e4c583d"
-				CHECKSUMTYPE="SHA-1" SIZE="6363123">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:59:21" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="f53fa75c834a2168eb0730fef3efd7900e4c583d" CHECKSUMTYPE="SHA-1" SIZE="6363123">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:59:54"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="aa73a57128e4d7ca6803535fe719df96a42242d9"
-				CHECKSUMTYPE="SHA-1" SIZE="6353218">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:59:54" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="aa73a57128e4d7ca6803535fe719df96a42242d9" CHECKSUMTYPE="SHA-1" SIZE="6353218">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T17:00:23"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="5d39bd5c70f996bad1c797411e0475f47e4e031c"
-				CHECKSUMTYPE="SHA-1" SIZE="6363121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T17:00:23" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="5d39bd5c70f996bad1c797411e0475f47e4e031c" CHECKSUMTYPE="SHA-1" SIZE="6363121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T17:00:56"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="36c40870780b9782c994b7d6a948149c3eb26e1c"
-				CHECKSUMTYPE="SHA-1" SIZE="6353228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T17:00:56" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="36c40870780b9782c994b7d6a948149c3eb26e1c" CHECKSUMTYPE="SHA-1" SIZE="6353228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T17:01:24"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="daec3bb20f9177c2195dd48281affe60ec272c34"
-				CHECKSUMTYPE="SHA-1" SIZE="6363126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T17:01:24" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="daec3bb20f9177c2195dd48281affe60ec272c34" CHECKSUMTYPE="SHA-1" SIZE="6363126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T17:01:56"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="488a37b8d9069056fbeb770fce66ec71f75b803f"
-				CHECKSUMTYPE="SHA-1" SIZE="6353229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T17:01:56" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="488a37b8d9069056fbeb770fce66ec71f75b803f" CHECKSUMTYPE="SHA-1" SIZE="6353229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/delivery/bmtnabf_1899-06_01_0032.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:02:13" MIMETYPE="text/xml"
-				CHECKSUM="cd1b214f23a4c9c8479f478490ca5009de774ffb" CHECKSUMTYPE="SHA-1"
-				SIZE="19217">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:02:13" MIMETYPE="text/xml" CHECKSUM="cd1b214f23a4c9c8479f478490ca5009de774ffb" CHECKSUMTYPE="SHA-1" SIZE="19217">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:02:13" MIMETYPE="text/xml"
-				CHECKSUM="a7c2231640c070aa0f6eaf5f78eca6267b794c6d" CHECKSUMTYPE="SHA-1" SIZE="4323">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:02:13" MIMETYPE="text/xml" CHECKSUM="a7c2231640c070aa0f6eaf5f78eca6267b794c6d" CHECKSUMTYPE="SHA-1" SIZE="4323">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:02:13" MIMETYPE="text/xml"
-				CHECKSUM="9ce1f7ff9302fb98ea426bcaaa2ca2b95c314105" CHECKSUMTYPE="SHA-1"
-				SIZE="148767">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:02:13" MIMETYPE="text/xml" CHECKSUM="9ce1f7ff9302fb98ea426bcaaa2ca2b95c314105" CHECKSUMTYPE="SHA-1" SIZE="148767">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:02:14" MIMETYPE="text/xml"
-				CHECKSUM="6ffd17c817c0d445b79af355d59bd6654cbba24f" CHECKSUMTYPE="SHA-1"
-				SIZE="165464">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:02:14" MIMETYPE="text/xml" CHECKSUM="6ffd17c817c0d445b79af355d59bd6654cbba24f" CHECKSUMTYPE="SHA-1" SIZE="165464">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:02:14" MIMETYPE="text/xml"
-				CHECKSUM="7e8d54a837d9dd38acd29e6b42819dddafc11ecd" CHECKSUMTYPE="SHA-1" SIZE="4291">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:02:14" MIMETYPE="text/xml" CHECKSUM="7e8d54a837d9dd38acd29e6b42819dddafc11ecd" CHECKSUMTYPE="SHA-1" SIZE="4291">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:02:14" MIMETYPE="text/xml"
-				CHECKSUM="a8695d99fee6f70b7964febb3514226d23db0cef" CHECKSUMTYPE="SHA-1" SIZE="4649">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:02:14" MIMETYPE="text/xml" CHECKSUM="a8695d99fee6f70b7964febb3514226d23db0cef" CHECKSUMTYPE="SHA-1" SIZE="4649">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:02:14" MIMETYPE="text/xml"
-				CHECKSUM="d67a9d56f5706ae8575f224acda0ab925c433415" CHECKSUMTYPE="SHA-1"
-				SIZE="142633">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:02:14" MIMETYPE="text/xml" CHECKSUM="d67a9d56f5706ae8575f224acda0ab925c433415" CHECKSUMTYPE="SHA-1" SIZE="142633">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:02:15" MIMETYPE="text/xml"
-				CHECKSUM="d10246b08b3bd8beb527d77976b76708f1e755ae" CHECKSUMTYPE="SHA-1"
-				SIZE="154774">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:02:15" MIMETYPE="text/xml" CHECKSUM="d10246b08b3bd8beb527d77976b76708f1e755ae" CHECKSUMTYPE="SHA-1" SIZE="154774">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:02:15" MIMETYPE="text/xml"
-				CHECKSUM="cca48413d2b71e8ea283e0c222337aa025073c85" CHECKSUMTYPE="SHA-1"
-				SIZE="152376">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:02:15" MIMETYPE="text/xml" CHECKSUM="cca48413d2b71e8ea283e0c222337aa025073c85" CHECKSUMTYPE="SHA-1" SIZE="152376">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:02:15" MIMETYPE="text/xml"
-				CHECKSUM="25a8e998fcb917c6607ddb1fd979f06e205eafad" CHECKSUMTYPE="SHA-1"
-				SIZE="132299">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:02:15" MIMETYPE="text/xml" CHECKSUM="25a8e998fcb917c6607ddb1fd979f06e205eafad" CHECKSUMTYPE="SHA-1" SIZE="132299">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:02:16" MIMETYPE="text/xml"
-				CHECKSUM="6b547733f14974cdab46589a6f6f8226f7467be0" CHECKSUMTYPE="SHA-1" SIZE="4552">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:02:16" MIMETYPE="text/xml" CHECKSUM="6b547733f14974cdab46589a6f6f8226f7467be0" CHECKSUMTYPE="SHA-1" SIZE="4552">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:02:16" MIMETYPE="text/xml"
-				CHECKSUM="e667bc5b3aca9e4d28fcd2e44db0c9ccd81a813e" CHECKSUMTYPE="SHA-1" SIZE="4685">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:02:16" MIMETYPE="text/xml" CHECKSUM="e667bc5b3aca9e4d28fcd2e44db0c9ccd81a813e" CHECKSUMTYPE="SHA-1" SIZE="4685">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:02:16" MIMETYPE="text/xml"
-				CHECKSUM="c2a32f2592f23cbb9aaf05331073f123b8b3ea11" CHECKSUMTYPE="SHA-1"
-				SIZE="128939">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:02:16" MIMETYPE="text/xml" CHECKSUM="c2a32f2592f23cbb9aaf05331073f123b8b3ea11" CHECKSUMTYPE="SHA-1" SIZE="128939">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:02:17" MIMETYPE="text/xml"
-				CHECKSUM="f58e296ac46e83ed2c7156af27749e9729606bfb" CHECKSUMTYPE="SHA-1"
-				SIZE="100832">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:02:17" MIMETYPE="text/xml" CHECKSUM="f58e296ac46e83ed2c7156af27749e9729606bfb" CHECKSUMTYPE="SHA-1" SIZE="100832">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:02:18" MIMETYPE="text/xml"
-				CHECKSUM="dd12d2e59be50cc1eba6cd79ae2ca25c52e01e2b" CHECKSUMTYPE="SHA-1" SIZE="4399">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:02:18" MIMETYPE="text/xml" CHECKSUM="dd12d2e59be50cc1eba6cd79ae2ca25c52e01e2b" CHECKSUMTYPE="SHA-1" SIZE="4399">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:02:18" MIMETYPE="text/xml"
-				CHECKSUM="20882a9091bc6f20536b0606961b5b1b2e716049" CHECKSUMTYPE="SHA-1" SIZE="5500">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:02:18" MIMETYPE="text/xml" CHECKSUM="20882a9091bc6f20536b0606961b5b1b2e716049" CHECKSUMTYPE="SHA-1" SIZE="5500">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:02:19" MIMETYPE="text/xml"
-				CHECKSUM="7a505ddd8e65e2ecf003d03535c8e215519c9f28" CHECKSUMTYPE="SHA-1"
-				SIZE="77249">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:02:19" MIMETYPE="text/xml" CHECKSUM="7a505ddd8e65e2ecf003d03535c8e215519c9f28" CHECKSUMTYPE="SHA-1" SIZE="77249">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:02:19" MIMETYPE="text/xml"
-				CHECKSUM="7d94f32ae1a7175bd19aa6d5dc18d59e65b5ae9b" CHECKSUMTYPE="SHA-1" SIZE="4134">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:02:19" MIMETYPE="text/xml" CHECKSUM="7d94f32ae1a7175bd19aa6d5dc18d59e65b5ae9b" CHECKSUMTYPE="SHA-1" SIZE="4134">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:02:19" MIMETYPE="text/xml"
-				CHECKSUM="cf0d2b22ee172682c5d7e7340e06d1daf15f7355" CHECKSUMTYPE="SHA-1"
-				SIZE="59793">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:02:19" MIMETYPE="text/xml" CHECKSUM="cf0d2b22ee172682c5d7e7340e06d1daf15f7355" CHECKSUMTYPE="SHA-1" SIZE="59793">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:02:20" MIMETYPE="text/xml"
-				CHECKSUM="944b76dfa13af194eaa9589afcfbffbb6392db2a" CHECKSUMTYPE="SHA-1" SIZE="4762">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:02:20" MIMETYPE="text/xml" CHECKSUM="944b76dfa13af194eaa9589afcfbffbb6392db2a" CHECKSUMTYPE="SHA-1" SIZE="4762">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:02:20" MIMETYPE="text/xml"
-				CHECKSUM="525b9c8b7eab80e6efcda5b95368547e534e6c15" CHECKSUMTYPE="SHA-1"
-				SIZE="50856">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:02:20" MIMETYPE="text/xml" CHECKSUM="525b9c8b7eab80e6efcda5b95368547e534e6c15" CHECKSUMTYPE="SHA-1" SIZE="50856">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:02:20" MIMETYPE="text/xml"
-				CHECKSUM="0b66b712c8493a9dd4ef8969431bfe20b81ff916" CHECKSUMTYPE="SHA-1" SIZE="4726">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:02:20" MIMETYPE="text/xml" CHECKSUM="0b66b712c8493a9dd4ef8969431bfe20b81ff916" CHECKSUMTYPE="SHA-1" SIZE="4726">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:02:20" MIMETYPE="text/xml"
-				CHECKSUM="2b696c81df448549e500091f9a1de56ed7d424c2" CHECKSUMTYPE="SHA-1"
-				SIZE="121952">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:02:20" MIMETYPE="text/xml" CHECKSUM="2b696c81df448549e500091f9a1de56ed7d424c2" CHECKSUMTYPE="SHA-1" SIZE="121952">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:02:21" MIMETYPE="text/xml"
-				CHECKSUM="f1462cc1d59eca4d64ddb1621a1937c4786e8d1d" CHECKSUMTYPE="SHA-1"
-				SIZE="75136">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:02:21" MIMETYPE="text/xml" CHECKSUM="f1462cc1d59eca4d64ddb1621a1937c4786e8d1d" CHECKSUMTYPE="SHA-1" SIZE="75136">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T17:02:21" MIMETYPE="text/xml"
-				CHECKSUM="ef28c87066b1ad97573f74b8cd6fda213fdc7738" CHECKSUMTYPE="SHA-1"
-				SIZE="66146">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T17:02:21" MIMETYPE="text/xml" CHECKSUM="ef28c87066b1ad97573f74b8cd6fda213fdc7738" CHECKSUMTYPE="SHA-1" SIZE="66146">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T17:02:23" MIMETYPE="text/xml"
-				CHECKSUM="52d0e41afcb565b85486debfc3c6aa3ef46943df" CHECKSUMTYPE="SHA-1" SIZE="4725">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T17:02:23" MIMETYPE="text/xml" CHECKSUM="52d0e41afcb565b85486debfc3c6aa3ef46943df" CHECKSUMTYPE="SHA-1" SIZE="4725">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T17:02:24" MIMETYPE="text/xml"
-				CHECKSUM="287ca49970bdcffa09a3302f4786ce651e194fab" CHECKSUMTYPE="SHA-1"
-				SIZE="84862">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T17:02:24" MIMETYPE="text/xml" CHECKSUM="287ca49970bdcffa09a3302f4786ce651e194fab" CHECKSUMTYPE="SHA-1" SIZE="84862">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T17:02:24" MIMETYPE="text/xml"
-				CHECKSUM="ad086625a632284c6ddacca21a84b6665640ab36" CHECKSUMTYPE="SHA-1"
-				SIZE="66965">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T17:02:24" MIMETYPE="text/xml" CHECKSUM="ad086625a632284c6ddacca21a84b6665640ab36" CHECKSUMTYPE="SHA-1" SIZE="66965">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T17:02:25" MIMETYPE="text/xml"
-				CHECKSUM="2d4401f10e52efff30fc7e7ff0dc9980dc8cb0a8" CHECKSUMTYPE="SHA-1"
-				SIZE="122178">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T17:02:25" MIMETYPE="text/xml" CHECKSUM="2d4401f10e52efff30fc7e7ff0dc9980dc8cb0a8" CHECKSUMTYPE="SHA-1" SIZE="122178">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T17:02:25" MIMETYPE="text/xml"
-				CHECKSUM="0d0c1d2b2686b855b98bf24faaeb87dc39b843ef" CHECKSUMTYPE="SHA-1"
-				SIZE="55577">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T17:02:25" MIMETYPE="text/xml" CHECKSUM="0d0c1d2b2686b855b98bf24faaeb87dc39b843ef" CHECKSUMTYPE="SHA-1" SIZE="55577">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T17:02:25" MIMETYPE="text/xml"
-				CHECKSUM="4df6cdacc9458c186277d47252aace94414c0257" CHECKSUMTYPE="SHA-1" SIZE="4653">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T17:02:25" MIMETYPE="text/xml" CHECKSUM="4df6cdacc9458c186277d47252aace94414c0257" CHECKSUMTYPE="SHA-1" SIZE="4653">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T17:02:26" MIMETYPE="text/xml"
-				CHECKSUM="21ad79d9f7b08475e7493c5328a5863ef4327c58" CHECKSUMTYPE="SHA-1"
-				SIZE="69283">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T17:02:26" MIMETYPE="text/xml" CHECKSUM="21ad79d9f7b08475e7493c5328a5863ef4327c58" CHECKSUMTYPE="SHA-1" SIZE="69283">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-06_01_0032.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:03:15" MIMETYPE="application/pdf"
-				CHECKSUM="68783be357d4ecd2624b4dd0a339e6eb3177b2b1" CHECKSUMTYPE="SHA-1"
-				SIZE="8345709">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/bmtnabf_1899-06_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:03:15" MIMETYPE="application/pdf" CHECKSUM="68783be357d4ecd2624b4dd0a339e6eb3177b2b1" CHECKSUMTYPE="SHA-1" SIZE="8345709">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/06_01/bmtnabf_1899-06_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3724,10 +3534,8 @@
 								<div ID="L.1.1.2.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00001"
-												BEGIN="P1_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00001"
-												BEGIN="P1_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3735,8 +3543,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.3" TYPE="Illustration" ORDER="3" DMDID="c002"
-					LABEL="MÄDCHEN AUS TAORMINA">
+				<div ID="L.1.1.3" TYPE="Illustration" ORDER="3" DMDID="c002" LABEL="MÄDCHEN AUS TAORMINA">
 					<div ID="L.1.1.3.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_TB00005"/>
@@ -3753,8 +3560,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="4" DMDID="c003"
-					LABEL="ARABISCHER DEPESCHENTRÄGER">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="4" DMDID="c003" LABEL="ARABISCHER DEPESCHENTRÄGER">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00002" BEGIN="P2_TB00002"/>
@@ -3791,14 +3597,10 @@
 								<div ID="L.1.1.7.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00003"
-												BEGIN="P3_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00003"
-												BEGIN="P3_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00004"
-												BEGIN="P4_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00004"
-												BEGIN="P4_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3807,26 +3609,16 @@
 								<div ID="L.1.1.7.3.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00005"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3868,8 +3660,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="6" DMDID="c005"
-					LABEL="ALTER KLOSTERGARTEN IN TAORMINA">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="6" DMDID="c005" LABEL="ALTER KLOSTERGARTEN IN TAORMINA">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
@@ -3886,8 +3677,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="8" DMDID="c008"
-					LABEL="SKIZZE ZUR KREUZABNAHME">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="8" DMDID="c008" LABEL="SKIZZE ZUR KREUZABNAHME">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -3904,8 +3694,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="9" DMDID="c009"
-					LABEL="STUDIE ZU EINEM CHRISTUS">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="9" DMDID="c009" LABEL="STUDIE ZU EINEM CHRISTUS">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -3922,8 +3711,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="TextContent" ORDER="10" DMDID="c010"
-					LABEL="WAS FANGEN WIR MIT DEN ANDERN AN?">
+				<div ID="L.1.1.10" TYPE="TextContent" ORDER="10" DMDID="c010" LABEL="WAS FANGEN WIR MIT DEN ANDERN AN?">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -3939,16 +3727,14 @@
 							<div ID="L.1.1.10.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.10.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.10.3.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.10.3.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
 									</fptr>
 								</div>
 							</div>
@@ -3956,14 +3742,10 @@
 								<div ID="L.1.1.10.3.1.3.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3972,20 +3754,16 @@
 								<div ID="L.1.1.10.3.1.4.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="1" DMDID="c011"
-						LABEL="ARABISCHER BÄNKELSÄNGER">
+					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="1" DMDID="c011" LABEL="ARABISCHER BÄNKELSÄNGER">
 						<div ID="L.1.1.10.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00006"/>
@@ -4002,8 +3780,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.5" TYPE="Illustration" ORDER="2" DMDID="c012"
-						LABEL="STUDIEN ZUR KREUZABNAHME">
+					<div ID="L.1.1.10.5" TYPE="Illustration" ORDER="2" DMDID="c012" LABEL="STUDIEN ZUR KREUZABNAHME">
 						<div ID="L.1.1.10.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00005"/>
@@ -4021,8 +3798,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.10.5.4" TYPE="Illustration" ORDER="2" DMDID="c013"
-							LABEL="STUDIEN ZUR KREUZABNAHME">
+						<div ID="L.1.1.10.5.4" TYPE="Illustration" ORDER="2" DMDID="c013" LABEL="STUDIEN ZUR KREUZABNAHME">
 							<div ID="L.1.1.10.5.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00002"/>
@@ -4030,8 +3806,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.10.6" TYPE="Illustration" ORDER="3" DMDID="c014"
-						LABEL="STUDIEN ZU EINEM PHARISÄER UND ZUR KREUZ – ABNAHME">
+					<div ID="L.1.1.10.6" TYPE="Illustration" ORDER="3" DMDID="c014" LABEL="STUDIEN ZU EINEM PHARISÄER UND ZUR KREUZ – ABNAHME">
 						<div ID="L.1.1.10.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00006"/>
@@ -4049,8 +3824,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.10.6.4" TYPE="Illustration" ORDER="2" DMDID="c015"
-							LABEL="Untitled Image by Johann v Kramer">
+						<div ID="L.1.1.10.6.4" TYPE="Illustration" ORDER="2" DMDID="c015" LABEL="Untitled Image by Johann v Kramer">
 							<div ID="L.1.1.10.6.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_CB00002"/>
@@ -4071,8 +3845,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="Illustration" ORDER="11" DMDID="c017"
-					LABEL="ARABISCHER BETTLER">
+				<div ID="L.1.1.11" TYPE="Illustration" ORDER="11" DMDID="c017" LABEL="ARABISCHER BETTLER">
 					<div ID="L.1.1.11.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -4089,8 +3862,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="Illustration" ORDER="12" DMDID="c018"
-					LABEL="STUDIE ZU EINER ENGELSFIGUR IN DER HIMMELFAHRT">
+				<div ID="L.1.1.12" TYPE="Illustration" ORDER="12" DMDID="c018" LABEL="STUDIE ZU EINER ENGELSFIGUR IN DER HIMMELFAHRT">
 					<div ID="L.1.1.12.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -4124,8 +3896,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.14" TYPE="TextContent" ORDER="14" DMDID="c020"
-					LABEL="CONRAD FERDINAND MEYER">
+				<div ID="L.1.1.14" TYPE="TextContent" ORDER="14" DMDID="c020" LABEL="CONRAD FERDINAND MEYER">
 					<div ID="L.1.1.14.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
@@ -4141,15 +3912,13 @@
 							<div ID="L.1.1.14.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.14.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.14.4" TYPE="Illustration" ORDER="1" DMDID="c021"
-						LABEL="Untitled Image by JOSEF HOFFMANN">
+					<div ID="L.1.1.14.4" TYPE="Illustration" ORDER="1" DMDID="c021" LABEL="Untitled Image by JOSEF HOFFMANN">
 						<div ID="L.1.1.14.4.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00005"/>
@@ -4167,8 +3936,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="Illustration" ORDER="15" DMDID="c023"
-					LABEL="AUS EINER FOLGE VON FELSENLANDSCHAFTEN">
+				<div ID="L.1.1.15" TYPE="Illustration" ORDER="15" DMDID="c023" LABEL="AUS EINER FOLGE VON FELSENLANDSCHAFTEN">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
@@ -4204,8 +3972,7 @@
 							<div ID="L.1.1.16.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.16.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00006"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00006"/>
 									</fptr>
 								</div>
 							</div>
@@ -4218,12 +3985,9 @@
 								<div ID="L.1.1.16.3.1.3.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00008"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00009"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00008"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00009"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4236,8 +4000,7 @@
 							<div ID="L.1.1.16.3.1.5" TYPE="Paragraph" ORDER="5">
 								<div ID="L.1.1.16.3.1.5.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
 									</fptr>
 								</div>
 							</div>
@@ -4250,10 +4013,8 @@
 								<div ID="L.1.1.16.3.1.7.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00007"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4267,10 +4028,8 @@
 								<div ID="L.1.1.16.3.1.9.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00009"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00009"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4284,12 +4043,9 @@
 								<div ID="L.1.1.16.3.1.11.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4303,10 +4059,8 @@
 								<div ID="L.1.1.16.3.1.13.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00006"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4320,10 +4074,8 @@
 								<div ID="L.1.1.16.3.1.15.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00008"/>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00008"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4337,12 +4089,9 @@
 								<div ID="L.1.1.16.3.1.17.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4356,12 +4105,9 @@
 								<div ID="L.1.1.16.3.1.19.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00029"
-												BEGIN="P29_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4374,8 +4120,7 @@
 							<div ID="L.1.1.16.3.1.21" TYPE="Paragraph" ORDER="21">
 								<div ID="L.1.1.16.3.1.21.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00004"/>
 									</fptr>
 								</div>
 							</div>
@@ -4388,10 +4133,8 @@
 								<div ID="L.1.1.16.3.1.23.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00029"
-												BEGIN="P29_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4405,20 +4148,16 @@
 								<div ID="L.1.1.16.3.1.25.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00006"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.16.4" TYPE="Illustration" ORDER="1" DMDID="c025"
-						LABEL="Untitled Image by RUDOLF JETTMAR">
+					<div ID="L.1.1.16.4" TYPE="Illustration" ORDER="1" DMDID="c025" LABEL="Untitled Image by RUDOLF JETTMAR">
 						<div ID="L.1.1.16.4.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00004"/>
@@ -4430,16 +4169,14 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.5" TYPE="Illustration" ORDER="1" DMDID="c026"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.16.5" TYPE="Illustration" ORDER="1" DMDID="c026" LABEL="Untitled Image">
 						<div ID="L.1.1.16.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.6" TYPE="Illustration" ORDER="3" DMDID="c027"
-						LABEL="Untitled Image by RUDOLF JETTMAR">
+					<div ID="L.1.1.16.6" TYPE="Illustration" ORDER="3" DMDID="c027" LABEL="Untitled Image by RUDOLF JETTMAR">
 						<div ID="L.1.1.16.6.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00004"/>
@@ -4451,8 +4188,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.7" TYPE="Illustration" ORDER="4" DMDID="c028"
-						LABEL="Untitled Image by RUDOLF JETTMAR">
+					<div ID="L.1.1.16.7" TYPE="Illustration" ORDER="4" DMDID="c028" LABEL="Untitled Image by RUDOLF JETTMAR">
 						<div ID="L.1.1.16.7.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00003"/>
@@ -4464,8 +4200,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.8" TYPE="Illustration" ORDER="5" DMDID="c029"
-						LABEL="Untitled Image by RUDOLF JETTMAR">
+					<div ID="L.1.1.16.8" TYPE="Illustration" ORDER="5" DMDID="c029" LABEL="Untitled Image by RUDOLF JETTMAR">
 						<div ID="L.1.1.16.8.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00003"/>
@@ -4477,8 +4212,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.9" TYPE="Illustration" ORDER="6" DMDID="c030"
-						LABEL="Untitled Image by RUDOLF JETTMAR">
+					<div ID="L.1.1.16.9" TYPE="Illustration" ORDER="6" DMDID="c030" LABEL="Untitled Image by RUDOLF JETTMAR">
 						<div ID="L.1.1.16.9.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00007"/>
@@ -4491,8 +4225,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.17" TYPE="Illustration" ORDER="17" DMDID="c031"
-					LABEL="AUS EINER FOLGE VON FELSENLANDSCHAFTEN">
+				<div ID="L.1.1.17" TYPE="Illustration" ORDER="17" DMDID="c031" LABEL="AUS EINER FOLGE VON FELSENLANDSCHAFTEN">
 					<div ID="L.1.1.17.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
@@ -4509,8 +4242,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.18" TYPE="Illustration" ORDER="18" DMDID="c032"
-					LABEL="AUS EINER FOLGE VON FELSENLANDSCHAFTEN">
+				<div ID="L.1.1.18" TYPE="Illustration" ORDER="18" DMDID="c032" LABEL="AUS EINER FOLGE VON FELSENLANDSCHAFTEN">
 					<div ID="L.1.1.18.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
@@ -4527,8 +4259,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.19" TYPE="Illustration" ORDER="19" DMDID="c033"
-					LABEL="AUS EINER FOLGE VON FELSENLANDSCHAFTEN">
+				<div ID="L.1.1.19" TYPE="Illustration" ORDER="19" DMDID="c033" LABEL="AUS EINER FOLGE VON FELSENLANDSCHAFTEN">
 					<div ID="L.1.1.19.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00002"/>
@@ -4545,8 +4276,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.20" TYPE="TextContent" ORDER="20" DMDID="c034"
-					LABEL="IV. AUSSTELLUNG DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS, SECESSION, WIEN, VOM 17. MÄRZ BIS 31. MAI 1899">
+				<div ID="L.1.1.20" TYPE="TextContent" ORDER="20" DMDID="c034" LABEL="IV. AUSSTELLUNG DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS, SECESSION, WIEN, VOM 17. MÄRZ BIS 31. MAI 1899">
 					<div ID="L.1.1.20.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00003"/>
@@ -4557,40 +4287,35 @@
 							<div ID="L.1.1.20.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.20.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.20.2.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.20.2.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00005"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00005"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.20.2.1.3" TYPE="Paragraph" ORDER="3">
 								<div ID="L.1.1.20.2.1.3.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00006"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00006"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.20.2.1.4" TYPE="Paragraph" ORDER="4">
 								<div ID="L.1.1.20.2.1.4.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00007"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00007"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.20.2.1.5" TYPE="Paragraph" ORDER="5">
 								<div ID="L.1.1.20.2.1.5.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00008"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00008"/>
 									</fptr>
 								</div>
 							</div>

--- a/metadata/periodicals/bmtnabf/issues/1899/07_01/bmtnabf_1899-07_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1899/07_01/bmtnabf_1899-07_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-07_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-07_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-07_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1899-07_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-07_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3264,388 +3258,204 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:48:06"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="99956527d997af17b6a8304d8ea23f2bd4fc594b"
-				CHECKSUMTYPE="SHA-1" SIZE="6304575">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:48:06" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="99956527d997af17b6a8304d8ea23f2bd4fc594b" CHECKSUMTYPE="SHA-1" SIZE="6304575">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:48:42"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="35c76341d283e100cef6d3615066b5e7a7081c26"
-				CHECKSUMTYPE="SHA-1" SIZE="6353062">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:48:42" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="35c76341d283e100cef6d3615066b5e7a7081c26" CHECKSUMTYPE="SHA-1" SIZE="6353062">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:49:16"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="30d2ebe46291ac95f7e36f0b4aa12f2493c4aac3"
-				CHECKSUMTYPE="SHA-1" SIZE="6304627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:49:16" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="30d2ebe46291ac95f7e36f0b4aa12f2493c4aac3" CHECKSUMTYPE="SHA-1" SIZE="6304627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:49:57"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="5bee2a6ca041a88af2c1ecf9a33bca38877280fa"
-				CHECKSUMTYPE="SHA-1" SIZE="6353226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:49:57" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="5bee2a6ca041a88af2c1ecf9a33bca38877280fa" CHECKSUMTYPE="SHA-1" SIZE="6353226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:50:35"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="08c779bb32b8371bf3bf6afe63f571670787128e"
-				CHECKSUMTYPE="SHA-1" SIZE="6304625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:50:35" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="08c779bb32b8371bf3bf6afe63f571670787128e" CHECKSUMTYPE="SHA-1" SIZE="6304625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:51:11"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="d32b1b1f710f188eade96257dd043df361682420"
-				CHECKSUMTYPE="SHA-1" SIZE="6353229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:51:11" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="d32b1b1f710f188eade96257dd043df361682420" CHECKSUMTYPE="SHA-1" SIZE="6353229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:51:47"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="c311b5c47fed9b79b6358c7ac919c791a7bae5eb"
-				CHECKSUMTYPE="SHA-1" SIZE="6304615">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:51:47" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="c311b5c47fed9b79b6358c7ac919c791a7bae5eb" CHECKSUMTYPE="SHA-1" SIZE="6304615">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:52:26"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="4488af8f3e6a5358b66ccc3083ddf5ab3d8337ed"
-				CHECKSUMTYPE="SHA-1" SIZE="6353228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:52:26" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="4488af8f3e6a5358b66ccc3083ddf5ab3d8337ed" CHECKSUMTYPE="SHA-1" SIZE="6353228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:53:02"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="637c4e72a2d6790128f661d6475d37232300e485"
-				CHECKSUMTYPE="SHA-1" SIZE="6319928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:53:02" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="637c4e72a2d6790128f661d6475d37232300e485" CHECKSUMTYPE="SHA-1" SIZE="6319928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:53:40"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="cfe823a47f9a52c36abd94e87847db8d0d754fa0"
-				CHECKSUMTYPE="SHA-1" SIZE="6353214">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:53:40" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="cfe823a47f9a52c36abd94e87847db8d0d754fa0" CHECKSUMTYPE="SHA-1" SIZE="6353214">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:54:16"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="63437633e204233ff6f179d924b7cce9854a8e95"
-				CHECKSUMTYPE="SHA-1" SIZE="6319926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:54:16" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="63437633e204233ff6f179d924b7cce9854a8e95" CHECKSUMTYPE="SHA-1" SIZE="6319926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:54:50"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="84f8ab044387bd02f609ca5a3e793f1be2c52bd7"
-				CHECKSUMTYPE="SHA-1" SIZE="6353227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:54:50" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="84f8ab044387bd02f609ca5a3e793f1be2c52bd7" CHECKSUMTYPE="SHA-1" SIZE="6353227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:55:26"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="90e32b24e54143b149c53fd7626db80214993b54"
-				CHECKSUMTYPE="SHA-1" SIZE="6319921">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:55:26" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="90e32b24e54143b149c53fd7626db80214993b54" CHECKSUMTYPE="SHA-1" SIZE="6319921">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:56:03"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="a02ad568f7bae0425765a33ad093b49934131dd7"
-				CHECKSUMTYPE="SHA-1" SIZE="6353227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:56:03" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="a02ad568f7bae0425765a33ad093b49934131dd7" CHECKSUMTYPE="SHA-1" SIZE="6353227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:56:41"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="e4e5761ce6124d50eb902453e2e0a50c6a77f629"
-				CHECKSUMTYPE="SHA-1" SIZE="6319925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:56:41" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="e4e5761ce6124d50eb902453e2e0a50c6a77f629" CHECKSUMTYPE="SHA-1" SIZE="6319925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:57:18"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="e891706b53835b707c2dc375c640bdb9fdb7fa6c"
-				CHECKSUMTYPE="SHA-1" SIZE="6353227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:57:18" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="e891706b53835b707c2dc375c640bdb9fdb7fa6c" CHECKSUMTYPE="SHA-1" SIZE="6353227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:57:56"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="abeaca7945e97fdf995f586cc2cf3c5598b294d1"
-				CHECKSUMTYPE="SHA-1" SIZE="6319928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:57:56" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="abeaca7945e97fdf995f586cc2cf3c5598b294d1" CHECKSUMTYPE="SHA-1" SIZE="6319928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:58:31"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="4b62baae4d20fdf983ff7413ab98a8021aab133f"
-				CHECKSUMTYPE="SHA-1" SIZE="6353117">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:58:31" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="4b62baae4d20fdf983ff7413ab98a8021aab133f" CHECKSUMTYPE="SHA-1" SIZE="6353117">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:59:08"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="d17297059e9f92936e39cedb7284de2072e071d4"
-				CHECKSUMTYPE="SHA-1" SIZE="6319927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:59:08" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="d17297059e9f92936e39cedb7284de2072e071d4" CHECKSUMTYPE="SHA-1" SIZE="6319927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:59:44"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="1d3f35362086ff567de88ee0b13fd54d3abfb3e1"
-				CHECKSUMTYPE="SHA-1" SIZE="6353215">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:59:44" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="1d3f35362086ff567de88ee0b13fd54d3abfb3e1" CHECKSUMTYPE="SHA-1" SIZE="6353215">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T17:00:20"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="cccd330a7d6b9aefeef01c30cf8c3955035c51f1"
-				CHECKSUMTYPE="SHA-1" SIZE="6319929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T17:00:20" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="cccd330a7d6b9aefeef01c30cf8c3955035c51f1" CHECKSUMTYPE="SHA-1" SIZE="6319929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T17:00:57"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="9d16e2a345234568097330c6e9172198cdbb023e"
-				CHECKSUMTYPE="SHA-1" SIZE="6353228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T17:00:57" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="9d16e2a345234568097330c6e9172198cdbb023e" CHECKSUMTYPE="SHA-1" SIZE="6353228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T17:01:31"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="3cb9722e2fb1a69a3992a929677436c24457cded"
-				CHECKSUMTYPE="SHA-1" SIZE="6319928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T17:01:31" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="3cb9722e2fb1a69a3992a929677436c24457cded" CHECKSUMTYPE="SHA-1" SIZE="6319928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T17:02:08"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="42c54b089deec167cc8d07ac6d8496829501ade4"
-				CHECKSUMTYPE="SHA-1" SIZE="6353228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T17:02:08" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="42c54b089deec167cc8d07ac6d8496829501ade4" CHECKSUMTYPE="SHA-1" SIZE="6353228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T17:02:42"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="426b98edded61b169341272c347149752d03cbd1"
-				CHECKSUMTYPE="SHA-1" SIZE="6319928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T17:02:42" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="426b98edded61b169341272c347149752d03cbd1" CHECKSUMTYPE="SHA-1" SIZE="6319928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T17:03:17"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="cd7ada05e791f638845e3e47725bf465246643ca"
-				CHECKSUMTYPE="SHA-1" SIZE="6353228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T17:03:17" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="cd7ada05e791f638845e3e47725bf465246643ca" CHECKSUMTYPE="SHA-1" SIZE="6353228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T17:03:53"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="83981952b816e148efed6d03dbb296e2b2220cfa"
-				CHECKSUMTYPE="SHA-1" SIZE="6319921">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T17:03:53" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="83981952b816e148efed6d03dbb296e2b2220cfa" CHECKSUMTYPE="SHA-1" SIZE="6319921">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T17:04:29"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="21f68d558379aa19f8877ba69c51057ff980e0cd"
-				CHECKSUMTYPE="SHA-1" SIZE="6353215">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T17:04:29" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="21f68d558379aa19f8877ba69c51057ff980e0cd" CHECKSUMTYPE="SHA-1" SIZE="6353215">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T17:05:04"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="8a6c2a7aa9fc592483294ce74ecb2dd4e360353a"
-				CHECKSUMTYPE="SHA-1" SIZE="6319922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T17:05:04" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="8a6c2a7aa9fc592483294ce74ecb2dd4e360353a" CHECKSUMTYPE="SHA-1" SIZE="6319922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T17:05:46"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="982889d938ca6b51e628b508cb2a145e19016209"
-				CHECKSUMTYPE="SHA-1" SIZE="6353229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T17:05:46" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="982889d938ca6b51e628b508cb2a145e19016209" CHECKSUMTYPE="SHA-1" SIZE="6353229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T17:06:24"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="b360a8dc60ab9dbb578f07fb6408d3fbb4dd8569"
-				CHECKSUMTYPE="SHA-1" SIZE="6319914">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T17:06:24" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="b360a8dc60ab9dbb578f07fb6408d3fbb4dd8569" CHECKSUMTYPE="SHA-1" SIZE="6319914">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T17:07:01"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="1523b0a0208b89b42207d0714e51af52b0dbf74c"
-				CHECKSUMTYPE="SHA-1" SIZE="6353219">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T17:07:01" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="1523b0a0208b89b42207d0714e51af52b0dbf74c" CHECKSUMTYPE="SHA-1" SIZE="6353219">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/delivery/bmtnabf_1899-07_01_0032.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:07:22" MIMETYPE="text/xml"
-				CHECKSUM="f07f6893444182bed247fc69b1fc50a83b884c24" CHECKSUMTYPE="SHA-1"
-				SIZE="17082">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:07:22" MIMETYPE="text/xml" CHECKSUM="f07f6893444182bed247fc69b1fc50a83b884c24" CHECKSUMTYPE="SHA-1" SIZE="17082">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:07:23" MIMETYPE="text/xml"
-				CHECKSUM="289687c9becaa3418610a758ce76c5a7dc9f6c24" CHECKSUMTYPE="SHA-1" SIZE="5367">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:07:23" MIMETYPE="text/xml" CHECKSUM="289687c9becaa3418610a758ce76c5a7dc9f6c24" CHECKSUMTYPE="SHA-1" SIZE="5367">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:07:23" MIMETYPE="text/xml"
-				CHECKSUM="8ab16cbd1cb7a2d8d9768d6d38e7e45678ad4a08" CHECKSUMTYPE="SHA-1"
-				SIZE="56354">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:07:23" MIMETYPE="text/xml" CHECKSUM="8ab16cbd1cb7a2d8d9768d6d38e7e45678ad4a08" CHECKSUMTYPE="SHA-1" SIZE="56354">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:07:23" MIMETYPE="text/xml"
-				CHECKSUM="c2e4af49ef2f354e3b84a229b7637fdcf9e4a485" CHECKSUMTYPE="SHA-1"
-				SIZE="53573">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:07:23" MIMETYPE="text/xml" CHECKSUM="c2e4af49ef2f354e3b84a229b7637fdcf9e4a485" CHECKSUMTYPE="SHA-1" SIZE="53573">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:07:23" MIMETYPE="text/xml"
-				CHECKSUM="ec698add70c17fc85238770cce0cc766960323b6" CHECKSUMTYPE="SHA-1" SIZE="5520">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:07:23" MIMETYPE="text/xml" CHECKSUM="ec698add70c17fc85238770cce0cc766960323b6" CHECKSUMTYPE="SHA-1" SIZE="5520">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:07:24" MIMETYPE="text/xml"
-				CHECKSUM="fe908f4e5c84900f9e70fa9a746024f55a84aa66" CHECKSUMTYPE="SHA-1"
-				SIZE="33881">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:07:24" MIMETYPE="text/xml" CHECKSUM="fe908f4e5c84900f9e70fa9a746024f55a84aa66" CHECKSUMTYPE="SHA-1" SIZE="33881">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:07:24" MIMETYPE="text/xml"
-				CHECKSUM="260d1050584dddf27961313e981f3ebfd7de7aed" CHECKSUMTYPE="SHA-1" SIZE="4866">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:07:24" MIMETYPE="text/xml" CHECKSUM="260d1050584dddf27961313e981f3ebfd7de7aed" CHECKSUMTYPE="SHA-1" SIZE="4866">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:07:24" MIMETYPE="text/xml"
-				CHECKSUM="7d81034ecfdfdd530e9260567d330dbaf3081ffc" CHECKSUMTYPE="SHA-1" SIZE="4755">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:07:24" MIMETYPE="text/xml" CHECKSUM="7d81034ecfdfdd530e9260567d330dbaf3081ffc" CHECKSUMTYPE="SHA-1" SIZE="4755">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:07:24" MIMETYPE="text/xml"
-				CHECKSUM="6e6dfa2a17d861e9b10075a196c4bb9c60daa664" CHECKSUMTYPE="SHA-1" SIZE="4581">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:07:24" MIMETYPE="text/xml" CHECKSUM="6e6dfa2a17d861e9b10075a196c4bb9c60daa664" CHECKSUMTYPE="SHA-1" SIZE="4581">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:07:25" MIMETYPE="text/xml"
-				CHECKSUM="a0b5f8666409398323364e798eb4dc1296b74abe" CHECKSUMTYPE="SHA-1" SIZE="4365">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:07:25" MIMETYPE="text/xml" CHECKSUM="a0b5f8666409398323364e798eb4dc1296b74abe" CHECKSUMTYPE="SHA-1" SIZE="4365">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:07:25" MIMETYPE="text/xml"
-				CHECKSUM="89f554cad5dfa79e81315074c2f0f9ead08b6c05" CHECKSUMTYPE="SHA-1"
-				SIZE="73579">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:07:25" MIMETYPE="text/xml" CHECKSUM="89f554cad5dfa79e81315074c2f0f9ead08b6c05" CHECKSUMTYPE="SHA-1" SIZE="73579">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:07:25" MIMETYPE="text/xml"
-				CHECKSUM="85ab8128b42a48405a955a42cdf6a4d34398718b" CHECKSUMTYPE="SHA-1"
-				SIZE="62079">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:07:25" MIMETYPE="text/xml" CHECKSUM="85ab8128b42a48405a955a42cdf6a4d34398718b" CHECKSUMTYPE="SHA-1" SIZE="62079">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:07:26" MIMETYPE="text/xml"
-				CHECKSUM="fda009714e2034c563bc7d94931df3881f67db4a" CHECKSUMTYPE="SHA-1" SIZE="5066">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:07:26" MIMETYPE="text/xml" CHECKSUM="fda009714e2034c563bc7d94931df3881f67db4a" CHECKSUMTYPE="SHA-1" SIZE="5066">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:07:26" MIMETYPE="text/xml"
-				CHECKSUM="e66f2500fc5517af34d30f7cc66e605e05e3b98f" CHECKSUMTYPE="SHA-1" SIZE="4677">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:07:26" MIMETYPE="text/xml" CHECKSUM="e66f2500fc5517af34d30f7cc66e605e05e3b98f" CHECKSUMTYPE="SHA-1" SIZE="4677">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:07:26" MIMETYPE="text/xml"
-				CHECKSUM="2bb056d5141fe37310e217ab2370ed359f2f186c" CHECKSUMTYPE="SHA-1"
-				SIZE="41525">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:07:26" MIMETYPE="text/xml" CHECKSUM="2bb056d5141fe37310e217ab2370ed359f2f186c" CHECKSUMTYPE="SHA-1" SIZE="41525">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:07:27" MIMETYPE="text/xml"
-				CHECKSUM="6ac87a4385b9b30e671b92530b01e0a19595aa9d" CHECKSUMTYPE="SHA-1" SIZE="4745">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:07:27" MIMETYPE="text/xml" CHECKSUM="6ac87a4385b9b30e671b92530b01e0a19595aa9d" CHECKSUMTYPE="SHA-1" SIZE="4745">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:07:27" MIMETYPE="text/xml"
-				CHECKSUM="e030fe2e920144464ffbfca779630e2ff8d81052" CHECKSUMTYPE="SHA-1"
-				SIZE="95733">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:07:27" MIMETYPE="text/xml" CHECKSUM="e030fe2e920144464ffbfca779630e2ff8d81052" CHECKSUMTYPE="SHA-1" SIZE="95733">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:07:27" MIMETYPE="text/xml"
-				CHECKSUM="f3f6dc039365e885716f7d8501dd07b1abaaa5f9" CHECKSUMTYPE="SHA-1"
-				SIZE="85943">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:07:27" MIMETYPE="text/xml" CHECKSUM="f3f6dc039365e885716f7d8501dd07b1abaaa5f9" CHECKSUMTYPE="SHA-1" SIZE="85943">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:07:27" MIMETYPE="text/xml"
-				CHECKSUM="6b6165b0e0733532ee1fbed2b3b77004e77a0d87" CHECKSUMTYPE="SHA-1"
-				SIZE="82839">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:07:27" MIMETYPE="text/xml" CHECKSUM="6b6165b0e0733532ee1fbed2b3b77004e77a0d87" CHECKSUMTYPE="SHA-1" SIZE="82839">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:07:28" MIMETYPE="text/xml"
-				CHECKSUM="d3e8ff0163d9c1b1fff5ab30113974f43362b015" CHECKSUMTYPE="SHA-1"
-				SIZE="103019">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:07:28" MIMETYPE="text/xml" CHECKSUM="d3e8ff0163d9c1b1fff5ab30113974f43362b015" CHECKSUMTYPE="SHA-1" SIZE="103019">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:07:28" MIMETYPE="text/xml"
-				CHECKSUM="3d682b39ddaedf36fbd46758d8540145d3840052" CHECKSUMTYPE="SHA-1" SIZE="4888">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:07:28" MIMETYPE="text/xml" CHECKSUM="3d682b39ddaedf36fbd46758d8540145d3840052" CHECKSUMTYPE="SHA-1" SIZE="4888">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:07:28" MIMETYPE="text/xml"
-				CHECKSUM="946e531f4143c50f0afb2b20089c1a2d7b2d69f2" CHECKSUMTYPE="SHA-1"
-				SIZE="63493">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:07:28" MIMETYPE="text/xml" CHECKSUM="946e531f4143c50f0afb2b20089c1a2d7b2d69f2" CHECKSUMTYPE="SHA-1" SIZE="63493">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:07:29" MIMETYPE="text/xml"
-				CHECKSUM="958c0feb277001484fe8ea5fde4e352f20c66343" CHECKSUMTYPE="SHA-1"
-				SIZE="63875">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:07:29" MIMETYPE="text/xml" CHECKSUM="958c0feb277001484fe8ea5fde4e352f20c66343" CHECKSUMTYPE="SHA-1" SIZE="63875">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:07:29" MIMETYPE="text/xml"
-				CHECKSUM="be1a6867e1b0f1447a9bad282ddd149e5d679263" CHECKSUMTYPE="SHA-1"
-				SIZE="57595">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:07:29" MIMETYPE="text/xml" CHECKSUM="be1a6867e1b0f1447a9bad282ddd149e5d679263" CHECKSUMTYPE="SHA-1" SIZE="57595">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T17:07:29" MIMETYPE="text/xml"
-				CHECKSUM="9d2a9190c69825aa0946828a35a05795b513d9bf" CHECKSUMTYPE="SHA-1"
-				SIZE="24851">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T17:07:29" MIMETYPE="text/xml" CHECKSUM="9d2a9190c69825aa0946828a35a05795b513d9bf" CHECKSUMTYPE="SHA-1" SIZE="24851">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T17:07:29" MIMETYPE="text/xml"
-				CHECKSUM="c990701ab510557d31346a9ccdf06619e5c0f4f0" CHECKSUMTYPE="SHA-1"
-				SIZE="34760">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T17:07:29" MIMETYPE="text/xml" CHECKSUM="c990701ab510557d31346a9ccdf06619e5c0f4f0" CHECKSUMTYPE="SHA-1" SIZE="34760">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T17:07:30" MIMETYPE="text/xml"
-				CHECKSUM="259e84a111ea3fae66fe3385eb3ef4807b4bcba0" CHECKSUMTYPE="SHA-1"
-				SIZE="76553">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T17:07:30" MIMETYPE="text/xml" CHECKSUM="259e84a111ea3fae66fe3385eb3ef4807b4bcba0" CHECKSUMTYPE="SHA-1" SIZE="76553">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T17:07:30" MIMETYPE="text/xml"
-				CHECKSUM="c1e1bfc4da276e337fbbeb01239c14ec90c8959d" CHECKSUMTYPE="SHA-1"
-				SIZE="63335">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T17:07:30" MIMETYPE="text/xml" CHECKSUM="c1e1bfc4da276e337fbbeb01239c14ec90c8959d" CHECKSUMTYPE="SHA-1" SIZE="63335">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T17:07:30" MIMETYPE="text/xml"
-				CHECKSUM="c1f7063d8ada39b05527e8182a2a3e98b245fd4d" CHECKSUMTYPE="SHA-1" SIZE="4594">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T17:07:30" MIMETYPE="text/xml" CHECKSUM="c1f7063d8ada39b05527e8182a2a3e98b245fd4d" CHECKSUMTYPE="SHA-1" SIZE="4594">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T17:07:30" MIMETYPE="text/xml"
-				CHECKSUM="95e9e70156a3b928f24a851d0c57d06f99c35deb" CHECKSUMTYPE="SHA-1" SIZE="4629">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T17:07:30" MIMETYPE="text/xml" CHECKSUM="95e9e70156a3b928f24a851d0c57d06f99c35deb" CHECKSUMTYPE="SHA-1" SIZE="4629">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T17:07:31" MIMETYPE="text/xml"
-				CHECKSUM="cd117b22c12a96ecf8b9d1cdf594899616cc7e67" CHECKSUMTYPE="SHA-1"
-				SIZE="42510">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T17:07:31" MIMETYPE="text/xml" CHECKSUM="cd117b22c12a96ecf8b9d1cdf594899616cc7e67" CHECKSUMTYPE="SHA-1" SIZE="42510">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T17:07:31" MIMETYPE="text/xml"
-				CHECKSUM="8b883d4f9a236b317fb5079027882e6009f7e3e4" CHECKSUMTYPE="SHA-1"
-				SIZE="44281">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T17:07:31" MIMETYPE="text/xml" CHECKSUM="8b883d4f9a236b317fb5079027882e6009f7e3e4" CHECKSUMTYPE="SHA-1" SIZE="44281">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-07_01_0032.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:08:16" MIMETYPE="application/pdf"
-				CHECKSUM="4a6cb5feca2e51ef05ea23b06b17acc625c187a3" CHECKSUMTYPE="SHA-1"
-				SIZE="7878076">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/bmtnabf_1899-07_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:08:16" MIMETYPE="application/pdf" CHECKSUM="4a6cb5feca2e51ef05ea23b06b17acc625c187a3" CHECKSUMTYPE="SHA-1" SIZE="7878076">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/07_01/bmtnabf_1899-07_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3931,10 +3741,8 @@
 								<div ID="L.1.1.2.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00001"
-												BEGIN="P1_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00001"
-												BEGIN="P1_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3959,8 +3767,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="4" DMDID="c003"
-					LABEL="INTERIEUR MIT GRÜNEM KOFFER">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="4" DMDID="c003" LABEL="INTERIEUR MIT GRÜNEM KOFFER">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00002" BEGIN="P2_TB00002"/>
@@ -3982,8 +3789,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="5" DMDID="c004"
-					LABEL="ZWEI JAHRE SEZESSION">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="5" DMDID="c004" LABEL="ZWEI JAHRE SEZESSION">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00002"/>
@@ -4000,24 +3806,15 @@
 								<div ID="L.1.1.5.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00003"
-												BEGIN="P3_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00003"
-												BEGIN="P3_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00004"
-												BEGIN="P4_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00004"
-												BEGIN="P4_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4071,8 +3868,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="3" DMDID="c007"
-						LABEL="JUNGE FRAU MIT KIND">
+					<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="3" DMDID="c007" LABEL="JUNGE FRAU MIT KIND">
 						<div ID="L.1.1.5.6.1" TYPE="Head">
 							<fptr>
 
@@ -4100,8 +3896,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.6.4" TYPE="Illustration" ORDER="2" DMDID="c008"
-						LABEL="JUNGES MÄDCHEN">
+					<div ID="L.1.1.5.6.4" TYPE="Illustration" ORDER="2" DMDID="c008" LABEL="JUNGES MÄDCHEN">
 						<div ID="L.1.1.5.6.1.2" TYPE="Head">
 							<fptr>
 
@@ -4144,8 +3939,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="5" DMDID="c010"
-						LABEL="SCHOTTISCHE LANDSCHAFT">
+					<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="5" DMDID="c010" LABEL="SCHOTTISCHE LANDSCHAFT">
 						<div ID="L.1.1.5.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00004"/>
@@ -4168,8 +3962,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="6" DMDID="c011"
-					LABEL="WENN DIE NACHTIGALLEN SINGEN">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="6" DMDID="c011" LABEL="WENN DIE NACHTIGALLEN SINGEN">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -4191,8 +3984,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="7" DMDID="c012"
-					LABEL="ROCHEFORT BRONZE">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="7" DMDID="c012" LABEL="ROCHEFORT BRONZE">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -4280,8 +4072,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="Illustration" ORDER="11" DMDID="c016"
-					LABEL="DOMINE QUO VADIS">
+				<div ID="L.1.1.11" TYPE="Illustration" ORDER="11" DMDID="c016" LABEL="DOMINE QUO VADIS">
 					<div ID="L.1.1.11.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -4303,8 +4094,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="Illustration" ORDER="12" DMDID="c017"
-					LABEL="JUNGES MÄDCHEN">
+				<div ID="L.1.1.12" TYPE="Illustration" ORDER="12" DMDID="c017" LABEL="JUNGES MÄDCHEN">
 					<div ID="L.1.1.12.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
@@ -4326,8 +4116,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="TextContent" ORDER="13" DMDID="c018"
-					LABEL="GRAPHISCHE KÜNSTE">
+				<div ID="L.1.1.13" TYPE="TextContent" ORDER="13" DMDID="c018" LABEL="GRAPHISCHE KÜNSTE">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -4344,42 +4133,24 @@
 								<div ID="L.1.1.13.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4408,8 +4179,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13.5" TYPE="Illustration" ORDER="2" DMDID="c020"
-						LABEL="IN DER KIRCHE">
+					<div ID="L.1.1.13.5" TYPE="Illustration" ORDER="2" DMDID="c020" LABEL="IN DER KIRCHE">
 						<div ID="L.1.1.13.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00004"/>
@@ -4431,8 +4201,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13.6" TYPE="Illustration" ORDER="3" DMDID="c021"
-						LABEL="MÄDCHEN MIT KATZE">
+					<div ID="L.1.1.13.6" TYPE="Illustration" ORDER="3" DMDID="c021" LABEL="MÄDCHEN MIT KATZE">
 						<div ID="L.1.1.13.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"/>
@@ -4454,8 +4223,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13.7" TYPE="Illustration" ORDER="4" DMDID="c022"
-						LABEL="PORTRÄTBÜSTE">
+					<div ID="L.1.1.13.7" TYPE="Illustration" ORDER="4" DMDID="c022" LABEL="PORTRÄTBÜSTE">
 						<div ID="L.1.1.13.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
@@ -4477,8 +4245,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13.8" TYPE="Illustration" ORDER="5" DMDID="c023"
-						LABEL="HERRENPORTRÄT">
+					<div ID="L.1.1.13.8" TYPE="Illustration" ORDER="5" DMDID="c023" LABEL="HERRENPORTRÄT">
 						<div ID="L.1.1.13.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00006"/>
@@ -4504,8 +4271,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.13.9" TYPE="Illustration" ORDER="6" DMDID="c025"
-						LABEL="FLUSSLANDSCHAFT">
+					<div ID="L.1.1.13.9" TYPE="Illustration" ORDER="6" DMDID="c025" LABEL="FLUSSLANDSCHAFT">
 						<div ID="L.1.1.13.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00004"/>
@@ -4527,8 +4293,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13.10" TYPE="Illustration" ORDER="7" DMDID="c026"
-						LABEL="VOR DEM DINER">
+					<div ID="L.1.1.13.10" TYPE="Illustration" ORDER="7" DMDID="c026" LABEL="VOR DEM DINER">
 						<div ID="L.1.1.13.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
@@ -4633,15 +4398,13 @@
 							<div ID="L.1.1.16.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.16.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.16.4" TYPE="Illustration" ORDER="1" DMDID="c031"
-						LABEL="TEXTUMRAHMUNG">
+					<div ID="L.1.1.16.4" TYPE="Illustration" ORDER="1" DMDID="c031" LABEL="TEXTUMRAHMUNG">
 						<div ID="L.1.1.16.4.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00005"/>
@@ -4659,8 +4422,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.17" TYPE="TextContent" ORDER="17" DMDID="c032"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.17" TYPE="TextContent" ORDER="17" DMDID="c032" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.17.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
@@ -4671,15 +4433,13 @@
 							<div ID="L.1.1.17.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.17.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.17.3" TYPE="Illustration" ORDER="1" DMDID="c033"
-						LABEL="BUCHSCHMUCK">
+					<div ID="L.1.1.17.3" TYPE="Illustration" ORDER="1" DMDID="c033" LABEL="BUCHSCHMUCK">
 						<div ID="L.1.1.17.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00004"/>
@@ -4697,8 +4457,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.18" TYPE="TextContent" ORDER="18" DMDID="c034"
-					LABEL="WIDMUNGSURKUNDE">
+				<div ID="L.1.1.18" TYPE="TextContent" ORDER="18" DMDID="c034" LABEL="WIDMUNGSURKUNDE">
 					<div ID="L.1.1.18.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00002"/>
@@ -4715,20 +4474,16 @@
 								<div ID="L.1.1.18.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.18.4" TYPE="Illustration" ORDER="1" DMDID="c035"
-						LABEL="BUCHSCHMUCK">
+					<div ID="L.1.1.18.4" TYPE="Illustration" ORDER="1" DMDID="c035" LABEL="BUCHSCHMUCK">
 						<div ID="L.1.1.18.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00004"/>
@@ -4745,8 +4500,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18.5" TYPE="Illustration" ORDER="2" DMDID="c036"
-						LABEL="BUCHSCHMUCK">
+					<div ID="L.1.1.18.5" TYPE="Illustration" ORDER="2" DMDID="c036" LABEL="BUCHSCHMUCK">
 						<div ID="L.1.1.18.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00005"/>
@@ -4786,8 +4540,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.20" TYPE="Illustration" ORDER="20" DMDID="c038"
-					LABEL="LÄNDLICHES STILLEBEN">
+				<div ID="L.1.1.20" TYPE="Illustration" ORDER="20" DMDID="c038" LABEL="LÄNDLICHES STILLEBEN">
 					<div ID="L.1.1.20.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00002"/>
@@ -4809,8 +4562,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.21" TYPE="TextContent" ORDER="21" DMDID="c039"
-					LABEL="Untitled text by V.S.">
+				<div ID="L.1.1.21" TYPE="TextContent" ORDER="21" DMDID="c039" LABEL="Untitled text by V.S.">
 					<div ID="L.1.1.21.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00005"/>
@@ -4822,20 +4574,16 @@
 								<div ID="L.1.1.21.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00031"
-												BEGIN="P31_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00032"
-												BEGIN="P32_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00032"
-												BEGIN="P32_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.21.3" TYPE="Illustration" ORDER="1" DMDID="c040"
-						LABEL="AKTSTUDIE">
+					<div ID="L.1.1.21.3" TYPE="Illustration" ORDER="1" DMDID="c040" LABEL="AKTSTUDIE">
 						<div ID="L.1.1.21.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00003"/>
@@ -4857,8 +4605,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.21.4" TYPE="Illustration" ORDER="2" DMDID="c041"
-						LABEL="SPINNENDES MÄDCHEN">
+					<div ID="L.1.1.21.4" TYPE="Illustration" ORDER="2" DMDID="c041" LABEL="SPINNENDES MÄDCHEN">
 						<div ID="L.1.1.21.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00006"/>

--- a/metadata/periodicals/bmtnabf/issues/1899/08_01/bmtnabf_1899-08_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1899/08_01/bmtnabf_1899-08_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-08_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-08_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-08_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1899-08_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-08_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3111,388 +3105,204 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:50:02"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="ae70021e4d2bf7d95cec102e17ebf48a137a367b"
-				CHECKSUMTYPE="SHA-1" SIZE="6278527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:50:02" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="ae70021e4d2bf7d95cec102e17ebf48a137a367b" CHECKSUMTYPE="SHA-1" SIZE="6278527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:50:36"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="43d01a5513d275d8f8b0aca0e53b747f3e73782a"
-				CHECKSUMTYPE="SHA-1" SIZE="6292022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:50:36" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="43d01a5513d275d8f8b0aca0e53b747f3e73782a" CHECKSUMTYPE="SHA-1" SIZE="6292022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:51:09"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="5e4e29be06cd1ce1be06652af771fb2e5d8b2783"
-				CHECKSUMTYPE="SHA-1" SIZE="6278525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:51:09" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="5e4e29be06cd1ce1be06652af771fb2e5d8b2783" CHECKSUMTYPE="SHA-1" SIZE="6278525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:51:39"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="1c91a20594d7f1a7f26f2d5ed9f53646245a935a"
-				CHECKSUMTYPE="SHA-1" SIZE="6292005">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:51:39" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="1c91a20594d7f1a7f26f2d5ed9f53646245a935a" CHECKSUMTYPE="SHA-1" SIZE="6292005">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:52:10"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="21cd448cd034338af7831eb30208d8cbbe917ff0"
-				CHECKSUMTYPE="SHA-1" SIZE="6319929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:52:10" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="21cd448cd034338af7831eb30208d8cbbe917ff0" CHECKSUMTYPE="SHA-1" SIZE="6319929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:52:40"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="50875056126f41cd21ab3c12d9999e2563122b20"
-				CHECKSUMTYPE="SHA-1" SIZE="6292023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:52:40" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="50875056126f41cd21ab3c12d9999e2563122b20" CHECKSUMTYPE="SHA-1" SIZE="6292023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:53:13"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="8735e711aeee965bee5483501da03c6f7d85923f"
-				CHECKSUMTYPE="SHA-1" SIZE="6319926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:53:13" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="8735e711aeee965bee5483501da03c6f7d85923f" CHECKSUMTYPE="SHA-1" SIZE="6319926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:53:46"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="2f2b704b51737c947ded4fab6d8d694a038855fc"
-				CHECKSUMTYPE="SHA-1" SIZE="6292029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:53:46" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="2f2b704b51737c947ded4fab6d8d694a038855fc" CHECKSUMTYPE="SHA-1" SIZE="6292029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:54:18"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="ca86490e33b38aec4884bc7f0f595089a9e22e96"
-				CHECKSUMTYPE="SHA-1" SIZE="6292010">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:54:18" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="ca86490e33b38aec4884bc7f0f595089a9e22e96" CHECKSUMTYPE="SHA-1" SIZE="6292010">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:54:48"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="caaa15ed1f55c4f3c3dc8e7d7dec88b02ff07ad1"
-				CHECKSUMTYPE="SHA-1" SIZE="6328926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:54:48" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="caaa15ed1f55c4f3c3dc8e7d7dec88b02ff07ad1" CHECKSUMTYPE="SHA-1" SIZE="6328926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:55:20"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="33f7331f423a87e85aee2207976ff57567b2f64b"
-				CHECKSUMTYPE="SHA-1" SIZE="6292029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:55:20" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="33f7331f423a87e85aee2207976ff57567b2f64b" CHECKSUMTYPE="SHA-1" SIZE="6292029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:55:55"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="30a88a85633ecda51d03570c9cc1909c82397a7c"
-				CHECKSUMTYPE="SHA-1" SIZE="6328923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:55:55" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="30a88a85633ecda51d03570c9cc1909c82397a7c" CHECKSUMTYPE="SHA-1" SIZE="6328923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:56:26"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="4d17c91dc450d8bcc15a1815e95b49afafcb4815"
-				CHECKSUMTYPE="SHA-1" SIZE="6292017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:56:26" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="4d17c91dc450d8bcc15a1815e95b49afafcb4815" CHECKSUMTYPE="SHA-1" SIZE="6292017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:56:58"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="b0fdc49c30dcaee25048186d577f6b912ff8f422"
-				CHECKSUMTYPE="SHA-1" SIZE="6355029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:56:58" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="b0fdc49c30dcaee25048186d577f6b912ff8f422" CHECKSUMTYPE="SHA-1" SIZE="6355029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:57:32"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="2457303668015b6eaffc4461866aac70be7c5909"
-				CHECKSUMTYPE="SHA-1" SIZE="6314522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:57:32" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="2457303668015b6eaffc4461866aac70be7c5909" CHECKSUMTYPE="SHA-1" SIZE="6314522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:58:06"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="c295c566cdd928381ea44e4ffdce648b867067a0"
-				CHECKSUMTYPE="SHA-1" SIZE="6355024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:58:06" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="c295c566cdd928381ea44e4ffdce648b867067a0" CHECKSUMTYPE="SHA-1" SIZE="6355024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:58:38"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="9180dd2da1a203128b34f9ea3d17bec023d217f3"
-				CHECKSUMTYPE="SHA-1" SIZE="6314512">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:58:38" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="9180dd2da1a203128b34f9ea3d17bec023d217f3" CHECKSUMTYPE="SHA-1" SIZE="6314512">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:59:13"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="e736ad03e516a6a9302d5aa02fd8d870158fa83e"
-				CHECKSUMTYPE="SHA-1" SIZE="6355029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:59:13" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="e736ad03e516a6a9302d5aa02fd8d870158fa83e" CHECKSUMTYPE="SHA-1" SIZE="6355029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:59:46"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="38eb2e40180ded92d72f39c7c9f7a0b01f818b34"
-				CHECKSUMTYPE="SHA-1" SIZE="6314527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:59:46" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="38eb2e40180ded92d72f39c7c9f7a0b01f818b34" CHECKSUMTYPE="SHA-1" SIZE="6314527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T17:00:19"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="bfcdc89d56643753bf981dbc8f6887da827d3d42"
-				CHECKSUMTYPE="SHA-1" SIZE="6355021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T17:00:19" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="bfcdc89d56643753bf981dbc8f6887da827d3d42" CHECKSUMTYPE="SHA-1" SIZE="6355021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T17:00:50"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="009fe6eee7b5dec280693bcd9a91fadef350e578"
-				CHECKSUMTYPE="SHA-1" SIZE="6314521">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T17:00:50" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="009fe6eee7b5dec280693bcd9a91fadef350e578" CHECKSUMTYPE="SHA-1" SIZE="6314521">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T17:01:21"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="15dcb44c36a48acf44cab33c9f7fc9a541e7d51a"
-				CHECKSUMTYPE="SHA-1" SIZE="6355024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T17:01:21" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="15dcb44c36a48acf44cab33c9f7fc9a541e7d51a" CHECKSUMTYPE="SHA-1" SIZE="6355024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T17:01:54"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="2e5f5a57fe025ed41a83e59d54d291bbd0a45646"
-				CHECKSUMTYPE="SHA-1" SIZE="6314522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T17:01:54" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="2e5f5a57fe025ed41a83e59d54d291bbd0a45646" CHECKSUMTYPE="SHA-1" SIZE="6314522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T17:02:26"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="db99a8ddf741020e29997200353a44095967f58e"
-				CHECKSUMTYPE="SHA-1" SIZE="6337927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T17:02:26" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="db99a8ddf741020e29997200353a44095967f58e" CHECKSUMTYPE="SHA-1" SIZE="6337927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T17:02:58"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="873ab411a79aa241fe69c0d9751fe0657298a9fa"
-				CHECKSUMTYPE="SHA-1" SIZE="6316151">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T17:02:58" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="873ab411a79aa241fe69c0d9751fe0657298a9fa" CHECKSUMTYPE="SHA-1" SIZE="6316151">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T17:03:29"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="24fa4d040721f13ec27ec72711f388b610b85b04"
-				CHECKSUMTYPE="SHA-1" SIZE="6337924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T17:03:29" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="24fa4d040721f13ec27ec72711f388b610b85b04" CHECKSUMTYPE="SHA-1" SIZE="6337924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T17:04:00"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="b44122deaf817d9dfa052c4316db5e0a6ec77c71"
-				CHECKSUMTYPE="SHA-1" SIZE="6316303">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T17:04:00" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="b44122deaf817d9dfa052c4316db5e0a6ec77c71" CHECKSUMTYPE="SHA-1" SIZE="6316303">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T17:04:32"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="9cda71dbdb69f05586bc4cc50d840ddd2435ffc8"
-				CHECKSUMTYPE="SHA-1" SIZE="6337929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T17:04:32" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="9cda71dbdb69f05586bc4cc50d840ddd2435ffc8" CHECKSUMTYPE="SHA-1" SIZE="6337929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T17:05:07"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="a4009eff86e7af75c7d30afeb7164da21e2a86fd"
-				CHECKSUMTYPE="SHA-1" SIZE="6316325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T17:05:07" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="a4009eff86e7af75c7d30afeb7164da21e2a86fd" CHECKSUMTYPE="SHA-1" SIZE="6316325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T17:05:38"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="95d88b1c2a23236b050450dfded84f1ede7e118c"
-				CHECKSUMTYPE="SHA-1" SIZE="6337863">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T17:05:38" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="95d88b1c2a23236b050450dfded84f1ede7e118c" CHECKSUMTYPE="SHA-1" SIZE="6337863">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T17:06:10"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="f58f2c160d0a9d73533f5d365a93d8576f4dbd02"
-				CHECKSUMTYPE="SHA-1" SIZE="6316322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T17:06:10" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="f58f2c160d0a9d73533f5d365a93d8576f4dbd02" CHECKSUMTYPE="SHA-1" SIZE="6316322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T17:06:44"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="30dd10ede3a1b2cdc5b9112e43a1940dac932af4"
-				CHECKSUMTYPE="SHA-1" SIZE="6304628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T17:06:44" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="30dd10ede3a1b2cdc5b9112e43a1940dac932af4" CHECKSUMTYPE="SHA-1" SIZE="6304628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/delivery/bmtnabf_1899-08_01_0032.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:07:01" MIMETYPE="text/xml"
-				CHECKSUM="f55407601a2e7c63411a8e7ab31c137a88cc2d77" CHECKSUMTYPE="SHA-1"
-				SIZE="22546">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:07:01" MIMETYPE="text/xml" CHECKSUM="f55407601a2e7c63411a8e7ab31c137a88cc2d77" CHECKSUMTYPE="SHA-1" SIZE="22546">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:07:02" MIMETYPE="text/xml"
-				CHECKSUM="b8a341a703c50cbd56a23abac2be8251355051cf" CHECKSUMTYPE="SHA-1" SIZE="3974">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:07:02" MIMETYPE="text/xml" CHECKSUM="b8a341a703c50cbd56a23abac2be8251355051cf" CHECKSUMTYPE="SHA-1" SIZE="3974">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:07:02" MIMETYPE="text/xml"
-				CHECKSUM="f86102ca3b318f3dc443159987f9f60349d0ceb8" CHECKSUMTYPE="SHA-1"
-				SIZE="54103">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:07:02" MIMETYPE="text/xml" CHECKSUM="f86102ca3b318f3dc443159987f9f60349d0ceb8" CHECKSUMTYPE="SHA-1" SIZE="54103">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:07:02" MIMETYPE="text/xml"
-				CHECKSUM="d00fe4fe32f6f6fb39ec1b2f1d809d902b87c943" CHECKSUMTYPE="SHA-1" SIZE="3803">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:07:02" MIMETYPE="text/xml" CHECKSUM="d00fe4fe32f6f6fb39ec1b2f1d809d902b87c943" CHECKSUMTYPE="SHA-1" SIZE="3803">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:07:02" MIMETYPE="text/xml"
-				CHECKSUM="cefa1b6911d75b3ea8f840abcc7d15708ff368e5" CHECKSUMTYPE="SHA-1"
-				SIZE="54043">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:07:02" MIMETYPE="text/xml" CHECKSUM="cefa1b6911d75b3ea8f840abcc7d15708ff368e5" CHECKSUMTYPE="SHA-1" SIZE="54043">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:07:03" MIMETYPE="text/xml"
-				CHECKSUM="0b93b5065fb1af17eed38db65d2452574b8e7bec" CHECKSUMTYPE="SHA-1"
-				SIZE="87644">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:07:03" MIMETYPE="text/xml" CHECKSUM="0b93b5065fb1af17eed38db65d2452574b8e7bec" CHECKSUMTYPE="SHA-1" SIZE="87644">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:07:03" MIMETYPE="text/xml"
-				CHECKSUM="ba0fb31ef3ed569ec96a3915f7cbddce620efa28" CHECKSUMTYPE="SHA-1"
-				SIZE="67273">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:07:03" MIMETYPE="text/xml" CHECKSUM="ba0fb31ef3ed569ec96a3915f7cbddce620efa28" CHECKSUMTYPE="SHA-1" SIZE="67273">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:07:03" MIMETYPE="text/xml"
-				CHECKSUM="f1f332185a7ee6b7006dfa62b0124a51b86b9085" CHECKSUMTYPE="SHA-1" SIZE="4257">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:07:03" MIMETYPE="text/xml" CHECKSUM="f1f332185a7ee6b7006dfa62b0124a51b86b9085" CHECKSUMTYPE="SHA-1" SIZE="4257">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:07:03" MIMETYPE="text/xml"
-				CHECKSUM="d01ea098fdc935a2ddd6ec5b2a11e91d6dde1fd1" CHECKSUMTYPE="SHA-1"
-				SIZE="68448">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:07:03" MIMETYPE="text/xml" CHECKSUM="d01ea098fdc935a2ddd6ec5b2a11e91d6dde1fd1" CHECKSUMTYPE="SHA-1" SIZE="68448">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:07:04" MIMETYPE="text/xml"
-				CHECKSUM="e6f00ffa51859367bdee7ba3acb1788fa68dfc1b" CHECKSUMTYPE="SHA-1"
-				SIZE="24178">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:07:04" MIMETYPE="text/xml" CHECKSUM="e6f00ffa51859367bdee7ba3acb1788fa68dfc1b" CHECKSUMTYPE="SHA-1" SIZE="24178">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:07:04" MIMETYPE="text/xml"
-				CHECKSUM="3db38278875d7a7dab9dd669ec09e3571eace4ae" CHECKSUMTYPE="SHA-1" SIZE="3773">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:07:04" MIMETYPE="text/xml" CHECKSUM="3db38278875d7a7dab9dd669ec09e3571eace4ae" CHECKSUMTYPE="SHA-1" SIZE="3773">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:07:04" MIMETYPE="text/xml"
-				CHECKSUM="1f709477470d84b50069b5fe4eca1d019b1ddd9d" CHECKSUMTYPE="SHA-1" SIZE="4010">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:07:04" MIMETYPE="text/xml" CHECKSUM="1f709477470d84b50069b5fe4eca1d019b1ddd9d" CHECKSUMTYPE="SHA-1" SIZE="4010">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:07:04" MIMETYPE="text/xml"
-				CHECKSUM="da2967f1f43302647290e753d78ea94c6b9faa97" CHECKSUMTYPE="SHA-1"
-				SIZE="30803">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:07:04" MIMETYPE="text/xml" CHECKSUM="da2967f1f43302647290e753d78ea94c6b9faa97" CHECKSUMTYPE="SHA-1" SIZE="30803">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:07:05" MIMETYPE="text/xml"
-				CHECKSUM="c70233520ce9ae7a9a972fe7f58f8bf706e8c4e6" CHECKSUMTYPE="SHA-1"
-				SIZE="24444">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:07:05" MIMETYPE="text/xml" CHECKSUM="c70233520ce9ae7a9a972fe7f58f8bf706e8c4e6" CHECKSUMTYPE="SHA-1" SIZE="24444">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:07:05" MIMETYPE="text/xml"
-				CHECKSUM="3ece21bd915565cd570ad0c1aa78deb6aea1c872" CHECKSUMTYPE="SHA-1" SIZE="3942">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:07:05" MIMETYPE="text/xml" CHECKSUM="3ece21bd915565cd570ad0c1aa78deb6aea1c872" CHECKSUMTYPE="SHA-1" SIZE="3942">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:07:05" MIMETYPE="text/xml"
-				CHECKSUM="055b1b1f04373f20bb6361b88da6825cc344cca6" CHECKSUMTYPE="SHA-1" SIZE="3951">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:07:05" MIMETYPE="text/xml" CHECKSUM="055b1b1f04373f20bb6361b88da6825cc344cca6" CHECKSUMTYPE="SHA-1" SIZE="3951">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:07:05" MIMETYPE="text/xml"
-				CHECKSUM="c3c2c63fe9b4f4bd7c7ea68d84727a89ac9caa04" CHECKSUMTYPE="SHA-1"
-				SIZE="52963">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:07:05" MIMETYPE="text/xml" CHECKSUM="c3c2c63fe9b4f4bd7c7ea68d84727a89ac9caa04" CHECKSUMTYPE="SHA-1" SIZE="52963">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:07:06" MIMETYPE="text/xml"
-				CHECKSUM="b6dda6d64314780449e582e438fbfc3f694f8f35" CHECKSUMTYPE="SHA-1" SIZE="3932">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:07:06" MIMETYPE="text/xml" CHECKSUM="b6dda6d64314780449e582e438fbfc3f694f8f35" CHECKSUMTYPE="SHA-1" SIZE="3932">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:07:06" MIMETYPE="text/xml"
-				CHECKSUM="c52c3cb6b3f615151d34e9418386f6c2c7333e2b" CHECKSUMTYPE="SHA-1" SIZE="3942">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:07:06" MIMETYPE="text/xml" CHECKSUM="c52c3cb6b3f615151d34e9418386f6c2c7333e2b" CHECKSUMTYPE="SHA-1" SIZE="3942">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:07:06" MIMETYPE="text/xml"
-				CHECKSUM="32d35723ccdfb92ad5cf161a5f85aaa8d235ca2e" CHECKSUMTYPE="SHA-1"
-				SIZE="136088">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:07:06" MIMETYPE="text/xml" CHECKSUM="32d35723ccdfb92ad5cf161a5f85aaa8d235ca2e" CHECKSUMTYPE="SHA-1" SIZE="136088">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:07:06" MIMETYPE="text/xml"
-				CHECKSUM="76164a70387f1add9a254aefbed1f7997e6732f9" CHECKSUMTYPE="SHA-1" SIZE="3941">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:07:06" MIMETYPE="text/xml" CHECKSUM="76164a70387f1add9a254aefbed1f7997e6732f9" CHECKSUMTYPE="SHA-1" SIZE="3941">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:07:07" MIMETYPE="text/xml"
-				CHECKSUM="a0fe720061759ba36c4d2134ca30cdaabb9a5db0" CHECKSUMTYPE="SHA-1"
-				SIZE="89658">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:07:07" MIMETYPE="text/xml" CHECKSUM="a0fe720061759ba36c4d2134ca30cdaabb9a5db0" CHECKSUMTYPE="SHA-1" SIZE="89658">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:07:07" MIMETYPE="text/xml"
-				CHECKSUM="fbee593de36f30dea518eb178fa0e43367649770" CHECKSUMTYPE="SHA-1"
-				SIZE="54910">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:07:07" MIMETYPE="text/xml" CHECKSUM="fbee593de36f30dea518eb178fa0e43367649770" CHECKSUMTYPE="SHA-1" SIZE="54910">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:07:09" MIMETYPE="text/xml"
-				CHECKSUM="fd21e8a3ce7018d8943eb44cf3615ea55fc1a519" CHECKSUMTYPE="SHA-1"
-				SIZE="63653">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:07:09" MIMETYPE="text/xml" CHECKSUM="fd21e8a3ce7018d8943eb44cf3615ea55fc1a519" CHECKSUMTYPE="SHA-1" SIZE="63653">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T17:07:11" MIMETYPE="text/xml"
-				CHECKSUM="5cb238b28dede2733939efb5c7bbdc56cec5cc61" CHECKSUMTYPE="SHA-1" SIZE="6812">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T17:07:11" MIMETYPE="text/xml" CHECKSUM="5cb238b28dede2733939efb5c7bbdc56cec5cc61" CHECKSUMTYPE="SHA-1" SIZE="6812">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T17:07:11" MIMETYPE="text/xml"
-				CHECKSUM="1b09a91bcac7734038e6cf117e45f9cf4a63ad61" CHECKSUMTYPE="SHA-1"
-				SIZE="101708">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T17:07:11" MIMETYPE="text/xml" CHECKSUM="1b09a91bcac7734038e6cf117e45f9cf4a63ad61" CHECKSUMTYPE="SHA-1" SIZE="101708">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T17:07:12" MIMETYPE="text/xml"
-				CHECKSUM="4a5cd17bd2fe9f0067f58341df0c79819f23712f" CHECKSUMTYPE="SHA-1"
-				SIZE="114444">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T17:07:12" MIMETYPE="text/xml" CHECKSUM="4a5cd17bd2fe9f0067f58341df0c79819f23712f" CHECKSUMTYPE="SHA-1" SIZE="114444">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T17:07:12" MIMETYPE="text/xml"
-				CHECKSUM="d4c9b31d3a118a01ee90dbe9ccdbf445641b48a6" CHECKSUMTYPE="SHA-1"
-				SIZE="106214">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T17:07:12" MIMETYPE="text/xml" CHECKSUM="d4c9b31d3a118a01ee90dbe9ccdbf445641b48a6" CHECKSUMTYPE="SHA-1" SIZE="106214">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T17:07:13" MIMETYPE="text/xml"
-				CHECKSUM="8a037e4552ee8bf9d61a01c3d824ea8be988d140" CHECKSUMTYPE="SHA-1"
-				SIZE="98992">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T17:07:13" MIMETYPE="text/xml" CHECKSUM="8a037e4552ee8bf9d61a01c3d824ea8be988d140" CHECKSUMTYPE="SHA-1" SIZE="98992">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T17:07:13" MIMETYPE="text/xml"
-				CHECKSUM="c148512e18d98fcd3437dd25f647aac635853756" CHECKSUMTYPE="SHA-1"
-				SIZE="103772">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T17:07:13" MIMETYPE="text/xml" CHECKSUM="c148512e18d98fcd3437dd25f647aac635853756" CHECKSUMTYPE="SHA-1" SIZE="103772">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T17:07:13" MIMETYPE="text/xml"
-				CHECKSUM="7472408bbb745d7fc5d386c4ef800b5f06e16898" CHECKSUMTYPE="SHA-1"
-				SIZE="19608">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T17:07:13" MIMETYPE="text/xml" CHECKSUM="7472408bbb745d7fc5d386c4ef800b5f06e16898" CHECKSUMTYPE="SHA-1" SIZE="19608">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T17:07:13" MIMETYPE="text/xml"
-				CHECKSUM="1dcb6d61d6cb81f5f2275d4a79dd02ed11aea440" CHECKSUMTYPE="SHA-1" SIZE="6824">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T17:07:13" MIMETYPE="text/xml" CHECKSUM="1dcb6d61d6cb81f5f2275d4a79dd02ed11aea440" CHECKSUMTYPE="SHA-1" SIZE="6824">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-08_01_0032.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:07:55" MIMETYPE="application/pdf"
-				CHECKSUM="614aad949d541896c194355b7efe7cfe617a42da" CHECKSUMTYPE="SHA-1"
-				SIZE="8639490">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/bmtnabf_1899-08_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:07:55" MIMETYPE="application/pdf" CHECKSUM="614aad949d541896c194355b7efe7cfe617a42da" CHECKSUMTYPE="SHA-1" SIZE="8639490">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/08_01/bmtnabf_1899-08_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3784,8 +3594,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.3" TYPE="Illustration" ORDER="3" DMDID="c002"
-					LABEL="WANDFULLUNGEN IM HOFSALON">
+				<div ID="L.1.1.3" TYPE="Illustration" ORDER="3" DMDID="c002" LABEL="WANDFULLUNGEN IM HOFSALON">
 					<div ID="L.1.1.3.1" TYPE="HeadingText">
 						<div ID="L.1.1.3.1.1" TYPE="Text">
 							<fptr>
@@ -3809,8 +3618,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="4" DMDID="c006"
-					LABEL="ANSICHT DES HOFPAVILLONS. HAUPTFAÇADE">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="4" DMDID="c006" LABEL="ANSICHT DES HOFPAVILLONS. HAUPTFAÇADE">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00002" BEGIN="P2_TB00002"/>
@@ -3822,8 +3630,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="5" DMDID="c007"
-					LABEL="HOFPAVILLON DER WIENER STADTBAHN">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="5" DMDID="c007" LABEL="HOFPAVILLON DER WIENER STADTBAHN">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00002"/>
@@ -3840,26 +3647,16 @@
 								<div ID="L.1.1.5.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00003"
-												BEGIN="P3_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00003"
-												BEGIN="P3_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3868,10 +3665,8 @@
 								<div ID="L.1.1.5.3.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3879,23 +3674,20 @@
 							<div ID="L.1.1.5.3.1.3" TYPE="Paragraph" ORDER="3">
 								<div ID="L.1.1.5.3.1.3.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00005"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00005"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="1" DMDID="c008"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="1" DMDID="c008" LABEL="Untitled Image">
 						<div ID="L.1.1.5.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6" TYPE="Illustration" ORDER="6" DMDID="c016"
-						LABEL="UNTERFAHRT DES HOFPAVILLONS">
+					<div ID="L.1.1.6" TYPE="Illustration" ORDER="6" DMDID="c016" LABEL="UNTERFAHRT DES HOFPAVILLONS">
 						<div ID="L.1.1.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00002"/>
@@ -3907,8 +3699,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="2" DMDID="c009"
-						LABEL="GITTER DER TERRASSE">
+					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="2" DMDID="c009" LABEL="GITTER DER TERRASSE">
 						<div ID="L.1.1.5.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00004"/>
@@ -3920,8 +3711,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="3" DMDID="c010"
-						LABEL="LAMPE IM STIEGENHAUS">
+					<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="3" DMDID="c010" LABEL="LAMPE IM STIEGENHAUS">
 						<div ID="L.1.1.5.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00005"/>
@@ -3933,8 +3723,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="4" DMDID="c011"
-						LABEL="CANDELABER DER RAMPE">
+					<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="4" DMDID="c011" LABEL="CANDELABER DER RAMPE">
 						<div ID="L.1.1.5.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00004"/>
@@ -3946,8 +3735,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="5" DMDID="c012"
-						LABEL="LOGGIA-ECKE">
+					<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="5" DMDID="c012" LABEL="LOGGIA-ECKE">
 						<div ID="L.1.1.5.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
@@ -3959,8 +3747,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7" TYPE="Illustration" ORDER="7" DMDID="c017"
-						LABEL="TEPPICH DES HOFWARTESALONS">
+					<div ID="L.1.1.7" TYPE="Illustration" ORDER="7" DMDID="c017" LABEL="TEPPICH DES HOFWARTESALONS">
 						<div ID="L.1.1.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
@@ -3972,8 +3759,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.9" TYPE="Illustration" ORDER="6" DMDID="c013"
-						LABEL="LOGGIA-KAMIN">
+					<div ID="L.1.1.5.9" TYPE="Illustration" ORDER="6" DMDID="c013" LABEL="LOGGIA-KAMIN">
 						<div ID="L.1.1.5.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
@@ -3985,8 +3771,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.10" TYPE="Illustration" ORDER="7" DMDID="c014"
-						LABEL="GESTICKTE TISCHDECKE IM HOFWARTESALON">
+					<div ID="L.1.1.5.10" TYPE="Illustration" ORDER="7" DMDID="c014" LABEL="GESTICKTE TISCHDECKE IM HOFWARTESALON">
 						<div ID="L.1.1.5.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00004"/>
@@ -3998,8 +3783,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8" TYPE="Illustration" ORDER="8" DMDID="c018"
-						LABEL="SALON DER SUITE">
+					<div ID="L.1.1.8" TYPE="Illustration" ORDER="8" DMDID="c018" LABEL="SALON DER SUITE">
 						<div ID="L.1.1.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -4011,8 +3795,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9" TYPE="Illustration" ORDER="9" DMDID="c019"
-						LABEL="KUPPELRAUM DES BAUES. HOFWARTESALON">
+					<div ID="L.1.1.9" TYPE="Illustration" ORDER="9" DMDID="c019" LABEL="KUPPELRAUM DES BAUES. HOFWARTESALON">
 						<div ID="L.1.1.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -4024,8 +3807,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.11" TYPE="Illustration" ORDER="8" DMDID="c015"
-						LABEL="DECKENFENSTER DES KUPPELRAUMES">
+					<div ID="L.1.1.5.11" TYPE="Illustration" ORDER="8" DMDID="c015" LABEL="DECKENFENSTER DES KUPPELRAUMES">
 						<div ID="L.1.1.5.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00006"/>
@@ -4054,8 +3836,7 @@
 							<div ID="L.1.1.10.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.10.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
 									</fptr>
 								</div>
 							</div>
@@ -4112,8 +3893,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.4" TYPE="Illustration" ORDER="1" DMDID="c025"
-						LABEL="AM STRANDE">
+					<div ID="L.1.1.11.4" TYPE="Illustration" ORDER="1" DMDID="c025" LABEL="AM STRANDE">
 						<div ID="L.1.1.11.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00006"/>
@@ -4236,38 +4016,25 @@
 								<div ID="L.1.1.11.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.11.7" TYPE="Illustration" ORDER="4" DMDID="c028"
-						LABEL="BUCHSCHMUCK">
+					<div ID="L.1.1.11.7" TYPE="Illustration" ORDER="4" DMDID="c028" LABEL="BUCHSCHMUCK">
 						<div ID="L.1.1.11.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00006"/>
@@ -4285,8 +4052,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="Illustration" ORDER="15" DMDID="c032"
-					LABEL="AUFSTELLUNG VON KLINGER’S CHRISTUS IM OLYMP IN DER III. AUSSTELLUNG DER VEREINIGUNG. RAUMGESTALTUNG">
+				<div ID="L.1.1.15" TYPE="Illustration" ORDER="15" DMDID="c032" LABEL="AUFSTELLUNG VON KLINGER’S CHRISTUS IM OLYMP IN DER III. AUSSTELLUNG DER VEREINIGUNG. RAUMGESTALTUNG">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
@@ -4303,8 +4069,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.16" TYPE="TextContent" ORDER="16" DMDID="c033"
-					LABEL="REFORMIERTE AKADEMIE">
+				<div ID="L.1.1.16" TYPE="TextContent" ORDER="16" DMDID="c033" LABEL="REFORMIERTE AKADEMIE">
 					<div ID="L.1.1.16.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
@@ -4327,16 +4092,14 @@
 							<div ID="L.1.1.16.4.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.16.4.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.16.4.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.16.4.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00005"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00005"/>
 									</fptr>
 								</div>
 							</div>
@@ -4344,30 +4107,21 @@
 								<div ID="L.1.1.16.4.1.3.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00029"
-												BEGIN="P29_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00029"
-												BEGIN="P29_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.16.5" TYPE="Illustration" ORDER="1" DMDID="c034"
-						LABEL="EX LIBRIS RICH FISCHER">
+					<div ID="L.1.1.16.5" TYPE="Illustration" ORDER="1" DMDID="c034" LABEL="EX LIBRIS RICH FISCHER">
 						<div ID="L.1.1.16.5.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00006"/>
@@ -4379,8 +4133,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.6" TYPE="Illustration" ORDER="2" DMDID="c035"
-						LABEL="EX LIBRIS ANSELM HARTOG">
+					<div ID="L.1.1.16.6" TYPE="Illustration" ORDER="2" DMDID="c035" LABEL="EX LIBRIS ANSELM HARTOG">
 						<div ID="L.1.1.16.6.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00004"/>
@@ -4392,8 +4145,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.7" TYPE="Illustration" ORDER="3" DMDID="c036"
-						LABEL="EX LIBRIS MARTIN BRESLAUER">
+					<div ID="L.1.1.16.7" TYPE="Illustration" ORDER="3" DMDID="c036" LABEL="EX LIBRIS MARTIN BRESLAUER">
 						<div ID="L.1.1.16.7.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00004"/>
@@ -4405,8 +4157,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.8" TYPE="Illustration" ORDER="4" DMDID="c037"
-						LABEL="EX LIBRIS RICHARD SCHUSTER">
+					<div ID="L.1.1.16.8" TYPE="Illustration" ORDER="4" DMDID="c037" LABEL="EX LIBRIS RICHARD SCHUSTER">
 						<div ID="L.1.1.16.8.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00004"/>
@@ -4418,8 +4169,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16.9" TYPE="Illustration" ORDER="5" DMDID="c038"
-						LABEL="Untitled image by ADOLF BÖHM">
+					<div ID="L.1.1.16.9" TYPE="Illustration" ORDER="5" DMDID="c038" LABEL="Untitled image by ADOLF BÖHM">
 						<div ID="L.1.1.16.9.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00005"/>
@@ -4437,8 +4187,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.17" TYPE="TextContent" ORDER="17" DMDID="c039"
-					LABEL="WEISSENARCISSEN">
+				<div ID="L.1.1.17" TYPE="TextContent" ORDER="17" DMDID="c039" LABEL="WEISSENARCISSEN">
 					<div ID="L.1.1.17.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00002"/>
@@ -4451,8 +4200,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17.3" TYPE="Illustration" ORDER="1" DMDID="c040"
-						LABEL="WEISSENARCISSEN">
+					<div ID="L.1.1.17.3" TYPE="Illustration" ORDER="1" DMDID="c040" LABEL="WEISSENARCISSEN">
 						<div ID="L.1.1.17.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00003"/>

--- a/metadata/periodicals/bmtnabf/issues/1899/09_01/bmtnabf_1899-09_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1899/09_01/bmtnabf_1899-09_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-09_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-09_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-09_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1899-09_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-09_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3652,393 +3646,204 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:53:02"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="f08ed0b75a490810b6f538736e88c22717d0c949"
-				CHECKSUMTYPE="SHA-1" SIZE="6275826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:53:02" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="f08ed0b75a490810b6f538736e88c22717d0c949" CHECKSUMTYPE="SHA-1" SIZE="6275826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:53:35"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="bf1e81986ee970fe1d70a4074d5f68543844c7bb"
-				CHECKSUMTYPE="SHA-1" SIZE="6376626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:53:35" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="bf1e81986ee970fe1d70a4074d5f68543844c7bb" CHECKSUMTYPE="SHA-1" SIZE="6376626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:54:10"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="9e17755eed2f1469ca9855f93e7a9bde0f119c21"
-				CHECKSUMTYPE="SHA-1" SIZE="6275823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:54:10" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="9e17755eed2f1469ca9855f93e7a9bde0f119c21" CHECKSUMTYPE="SHA-1" SIZE="6275823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:54:44"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="c41a6912ad615f172dfa1fcaab6da3ac4698f7d5"
-				CHECKSUMTYPE="SHA-1" SIZE="6376622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:54:44" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="c41a6912ad615f172dfa1fcaab6da3ac4698f7d5" CHECKSUMTYPE="SHA-1" SIZE="6376622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:55:20"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2a9dc4517538477adf5b7bc3084df6e3c0a85463"
-				CHECKSUMTYPE="SHA-1" SIZE="6275820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:55:20" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2a9dc4517538477adf5b7bc3084df6e3c0a85463" CHECKSUMTYPE="SHA-1" SIZE="6275820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:55:56"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="cee22d8beb2f0b65a82fcc7237f4dd526f9627de"
-				CHECKSUMTYPE="SHA-1" SIZE="6376627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:55:56" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="cee22d8beb2f0b65a82fcc7237f4dd526f9627de" CHECKSUMTYPE="SHA-1" SIZE="6376627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:56:32"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="5463156cc209de8349d3f480c173657a68f4fa0e"
-				CHECKSUMTYPE="SHA-1" SIZE="6275825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:56:32" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="5463156cc209de8349d3f480c173657a68f4fa0e" CHECKSUMTYPE="SHA-1" SIZE="6275825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:57:09"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="be181b3be02ecf3667209a290956e7e8e9da161f"
-				CHECKSUMTYPE="SHA-1" SIZE="6373925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:57:09" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="be181b3be02ecf3667209a290956e7e8e9da161f" CHECKSUMTYPE="SHA-1" SIZE="6373925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:57:43"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="9c245e01e65deec0df5bf075215751025e86a909"
-				CHECKSUMTYPE="SHA-1" SIZE="6348729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:57:43" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="9c245e01e65deec0df5bf075215751025e86a909" CHECKSUMTYPE="SHA-1" SIZE="6348729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:58:19"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="928bdcf10aa57b73869ba52593dca40283ef3980"
-				CHECKSUMTYPE="SHA-1" SIZE="6373929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:58:19" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="928bdcf10aa57b73869ba52593dca40283ef3980" CHECKSUMTYPE="SHA-1" SIZE="6373929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:58:56"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="a0f754fb962c9bac9a22419b8f541329e4146ec0"
-				CHECKSUMTYPE="SHA-1" SIZE="6348723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:58:56" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="a0f754fb962c9bac9a22419b8f541329e4146ec0" CHECKSUMTYPE="SHA-1" SIZE="6348723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:59:33"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="b2947d4dbb31d96d2d0ed38cb8872e4e4064866d"
-				CHECKSUMTYPE="SHA-1" SIZE="6373929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:59:33" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="b2947d4dbb31d96d2d0ed38cb8872e4e4064866d" CHECKSUMTYPE="SHA-1" SIZE="6373929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T17:00:09"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="a07489f27a832eb4da65e4f75c2547823b348dff"
-				CHECKSUMTYPE="SHA-1" SIZE="6348724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T17:00:09" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="a07489f27a832eb4da65e4f75c2547823b348dff" CHECKSUMTYPE="SHA-1" SIZE="6348724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:00:45"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="805a0ae74e90807221ea50ea2a1d2eb098207cc9"
-				CHECKSUMTYPE="SHA-1" SIZE="6373926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:00:45" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="805a0ae74e90807221ea50ea2a1d2eb098207cc9" CHECKSUMTYPE="SHA-1" SIZE="6373926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T17:01:22"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="77c89c820a68efef55495a357d0f1ad30bb511e3"
-				CHECKSUMTYPE="SHA-1" SIZE="6348729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T17:01:22" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="77c89c820a68efef55495a357d0f1ad30bb511e3" CHECKSUMTYPE="SHA-1" SIZE="6348729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T17:01:57"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="3e4f39a657f46cd479738161e0173880fd8ca596"
-				CHECKSUMTYPE="SHA-1" SIZE="6373928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T17:01:57" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="3e4f39a657f46cd479738161e0173880fd8ca596" CHECKSUMTYPE="SHA-1" SIZE="6373928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T17:02:33"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7e730a620637cac529aea3b22573660a84bb8df0"
-				CHECKSUMTYPE="SHA-1" SIZE="6348726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T17:02:33" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7e730a620637cac529aea3b22573660a84bb8df0" CHECKSUMTYPE="SHA-1" SIZE="6348726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T17:03:10"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="5f814ad5f4d1afb09dec4330b8ebc91f9036db5e"
-				CHECKSUMTYPE="SHA-1" SIZE="6373929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T17:03:10" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="5f814ad5f4d1afb09dec4330b8ebc91f9036db5e" CHECKSUMTYPE="SHA-1" SIZE="6373929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T17:03:46"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="9f8146248d6af744a664be3c82b5c9a32adf9106"
-				CHECKSUMTYPE="SHA-1" SIZE="6348726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T17:03:46" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="9f8146248d6af744a664be3c82b5c9a32adf9106" CHECKSUMTYPE="SHA-1" SIZE="6348726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T17:04:21"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="756f7dd1a6be6332a5e1a0b5b069e01b0bb1a4c2"
-				CHECKSUMTYPE="SHA-1" SIZE="6373926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T17:04:21" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="756f7dd1a6be6332a5e1a0b5b069e01b0bb1a4c2" CHECKSUMTYPE="SHA-1" SIZE="6373926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T17:05:00"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="19450a114238480cf0c07df19a6f7aead07dc0a9"
-				CHECKSUMTYPE="SHA-1" SIZE="6348724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T17:05:00" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="19450a114238480cf0c07df19a6f7aead07dc0a9" CHECKSUMTYPE="SHA-1" SIZE="6348724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T17:05:34"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="9d77396db26c44c5286c748d4c22d0cd2e321b75"
-				CHECKSUMTYPE="SHA-1" SIZE="6373926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T17:05:34" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="9d77396db26c44c5286c748d4c22d0cd2e321b75" CHECKSUMTYPE="SHA-1" SIZE="6373926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T17:06:11"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="803d57273f26796140b8baefd913a41544dd6278"
-				CHECKSUMTYPE="SHA-1" SIZE="6348726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T17:06:11" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="803d57273f26796140b8baefd913a41544dd6278" CHECKSUMTYPE="SHA-1" SIZE="6348726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T17:06:53"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="4603d160ad1a3fa7a417bb87f0425ba1da4dc069"
-				CHECKSUMTYPE="SHA-1" SIZE="6373928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T17:06:53" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="4603d160ad1a3fa7a417bb87f0425ba1da4dc069" CHECKSUMTYPE="SHA-1" SIZE="6373928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T17:07:28"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="67c12fe152bc74ba3c7039323432e11fcf1390c4"
-				CHECKSUMTYPE="SHA-1" SIZE="6348726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T17:07:28" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="67c12fe152bc74ba3c7039323432e11fcf1390c4" CHECKSUMTYPE="SHA-1" SIZE="6348726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T17:08:07"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="44927de8b403a690400981457a747cef034300d4"
-				CHECKSUMTYPE="SHA-1" SIZE="6373916">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T17:08:07" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="44927de8b403a690400981457a747cef034300d4" CHECKSUMTYPE="SHA-1" SIZE="6373916">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T17:08:47"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="602fdcf809a8df9548ec37fcb5e42e5c392d4cc0"
-				CHECKSUMTYPE="SHA-1" SIZE="6348727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T17:08:47" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="602fdcf809a8df9548ec37fcb5e42e5c392d4cc0" CHECKSUMTYPE="SHA-1" SIZE="6348727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T17:09:23"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="58c4bbe54a56e65e90b54ed0fb78dba70b4a5c97"
-				CHECKSUMTYPE="SHA-1" SIZE="6373927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T17:09:23" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="58c4bbe54a56e65e90b54ed0fb78dba70b4a5c97" CHECKSUMTYPE="SHA-1" SIZE="6373927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T17:10:01"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="9be974d27f9024c72a00e2b54151c38415c6c808"
-				CHECKSUMTYPE="SHA-1" SIZE="6348721">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T17:10:01" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="9be974d27f9024c72a00e2b54151c38415c6c808" CHECKSUMTYPE="SHA-1" SIZE="6348721">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T17:10:38"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="a0250b287dadb99f51601264f3927b5709eb2abd"
-				CHECKSUMTYPE="SHA-1" SIZE="6373904">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T17:10:38" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="a0250b287dadb99f51601264f3927b5709eb2abd" CHECKSUMTYPE="SHA-1" SIZE="6373904">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T17:11:15"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="666cdd2312b2391a0f8304fd44906094ce36d15e"
-				CHECKSUMTYPE="SHA-1" SIZE="6348619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T17:11:15" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="666cdd2312b2391a0f8304fd44906094ce36d15e" CHECKSUMTYPE="SHA-1" SIZE="6348619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T17:11:50"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="cf99533dc853b4f731a923869233bb85ea579099"
-				CHECKSUMTYPE="SHA-1" SIZE="6373918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T17:11:50" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="cf99533dc853b4f731a923869233bb85ea579099" CHECKSUMTYPE="SHA-1" SIZE="6373918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/delivery/bmtnabf_1899-09_01_0032.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:12:12" MIMETYPE="text/xml"
-				CHECKSUM="f1bad85c9e54ef0cccaa0ba11abe46f5c471b7b7" CHECKSUMTYPE="SHA-1"
-				SIZE="35866">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:12:12" MIMETYPE="text/xml" CHECKSUM="f1bad85c9e54ef0cccaa0ba11abe46f5c471b7b7" CHECKSUMTYPE="SHA-1" SIZE="35866">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:12:12" MIMETYPE="text/xml"
-				CHECKSUM="90fd077515fede86ab458567fc260a7dc64a9963" CHECKSUMTYPE="SHA-1"
-				SIZE="16349">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:12:12" MIMETYPE="text/xml" CHECKSUM="90fd077515fede86ab458567fc260a7dc64a9963" CHECKSUMTYPE="SHA-1" SIZE="16349">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:12:12" MIMETYPE="text/xml"
-				CHECKSUM="805519419b562199af41abab450dd012acbd0719" CHECKSUMTYPE="SHA-1"
-				SIZE="33182">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:12:12" MIMETYPE="text/xml" CHECKSUM="805519419b562199af41abab450dd012acbd0719" CHECKSUMTYPE="SHA-1" SIZE="33182">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:12:13" MIMETYPE="text/xml"
-				CHECKSUM="6f678049d4d4f44e7cf87cff78268c17613bbb23" CHECKSUMTYPE="SHA-1"
-				SIZE="48587">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:12:13" MIMETYPE="text/xml" CHECKSUM="6f678049d4d4f44e7cf87cff78268c17613bbb23" CHECKSUMTYPE="SHA-1" SIZE="48587">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:12:13" MIMETYPE="text/xml"
-				CHECKSUM="dc9e1c32a2ee62f95c77fa7e36b0e4bb49b08cbb" CHECKSUMTYPE="SHA-1"
-				SIZE="43110">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:12:13" MIMETYPE="text/xml" CHECKSUM="dc9e1c32a2ee62f95c77fa7e36b0e4bb49b08cbb" CHECKSUMTYPE="SHA-1" SIZE="43110">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:12:13" MIMETYPE="text/xml"
-				CHECKSUM="9a942b739e00ab13a35700e23f60dbf0641144c8" CHECKSUMTYPE="SHA-1"
-				SIZE="43004">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:12:13" MIMETYPE="text/xml" CHECKSUM="9a942b739e00ab13a35700e23f60dbf0641144c8" CHECKSUMTYPE="SHA-1" SIZE="43004">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:12:14" MIMETYPE="text/xml"
-				CHECKSUM="ffb326a07e08289e5fb8b81e73879190112442df" CHECKSUMTYPE="SHA-1"
-				SIZE="44271">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:12:14" MIMETYPE="text/xml" CHECKSUM="ffb326a07e08289e5fb8b81e73879190112442df" CHECKSUMTYPE="SHA-1" SIZE="44271">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:12:14" MIMETYPE="text/xml"
-				CHECKSUM="225068834ccb64afc840ba02d4834d89832f5749" CHECKSUMTYPE="SHA-1"
-				SIZE="18234">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:12:14" MIMETYPE="text/xml" CHECKSUM="225068834ccb64afc840ba02d4834d89832f5749" CHECKSUMTYPE="SHA-1" SIZE="18234">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:12:14" MIMETYPE="text/xml"
-				CHECKSUM="935f1e3c6107f8bc2c0c367cbc21341843cb3586" CHECKSUMTYPE="SHA-1"
-				SIZE="29175">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:12:14" MIMETYPE="text/xml" CHECKSUM="935f1e3c6107f8bc2c0c367cbc21341843cb3586" CHECKSUMTYPE="SHA-1" SIZE="29175">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:12:15" MIMETYPE="text/xml"
-				CHECKSUM="ca527874e022099364650dcf34d71a9e748d8bb0" CHECKSUMTYPE="SHA-1"
-				SIZE="36571">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:12:15" MIMETYPE="text/xml" CHECKSUM="ca527874e022099364650dcf34d71a9e748d8bb0" CHECKSUMTYPE="SHA-1" SIZE="36571">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:12:15" MIMETYPE="text/xml"
-				CHECKSUM="50eb22d10ee184b717c8215f0fc103f200005156" CHECKSUMTYPE="SHA-1"
-				SIZE="39893">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:12:15" MIMETYPE="text/xml" CHECKSUM="50eb22d10ee184b717c8215f0fc103f200005156" CHECKSUMTYPE="SHA-1" SIZE="39893">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:12:15" MIMETYPE="text/xml"
-				CHECKSUM="850d0a96d187497053dcd4b7d8697af576c498e1" CHECKSUMTYPE="SHA-1"
-				SIZE="33429">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:12:15" MIMETYPE="text/xml" CHECKSUM="850d0a96d187497053dcd4b7d8697af576c498e1" CHECKSUMTYPE="SHA-1" SIZE="33429">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:12:15" MIMETYPE="text/xml"
-				CHECKSUM="c9ee0145c55314eb1129316e92af5efb89d8a5ac" CHECKSUMTYPE="SHA-1"
-				SIZE="122397">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:12:15" MIMETYPE="text/xml" CHECKSUM="c9ee0145c55314eb1129316e92af5efb89d8a5ac" CHECKSUMTYPE="SHA-1" SIZE="122397">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:12:16" MIMETYPE="text/xml"
-				CHECKSUM="73e432f4e005b066a050ba7e3491f6f358f2dbbc" CHECKSUMTYPE="SHA-1"
-				SIZE="30339">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:12:16" MIMETYPE="text/xml" CHECKSUM="73e432f4e005b066a050ba7e3491f6f358f2dbbc" CHECKSUMTYPE="SHA-1" SIZE="30339">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:12:16" MIMETYPE="text/xml"
-				CHECKSUM="5765ad9e079b737c939569fad831809f1aae6f4b" CHECKSUMTYPE="SHA-1"
-				SIZE="22694">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:12:16" MIMETYPE="text/xml" CHECKSUM="5765ad9e079b737c939569fad831809f1aae6f4b" CHECKSUMTYPE="SHA-1" SIZE="22694">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:12:16" MIMETYPE="text/xml"
-				CHECKSUM="9ff8a884f743b74ef51fc3ff07d6a5c6b0d36d3b" CHECKSUMTYPE="SHA-1"
-				SIZE="36752">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:12:16" MIMETYPE="text/xml" CHECKSUM="9ff8a884f743b74ef51fc3ff07d6a5c6b0d36d3b" CHECKSUMTYPE="SHA-1" SIZE="36752">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:12:16" MIMETYPE="text/xml"
-				CHECKSUM="817afb456c17954f6222447b6aaea54ca15f09b0" CHECKSUMTYPE="SHA-1" SIZE="4409">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:12:16" MIMETYPE="text/xml" CHECKSUM="817afb456c17954f6222447b6aaea54ca15f09b0" CHECKSUMTYPE="SHA-1" SIZE="4409">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:12:17" MIMETYPE="text/xml"
-				CHECKSUM="d68967020e1e48b5f3ea688edfb0fde57f129022" CHECKSUMTYPE="SHA-1"
-				SIZE="66286">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:12:17" MIMETYPE="text/xml" CHECKSUM="d68967020e1e48b5f3ea688edfb0fde57f129022" CHECKSUMTYPE="SHA-1" SIZE="66286">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:12:17" MIMETYPE="text/xml"
-				CHECKSUM="5a0c690e39b21fb54dd900a9755c91d9bee31086" CHECKSUMTYPE="SHA-1" SIZE="4895">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:12:17" MIMETYPE="text/xml" CHECKSUM="5a0c690e39b21fb54dd900a9755c91d9bee31086" CHECKSUMTYPE="SHA-1" SIZE="4895">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:12:17" MIMETYPE="text/xml"
-				CHECKSUM="354b6e524adb3df01ba394cf576bbdba7a3e3eb2" CHECKSUMTYPE="SHA-1" SIZE="5429">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:12:17" MIMETYPE="text/xml" CHECKSUM="354b6e524adb3df01ba394cf576bbdba7a3e3eb2" CHECKSUMTYPE="SHA-1" SIZE="5429">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:12:17" MIMETYPE="text/xml"
-				CHECKSUM="117bb3dcfce2c93abaf1f154589ed3bd4dfc6b8d" CHECKSUMTYPE="SHA-1"
-				SIZE="109040">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:12:17" MIMETYPE="text/xml" CHECKSUM="117bb3dcfce2c93abaf1f154589ed3bd4dfc6b8d" CHECKSUMTYPE="SHA-1" SIZE="109040">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:12:18" MIMETYPE="text/xml"
-				CHECKSUM="563e2b0e0affe66d3511888cb95c1ce21267e077" CHECKSUMTYPE="SHA-1"
-				SIZE="49261">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:12:18" MIMETYPE="text/xml" CHECKSUM="563e2b0e0affe66d3511888cb95c1ce21267e077" CHECKSUMTYPE="SHA-1" SIZE="49261">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:12:18" MIMETYPE="text/xml"
-				CHECKSUM="a64b50ce4efae3d8b9312bb6e36444265b914b20" CHECKSUMTYPE="SHA-1" SIZE="5676">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:12:18" MIMETYPE="text/xml" CHECKSUM="a64b50ce4efae3d8b9312bb6e36444265b914b20" CHECKSUMTYPE="SHA-1" SIZE="5676">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:12:18" MIMETYPE="text/xml"
-				CHECKSUM="533fe69027076c21f1a940643a61960cf9e6330d" CHECKSUMTYPE="SHA-1"
-				SIZE="59930">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:12:18" MIMETYPE="text/xml" CHECKSUM="533fe69027076c21f1a940643a61960cf9e6330d" CHECKSUMTYPE="SHA-1" SIZE="59930">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T17:12:18" MIMETYPE="text/xml"
-				CHECKSUM="b7f88b0a12388ae1f04e019bc8ef398950482be0" CHECKSUMTYPE="SHA-1"
-				SIZE="53304">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T17:12:18" MIMETYPE="text/xml" CHECKSUM="b7f88b0a12388ae1f04e019bc8ef398950482be0" CHECKSUMTYPE="SHA-1" SIZE="53304">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T17:12:19" MIMETYPE="text/xml"
-				CHECKSUM="6876674cb29604b2ed43904d85a2d03778989d2b" CHECKSUMTYPE="SHA-1"
-				SIZE="37131">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T17:12:19" MIMETYPE="text/xml" CHECKSUM="6876674cb29604b2ed43904d85a2d03778989d2b" CHECKSUMTYPE="SHA-1" SIZE="37131">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T17:12:19" MIMETYPE="text/xml"
-				CHECKSUM="602981ce90975c28646a1555fff3ab224bc39af4" CHECKSUMTYPE="SHA-1" SIZE="7964">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T17:12:19" MIMETYPE="text/xml" CHECKSUM="602981ce90975c28646a1555fff3ab224bc39af4" CHECKSUMTYPE="SHA-1" SIZE="7964">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T17:12:19" MIMETYPE="text/xml"
-				CHECKSUM="7931d2c949703e1104c31b9288c5f205ca1756fd" CHECKSUMTYPE="SHA-1"
-				SIZE="53171">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T17:12:19" MIMETYPE="text/xml" CHECKSUM="7931d2c949703e1104c31b9288c5f205ca1756fd" CHECKSUMTYPE="SHA-1" SIZE="53171">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T17:12:19" MIMETYPE="text/xml"
-				CHECKSUM="2bccc9555086e92c3c04a3f35bb5a4e823022640" CHECKSUMTYPE="SHA-1" SIZE="5064">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T17:12:19" MIMETYPE="text/xml" CHECKSUM="2bccc9555086e92c3c04a3f35bb5a4e823022640" CHECKSUMTYPE="SHA-1" SIZE="5064">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T17:12:20" MIMETYPE="text/xml"
-				CHECKSUM="cec133e163741acc30b5f897dc9d50639d4c9fa8" CHECKSUMTYPE="SHA-1" SIZE="5926">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T17:12:20" MIMETYPE="text/xml" CHECKSUM="cec133e163741acc30b5f897dc9d50639d4c9fa8" CHECKSUMTYPE="SHA-1" SIZE="5926">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T17:12:20" MIMETYPE="text/xml"
-				CHECKSUM="ec3fe927b3278b14a621c518fca3dbe9f7aa75ad" CHECKSUMTYPE="SHA-1"
-				SIZE="37993">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T17:12:20" MIMETYPE="text/xml" CHECKSUM="ec3fe927b3278b14a621c518fca3dbe9f7aa75ad" CHECKSUMTYPE="SHA-1" SIZE="37993">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T17:12:20" MIMETYPE="text/xml"
-				CHECKSUM="152ef2e2b081995491c31366229f554e030de543" CHECKSUMTYPE="SHA-1"
-				SIZE="61670">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T17:12:20" MIMETYPE="text/xml" CHECKSUM="152ef2e2b081995491c31366229f554e030de543" CHECKSUMTYPE="SHA-1" SIZE="61670">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-09_01_0032.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:13:05" MIMETYPE="application/pdf"
-				CHECKSUM="f7be6cd71348c881d3552a8669f1c5487a675d81" CHECKSUMTYPE="SHA-1"
-				SIZE="10049233">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/bmtnabf_1899-09_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:13:05" MIMETYPE="application/pdf" CHECKSUM="f7be6cd71348c881d3552a8669f1c5487a675d81" CHECKSUMTYPE="SHA-1" SIZE="10049233">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/09_01/bmtnabf_1899-09_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -4330,8 +4135,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.3" TYPE="Illustration" ORDER="3" DMDID="c002"
-					LABEL="JAPANISCHER SCHABLONENSCHNITT">
+				<div ID="L.1.1.3" TYPE="Illustration" ORDER="3" DMDID="c002" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 					<div ID="L.1.1.3.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00002" BEGIN="P2_TB00004"/>
@@ -4343,8 +4147,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="TextContent" ORDER="4" DMDID="c003"
-					LABEL="GIOVANNI SEGANTINI">
+				<div ID="L.1.1.4" TYPE="TextContent" ORDER="4" DMDID="c003" LABEL="GIOVANNI SEGANTINI">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_TB00002"/>
@@ -4362,8 +4165,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="5" DMDID="c004"
-					LABEL="THEEFEST AM HAKONE-SEE">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="5" DMDID="c004" LABEL="THEEFEST AM HAKONE-SEE">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00002"/>
@@ -4375,38 +4177,25 @@
 								<div ID="L.1.1.5.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00003"
-												BEGIN="P3_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00003"
-												BEGIN="P3_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00004"
-												BEGIN="P4_TB00001"/>
-											<area BETYPE="IDREF" FILEID="ALTO00004"
-												BEGIN="P4_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00001"/>
+											<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c005"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c005" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.5.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00005"/>
@@ -4418,8 +4207,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="2" DMDID="c006"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="2" DMDID="c006" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.5.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00003"/>
@@ -4432,8 +4220,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.4.3" TYPE="Illustration" ORDER="2" DMDID="c007"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.5.4.3" TYPE="Illustration" ORDER="2" DMDID="c007" LABEL="Untitled Image">
 							<div ID="L.1.1.5.4.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_CB00002"/>
@@ -4441,8 +4228,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="3" DMDID="c008"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="3" DMDID="c008" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.5.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00004"/>
@@ -4455,8 +4241,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.5.3" TYPE="Illustration" ORDER="2" DMDID="c009"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.5.5.3" TYPE="Illustration" ORDER="2" DMDID="c009" LABEL="Untitled Image">
 							<div ID="L.1.1.5.5.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00002"/>
@@ -4464,8 +4249,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="4" DMDID="c010"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="4" DMDID="c010" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.5.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00004"/>
@@ -4478,8 +4262,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.6.3" TYPE="Illustration" ORDER="2" DMDID="c011"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.5.6.3" TYPE="Illustration" ORDER="2" DMDID="c011" LABEL="Untitled Image">
 							<div ID="L.1.1.5.6.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_CB00002"/>
@@ -4487,8 +4270,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="5" DMDID="c012"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="5" DMDID="c012" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.5.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
@@ -4501,16 +4283,14 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.7.3" TYPE="Illustration" ORDER="2" DMDID="c013"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.5.7.3" TYPE="Illustration" ORDER="2" DMDID="c013" LABEL="Untitled Image">
 							<div ID="L.1.1.5.7.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00001"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.7.4" TYPE="Illustration" ORDER="3" DMDID="c014"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.5.7.4" TYPE="Illustration" ORDER="3" DMDID="c014" LABEL="Untitled Image">
 							<div ID="L.1.1.5.7.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00001"/>
@@ -4519,8 +4299,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="TextContent" ORDER="6" DMDID="c015"
-					LABEL="ZWEI SÄNFTENTRÄGER, EIN FÄCHER UND EIN WANDERER ALS SINNBILDER DER VERGÄNGLICHEN WELT – IN STATIONEN DER LANDSTRASSE">
+				<div ID="L.1.1.6" TYPE="TextContent" ORDER="6" DMDID="c015" LABEL="ZWEI SÄNFTENTRÄGER, EIN FÄCHER UND EIN WANDERER ALS SINNBILDER DER VERGÄNGLICHEN WELT – IN STATIONEN DER LANDSTRASSE">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -4532,30 +4311,21 @@
 								<div ID="L.1.1.6.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.3" TYPE="Illustration" ORDER="1" DMDID="c016"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.6.3" TYPE="Illustration" ORDER="1" DMDID="c016" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.6.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00005"/>
@@ -4567,8 +4337,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="2" DMDID="c017"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.6.4" TYPE="Illustration" ORDER="2" DMDID="c017" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.6.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00004"/>
@@ -4581,8 +4350,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.4.3" TYPE="Illustration" ORDER="2" DMDID="c018"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.4.3" TYPE="Illustration" ORDER="2" DMDID="c018" LABEL="Untitled Image">
 							<div ID="L.1.1.6.4.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00002"/>
@@ -4590,8 +4358,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="3" DMDID="c019"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="3" DMDID="c019" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.6.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
@@ -4604,8 +4371,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.5.3" TYPE="Illustration" ORDER="2" DMDID="c020"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.5.3" TYPE="Illustration" ORDER="2" DMDID="c020" LABEL="Untitled Image">
 							<div ID="L.1.1.6.5.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00002"/>
@@ -4613,8 +4379,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.6" TYPE="Illustration" ORDER="4" DMDID="c021"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.6.6" TYPE="Illustration" ORDER="4" DMDID="c021" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.6.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00004"/>
@@ -4627,8 +4392,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="TextContent" ORDER="7" DMDID="c022"
-					LABEL="WEIDE AN DEN VERLORENEN WASSERN">
+				<div ID="L.1.1.7" TYPE="TextContent" ORDER="7" DMDID="c022" LABEL="WEIDE AN DEN VERLORENEN WASSERN">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -4640,18 +4404,15 @@
 								<div ID="L.1.1.7.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="1" DMDID="c023"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="1" DMDID="c023" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.7.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00005"/>
@@ -4664,24 +4425,21 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.7.3.3" TYPE="Illustration" ORDER="2" DMDID="c024"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.7.3.3" TYPE="Illustration" ORDER="2" DMDID="c024" LABEL="Untitled Image">
 							<div ID="L.1.1.7.3.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.7.3.4" TYPE="Illustration" ORDER="3" DMDID="c025"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.7.3.4" TYPE="Illustration" ORDER="3" DMDID="c025" LABEL="Untitled Image">
 							<div ID="L.1.1.7.3.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.7.3.5" TYPE="Illustration" ORDER="4" DMDID="c026"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.7.3.5" TYPE="Illustration" ORDER="4" DMDID="c026" LABEL="Untitled Image">
 							<div ID="L.1.1.7.3.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00004"/>
@@ -4690,8 +4448,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="TextContent" ORDER="8" DMDID="c027"
-					LABEL="HÄNGENDEN BLÜTHEN">
+				<div ID="L.1.1.8" TYPE="TextContent" ORDER="8" DMDID="c027" LABEL="HÄNGENDEN BLÜTHEN">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00001"/>
@@ -4702,8 +4459,7 @@
 							<div ID="L.1.1.8.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.8.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
 									</fptr>
 								</div>
 							</div>
@@ -4711,20 +4467,16 @@
 								<div ID="L.1.1.8.2.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.8.3" TYPE="Illustration" ORDER="1" DMDID="c028"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.8.3" TYPE="Illustration" ORDER="1" DMDID="c028" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.8.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
@@ -4737,8 +4489,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.8.3.3" TYPE="Illustration" ORDER="2" DMDID="c029"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.8.3.3" TYPE="Illustration" ORDER="2" DMDID="c029" LABEL="Untitled Image">
 							<div ID="L.1.1.8.3.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00002"/>
@@ -4746,8 +4497,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.8.4" TYPE="Illustration" ORDER="2" DMDID="c030"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.8.4" TYPE="Illustration" ORDER="2" DMDID="c030" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.8.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"/>
@@ -4760,8 +4510,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.8.4.3" TYPE="Illustration" ORDER="2" DMDID="c031"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.8.4.3" TYPE="Illustration" ORDER="2" DMDID="c031" LABEL="Untitled Image">
 							<div ID="L.1.1.8.4.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00002"/>
@@ -4770,8 +4519,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="TextContent" ORDER="9" DMDID="c032"
-					LABEL="HÜTER DES SCHATZES UNTER DEM BREITEN DACHE">
+				<div ID="L.1.1.9" TYPE="TextContent" ORDER="9" DMDID="c032" LABEL="HÜTER DES SCHATZES UNTER DEM BREITEN DACHE">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -4782,23 +4530,20 @@
 							<div ID="L.1.1.9.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.9.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.9.2.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.9.2.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.9.3" TYPE="Illustration" ORDER="1" DMDID="c033"
-						LABEL="JAPANISCHER SCHABLONENSCHNITT">
+					<div ID="L.1.1.9.3" TYPE="Illustration" ORDER="1" DMDID="c033" LABEL="JAPANISCHER SCHABLONENSCHNITT">
 						<div ID="L.1.1.9.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00005"/>
@@ -4811,8 +4556,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="10" DMDID="c034"
-					LABEL="LUDGATE CIRCUS LONDON">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="10" DMDID="c034" LABEL="LUDGATE CIRCUS LONDON">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -4829,8 +4573,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="TextContent" ORDER="11" DMDID="c035"
-					LABEL="ZUR WERTHSCHÄTZUNG DER JAPANISCHEN KUNST">
+				<div ID="L.1.1.11" TYPE="TextContent" ORDER="11" DMDID="c035" LABEL="ZUR WERTHSCHÄTZUNG DER JAPANISCHEN KUNST">
 					<div ID="L.1.1.11.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
@@ -4841,8 +4584,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00005"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.11.3" TYPE="Illustration" ORDER="1" DMDID="c036"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.11.3" TYPE="Illustration" ORDER="1" DMDID="c036" LABEL="Untitled Image">
 						<div ID="L.1.1.11.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00002"/>
@@ -4855,44 +4597,28 @@
 								<div ID="L.1.1.11.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00031"
-												BEGIN="P31_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00031"
-												BEGIN="P31_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00031"
-												BEGIN="P31_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.11.5" TYPE="Illustration" ORDER="1" DMDID="c037"
-						LABEL="NACH EINEM ORIGINAL-HOLZSCHNITT">
+					<div ID="L.1.1.11.5" TYPE="Illustration" ORDER="1" DMDID="c037" LABEL="NACH EINEM ORIGINAL-HOLZSCHNITT">
 						<div ID="L.1.1.11.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00005"/>
@@ -4909,8 +4635,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.6" TYPE="Illustration" ORDER="2" DMDID="c038"
-						LABEL="Untitled Image by EMIL ORLIK">
+					<div ID="L.1.1.11.6" TYPE="Illustration" ORDER="2" DMDID="c038" LABEL="Untitled Image by EMIL ORLIK">
 						<div ID="L.1.1.11.6.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00004"/>
@@ -4923,24 +4648,21 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.11.6.3" TYPE="Illustration" ORDER="2" DMDID="c039"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.11.6.3" TYPE="Illustration" ORDER="2" DMDID="c039" LABEL="Untitled Image">
 							<div ID="L.1.1.11.6.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.11.6.4" TYPE="Illustration" ORDER="3" DMDID="c040"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.11.6.4" TYPE="Illustration" ORDER="3" DMDID="c040" LABEL="Untitled Image">
 							<div ID="L.1.1.11.6.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.11.6.5" TYPE="Illustration" ORDER="4" DMDID="c041"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.11.6.5" TYPE="Illustration" ORDER="4" DMDID="c041" LABEL="Untitled Image">
 							<div ID="L.1.1.11.6.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_CB00004"/>
@@ -4948,8 +4670,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.11.7" TYPE="Illustration" ORDER="3" DMDID="c042"
-						LABEL="NACH ORIGINALHOLZSCHNITTEN">
+					<div ID="L.1.1.11.7" TYPE="Illustration" ORDER="3" DMDID="c042" LABEL="NACH ORIGINALHOLZSCHNITTEN">
 						<div ID="L.1.1.11.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00004"/>
@@ -4967,16 +4688,14 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.11.7.4" TYPE="Illustration" ORDER="2" DMDID="c043"
-							LABEL="NACH ORIGINALHOLZSCHNITTEN">
+						<div ID="L.1.1.11.7.4" TYPE="Illustration" ORDER="2" DMDID="c043" LABEL="NACH ORIGINALHOLZSCHNITTEN">
 							<div ID="L.1.1.11.7.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.11.7.5" TYPE="Illustration" ORDER="3" DMDID="c044"
-							LABEL="NACH ORIGINALHOLZSCHNITTEN">
+						<div ID="L.1.1.11.7.5" TYPE="Illustration" ORDER="3" DMDID="c044" LABEL="NACH ORIGINALHOLZSCHNITTEN">
 							<div ID="L.1.1.11.7.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_CB00003"/>
@@ -5048,8 +4767,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.11" TYPE="Illustration" ORDER="7" DMDID="c048"
-						LABEL="NACH EINER ORIGINALRADIERUNG">
+					<div ID="L.1.1.11.11" TYPE="Illustration" ORDER="7" DMDID="c048" LABEL="NACH EINER ORIGINALRADIERUNG">
 						<div ID="L.1.1.11.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00004"/>
@@ -5066,8 +4784,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.12" TYPE="Illustration" ORDER="8" DMDID="c049"
-						LABEL="NACH EINER ORIGINALRADIERUNG">
+					<div ID="L.1.1.11.12" TYPE="Illustration" ORDER="8" DMDID="c049" LABEL="NACH EINER ORIGINALRADIERUNG">
 						<div ID="L.1.1.11.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00006"/>
@@ -5084,8 +4801,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.13" TYPE="Illustration" ORDER="9" DMDID="c050"
-						LABEL="NACH ORIGINALRADIERUNGEN">
+					<div ID="L.1.1.11.13" TYPE="Illustration" ORDER="9" DMDID="c050" LABEL="NACH ORIGINALRADIERUNGEN">
 						<div ID="L.1.1.11.13.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00006"/>
@@ -5103,16 +4819,14 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.11.13.4" TYPE="Illustration" ORDER="2" DMDID="c051"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.11.13.4" TYPE="Illustration" ORDER="2" DMDID="c051" LABEL="Untitled Image">
 							<div ID="L.1.1.11.13.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.11.13.5" TYPE="Illustration" ORDER="3" DMDID="c052"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.11.13.5" TYPE="Illustration" ORDER="3" DMDID="c052" LABEL="Untitled Image">
 							<div ID="L.1.1.11.13.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_CB00003"/>
@@ -5121,8 +4835,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="Illustration" ORDER="12" DMDID="c053"
-					LABEL="NACH EINER ORIGINALLITHOGRAPHIE VON">
+				<div ID="L.1.1.12" TYPE="Illustration" ORDER="12" DMDID="c053" LABEL="NACH EINER ORIGINALLITHOGRAPHIE VON">
 					<div ID="L.1.1.12.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
@@ -5139,8 +4852,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="Illustration" ORDER="13" DMDID="c054"
-					LABEL="AUSSICHT AUS MEINEM ATELIER, PRAG">
+				<div ID="L.1.1.13" TYPE="Illustration" ORDER="13" DMDID="c054" LABEL="AUSSICHT AUS MEINEM ATELIER, PRAG">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
@@ -5179,8 +4891,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="Illustration" ORDER="15" DMDID="c056"
-					LABEL="NACH EINEM ORIGINALHOLZSCHNITT">
+				<div ID="L.1.1.15" TYPE="Illustration" ORDER="15" DMDID="c056" LABEL="NACH EINEM ORIGINALHOLZSCHNITT">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
@@ -5219,8 +4930,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.17" TYPE="Illustration" ORDER="17" DMDID="c058"
-					LABEL="EX LIBRIS VON EMIL ORLIK">
+				<div ID="L.1.1.17" TYPE="Illustration" ORDER="17" DMDID="c058" LABEL="EX LIBRIS VON EMIL ORLIK">
 					<div ID="L.1.1.17.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00005"/>
@@ -5237,8 +4947,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.18" TYPE="Illustration" ORDER="18" DMDID="c059"
-					LABEL="EX LIBRIS VON EMIL ORLIK">
+				<div ID="L.1.1.18" TYPE="Illustration" ORDER="18" DMDID="c059" LABEL="EX LIBRIS VON EMIL ORLIK">
 					<div ID="L.1.1.18.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00007"/>
@@ -5266,8 +4975,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00003"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="1"
-						LABEL="NACH EINER ORIGINALRADIERUNG">
+					<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="1" LABEL="NACH EINER ORIGINALRADIERUNG">
 						<div ID="L.1.1.19.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_CB00001"/>
@@ -5279,8 +4987,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.19.4" TYPE="Illustration" ORDER="2" DMDID="c061"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.19.4" TYPE="Illustration" ORDER="2" DMDID="c061" LABEL="Untitled Image">
 						<div ID="L.1.1.19.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_CB00002"/>
@@ -5288,8 +4995,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.20" TYPE="Illustration" ORDER="20" DMDID="c062"
-					LABEL="ABBRUCH DES GHETTO IN PRAG">
+				<div ID="L.1.1.20" TYPE="Illustration" ORDER="20" DMDID="c062" LABEL="ABBRUCH DES GHETTO IN PRAG">
 					<div ID="L.1.1.20.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00002"/>
@@ -5311,8 +5017,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.21" TYPE="TextContent" ORDER="21" DMDID="c063"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.21" TYPE="TextContent" ORDER="21" DMDID="c063" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.21.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00003"/>
@@ -5323,15 +5028,13 @@
 							<div ID="L.1.1.21.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.21.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.21.3" TYPE="Illustration" ORDER="1" DMDID="c064"
-						LABEL="Untitled Image by EMIL ORLIK">
+					<div ID="L.1.1.21.3" TYPE="Illustration" ORDER="1" DMDID="c064" LABEL="Untitled Image by EMIL ORLIK">
 						<div ID="L.1.1.21.3.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00005"/>
@@ -5345,8 +5048,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.21.3.3" TYPE="Illustration" ORDER="2" DMDID="c065"
-						LABEL="Untitled Image by EMIL ORLIK">
+					<div ID="L.1.1.21.3.3" TYPE="Illustration" ORDER="2" DMDID="c065" LABEL="Untitled Image by EMIL ORLIK">
 						<div ID="L.1.1.21.3.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_CB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1899/10_01/bmtnabf_1899-10_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1899/10_01/bmtnabf_1899-10_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-10_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1899-10_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-10_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1899-10_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-10_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3626,393 +3620,216 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:53:16"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="87432fd3bf0948705729f827a2427624d0feac02"
-				CHECKSUMTYPE="SHA-1" SIZE="6379252">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:53:16" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="87432fd3bf0948705729f827a2427624d0feac02" CHECKSUMTYPE="SHA-1" SIZE="6379252">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:53:49"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="b9f4c6c18aa9bf0860571db2084eeee333419453"
-				CHECKSUMTYPE="SHA-1" SIZE="6378429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:53:49" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="b9f4c6c18aa9bf0860571db2084eeee333419453" CHECKSUMTYPE="SHA-1" SIZE="6378429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:54:20"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="182564585ff9906d3fb1468b36792db01ddad1c0"
-				CHECKSUMTYPE="SHA-1" SIZE="5811243">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:54:20" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="182564585ff9906d3fb1468b36792db01ddad1c0" CHECKSUMTYPE="SHA-1" SIZE="5811243">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:54:51"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="d68339e05f107f75235b4cae3dfee486aaa615af"
-				CHECKSUMTYPE="SHA-1" SIZE="6378395">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:54:51" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="d68339e05f107f75235b4cae3dfee486aaa615af" CHECKSUMTYPE="SHA-1" SIZE="6378395">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:55:25"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="ca40c795b916486dd643c340bba52b318c9383d4"
-				CHECKSUMTYPE="SHA-1" SIZE="6379326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:55:25" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="ca40c795b916486dd643c340bba52b318c9383d4" CHECKSUMTYPE="SHA-1" SIZE="6379326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:55:58"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="523a18e630986ba99d5b7f1631d9151acf61a53f"
-				CHECKSUMTYPE="SHA-1" SIZE="6378429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:55:58" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="523a18e630986ba99d5b7f1631d9151acf61a53f" CHECKSUMTYPE="SHA-1" SIZE="6378429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:56:31"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="09d6e2ffb08224f4ccf4326d4d758c469e7911d9"
-				CHECKSUMTYPE="SHA-1" SIZE="6379326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:56:31" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="09d6e2ffb08224f4ccf4326d4d758c469e7911d9" CHECKSUMTYPE="SHA-1" SIZE="6379326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:57:03"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="45214fabd7843e04c2a30b1689a7c0f1da9247df"
-				CHECKSUMTYPE="SHA-1" SIZE="6378397">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:57:03" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="45214fabd7843e04c2a30b1689a7c0f1da9247df" CHECKSUMTYPE="SHA-1" SIZE="6378397">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:57:36"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="a67b73e6c6225076d6728aaa23920acf729444fe"
-				CHECKSUMTYPE="SHA-1" SIZE="6361329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:57:36" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="a67b73e6c6225076d6728aaa23920acf729444fe" CHECKSUMTYPE="SHA-1" SIZE="6361329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:58:09"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="5c4ad5e8dcdef81a2d4ade67de60c5bfc0a87da3"
-				CHECKSUMTYPE="SHA-1" SIZE="6378425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:58:09" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="5c4ad5e8dcdef81a2d4ade67de60c5bfc0a87da3" CHECKSUMTYPE="SHA-1" SIZE="6378425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:58:40"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="24226dce44ac0e28d925a898ed9117b2c4bb6cbe"
-				CHECKSUMTYPE="SHA-1" SIZE="6361313">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:58:40" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="24226dce44ac0e28d925a898ed9117b2c4bb6cbe" CHECKSUMTYPE="SHA-1" SIZE="6361313">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:59:13"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="a2d4ace6183875807e32f379607743a465fd9449"
-				CHECKSUMTYPE="SHA-1" SIZE="6378415">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:59:13" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="a2d4ace6183875807e32f379607743a465fd9449" CHECKSUMTYPE="SHA-1" SIZE="6378415">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:59:46"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="bc193bd4087658e7fd39bb171434a248ee31fd40"
-				CHECKSUMTYPE="SHA-1" SIZE="6361326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:59:46" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="bc193bd4087658e7fd39bb171434a248ee31fd40" CHECKSUMTYPE="SHA-1" SIZE="6361326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:00:17"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="ef9e0e90cf749344c77126c7e42402fe11e4aa2f"
-				CHECKSUMTYPE="SHA-1" SIZE="6378421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:00:17" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="ef9e0e90cf749344c77126c7e42402fe11e4aa2f" CHECKSUMTYPE="SHA-1" SIZE="6378421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T17:00:47"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="32c8644e1f9caa307bf94c24d72db49b2af578a5"
-				CHECKSUMTYPE="SHA-1" SIZE="6361322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T17:00:47" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="32c8644e1f9caa307bf94c24d72db49b2af578a5" CHECKSUMTYPE="SHA-1" SIZE="6361322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T17:01:18"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="7b25bf86baeb1f80cbe933bc01c416f9a2acf2f2"
-				CHECKSUMTYPE="SHA-1" SIZE="6230826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T17:01:18" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="7b25bf86baeb1f80cbe933bc01c416f9a2acf2f2" CHECKSUMTYPE="SHA-1" SIZE="6230826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T17:01:50"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="cbbbc251b1a8005153a1385f2aec3b60976271f4"
-				CHECKSUMTYPE="SHA-1" SIZE="6361328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T17:01:50" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="cbbbc251b1a8005153a1385f2aec3b60976271f4" CHECKSUMTYPE="SHA-1" SIZE="6361328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T17:02:26"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="1f2d87984973e24113aa58b90cb92d95a492ac4c"
-				CHECKSUMTYPE="SHA-1" SIZE="6230829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T17:02:26" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="1f2d87984973e24113aa58b90cb92d95a492ac4c" CHECKSUMTYPE="SHA-1" SIZE="6230829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T17:03:00"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7d260b904f9154cf327d9941bd318f03377be919"
-				CHECKSUMTYPE="SHA-1" SIZE="6361314">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T17:03:00" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7d260b904f9154cf327d9941bd318f03377be919" CHECKSUMTYPE="SHA-1" SIZE="6361314">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T17:03:32"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="c997f4133ba8ab95ae3b0214db8f2db107ebea67"
-				CHECKSUMTYPE="SHA-1" SIZE="6328017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T17:03:32" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="c997f4133ba8ab95ae3b0214db8f2db107ebea67" CHECKSUMTYPE="SHA-1" SIZE="6328017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T17:04:02"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="7a0d44e55787b2523647032b6ba6c1b6c0d184db"
-				CHECKSUMTYPE="SHA-1" SIZE="6361295">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T17:04:02" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="7a0d44e55787b2523647032b6ba6c1b6c0d184db" CHECKSUMTYPE="SHA-1" SIZE="6361295">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T17:04:33"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="4436c751a99f41b01c7c920ba3cc0295e7ee21c8"
-				CHECKSUMTYPE="SHA-1" SIZE="6318117">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T17:04:33" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="4436c751a99f41b01c7c920ba3cc0295e7ee21c8" CHECKSUMTYPE="SHA-1" SIZE="6318117">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T17:05:07"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="597b24c2f42ef360ca5098a9b11d38f0075d58be"
-				CHECKSUMTYPE="SHA-1" SIZE="6361312">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T17:05:07" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="597b24c2f42ef360ca5098a9b11d38f0075d58be" CHECKSUMTYPE="SHA-1" SIZE="6361312">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T17:05:40"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="8de60f892cbe5ef5d21d63d4fc28c401982ed02d"
-				CHECKSUMTYPE="SHA-1" SIZE="6318111">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T17:05:40" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="8de60f892cbe5ef5d21d63d4fc28c401982ed02d" CHECKSUMTYPE="SHA-1" SIZE="6318111">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T17:06:14"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="4dcc51051cbfb1d242e23c7c5ee62ebfbf85c7e0"
-				CHECKSUMTYPE="SHA-1" SIZE="6361315">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T17:06:14" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="4dcc51051cbfb1d242e23c7c5ee62ebfbf85c7e0" CHECKSUMTYPE="SHA-1" SIZE="6361315">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T17:06:48"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="064b5a5a62f87e07c743a76ffe234626bba80dca"
-				CHECKSUMTYPE="SHA-1" SIZE="6318127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T17:06:48" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="064b5a5a62f87e07c743a76ffe234626bba80dca" CHECKSUMTYPE="SHA-1" SIZE="6318127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T17:07:19"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="a6b64f0bd1685cfedaf01298e4673a841084749f"
-				CHECKSUMTYPE="SHA-1" SIZE="6361329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T17:07:19" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="a6b64f0bd1685cfedaf01298e4673a841084749f" CHECKSUMTYPE="SHA-1" SIZE="6361329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T17:07:50"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="ebb091def35fc06f9d99d9d074554f0dae284b3a"
-				CHECKSUMTYPE="SHA-1" SIZE="6318105">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T17:07:50" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="ebb091def35fc06f9d99d9d074554f0dae284b3a" CHECKSUMTYPE="SHA-1" SIZE="6318105">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T17:08:19"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="da5f64d724027dd4a7814d16a3d54d4b3e04874a"
-				CHECKSUMTYPE="SHA-1" SIZE="6361322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T17:08:19" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="da5f64d724027dd4a7814d16a3d54d4b3e04874a" CHECKSUMTYPE="SHA-1" SIZE="6361322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T17:08:51"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="07b4075bca39eec46077dbd96a09e0df639ca716"
-				CHECKSUMTYPE="SHA-1" SIZE="6318120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T17:08:51" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="07b4075bca39eec46077dbd96a09e0df639ca716" CHECKSUMTYPE="SHA-1" SIZE="6318120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T17:09:22"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="0d9ad552efff03ec70eef9109e0756655d046486"
-				CHECKSUMTYPE="SHA-1" SIZE="6361275">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T17:09:22" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="0d9ad552efff03ec70eef9109e0756655d046486" CHECKSUMTYPE="SHA-1" SIZE="6361275">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T17:09:55"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="b6b1f8e832021269bb9996a839fcf4f0b9843d0a"
-				CHECKSUMTYPE="SHA-1" SIZE="6318114">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T17:09:55" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="b6b1f8e832021269bb9996a839fcf4f0b9843d0a" CHECKSUMTYPE="SHA-1" SIZE="6318114">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T17:10:29"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="1e9cb4ffdf09e48bd5072ad8bcfad4cdca74140c"
-				CHECKSUMTYPE="SHA-1" SIZE="6361259">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T17:10:29" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="1e9cb4ffdf09e48bd5072ad8bcfad4cdca74140c" CHECKSUMTYPE="SHA-1" SIZE="6361259">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T17:11:00"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="128b07e3676d84312baae6249e435454b45993c1"
-				CHECKSUMTYPE="SHA-1" SIZE="6318120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T17:11:00" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="128b07e3676d84312baae6249e435454b45993c1" CHECKSUMTYPE="SHA-1" SIZE="6318120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/delivery/bmtnabf_1899-10_01_0034.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:11:18" MIMETYPE="text/xml"
-				CHECKSUM="6b397f3d4105cf88851a2ba10252e8ae1634c7e1" CHECKSUMTYPE="SHA-1" SIZE="6764">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:11:18" MIMETYPE="text/xml" CHECKSUM="6b397f3d4105cf88851a2ba10252e8ae1634c7e1" CHECKSUMTYPE="SHA-1" SIZE="6764">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:11:19" MIMETYPE="text/xml"
-				CHECKSUM="00ac7fff02b86521b4c8ddeb045042edea603d32" CHECKSUMTYPE="SHA-1" SIZE="4935">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:11:19" MIMETYPE="text/xml" CHECKSUM="00ac7fff02b86521b4c8ddeb045042edea603d32" CHECKSUMTYPE="SHA-1" SIZE="4935">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:11:19" MIMETYPE="text/xml"
-				CHECKSUM="86f8fa83ea43401fc20e6f859d1b8671610b96a8" CHECKSUMTYPE="SHA-1"
-				SIZE="46975">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:11:19" MIMETYPE="text/xml" CHECKSUM="86f8fa83ea43401fc20e6f859d1b8671610b96a8" CHECKSUMTYPE="SHA-1" SIZE="46975">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:11:20" MIMETYPE="text/xml"
-				CHECKSUM="217ca10c52932b14f34ce84382a689d62c9488a1" CHECKSUMTYPE="SHA-1" SIZE="3976">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:11:20" MIMETYPE="text/xml" CHECKSUM="217ca10c52932b14f34ce84382a689d62c9488a1" CHECKSUMTYPE="SHA-1" SIZE="3976">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:11:21" MIMETYPE="text/xml"
-				CHECKSUM="22e7e371400a280f3c1a0df0ae902de2228f76c5" CHECKSUMTYPE="SHA-1" SIZE="3455">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:11:21" MIMETYPE="text/xml" CHECKSUM="22e7e371400a280f3c1a0df0ae902de2228f76c5" CHECKSUMTYPE="SHA-1" SIZE="3455">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:11:21" MIMETYPE="text/xml"
-				CHECKSUM="064e5530fba5252b9bb43e0b3cf9ae5a529a77eb" CHECKSUMTYPE="SHA-1" SIZE="5813">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:11:21" MIMETYPE="text/xml" CHECKSUM="064e5530fba5252b9bb43e0b3cf9ae5a529a77eb" CHECKSUMTYPE="SHA-1" SIZE="5813">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:11:22" MIMETYPE="text/xml"
-				CHECKSUM="a24839f5178a59c0211edec556a8817bb4d52b76" CHECKSUMTYPE="SHA-1" SIZE="5655">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:11:22" MIMETYPE="text/xml" CHECKSUM="a24839f5178a59c0211edec556a8817bb4d52b76" CHECKSUMTYPE="SHA-1" SIZE="5655">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:11:22" MIMETYPE="text/xml"
-				CHECKSUM="5764168c87c39e0001994bfe13fc9dcc548f18d8" CHECKSUMTYPE="SHA-1" SIZE="3798">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:11:22" MIMETYPE="text/xml" CHECKSUM="5764168c87c39e0001994bfe13fc9dcc548f18d8" CHECKSUMTYPE="SHA-1" SIZE="3798">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:11:22" MIMETYPE="text/xml"
-				CHECKSUM="4ab0106f2359bb31d495679d9e7cae9740f56be1" CHECKSUMTYPE="SHA-1" SIZE="3863">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:11:22" MIMETYPE="text/xml" CHECKSUM="4ab0106f2359bb31d495679d9e7cae9740f56be1" CHECKSUMTYPE="SHA-1" SIZE="3863">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:11:22" MIMETYPE="text/xml"
-				CHECKSUM="9bf48836241fb38d5346c6c6d3abad331ec5e703" CHECKSUMTYPE="SHA-1" SIZE="3653">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:11:22" MIMETYPE="text/xml" CHECKSUM="9bf48836241fb38d5346c6c6d3abad331ec5e703" CHECKSUMTYPE="SHA-1" SIZE="3653">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:11:23" MIMETYPE="text/xml"
-				CHECKSUM="b617ecaa1183401bed0dd850cb648449542481ab" CHECKSUMTYPE="SHA-1" SIZE="3569">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:11:23" MIMETYPE="text/xml" CHECKSUM="b617ecaa1183401bed0dd850cb648449542481ab" CHECKSUMTYPE="SHA-1" SIZE="3569">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:11:23" MIMETYPE="text/xml"
-				CHECKSUM="f740fac35a017c2aed2953dd79be4fc7c14cbc9b" CHECKSUMTYPE="SHA-1" SIZE="3953">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:11:23" MIMETYPE="text/xml" CHECKSUM="f740fac35a017c2aed2953dd79be4fc7c14cbc9b" CHECKSUMTYPE="SHA-1" SIZE="3953">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:11:23" MIMETYPE="text/xml"
-				CHECKSUM="95a7565c64a78fd28c5fd3d6c7f5dd2621e2f971" CHECKSUMTYPE="SHA-1" SIZE="4344">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:11:23" MIMETYPE="text/xml" CHECKSUM="95a7565c64a78fd28c5fd3d6c7f5dd2621e2f971" CHECKSUMTYPE="SHA-1" SIZE="4344">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:11:23" MIMETYPE="text/xml"
-				CHECKSUM="574ec91ab59a3fc425d791deea2a66efccf633fe" CHECKSUMTYPE="SHA-1" SIZE="6526">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:11:23" MIMETYPE="text/xml" CHECKSUM="574ec91ab59a3fc425d791deea2a66efccf633fe" CHECKSUMTYPE="SHA-1" SIZE="6526">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:11:24" MIMETYPE="text/xml"
-				CHECKSUM="4b0d81f88e14cdd954456ee047ee864a12054b48" CHECKSUMTYPE="SHA-1" SIZE="3945">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:11:24" MIMETYPE="text/xml" CHECKSUM="4b0d81f88e14cdd954456ee047ee864a12054b48" CHECKSUMTYPE="SHA-1" SIZE="3945">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:11:24" MIMETYPE="text/xml"
-				CHECKSUM="16fc29a6cba4540d1c6d6fbb3827d3859b026c8f" CHECKSUMTYPE="SHA-1" SIZE="5019">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:11:24" MIMETYPE="text/xml" CHECKSUM="16fc29a6cba4540d1c6d6fbb3827d3859b026c8f" CHECKSUMTYPE="SHA-1" SIZE="5019">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:11:24" MIMETYPE="text/xml"
-				CHECKSUM="dc6ef4dc54e36ee5d1001a625385efa647e7a845" CHECKSUMTYPE="SHA-1"
-				SIZE="48627">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:11:24" MIMETYPE="text/xml" CHECKSUM="dc6ef4dc54e36ee5d1001a625385efa647e7a845" CHECKSUMTYPE="SHA-1" SIZE="48627">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:11:24" MIMETYPE="text/xml"
-				CHECKSUM="3e03ec6f4043229e2774548871d7248980c6c439" CHECKSUMTYPE="SHA-1"
-				SIZE="40418">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:11:24" MIMETYPE="text/xml" CHECKSUM="3e03ec6f4043229e2774548871d7248980c6c439" CHECKSUMTYPE="SHA-1" SIZE="40418">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:11:25" MIMETYPE="text/xml"
-				CHECKSUM="2db9ebf976b15b6a0fa31629a35ac492e217a5e3" CHECKSUMTYPE="SHA-1" SIZE="7103">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:11:25" MIMETYPE="text/xml" CHECKSUM="2db9ebf976b15b6a0fa31629a35ac492e217a5e3" CHECKSUMTYPE="SHA-1" SIZE="7103">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:11:25" MIMETYPE="text/xml"
-				CHECKSUM="78904d63ffa981e5fd07e534a1fddaca8033f167" CHECKSUMTYPE="SHA-1" SIZE="4003">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:11:25" MIMETYPE="text/xml" CHECKSUM="78904d63ffa981e5fd07e534a1fddaca8033f167" CHECKSUMTYPE="SHA-1" SIZE="4003">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:11:25" MIMETYPE="text/xml"
-				CHECKSUM="5f37f07bf3765343a6758a6ddc9835a21619c7c1" CHECKSUMTYPE="SHA-1" SIZE="3944">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:11:25" MIMETYPE="text/xml" CHECKSUM="5f37f07bf3765343a6758a6ddc9835a21619c7c1" CHECKSUMTYPE="SHA-1" SIZE="3944">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:11:25" MIMETYPE="text/xml"
-				CHECKSUM="5f5f4f025465d800781b265adf49dd9ab57be8e1" CHECKSUMTYPE="SHA-1" SIZE="5731">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:11:25" MIMETYPE="text/xml" CHECKSUM="5f5f4f025465d800781b265adf49dd9ab57be8e1" CHECKSUMTYPE="SHA-1" SIZE="5731">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:11:26" MIMETYPE="text/xml"
-				CHECKSUM="42e38ca9f3eb8db0c17baa08ae13c6c5ade17d0e" CHECKSUMTYPE="SHA-1" SIZE="5962">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:11:26" MIMETYPE="text/xml" CHECKSUM="42e38ca9f3eb8db0c17baa08ae13c6c5ade17d0e" CHECKSUMTYPE="SHA-1" SIZE="5962">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:11:26" MIMETYPE="text/xml"
-				CHECKSUM="820039ec013608c030bec325047efa55dbe18250" CHECKSUMTYPE="SHA-1" SIZE="3415">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:11:26" MIMETYPE="text/xml" CHECKSUM="820039ec013608c030bec325047efa55dbe18250" CHECKSUMTYPE="SHA-1" SIZE="3415">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T17:11:27" MIMETYPE="text/xml"
-				CHECKSUM="5c78b0e64523142af995288c96eea1c2b1bade0d" CHECKSUMTYPE="SHA-1" SIZE="3600">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T17:11:27" MIMETYPE="text/xml" CHECKSUM="5c78b0e64523142af995288c96eea1c2b1bade0d" CHECKSUMTYPE="SHA-1" SIZE="3600">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T17:11:27" MIMETYPE="text/xml"
-				CHECKSUM="bf6e144e0a041cb5f23d5227d2b4f0cd1147a783" CHECKSUMTYPE="SHA-1" SIZE="4477">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T17:11:27" MIMETYPE="text/xml" CHECKSUM="bf6e144e0a041cb5f23d5227d2b4f0cd1147a783" CHECKSUMTYPE="SHA-1" SIZE="4477">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T17:11:27" MIMETYPE="text/xml"
-				CHECKSUM="2949aac8e9f76588c7592d9f3d92650987aa1fae" CHECKSUMTYPE="SHA-1" SIZE="4309">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T17:11:27" MIMETYPE="text/xml" CHECKSUM="2949aac8e9f76588c7592d9f3d92650987aa1fae" CHECKSUMTYPE="SHA-1" SIZE="4309">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T17:11:27" MIMETYPE="text/xml"
-				CHECKSUM="8996e6b34509cfcff1dbb43d77d806197bc67572" CHECKSUMTYPE="SHA-1" SIZE="3422">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T17:11:27" MIMETYPE="text/xml" CHECKSUM="8996e6b34509cfcff1dbb43d77d806197bc67572" CHECKSUMTYPE="SHA-1" SIZE="3422">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T17:11:28" MIMETYPE="text/xml"
-				CHECKSUM="a9157c81ac13974e6792efcc4349f703058f43a1" CHECKSUMTYPE="SHA-1" SIZE="3614">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T17:11:28" MIMETYPE="text/xml" CHECKSUM="a9157c81ac13974e6792efcc4349f703058f43a1" CHECKSUMTYPE="SHA-1" SIZE="3614">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T17:11:28" MIMETYPE="text/xml"
-				CHECKSUM="e3a2073b9c9ac176db14504f0da023a1201671e4" CHECKSUMTYPE="SHA-1" SIZE="6230">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T17:11:28" MIMETYPE="text/xml" CHECKSUM="e3a2073b9c9ac176db14504f0da023a1201671e4" CHECKSUMTYPE="SHA-1" SIZE="6230">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T17:11:28" MIMETYPE="text/xml"
-				CHECKSUM="ca6fd4527f9db92a2c1dd15435ed4b585495ec40" CHECKSUMTYPE="SHA-1" SIZE="6463">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T17:11:28" MIMETYPE="text/xml" CHECKSUM="ca6fd4527f9db92a2c1dd15435ed4b585495ec40" CHECKSUMTYPE="SHA-1" SIZE="6463">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T17:11:28" MIMETYPE="text/xml"
-				CHECKSUM="bca35664b5e7a72ebae316d993ece821faa977ba" CHECKSUMTYPE="SHA-1" SIZE="7361">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T17:11:28" MIMETYPE="text/xml" CHECKSUM="bca35664b5e7a72ebae316d993ece821faa977ba" CHECKSUMTYPE="SHA-1" SIZE="7361">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T17:11:28" MIMETYPE="text/xml"
-				CHECKSUM="0fd137cbd0232fa1a3ed15d27a0879986a9ee156" CHECKSUMTYPE="SHA-1" SIZE="4779">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T17:11:28" MIMETYPE="text/xml" CHECKSUM="0fd137cbd0232fa1a3ed15d27a0879986a9ee156" CHECKSUMTYPE="SHA-1" SIZE="4779">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T17:11:29" MIMETYPE="text/xml"
-				CHECKSUM="c2d56bd92a8331859d261a920c297e538fb8f078" CHECKSUMTYPE="SHA-1" SIZE="6549">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T17:11:29" MIMETYPE="text/xml" CHECKSUM="c2d56bd92a8331859d261a920c297e538fb8f078" CHECKSUMTYPE="SHA-1" SIZE="6549">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1899-10_01_0034.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:12:00" MIMETYPE="application/pdf"
-				CHECKSUM="e1abe2f5539901c44d4bf005d1937aaf6366cc9e" CHECKSUMTYPE="SHA-1"
-				SIZE="7639757">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/bmtnabf_1899-10_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:12:00" MIMETYPE="application/pdf" CHECKSUM="e1abe2f5539901c44d4bf005d1937aaf6366cc9e" CHECKSUMTYPE="SHA-1" SIZE="7639757">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1899/10_01/bmtnabf_1899-10_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -4337,8 +4154,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="4" DMDID="c003"
-					LABEL="NOTHELFER DER NAIVETÄT UND MEISTERSCHAFT">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="4" DMDID="c003" LABEL="NOTHELFER DER NAIVETÄT UND MEISTERSCHAFT">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00002" BEGIN="P2_TB00002"/>
@@ -4355,8 +4171,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="5" DMDID="c004"
-					LABEL="MAXIMILIAN PIRNER">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="5" DMDID="c004" LABEL="MAXIMILIAN PIRNER">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00002"/>
@@ -4380,8 +4195,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c005"
-						LABEL="STUDIE. LANDSCHAFT BEI DAVLE">
+					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c005" LABEL="STUDIE. LANDSCHAFT BEI DAVLE">
 						<div ID="L.1.1.5.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00005"/>
@@ -4445,8 +4259,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="9" DMDID="c009"
-					LABEL="REICH DES DIONYSOS">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="9" DMDID="c009" LABEL="REICH DES DIONYSOS">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00004"/>
@@ -4476,16 +4289,14 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.3" TYPE="Illustration" ORDER="2" DMDID="c011"
-						LABEL="Untitled Image by MAXIMILIAN PIRNER">
+					<div ID="L.1.1.10.3" TYPE="Illustration" ORDER="2" DMDID="c011" LABEL="Untitled Image by MAXIMILIAN PIRNER">
 						<div ID="L.1.1.10.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="3" DMDID="c012"
-						LABEL="Untitled Image by MAXIMILIAN PIRNER">
+					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="3" DMDID="c012" LABEL="Untitled Image by MAXIMILIAN PIRNER">
 						<div ID="L.1.1.10.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00003"/>
@@ -4532,8 +4343,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="Illustration" ORDER="13" DMDID="c015"
-					LABEL="BÖHMISCHE LANDSCHAFT">
+				<div ID="L.1.1.13" TYPE="Illustration" ORDER="13" DMDID="c015" LABEL="BÖHMISCHE LANDSCHAFT">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -4545,8 +4355,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.14" TYPE="Illustration" ORDER="14" DMDID="c016"
-					LABEL="BÖHMISCHE LANDSCHAFT">
+				<div ID="L.1.1.14" TYPE="Illustration" ORDER="14" DMDID="c016" LABEL="BÖHMISCHE LANDSCHAFT">
 					<div ID="L.1.1.14.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -4575,16 +4384,14 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.16" TYPE="Illustration" ORDER="1" DMDID="c018"
-					LABEL="Untitled Image by MAXIMILIAN PIRNER">
+				<div ID="L.1.1.16" TYPE="Illustration" ORDER="1" DMDID="c018" LABEL="Untitled Image by MAXIMILIAN PIRNER">
 					<div ID="L.1.1.16.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00002"/>
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.17" TYPE="Illustration" ORDER="17" DMDID="c019"
-					LABEL="MÜTTER UND SÖHNE">
+				<div ID="L.1.1.17" TYPE="Illustration" ORDER="17" DMDID="c019" LABEL="MÜTTER UND SÖHNE">
 					<div ID="L.1.1.17.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -4601,8 +4408,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.18" TYPE="Illustration" ORDER="18" DMDID="c020"
-					LABEL="INSELKLOSTER ST KILIAN IN BÖHMEN 1899">
+				<div ID="L.1.1.18" TYPE="Illustration" ORDER="18" DMDID="c020" LABEL="INSELKLOSTER ST KILIAN IN BÖHMEN 1899">
 					<div ID="L.1.1.18.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
@@ -4614,8 +4420,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.19" TYPE="Illustration" ORDER="19" DMDID="c021"
-					LABEL="Untitled Image by MAXIMILIAN PIRNER">
+				<div ID="L.1.1.19" TYPE="Illustration" ORDER="19" DMDID="c021" LABEL="Untitled Image by MAXIMILIAN PIRNER">
 					<div ID="L.1.1.19.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
@@ -4627,8 +4432,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.20" TYPE="Illustration" ORDER="20" DMDID="c022"
-					LABEL="Studie: PAN UND PSYCHE">
+				<div ID="L.1.1.20" TYPE="Illustration" ORDER="20" DMDID="c022" LABEL="Studie: PAN UND PSYCHE">
 					<div ID="L.1.1.20.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
@@ -4662,8 +4466,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.22" TYPE="Illustration" ORDER="22" DMDID="c024"
-					LABEL="AQUARELLIRTE SKIZZE ZU EINEM GLASGEMÄLDE FÜR PILSEN 1898—1899">
+				<div ID="L.1.1.22" TYPE="Illustration" ORDER="22" DMDID="c024" LABEL="AQUARELLIRTE SKIZZE ZU EINEM GLASGEMÄLDE FÜR PILSEN 1898—1899">
 					<div ID="L.1.1.22.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -4680,8 +4483,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.23" TYPE="TextContent" ORDER="23" DMDID="c026"
-					LABEL="AN UNSERE LESER!">
+				<div ID="L.1.1.23" TYPE="TextContent" ORDER="23" DMDID="c026" LABEL="AN UNSERE LESER!">
 					<div ID="L.1.1.23.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00001"/>
@@ -4692,24 +4494,21 @@
 							<div ID="L.1.1.23.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.23.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.23.2.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.23.2.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00001"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00001"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.24" TYPE="Illustration" ORDER="24" DMDID="c027"
-					LABEL="CARTONFRAGMENTE ZU EINEM GLASGEMÄLDE FÜR PILSEN 1899">
+				<div ID="L.1.1.24" TYPE="Illustration" ORDER="24" DMDID="c027" LABEL="CARTONFRAGMENTE ZU EINEM GLASGEMÄLDE FÜR PILSEN 1899">
 					<div ID="L.1.1.24.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
@@ -4772,8 +4571,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.28" TYPE="Illustration" ORDER="28" DMDID="c031"
-					LABEL="KYKLOP UND NAJADE">
+				<div ID="L.1.1.28" TYPE="Illustration" ORDER="28" DMDID="c031" LABEL="KYKLOP UND NAJADE">
 					<div ID="L.1.1.28.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
@@ -4802,8 +4600,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.30" TYPE="Illustration" ORDER="30" DMDID="c033"
-					LABEL="GIGANT UND WASSERWEIBER">
+				<div ID="L.1.1.30" TYPE="Illustration" ORDER="30" DMDID="c033" LABEL="GIGANT UND WASSERWEIBER">
 					<div ID="L.1.1.30.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
@@ -4820,8 +4617,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.31" TYPE="Illustration" ORDER="31" DMDID="c034"
-					LABEL="WASSERRIESEN UND PANISKE">
+				<div ID="L.1.1.31" TYPE="Illustration" ORDER="31" DMDID="c034" LABEL="WASSERRIESEN UND PANISKE">
 					<div ID="L.1.1.31.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
@@ -4866,8 +4662,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.34" TYPE="Illustration" ORDER="34" DMDID="c038"
-					LABEL="EROS UND DAS CHAOS">
+				<div ID="L.1.1.34" TYPE="Illustration" ORDER="34" DMDID="c038" LABEL="EROS UND DAS CHAOS">
 					<div ID="L.1.1.34.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
@@ -4884,8 +4679,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.35" TYPE="Illustration" ORDER="35" DMDID="c039"
-					LABEL="IRRENDEN RITTER">
+				<div ID="L.1.1.35" TYPE="Illustration" ORDER="35" DMDID="c039" LABEL="IRRENDEN RITTER">
 					<div ID="L.1.1.35.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00002"/>
@@ -4927,8 +4721,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.37.3" TYPE="Illustration" ORDER="2" DMDID="c042"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.37.3" TYPE="Illustration" ORDER="2" DMDID="c042" LABEL="Untitled Image">
 						<div ID="L.1.1.37.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_CB00002"/>
@@ -4936,8 +4729,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.38" TYPE="Illustration" ORDER="38" DMDID="c043"
-					LABEL="QUELLWEIBLEIN PASTELL">
+				<div ID="L.1.1.38" TYPE="Illustration" ORDER="38" DMDID="c043" LABEL="QUELLWEIBLEIN PASTELL">
 					<div ID="L.1.1.38.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00002"/>
@@ -4954,8 +4746,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.39" TYPE="Illustration" ORDER="39" DMDID="c044"
-					LABEL="NÄRRISCHE PSYCHE UND DIE GESCHEITEN">
+				<div ID="L.1.1.39" TYPE="Illustration" ORDER="39" DMDID="c044" LABEL="NÄRRISCHE PSYCHE UND DIE GESCHEITEN">
 					<div ID="L.1.1.39.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00004"/>
@@ -4972,8 +4763,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.40" TYPE="Illustration" ORDER="40" DMDID="c045"
-					LABEL="IN ABWESENHEIT DES KLAUSNERS">
+				<div ID="L.1.1.40" TYPE="Illustration" ORDER="40" DMDID="c045" LABEL="IN ABWESENHEIT DES KLAUSNERS">
 					<div ID="L.1.1.40.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00002"/>
@@ -5014,8 +4804,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.43" TYPE="Illustration" ORDER="43" DMDID="c048"
-					LABEL="AUS DEM LEBEN DER HEIL. CYRILL UND METHOD ENTWÜRFE FÜR WANDMALEREIEN EINER BASILIKA 1887">
+				<div ID="L.1.1.43" TYPE="Illustration" ORDER="43" DMDID="c048" LABEL="AUS DEM LEBEN DER HEIL. CYRILL UND METHOD ENTWÜRFE FÜR WANDMALEREIEN EINER BASILIKA 1887">
 					<div ID="L.1.1.43.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00002"/>
@@ -5066,8 +4855,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.45.3" TYPE="Illustration" ORDER="2" DMDID="c052"
-						LABEL="Untitled Image by MAXIMILIAN PIRNER">
+					<div ID="L.1.1.45.3" TYPE="Illustration" ORDER="2" DMDID="c052" LABEL="Untitled Image by MAXIMILIAN PIRNER">
 						<div ID="L.1.1.45.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00033" BEGIN="P33_CB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1899/11_01/bmtnabf_1899-11_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1899/11_01/bmtnabf_1899-11_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-11_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1899-11_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-11_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1899/12_01/bmtnabf_1899-12_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1899/12_01/bmtnabf_1899-12_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-12_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1899-12_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1899-12_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/01/01_01/bmtnabf_1900-01-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/01/01_01/bmtnabf_1900-01-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-01-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-01-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-01-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/01/15_01/bmtnabf_1900-01-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/01/15_01/bmtnabf_1900-01-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1900-01-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1900-01-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-01-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-01-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-01-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2382,320 +2376,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:04:55"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="9c7a22814dfa3630c5d8cb68aa9ff3ec93708a1b"
-				CHECKSUMTYPE="SHA-1" SIZE="6138120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:04:55" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="9c7a22814dfa3630c5d8cb68aa9ff3ec93708a1b" CHECKSUMTYPE="SHA-1" SIZE="6138120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:05:29"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="d71ab427389bc760c04dbac0590f3d9fdf947241"
-				CHECKSUMTYPE="SHA-1" SIZE="5930229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:05:29" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="d71ab427389bc760c04dbac0590f3d9fdf947241" CHECKSUMTYPE="SHA-1" SIZE="5930229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:06:02"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="acea575f04b42d5dbd4c136cae13ebfda23dbd1b"
-				CHECKSUMTYPE="SHA-1" SIZE="6007628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:06:02" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="acea575f04b42d5dbd4c136cae13ebfda23dbd1b" CHECKSUMTYPE="SHA-1" SIZE="6007628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:06:35"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="98858ba63d2e96a27d96c93dcc2d5c9e8c469d9c"
-				CHECKSUMTYPE="SHA-1" SIZE="5850100">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:06:35" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="98858ba63d2e96a27d96c93dcc2d5c9e8c469d9c" CHECKSUMTYPE="SHA-1" SIZE="5850100">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:07:13"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="49ea8c4ed877d5ef56f126720bb1b1a2ae380a40"
-				CHECKSUMTYPE="SHA-1" SIZE="6104820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:07:13" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="49ea8c4ed877d5ef56f126720bb1b1a2ae380a40" CHECKSUMTYPE="SHA-1" SIZE="6104820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:07:42"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="2eafe5c92502e72a4d3925d26540b20f2a368f22"
-				CHECKSUMTYPE="SHA-1" SIZE="6158684">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:07:42" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="2eafe5c92502e72a4d3925d26540b20f2a368f22" CHECKSUMTYPE="SHA-1" SIZE="6158684">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:08:14"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="91fb6d9440e6c4671020d39653967278e650a3b6"
-				CHECKSUMTYPE="SHA-1" SIZE="6034624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:08:14" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="91fb6d9440e6c4671020d39653967278e650a3b6" CHECKSUMTYPE="SHA-1" SIZE="6034624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:08:47"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="805dad0065e19c5538d0977798ea5d41e0b3f5cc"
-				CHECKSUMTYPE="SHA-1" SIZE="6158709">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:08:47" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="805dad0065e19c5538d0977798ea5d41e0b3f5cc" CHECKSUMTYPE="SHA-1" SIZE="6158709">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:09:18"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="e6e1ae917164231a4253acf602e48ca66cc6bea2"
-				CHECKSUMTYPE="SHA-1" SIZE="6032822">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:09:18" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="e6e1ae917164231a4253acf602e48ca66cc6bea2" CHECKSUMTYPE="SHA-1" SIZE="6032822">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:09:48"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="1c94a28cb7e051bbd4fd191cf990bd88a8f89521"
-				CHECKSUMTYPE="SHA-1" SIZE="6158797">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:09:48" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="1c94a28cb7e051bbd4fd191cf990bd88a8f89521" CHECKSUMTYPE="SHA-1" SIZE="6158797">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T17:10:20"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="e6bceee8de73c7781fbd94cd7cc8db11d33e6dcf"
-				CHECKSUMTYPE="SHA-1" SIZE="6034629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T17:10:20" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="e6bceee8de73c7781fbd94cd7cc8db11d33e6dcf" CHECKSUMTYPE="SHA-1" SIZE="6034629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T17:10:53"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="b90fe68c3e56db0d3fd9d28dcfd98355945df4be"
-				CHECKSUMTYPE="SHA-1" SIZE="6158829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T17:10:53" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="b90fe68c3e56db0d3fd9d28dcfd98355945df4be" CHECKSUMTYPE="SHA-1" SIZE="6158829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T17:11:25"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="6cc3eb6dca8b2c41cb600d12a4e8631c35b80795"
-				CHECKSUMTYPE="SHA-1" SIZE="6016627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T17:11:25" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="6cc3eb6dca8b2c41cb600d12a4e8631c35b80795" CHECKSUMTYPE="SHA-1" SIZE="6016627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:11:55"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="470f97ce41428d5092d858aaf80a7df7609542ff"
-				CHECKSUMTYPE="SHA-1" SIZE="6158820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:11:55" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="470f97ce41428d5092d858aaf80a7df7609542ff" CHECKSUMTYPE="SHA-1" SIZE="6158820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T17:12:25"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="5f6dff109f6517c6a79d4f8520cfe3bd8d5aada7"
-				CHECKSUMTYPE="SHA-1" SIZE="6016625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T17:12:25" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="5f6dff109f6517c6a79d4f8520cfe3bd8d5aada7" CHECKSUMTYPE="SHA-1" SIZE="6016625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T17:12:56"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="960288f128ae0b1360b5af2b3a7349cbc27fe686"
-				CHECKSUMTYPE="SHA-1" SIZE="6158823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T17:12:56" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="960288f128ae0b1360b5af2b3a7349cbc27fe686" CHECKSUMTYPE="SHA-1" SIZE="6158823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T17:13:24"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e4e5cdc988dc6c9eaf2a82ccb289678f2b90eb21"
-				CHECKSUMTYPE="SHA-1" SIZE="6016626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T17:13:24" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e4e5cdc988dc6c9eaf2a82ccb289678f2b90eb21" CHECKSUMTYPE="SHA-1" SIZE="6016626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T17:13:55"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="2f2875102f9a87951b3660b30a93439289b5750d"
-				CHECKSUMTYPE="SHA-1" SIZE="6157029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T17:13:55" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="2f2875102f9a87951b3660b30a93439289b5750d" CHECKSUMTYPE="SHA-1" SIZE="6157029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T17:14:25"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="f9f8bb8b72f445a3e47d160397166d3635fe0605"
-				CHECKSUMTYPE="SHA-1" SIZE="6017529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T17:14:25" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="f9f8bb8b72f445a3e47d160397166d3635fe0605" CHECKSUMTYPE="SHA-1" SIZE="6017529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T17:14:56"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="ce6b560618b9a611aa459511804892657b048931"
-				CHECKSUMTYPE="SHA-1" SIZE="6157029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T17:14:56" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="ce6b560618b9a611aa459511804892657b048931" CHECKSUMTYPE="SHA-1" SIZE="6157029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T17:15:31"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="2138542221a6d51e513b721f0107cc205c959cdf"
-				CHECKSUMTYPE="SHA-1" SIZE="6017529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T17:15:31" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="2138542221a6d51e513b721f0107cc205c959cdf" CHECKSUMTYPE="SHA-1" SIZE="6017529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T17:16:03"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="6667674a4dfcde37978f9111f7f82fdab3926dd8"
-				CHECKSUMTYPE="SHA-1" SIZE="6091326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T17:16:03" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="6667674a4dfcde37978f9111f7f82fdab3926dd8" CHECKSUMTYPE="SHA-1" SIZE="6091326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T17:16:35"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="b55ae49c4190c4413d7d86235b476ce83d34729b"
-				CHECKSUMTYPE="SHA-1" SIZE="6016626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T17:16:35" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="b55ae49c4190c4413d7d86235b476ce83d34729b" CHECKSUMTYPE="SHA-1" SIZE="6016626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T17:17:09"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="67c98bbe0771125b3ccb97728427a3d1a263bc18"
-				CHECKSUMTYPE="SHA-1" SIZE="6145313">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T17:17:09" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="67c98bbe0771125b3ccb97728427a3d1a263bc18" CHECKSUMTYPE="SHA-1" SIZE="6145313">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/delivery/bmtnabf_1900-01-15_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:17:27" MIMETYPE="text/xml"
-				CHECKSUM="2f2e077e426a2a94e3484abf2fea41f47f91095c" CHECKSUMTYPE="SHA-1" SIZE="4750">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:17:27" MIMETYPE="text/xml" CHECKSUM="2f2e077e426a2a94e3484abf2fea41f47f91095c" CHECKSUMTYPE="SHA-1" SIZE="4750">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:17:27" MIMETYPE="text/xml"
-				CHECKSUM="36b043cd1cfa782842f4e5a70e53698cd2bc5397" CHECKSUMTYPE="SHA-1"
-				SIZE="29587">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:17:27" MIMETYPE="text/xml" CHECKSUM="36b043cd1cfa782842f4e5a70e53698cd2bc5397" CHECKSUMTYPE="SHA-1" SIZE="29587">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:17:27" MIMETYPE="text/xml"
-				CHECKSUM="f82127326b1ebf92d31789668be8866990e0e73d" CHECKSUMTYPE="SHA-1"
-				SIZE="10279">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:17:27" MIMETYPE="text/xml" CHECKSUM="f82127326b1ebf92d31789668be8866990e0e73d" CHECKSUMTYPE="SHA-1" SIZE="10279">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:17:28" MIMETYPE="text/xml"
-				CHECKSUM="1acadad0a48290086fd5de8f42fae53c9c2d8084" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:17:28" MIMETYPE="text/xml" CHECKSUM="1acadad0a48290086fd5de8f42fae53c9c2d8084" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:17:28" MIMETYPE="text/xml"
-				CHECKSUM="f08def6ba32f583b1d188bc0ac3de560a9420790" CHECKSUMTYPE="SHA-1" SIZE="1719">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:17:28" MIMETYPE="text/xml" CHECKSUM="f08def6ba32f583b1d188bc0ac3de560a9420790" CHECKSUMTYPE="SHA-1" SIZE="1719">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:17:28" MIMETYPE="text/xml"
-				CHECKSUM="c797345421774d7cd3a5f7f3054cd908731ec64b" CHECKSUMTYPE="SHA-1" SIZE="4476">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:17:28" MIMETYPE="text/xml" CHECKSUM="c797345421774d7cd3a5f7f3054cd908731ec64b" CHECKSUMTYPE="SHA-1" SIZE="4476">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:17:28" MIMETYPE="text/xml"
-				CHECKSUM="c0afb5c255ec04f9071a04443c543b78a202a76f" CHECKSUMTYPE="SHA-1"
-				SIZE="36415">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:17:28" MIMETYPE="text/xml" CHECKSUM="c0afb5c255ec04f9071a04443c543b78a202a76f" CHECKSUMTYPE="SHA-1" SIZE="36415">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:17:29" MIMETYPE="text/xml"
-				CHECKSUM="c75155586daab41a58c8213fc2b41433cd33e135" CHECKSUMTYPE="SHA-1" SIZE="6112">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:17:29" MIMETYPE="text/xml" CHECKSUM="c75155586daab41a58c8213fc2b41433cd33e135" CHECKSUMTYPE="SHA-1" SIZE="6112">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:17:29" MIMETYPE="text/xml"
-				CHECKSUM="ffaf3a82562655e4ede9434598adcc6469572039" CHECKSUMTYPE="SHA-1"
-				SIZE="40487">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:17:29" MIMETYPE="text/xml" CHECKSUM="ffaf3a82562655e4ede9434598adcc6469572039" CHECKSUMTYPE="SHA-1" SIZE="40487">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:17:29" MIMETYPE="text/xml"
-				CHECKSUM="1bbca77bc6a109c5f188f97f873a8be7c64d6351" CHECKSUMTYPE="SHA-1"
-				SIZE="22930">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:17:29" MIMETYPE="text/xml" CHECKSUM="1bbca77bc6a109c5f188f97f873a8be7c64d6351" CHECKSUMTYPE="SHA-1" SIZE="22930">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:17:29" MIMETYPE="text/xml"
-				CHECKSUM="67e33206b92d330b7796166b7fe19936ceec7f09" CHECKSUMTYPE="SHA-1"
-				SIZE="25370">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:17:29" MIMETYPE="text/xml" CHECKSUM="67e33206b92d330b7796166b7fe19936ceec7f09" CHECKSUMTYPE="SHA-1" SIZE="25370">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:17:30" MIMETYPE="text/xml"
-				CHECKSUM="e0caacb98cfdb78b7c3658f7809841d0550f2d99" CHECKSUMTYPE="SHA-1"
-				SIZE="36980">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:17:30" MIMETYPE="text/xml" CHECKSUM="e0caacb98cfdb78b7c3658f7809841d0550f2d99" CHECKSUMTYPE="SHA-1" SIZE="36980">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:17:30" MIMETYPE="text/xml"
-				CHECKSUM="ad1d726eaa88782dda64e8927d7472c9962cc3ee" CHECKSUMTYPE="SHA-1"
-				SIZE="36533">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:17:30" MIMETYPE="text/xml" CHECKSUM="ad1d726eaa88782dda64e8927d7472c9962cc3ee" CHECKSUMTYPE="SHA-1" SIZE="36533">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:17:30" MIMETYPE="text/xml"
-				CHECKSUM="3947d9d82f23e32e25bf1a6aa6cd5e17cb9ae197" CHECKSUMTYPE="SHA-1"
-				SIZE="34505">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:17:30" MIMETYPE="text/xml" CHECKSUM="3947d9d82f23e32e25bf1a6aa6cd5e17cb9ae197" CHECKSUMTYPE="SHA-1" SIZE="34505">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:17:30" MIMETYPE="text/xml"
-				CHECKSUM="c795e261dabf563f40e3e7d3c738f0eccf436263" CHECKSUMTYPE="SHA-1" SIZE="4112">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:17:30" MIMETYPE="text/xml" CHECKSUM="c795e261dabf563f40e3e7d3c738f0eccf436263" CHECKSUMTYPE="SHA-1" SIZE="4112">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:17:31" MIMETYPE="text/xml"
-				CHECKSUM="5819cef773a75d02dd55bd23ba4c88b871431ac6" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:17:31" MIMETYPE="text/xml" CHECKSUM="5819cef773a75d02dd55bd23ba4c88b871431ac6" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:17:31" MIMETYPE="text/xml"
-				CHECKSUM="63c8c193fd018190158924b92cb94198067b6b2c" CHECKSUMTYPE="SHA-1"
-				SIZE="28383">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:17:31" MIMETYPE="text/xml" CHECKSUM="63c8c193fd018190158924b92cb94198067b6b2c" CHECKSUMTYPE="SHA-1" SIZE="28383">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:17:31" MIMETYPE="text/xml"
-				CHECKSUM="f9afa9f12afc49177be2b4220d64a309ab57264e" CHECKSUMTYPE="SHA-1"
-				SIZE="42193">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:17:31" MIMETYPE="text/xml" CHECKSUM="f9afa9f12afc49177be2b4220d64a309ab57264e" CHECKSUMTYPE="SHA-1" SIZE="42193">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:17:31" MIMETYPE="text/xml"
-				CHECKSUM="57d8c4ee9a1d9f8143076bd8379cf657057b47bf" CHECKSUMTYPE="SHA-1"
-				SIZE="15570">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T17:17:31" MIMETYPE="text/xml" CHECKSUM="57d8c4ee9a1d9f8143076bd8379cf657057b47bf" CHECKSUMTYPE="SHA-1" SIZE="15570">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:17:31" MIMETYPE="text/xml"
-				CHECKSUM="b0074685d3119cae5962b0e626126d7c6e9511cb" CHECKSUMTYPE="SHA-1"
-				SIZE="30591">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T17:17:31" MIMETYPE="text/xml" CHECKSUM="b0074685d3119cae5962b0e626126d7c6e9511cb" CHECKSUMTYPE="SHA-1" SIZE="30591">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:17:32" MIMETYPE="text/xml"
-				CHECKSUM="fb30dcc1ec1498f5717fad2eb0536e031966b1a2" CHECKSUMTYPE="SHA-1"
-				SIZE="33899">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T17:17:32" MIMETYPE="text/xml" CHECKSUM="fb30dcc1ec1498f5717fad2eb0536e031966b1a2" CHECKSUMTYPE="SHA-1" SIZE="33899">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:17:32" MIMETYPE="text/xml"
-				CHECKSUM="f52722257503171636413a7175107d834b6eb174" CHECKSUMTYPE="SHA-1"
-				SIZE="25220">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T17:17:32" MIMETYPE="text/xml" CHECKSUM="f52722257503171636413a7175107d834b6eb174" CHECKSUMTYPE="SHA-1" SIZE="25220">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:17:32" MIMETYPE="text/xml"
-				CHECKSUM="95cd1713a2990d47a05e29937c0a2018e7ecd4a7" CHECKSUMTYPE="SHA-1"
-				SIZE="16506">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T17:17:32" MIMETYPE="text/xml" CHECKSUM="95cd1713a2990d47a05e29937c0a2018e7ecd4a7" CHECKSUMTYPE="SHA-1" SIZE="16506">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:17:33" MIMETYPE="text/xml"
-				CHECKSUM="d242b2749f647fdee5a2592c42c4f640479dd55b" CHECKSUMTYPE="SHA-1" SIZE="8117">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T17:17:33" MIMETYPE="text/xml" CHECKSUM="d242b2749f647fdee5a2592c42c4f640479dd55b" CHECKSUMTYPE="SHA-1" SIZE="8117">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-01-15_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:17:59" MIMETYPE="application/pdf"
-				CHECKSUM="189f2026f8436ce73920b6485d7ffb64aa0b8e72" CHECKSUMTYPE="SHA-1"
-				SIZE="7390939">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/bmtnabf_1900-01-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:17:59" MIMETYPE="application/pdf" CHECKSUM="189f2026f8436ce73920b6485d7ffb64aa0b8e72" CHECKSUMTYPE="SHA-1" SIZE="7390939">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/01/15_01/bmtnabf_1900-01-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2976,8 +2806,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c008"
-					LABEL="[Internationale Graphische Ausstellung ]">
+				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c008" LABEL="[Internationale Graphische Ausstellung ]">
 					<div ID="L.1.1.6.1" TYPE="Illustration" ORDER="1" DMDID="c009" LABEL="[Initial]">
 						<div ID="L.1.1.6.1.1" TYPE="Image">
 							<fptr>
@@ -2991,20 +2820,16 @@
 								<div ID="L.1.1.6.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c022"
-						LABEL="Ver Sacrum-Zimmer">
+					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c022" LABEL="Ver Sacrum-Zimmer">
 						<div ID="L.1.1.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
@@ -3021,8 +2846,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.6" TYPE="Illustration" ORDER="1" DMDID="c012"
-						LABEL="Gelber Saal">
+					<div ID="L.1.1.7.6" TYPE="Illustration" ORDER="1" DMDID="c012" LABEL="Gelber Saal">
 						<div ID="L.1.1.7.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
@@ -3039,8 +2863,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.7" TYPE="Illustration" ORDER="2" DMDID="c013"
-						LABEL="Blick in den Mittelraum">
+					<div ID="L.1.1.7.7" TYPE="Illustration" ORDER="2" DMDID="c013" LABEL="Blick in den Mittelraum">
 						<div ID="L.1.1.7.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
@@ -3057,8 +2880,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.8" TYPE="Illustration" ORDER="3" DMDID="c014"
-						LABEL="Violetter Saal">
+					<div ID="L.1.1.7.8" TYPE="Illustration" ORDER="3" DMDID="c014" LABEL="Violetter Saal">
 						<div ID="L.1.1.7.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
@@ -3075,8 +2897,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.9" TYPE="Illustration" ORDER="4" DMDID="c015"
-						LABEL="Violetter Saal">
+					<div ID="L.1.1.7.9" TYPE="Illustration" ORDER="4" DMDID="c015" LABEL="Violetter Saal">
 						<div ID="L.1.1.7.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
@@ -3117,8 +2938,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="1" DMDID="c011"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="1" DMDID="c011" LABEL="Untitled Image">
 						<div ID="L.1.1.7.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00001"/>
@@ -3138,36 +2958,24 @@
 								<div ID="L.1.1.7.5.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7.10" TYPE="Illustration" ORDER="5" DMDID="c016"
-						LABEL="Thierstudie">
+					<div ID="L.1.1.7.10" TYPE="Illustration" ORDER="5" DMDID="c016" LABEL="Thierstudie">
 						<div ID="L.1.1.7.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
@@ -3184,8 +2992,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.12" TYPE="Illustration" ORDER="7" DMDID="c018"
-						LABEL="Kopf einer Madonna">
+					<div ID="L.1.1.7.12" TYPE="Illustration" ORDER="7" DMDID="c018" LABEL="Kopf einer Madonna">
 						<div ID="L.1.1.7.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
@@ -3202,8 +3009,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.13" TYPE="Illustration" ORDER="8" DMDID="c019"
-						LABEL="Kinderköpfchen">
+					<div ID="L.1.1.7.13" TYPE="Illustration" ORDER="8" DMDID="c019" LABEL="Kinderköpfchen">
 						<div ID="L.1.1.7.13.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00005"/>
@@ -3237,8 +3043,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.15" TYPE="Illustration" ORDER="10" DMDID="c021"
-						LABEL="Kopf eines jungen Mannes, Studie">
+					<div ID="L.1.1.7.15" TYPE="Illustration" ORDER="10" DMDID="c021" LABEL="Kopf eines jungen Mannes, Studie">
 						<div ID="L.1.1.7.15.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00004"/>

--- a/metadata/periodicals/bmtnabf/issues/1900/02/01_01/bmtnabf_1900-02-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/02/01_01/bmtnabf_1900-02-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-02-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-02-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-02-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/02/15_01/bmtnabf_1900-02-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/02/15_01/bmtnabf_1900-02-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-02-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-02-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-02-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/03/01_01/bmtnabf_1900-03-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/03/01_01/bmtnabf_1900-03-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-03-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-03-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-03-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/04/01_01/bmtnabf_1900-04-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/04/01_01/bmtnabf_1900-04-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1900-04-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1900-04-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-04-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-04-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-04-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -1726,245 +1720,120 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:15:21"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="fdbede307b180d431df1bb0e57c19af4eb7227b2"
-				CHECKSUMTYPE="SHA-1" SIZE="6065221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:15:21" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="fdbede307b180d431df1bb0e57c19af4eb7227b2" CHECKSUMTYPE="SHA-1" SIZE="6065221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:15:54"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="19399241734080f03a787db60001b69c0f14b39f"
-				CHECKSUMTYPE="SHA-1" SIZE="6120126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:15:54" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="19399241734080f03a787db60001b69c0f14b39f" CHECKSUMTYPE="SHA-1" SIZE="6120126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:16:29"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="8d83aeaa6e9606d41beb8cfc546889be0097c414"
-				CHECKSUMTYPE="SHA-1" SIZE="6051729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:16:29" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="8d83aeaa6e9606d41beb8cfc546889be0097c414" CHECKSUMTYPE="SHA-1" SIZE="6051729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:16:57"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="61b4ca01d635e050d1a307a5e97119f5abd468e2"
-				CHECKSUMTYPE="SHA-1" SIZE="6095827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:16:57" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="61b4ca01d635e050d1a307a5e97119f5abd468e2" CHECKSUMTYPE="SHA-1" SIZE="6095827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:17:27"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="277ee48bb0f32c061a775b5026162c6a728c1eb1"
-				CHECKSUMTYPE="SHA-1" SIZE="6052627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:17:27" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="277ee48bb0f32c061a775b5026162c6a728c1eb1" CHECKSUMTYPE="SHA-1" SIZE="6052627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:17:58"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="f8a5d691c9102558d305daa597fb266aa56fa826"
-				CHECKSUMTYPE="SHA-1" SIZE="6095792">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:17:58" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="f8a5d691c9102558d305daa597fb266aa56fa826" CHECKSUMTYPE="SHA-1" SIZE="6095792">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:18:28"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="10a31aff48dcee96eb0f392a4ec5a4e3f87b15d1"
-				CHECKSUMTYPE="SHA-1" SIZE="6052626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:18:28" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="10a31aff48dcee96eb0f392a4ec5a4e3f87b15d1" CHECKSUMTYPE="SHA-1" SIZE="6052626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:18:58"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="163dbba31efee15526d51ea74d16b68e60a9a1dc"
-				CHECKSUMTYPE="SHA-1" SIZE="6095825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:18:58" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="163dbba31efee15526d51ea74d16b68e60a9a1dc" CHECKSUMTYPE="SHA-1" SIZE="6095825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:19:28"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="06fde3d90515f20fd7412b9b528b9d2f33dd2e0d"
-				CHECKSUMTYPE="SHA-1" SIZE="6052617">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:19:28" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="06fde3d90515f20fd7412b9b528b9d2f33dd2e0d" CHECKSUMTYPE="SHA-1" SIZE="6052617">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:19:57"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="b9368acaae4de4baa639999785f10356dc1c65c8"
-				CHECKSUMTYPE="SHA-1" SIZE="6095827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:19:57" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="b9368acaae4de4baa639999785f10356dc1c65c8" CHECKSUMTYPE="SHA-1" SIZE="6095827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T17:20:26"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="ea49bab51dc592b14cc0b60c99028571b77b2a4a"
-				CHECKSUMTYPE="SHA-1" SIZE="6052388">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T17:20:26" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="ea49bab51dc592b14cc0b60c99028571b77b2a4a" CHECKSUMTYPE="SHA-1" SIZE="6052388">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T17:20:57"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="343e5ca253b49f9ddd2d745718d2ec7cc3f0c8ee"
-				CHECKSUMTYPE="SHA-1" SIZE="6095807">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T17:20:57" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="343e5ca253b49f9ddd2d745718d2ec7cc3f0c8ee" CHECKSUMTYPE="SHA-1" SIZE="6095807">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T17:21:27"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="3b7369d4f1300817e794f2575ba87a41583d3ba8"
-				CHECKSUMTYPE="SHA-1" SIZE="6124617">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T17:21:27" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="3b7369d4f1300817e794f2575ba87a41583d3ba8" CHECKSUMTYPE="SHA-1" SIZE="6124617">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:21:56"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="b36134309c29ceea359136c9f94107e14b722338"
-				CHECKSUMTYPE="SHA-1" SIZE="6074225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:21:56" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="b36134309c29ceea359136c9f94107e14b722338" CHECKSUMTYPE="SHA-1" SIZE="6074225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T17:22:30"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="8deb335f375156390f35afa8b973ee408948152c"
-				CHECKSUMTYPE="SHA-1" SIZE="6090428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T17:22:30" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="8deb335f375156390f35afa8b973ee408948152c" CHECKSUMTYPE="SHA-1" SIZE="6090428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T17:23:03"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="086c31956f844c1b00178418440d7f5d5da8f8ee"
-				CHECKSUMTYPE="SHA-1" SIZE="6074225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T17:23:03" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="086c31956f844c1b00178418440d7f5d5da8f8ee" CHECKSUMTYPE="SHA-1" SIZE="6074225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T17:23:32"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="c1082a8458a825a452dc5152b324857d53c1f596"
-				CHECKSUMTYPE="SHA-1" SIZE="6091324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T17:23:32" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="c1082a8458a825a452dc5152b324857d53c1f596" CHECKSUMTYPE="SHA-1" SIZE="6091324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T17:24:05"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="604d13ff6d6d6d09aa3abbec153cb287720a2c55"
-				CHECKSUMTYPE="SHA-1" SIZE="6084125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T17:24:05" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="604d13ff6d6d6d09aa3abbec153cb287720a2c55" CHECKSUMTYPE="SHA-1" SIZE="6084125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/delivery/bmtnabf_1900-04-01_01_0018.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:24:24" MIMETYPE="text/xml"
-				CHECKSUM="d3d09fbac77c5540472e2416eef916e33e9f7573" CHECKSUMTYPE="SHA-1" SIZE="4998">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T17:24:24" MIMETYPE="text/xml" CHECKSUM="d3d09fbac77c5540472e2416eef916e33e9f7573" CHECKSUMTYPE="SHA-1" SIZE="4998">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:24:24" MIMETYPE="text/xml"
-				CHECKSUM="7ec01eb3b1ccf5265f62a201e7813e4768e8416a" CHECKSUMTYPE="SHA-1"
-				SIZE="31611">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T17:24:24" MIMETYPE="text/xml" CHECKSUM="7ec01eb3b1ccf5265f62a201e7813e4768e8416a" CHECKSUMTYPE="SHA-1" SIZE="31611">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:24:24" MIMETYPE="text/xml"
-				CHECKSUM="d2c41f13f6cdba6eecc5c57f5b92fc957f8baa39" CHECKSUMTYPE="SHA-1"
-				SIZE="31207">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T17:24:24" MIMETYPE="text/xml" CHECKSUM="d2c41f13f6cdba6eecc5c57f5b92fc957f8baa39" CHECKSUMTYPE="SHA-1" SIZE="31207">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:24:24" MIMETYPE="text/xml"
-				CHECKSUM="4282886a75829c45fa8144c6beec17861dbb73db" CHECKSUMTYPE="SHA-1"
-				SIZE="21212">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T17:24:24" MIMETYPE="text/xml" CHECKSUM="4282886a75829c45fa8144c6beec17861dbb73db" CHECKSUMTYPE="SHA-1" SIZE="21212">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:24:25" MIMETYPE="text/xml"
-				CHECKSUM="b87e4f5404c78ff8859ab70f414784317e8a9a16" CHECKSUMTYPE="SHA-1"
-				SIZE="22903">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T17:24:25" MIMETYPE="text/xml" CHECKSUM="b87e4f5404c78ff8859ab70f414784317e8a9a16" CHECKSUMTYPE="SHA-1" SIZE="22903">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:24:25" MIMETYPE="text/xml"
-				CHECKSUM="60f901404f5c5737e0043a1b8d14d4ede06bfca1" CHECKSUMTYPE="SHA-1"
-				SIZE="20409">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T17:24:25" MIMETYPE="text/xml" CHECKSUM="60f901404f5c5737e0043a1b8d14d4ede06bfca1" CHECKSUMTYPE="SHA-1" SIZE="20409">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:24:25" MIMETYPE="text/xml"
-				CHECKSUM="95873c6f52fa566dcbfa1454e7d08afba7e45f7e" CHECKSUMTYPE="SHA-1"
-				SIZE="48116">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T17:24:25" MIMETYPE="text/xml" CHECKSUM="95873c6f52fa566dcbfa1454e7d08afba7e45f7e" CHECKSUMTYPE="SHA-1" SIZE="48116">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:24:25" MIMETYPE="text/xml"
-				CHECKSUM="e163cd8f0150324e9792ebc6bae19bc69cebcf76" CHECKSUMTYPE="SHA-1" SIZE="2992">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T17:24:25" MIMETYPE="text/xml" CHECKSUM="e163cd8f0150324e9792ebc6bae19bc69cebcf76" CHECKSUMTYPE="SHA-1" SIZE="2992">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:24:26" MIMETYPE="text/xml"
-				CHECKSUM="783ee0be83c1cad3ec9ea78f1bdf44f1869595d9" CHECKSUMTYPE="SHA-1"
-				SIZE="50980">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T17:24:26" MIMETYPE="text/xml" CHECKSUM="783ee0be83c1cad3ec9ea78f1bdf44f1869595d9" CHECKSUMTYPE="SHA-1" SIZE="50980">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:24:26" MIMETYPE="text/xml"
-				CHECKSUM="f2d5d08e9f8b9bf370615e9a770f125ff6b01e9f" CHECKSUMTYPE="SHA-1"
-				SIZE="25507">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T17:24:26" MIMETYPE="text/xml" CHECKSUM="f2d5d08e9f8b9bf370615e9a770f125ff6b01e9f" CHECKSUMTYPE="SHA-1" SIZE="25507">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:24:26" MIMETYPE="text/xml"
-				CHECKSUM="4c7fab56475e463f52093e990ca30876be6a15d1" CHECKSUMTYPE="SHA-1" SIZE="2404">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T17:24:26" MIMETYPE="text/xml" CHECKSUM="4c7fab56475e463f52093e990ca30876be6a15d1" CHECKSUMTYPE="SHA-1" SIZE="2404">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:24:26" MIMETYPE="text/xml"
-				CHECKSUM="f85b4d60cc75dc031d2df86cb1b53632eaf42db4" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T17:24:26" MIMETYPE="text/xml" CHECKSUM="f85b4d60cc75dc031d2df86cb1b53632eaf42db4" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:24:27" MIMETYPE="text/xml"
-				CHECKSUM="268c4865da42bb7f55c713d80b4d9ec4f695ad56" CHECKSUMTYPE="SHA-1"
-				SIZE="21618">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T17:24:27" MIMETYPE="text/xml" CHECKSUM="268c4865da42bb7f55c713d80b4d9ec4f695ad56" CHECKSUMTYPE="SHA-1" SIZE="21618">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:24:27" MIMETYPE="text/xml"
-				CHECKSUM="123342c174e32b18ffaf1d3f56a0523dfee3a139" CHECKSUMTYPE="SHA-1"
-				SIZE="21167">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T17:24:27" MIMETYPE="text/xml" CHECKSUM="123342c174e32b18ffaf1d3f56a0523dfee3a139" CHECKSUMTYPE="SHA-1" SIZE="21167">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:24:27" MIMETYPE="text/xml"
-				CHECKSUM="ebbd1c4f3eb5c401429c3c3865e2f6d43c4e246f" CHECKSUMTYPE="SHA-1"
-				SIZE="19721">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T17:24:27" MIMETYPE="text/xml" CHECKSUM="ebbd1c4f3eb5c401429c3c3865e2f6d43c4e246f" CHECKSUMTYPE="SHA-1" SIZE="19721">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:24:28" MIMETYPE="text/xml"
-				CHECKSUM="4356f1ec8fb5bc6773b2bd9aca720e4b7811eeb4" CHECKSUMTYPE="SHA-1"
-				SIZE="40876">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T17:24:28" MIMETYPE="text/xml" CHECKSUM="4356f1ec8fb5bc6773b2bd9aca720e4b7811eeb4" CHECKSUMTYPE="SHA-1" SIZE="40876">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:24:28" MIMETYPE="text/xml"
-				CHECKSUM="d4b20344199fbe4cea0446c063406444f8f2876f" CHECKSUMTYPE="SHA-1"
-				SIZE="19476">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T17:24:28" MIMETYPE="text/xml" CHECKSUM="d4b20344199fbe4cea0446c063406444f8f2876f" CHECKSUMTYPE="SHA-1" SIZE="19476">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:24:28" MIMETYPE="text/xml"
-				CHECKSUM="5307d54dc71e1f7d1980e8a11162db235679c592" CHECKSUMTYPE="SHA-1" SIZE="7940">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T17:24:28" MIMETYPE="text/xml" CHECKSUM="5307d54dc71e1f7d1980e8a11162db235679c592" CHECKSUMTYPE="SHA-1" SIZE="7940">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1900-04-01_01_0018.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:24:49" MIMETYPE="application/pdf"
-				CHECKSUM="36272162ab9978911b908e78b9c9aa23f45a8e20" CHECKSUMTYPE="SHA-1"
-				SIZE="5696381">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/bmtnabf_1900-04-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T17:24:49" MIMETYPE="application/pdf" CHECKSUM="36272162ab9978911b908e78b9c9aa23f45a8e20" CHECKSUMTYPE="SHA-1" SIZE="5696381">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1900/04/01_01/bmtnabf_1900-04-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2164,8 +2033,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.4.3" TYPE="Illustration" ORDER="1" DMDID="c007"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.4.3" TYPE="Illustration" ORDER="1" DMDID="c007" LABEL="Untitled Image">
 						<div ID="L.1.1.4.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_CB00002"/>
@@ -2178,36 +2046,24 @@
 								<div ID="L.1.1.4.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00003"
-												BEGIN="P3_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00004"
-												BEGIN="P4_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00004" BEGIN="P4_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.4.5" TYPE="Illustration" ORDER="1" DMDID="c008"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.4.5" TYPE="Illustration" ORDER="1" DMDID="c008" LABEL="Untitled Image">
 						<div ID="L.1.1.4.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_CB00001"/>
@@ -2238,72 +2094,63 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.4.6.4" TYPE="Illustration" ORDER="2" DMDID="c010"
-						LABEL="Untitled Image by Emil Orlik OM">
+					<div ID="L.1.1.4.6.4" TYPE="Illustration" ORDER="2" DMDID="c010" LABEL="Untitled Image by Emil Orlik OM">
 						<div ID="L.1.1.4.6.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.6.5" TYPE="Illustration" ORDER="3" DMDID="c011"
-						LABEL="Untitled Image by Emil Orlik OM">
+					<div ID="L.1.1.4.6.5" TYPE="Illustration" ORDER="3" DMDID="c011" LABEL="Untitled Image by Emil Orlik OM">
 						<div ID="L.1.1.4.6.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.6.6" TYPE="Illustration" ORDER="4" DMDID="c012"
-						LABEL="Untitled Image by Emil Orlik OM">
+					<div ID="L.1.1.4.6.6" TYPE="Illustration" ORDER="4" DMDID="c012" LABEL="Untitled Image by Emil Orlik OM">
 						<div ID="L.1.1.4.6.6.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.6.7" TYPE="Illustration" ORDER="5" DMDID="c013"
-						LABEL="Untitled Image by Emil Orlik OM">
+					<div ID="L.1.1.4.6.7" TYPE="Illustration" ORDER="5" DMDID="c013" LABEL="Untitled Image by Emil Orlik OM">
 						<div ID="L.1.1.4.6.7.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.6.8" TYPE="Illustration" ORDER="6" DMDID="c014"
-						LABEL="Untitled Image by Emil Orlik OM">
+					<div ID="L.1.1.4.6.8" TYPE="Illustration" ORDER="6" DMDID="c014" LABEL="Untitled Image by Emil Orlik OM">
 						<div ID="L.1.1.4.6.8.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.6.9" TYPE="Illustration" ORDER="7" DMDID="c015"
-						LABEL="Untitled Image by Emil Orlik OM">
+					<div ID="L.1.1.4.6.9" TYPE="Illustration" ORDER="7" DMDID="c015" LABEL="Untitled Image by Emil Orlik OM">
 						<div ID="L.1.1.4.6.9.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.6.10" TYPE="Illustration" ORDER="8" DMDID="c016"
-						LABEL="Untitled Image by Emil Orlik OM">
+					<div ID="L.1.1.4.6.10" TYPE="Illustration" ORDER="8" DMDID="c016" LABEL="Untitled Image by Emil Orlik OM">
 						<div ID="L.1.1.4.6.10.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.6.11" TYPE="Illustration" ORDER="9" DMDID="c017"
-						LABEL="Untitled Image by Emil Orlik OM">
+					<div ID="L.1.1.4.6.11" TYPE="Illustration" ORDER="9" DMDID="c017" LABEL="Untitled Image by Emil Orlik OM">
 						<div ID="L.1.1.4.6.11.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.6.12" TYPE="Illustration" ORDER="10" DMDID="c018"
-						LABEL="Untitled Image by Emil Orlik OM">
+					<div ID="L.1.1.4.6.12" TYPE="Illustration" ORDER="10" DMDID="c018" LABEL="Untitled Image by Emil Orlik OM">
 						<div ID="L.1.1.4.6.12.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00001"/>

--- a/metadata/periodicals/bmtnabf/issues/1900/04/15_01/bmtnabf_1900-04-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/04/15_01/bmtnabf_1900-04-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-04-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-04-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-04-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/05/01_01/bmtnabf_1900-05-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/05/01_01/bmtnabf_1900-05-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-05-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-05-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-05-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/05/15_01/bmtnabf_1900-05-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/05/15_01/bmtnabf_1900-05-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-05-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-05-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-05-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/06/01_01/bmtnabf_1900-06-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/06/01_01/bmtnabf_1900-06-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-06-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-06-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-06-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/06/15_01/bmtnabf_1900-06-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/06/15_01/bmtnabf_1900-06-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-06-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-06-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-06-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/07/01_01/bmtnabf_1900-07-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/07/01_01/bmtnabf_1900-07-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-07-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-07-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-07-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/07/15_01/bmtnabf_1900-07-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/07/15_01/bmtnabf_1900-07-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-07-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-07-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-07-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/08/01_01/bmtnabf_1900-08-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/08/01_01/bmtnabf_1900-08-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-08-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-08-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-08-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/08/15_01/bmtnabf_1900-08-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/08/15_01/bmtnabf_1900-08-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-08-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-08-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-08-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/09/01_01/bmtnabf_1900-09-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/09/01_01/bmtnabf_1900-09-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-09-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-09-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-09-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/09/15_01/bmtnabf_1900-09-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/09/15_01/bmtnabf_1900-09-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-09-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-09-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-09-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/10/01_01/bmtnabf_1900-10-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/10/01_01/bmtnabf_1900-10-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-10-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-10-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-10-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/10/15_01/bmtnabf_1900-10-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/10/15_01/bmtnabf_1900-10-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-10-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-10-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-10-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/11/01_01/bmtnabf_1900-11-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/11/01_01/bmtnabf_1900-11-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-11-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-11-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-11-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					

--- a/metadata/periodicals/bmtnabf/issues/1900/11/15_01/bmtnabf_1900-11-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/11/15_01/bmtnabf_1900-11-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-11-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-11-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-11-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/12/01_01/bmtnabf_1900-12-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/12/01_01/bmtnabf_1900-12-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-12-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-12-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-12-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1900/12/15_01/bmtnabf_1900-12-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1900/12/15_01/bmtnabf_1900-12-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-12-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1900-12-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1900-12-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1901/01/01_01/bmtnabf_1901-01-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/01/01_01/bmtnabf_1901-01-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-01-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-01-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-01-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-01-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-01-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3077,402 +3071,204 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:51:02"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="ca2aec139e662c912d65af742333afce417bb7ae"
-				CHECKSUMTYPE="SHA-1" SIZE="6017526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:51:02" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="ca2aec139e662c912d65af742333afce417bb7ae" CHECKSUMTYPE="SHA-1" SIZE="6017526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:51:38"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="57f26c37b4fc22758f4f174b9789218041414aa1"
-				CHECKSUMTYPE="SHA-1" SIZE="6044528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:51:38" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="57f26c37b4fc22758f4f174b9789218041414aa1" CHECKSUMTYPE="SHA-1" SIZE="6044528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:52:10"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="ed0fb8d1337262ecd8ce7485ce9f245c22852ecd"
-				CHECKSUMTYPE="SHA-1" SIZE="6056216">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:52:10" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="ed0fb8d1337262ecd8ce7485ce9f245c22852ecd" CHECKSUMTYPE="SHA-1" SIZE="6056216">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:52:44"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="8bf8e769770240cab373369126c1d2458d2195fe"
-				CHECKSUMTYPE="SHA-1" SIZE="6044529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:52:44" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="8bf8e769770240cab373369126c1d2458d2195fe" CHECKSUMTYPE="SHA-1" SIZE="6044529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:53:19"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="69d56521a4c487329947d55da5f3925436f960c5"
-				CHECKSUMTYPE="SHA-1" SIZE="6000414">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:53:19" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="69d56521a4c487329947d55da5f3925436f960c5" CHECKSUMTYPE="SHA-1" SIZE="6000414">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:53:48"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="b6316852d9724d1d00f43caa39027701f6b3fbbd"
-				CHECKSUMTYPE="SHA-1" SIZE="6043597">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:53:48" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="b6316852d9724d1d00f43caa39027701f6b3fbbd" CHECKSUMTYPE="SHA-1" SIZE="6043597">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:54:20"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="a9825b8e29e2c5a692dd314806c07245b8c56027"
-				CHECKSUMTYPE="SHA-1" SIZE="5953626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:54:20" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="a9825b8e29e2c5a692dd314806c07245b8c56027" CHECKSUMTYPE="SHA-1" SIZE="5953626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:54:49"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a82ec2fba77a17459bdc511d53971a7145010e6f"
-				CHECKSUMTYPE="SHA-1" SIZE="6043571">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:54:49" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a82ec2fba77a17459bdc511d53971a7145010e6f" CHECKSUMTYPE="SHA-1" SIZE="6043571">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:55:21"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="9772a72cf26204352d81d8f4e7c64eb82f1e01cd"
-				CHECKSUMTYPE="SHA-1" SIZE="5954529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:55:21" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="9772a72cf26204352d81d8f4e7c64eb82f1e01cd" CHECKSUMTYPE="SHA-1" SIZE="5954529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:55:53"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="236a7cee13b761457b9f519ac28f4fb5b70f2c71"
-				CHECKSUMTYPE="SHA-1" SIZE="6043626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:55:53" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="236a7cee13b761457b9f519ac28f4fb5b70f2c71" CHECKSUMTYPE="SHA-1" SIZE="6043626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T17:56:28"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="2dec768da3779bafcf07707dfe16f3220aeebe8a"
-				CHECKSUMTYPE="SHA-1" SIZE="5955428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T17:56:28" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="2dec768da3779bafcf07707dfe16f3220aeebe8a" CHECKSUMTYPE="SHA-1" SIZE="5955428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T17:56:58"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="088fedc0eabd4f0498a8b20c8671ce71725a970c"
-				CHECKSUMTYPE="SHA-1" SIZE="6073327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T17:56:58" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="088fedc0eabd4f0498a8b20c8671ce71725a970c" CHECKSUMTYPE="SHA-1" SIZE="6073327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T17:57:29"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="2495dbc5c309b1fa369dda8ad11d587ad7574af3"
-				CHECKSUMTYPE="SHA-1" SIZE="5955427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T17:57:29" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="2495dbc5c309b1fa369dda8ad11d587ad7574af3" CHECKSUMTYPE="SHA-1" SIZE="5955427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:57:59"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="520d45f672b1feb1d10a2cfe45d7f2209f930adf"
-				CHECKSUMTYPE="SHA-1" SIZE="6106613">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:57:59" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="520d45f672b1feb1d10a2cfe45d7f2209f930adf" CHECKSUMTYPE="SHA-1" SIZE="6106613">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T17:58:29"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="9ee9d31468ee8de77c37fff5124d9eed0b696681"
-				CHECKSUMTYPE="SHA-1" SIZE="5898728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T17:58:29" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="9ee9d31468ee8de77c37fff5124d9eed0b696681" CHECKSUMTYPE="SHA-1" SIZE="5898728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T17:59:00"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="880d20cc097ec9aec543be98abd1bda1d0727fe1"
-				CHECKSUMTYPE="SHA-1" SIZE="6162424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T17:59:00" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="880d20cc097ec9aec543be98abd1bda1d0727fe1" CHECKSUMTYPE="SHA-1" SIZE="6162424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T17:59:31"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e53bed6a4c0eb41f7b38878d612d87b2cb38d9ad"
-				CHECKSUMTYPE="SHA-1" SIZE="5897829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T17:59:31" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e53bed6a4c0eb41f7b38878d612d87b2cb38d9ad" CHECKSUMTYPE="SHA-1" SIZE="5897829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:00:02"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="036de66f485bc32ca7ba8db158c474c10ccce661"
-				CHECKSUMTYPE="SHA-1" SIZE="6161525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:00:02" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="036de66f485bc32ca7ba8db158c474c10ccce661" CHECKSUMTYPE="SHA-1" SIZE="6161525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:00:35"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="4967e725bc14c1aa422478886a43ab54fd51ed1e"
-				CHECKSUMTYPE="SHA-1" SIZE="5898729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:00:35" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="4967e725bc14c1aa422478886a43ab54fd51ed1e" CHECKSUMTYPE="SHA-1" SIZE="5898729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:01:06"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="20f6e68e02a49d726ac6c188cecd454caafaf71d"
-				CHECKSUMTYPE="SHA-1" SIZE="6161529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:01:06" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="20f6e68e02a49d726ac6c188cecd454caafaf71d" CHECKSUMTYPE="SHA-1" SIZE="6161529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:01:36"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="1f0131313f0fcd472b3d310c8578f82158552b59"
-				CHECKSUMTYPE="SHA-1" SIZE="5898728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:01:36" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="1f0131313f0fcd472b3d310c8578f82158552b59" CHECKSUMTYPE="SHA-1" SIZE="5898728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:02:06"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="e2c291704fdc04788adf6276d59373c08264f4a6"
-				CHECKSUMTYPE="SHA-1" SIZE="6161312">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:02:06" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="e2c291704fdc04788adf6276d59373c08264f4a6" CHECKSUMTYPE="SHA-1" SIZE="6161312">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:02:35"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="413ff36fe1646437bcf8a2e3b27bd5250e02a9ca"
-				CHECKSUMTYPE="SHA-1" SIZE="5898724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:02:35" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="413ff36fe1646437bcf8a2e3b27bd5250e02a9ca" CHECKSUMTYPE="SHA-1" SIZE="5898724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:03:06"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f1daade95e77260feb91a9e83fa6a95f862b0e96"
-				CHECKSUMTYPE="SHA-1" SIZE="6161529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:03:06" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f1daade95e77260feb91a9e83fa6a95f862b0e96" CHECKSUMTYPE="SHA-1" SIZE="6161529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:03:36"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="da1cb6a989ac7be605953da448460f1170f71031"
-				CHECKSUMTYPE="SHA-1" SIZE="5897823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:03:36" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="da1cb6a989ac7be605953da448460f1170f71031" CHECKSUMTYPE="SHA-1" SIZE="5897823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:04:05"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="0377246e840407b3f7f43b8eb04ba13fe7f2a2d4"
-				CHECKSUMTYPE="SHA-1" SIZE="6100325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:04:05" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="0377246e840407b3f7f43b8eb04ba13fe7f2a2d4" CHECKSUMTYPE="SHA-1" SIZE="6100325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:04:35"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="9ca255bba6401db035168317ad6c53dab7443284"
-				CHECKSUMTYPE="SHA-1" SIZE="5897820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:04:35" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="9ca255bba6401db035168317ad6c53dab7443284" CHECKSUMTYPE="SHA-1" SIZE="5897820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:05:06"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="c4a361292790f031aff9b0dd40ffb69e98f61bf1"
-				CHECKSUMTYPE="SHA-1" SIZE="6043626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:05:06" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="c4a361292790f031aff9b0dd40ffb69e98f61bf1" CHECKSUMTYPE="SHA-1" SIZE="6043626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:05:36"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="472fb7c9418448b084bb6a86882d913d749d7cc4"
-				CHECKSUMTYPE="SHA-1" SIZE="5931128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:05:36" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="472fb7c9418448b084bb6a86882d913d749d7cc4" CHECKSUMTYPE="SHA-1" SIZE="5931128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:06:05"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="303d65f3cbba52a104dbf52eb9053305df24a35f"
-				CHECKSUMTYPE="SHA-1" SIZE="6043538">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:06:05" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="303d65f3cbba52a104dbf52eb9053305df24a35f" CHECKSUMTYPE="SHA-1" SIZE="6043538">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T18:06:35"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="3cfe6851fe9f699246b2eaf65a490b25707a3135"
-				CHECKSUMTYPE="SHA-1" SIZE="5966228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T18:06:35" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="3cfe6851fe9f699246b2eaf65a490b25707a3135" CHECKSUMTYPE="SHA-1" SIZE="5966228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T18:07:08"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="e6e909cc35d5840f860441e1c1f333d6c9466081"
-				CHECKSUMTYPE="SHA-1" SIZE="5995925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T18:07:08" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="e6e909cc35d5840f860441e1c1f333d6c9466081" CHECKSUMTYPE="SHA-1" SIZE="5995925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/delivery/bmtnabf_1901-01-01_01_0032.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml"
-				CHECKSUM="c7bb50d8c3116d71302925dede43f4316e83277c" CHECKSUMTYPE="SHA-1" SIZE="4923">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml" CHECKSUM="c7bb50d8c3116d71302925dede43f4316e83277c" CHECKSUMTYPE="SHA-1" SIZE="4923">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml"
-				CHECKSUM="90a6362b0ccf9edc0876dd7c692f8260b2fd6301" CHECKSUMTYPE="SHA-1"
-				SIZE="46217">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml" CHECKSUM="90a6362b0ccf9edc0876dd7c692f8260b2fd6301" CHECKSUMTYPE="SHA-1" SIZE="46217">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml"
-				CHECKSUM="8872d69d116ef84f6f65c3308e76f8e9cf0c20eb" CHECKSUMTYPE="SHA-1" SIZE="9598">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml" CHECKSUM="8872d69d116ef84f6f65c3308e76f8e9cf0c20eb" CHECKSUMTYPE="SHA-1" SIZE="9598">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml"
-				CHECKSUM="52d3005bf5d18886e838829499b1086262e78ac5" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml" CHECKSUM="52d3005bf5d18886e838829499b1086262e78ac5" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml"
-				CHECKSUM="ce8e287f024c77657724263f8b36eeaec6c3d6e9" CHECKSUMTYPE="SHA-1" SIZE="7715">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml" CHECKSUM="ce8e287f024c77657724263f8b36eeaec6c3d6e9" CHECKSUMTYPE="SHA-1" SIZE="7715">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml"
-				CHECKSUM="752527452722729c1596d87b8679879f29a6598f" CHECKSUMTYPE="SHA-1" SIZE="5767">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml" CHECKSUM="752527452722729c1596d87b8679879f29a6598f" CHECKSUMTYPE="SHA-1" SIZE="5767">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml"
-				CHECKSUM="b640246649243a5c814456feb71c426599a6fc92" CHECKSUMTYPE="SHA-1" SIZE="5219">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml" CHECKSUM="b640246649243a5c814456feb71c426599a6fc92" CHECKSUMTYPE="SHA-1" SIZE="5219">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml"
-				CHECKSUM="331165332d07c6e87e48b20353230cac4dd33f9d" CHECKSUMTYPE="SHA-1" SIZE="5630">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml" CHECKSUM="331165332d07c6e87e48b20353230cac4dd33f9d" CHECKSUMTYPE="SHA-1" SIZE="5630">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml"
-				CHECKSUM="c31e563ac1bdc5493f758e8263d3a15361239cd5" CHECKSUMTYPE="SHA-1" SIZE="5233">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml" CHECKSUM="c31e563ac1bdc5493f758e8263d3a15361239cd5" CHECKSUMTYPE="SHA-1" SIZE="5233">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml"
-				CHECKSUM="30e26eafcb78ae7e3b44977e70625bcb4e276206" CHECKSUMTYPE="SHA-1" SIZE="5550">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml" CHECKSUM="30e26eafcb78ae7e3b44977e70625bcb4e276206" CHECKSUMTYPE="SHA-1" SIZE="5550">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml"
-				CHECKSUM="6a8a7a0307e77220ab9902d97369503a81cae517" CHECKSUMTYPE="SHA-1" SIZE="5245">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml" CHECKSUM="6a8a7a0307e77220ab9902d97369503a81cae517" CHECKSUMTYPE="SHA-1" SIZE="5245">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml"
-				CHECKSUM="2dd8401588996183f4862d58918656267fe82299" CHECKSUMTYPE="SHA-1" SIZE="5495">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml" CHECKSUM="2dd8401588996183f4862d58918656267fe82299" CHECKSUMTYPE="SHA-1" SIZE="5495">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:07:27" MIMETYPE="text/xml"
-				CHECKSUM="9e1b030f44cb79f3b8163259a05bcf83235fc785" CHECKSUMTYPE="SHA-1" SIZE="5013">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:07:27" MIMETYPE="text/xml" CHECKSUM="9e1b030f44cb79f3b8163259a05bcf83235fc785" CHECKSUMTYPE="SHA-1" SIZE="5013">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:07:27" MIMETYPE="text/xml"
-				CHECKSUM="32bbde819c2cf949bf1b6f0d318a27efaac8ed8f" CHECKSUMTYPE="SHA-1" SIZE="5167">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:07:27" MIMETYPE="text/xml" CHECKSUM="32bbde819c2cf949bf1b6f0d318a27efaac8ed8f" CHECKSUMTYPE="SHA-1" SIZE="5167">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:07:27" MIMETYPE="text/xml"
-				CHECKSUM="0d12b13c0f43ebd149e9966f5b914314c1638ee1" CHECKSUMTYPE="SHA-1" SIZE="4725">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:07:27" MIMETYPE="text/xml" CHECKSUM="0d12b13c0f43ebd149e9966f5b914314c1638ee1" CHECKSUMTYPE="SHA-1" SIZE="4725">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:07:27" MIMETYPE="text/xml"
-				CHECKSUM="a589103d1489720356b61afc268fec9246e86d25" CHECKSUMTYPE="SHA-1" SIZE="5642">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:07:27" MIMETYPE="text/xml" CHECKSUM="a589103d1489720356b61afc268fec9246e86d25" CHECKSUMTYPE="SHA-1" SIZE="5642">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:07:28" MIMETYPE="text/xml"
-				CHECKSUM="f4958b6c5db0606615276479ba8521529b3f1596" CHECKSUMTYPE="SHA-1" SIZE="5259">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:07:28" MIMETYPE="text/xml" CHECKSUM="f4958b6c5db0606615276479ba8521529b3f1596" CHECKSUMTYPE="SHA-1" SIZE="5259">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:07:28" MIMETYPE="text/xml"
-				CHECKSUM="519dbfa1e7cc087a4833910c7e5002df3914b6df" CHECKSUMTYPE="SHA-1" SIZE="5627">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:07:28" MIMETYPE="text/xml" CHECKSUM="519dbfa1e7cc087a4833910c7e5002df3914b6df" CHECKSUMTYPE="SHA-1" SIZE="5627">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:07:28" MIMETYPE="text/xml"
-				CHECKSUM="41e99900924e9b14f3a2ba22f1fe656487b6e627" CHECKSUMTYPE="SHA-1" SIZE="5316">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:07:28" MIMETYPE="text/xml" CHECKSUM="41e99900924e9b14f3a2ba22f1fe656487b6e627" CHECKSUMTYPE="SHA-1" SIZE="5316">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:07:28" MIMETYPE="text/xml"
-				CHECKSUM="011eac1451027dea235f010c0c99dae31d29eb7c" CHECKSUMTYPE="SHA-1" SIZE="5538">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:07:28" MIMETYPE="text/xml" CHECKSUM="011eac1451027dea235f010c0c99dae31d29eb7c" CHECKSUMTYPE="SHA-1" SIZE="5538">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:07:29" MIMETYPE="text/xml"
-				CHECKSUM="711a0e306ba301a51e1820614b5474fb79573f48" CHECKSUMTYPE="SHA-1" SIZE="5250">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:07:29" MIMETYPE="text/xml" CHECKSUM="711a0e306ba301a51e1820614b5474fb79573f48" CHECKSUMTYPE="SHA-1" SIZE="5250">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:07:29" MIMETYPE="text/xml"
-				CHECKSUM="d23a186c0db52e68dab470662d90153de449442c" CHECKSUMTYPE="SHA-1" SIZE="5638">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:07:29" MIMETYPE="text/xml" CHECKSUM="d23a186c0db52e68dab470662d90153de449442c" CHECKSUMTYPE="SHA-1" SIZE="5638">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:07:29" MIMETYPE="text/xml"
-				CHECKSUM="b9d3cb8966ff9aafaf3175b0c6ace7839b61023b" CHECKSUMTYPE="SHA-1" SIZE="5142">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:07:29" MIMETYPE="text/xml" CHECKSUM="b9d3cb8966ff9aafaf3175b0c6ace7839b61023b" CHECKSUMTYPE="SHA-1" SIZE="5142">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:07:29" MIMETYPE="text/xml"
-				CHECKSUM="5cade7538cc101531fb903413167c66262f427ea" CHECKSUMTYPE="SHA-1" SIZE="5644">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:07:29" MIMETYPE="text/xml" CHECKSUM="5cade7538cc101531fb903413167c66262f427ea" CHECKSUMTYPE="SHA-1" SIZE="5644">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:07:29" MIMETYPE="text/xml"
-				CHECKSUM="2077d7524b63de84df651648b9db5fbe9b7527e5" CHECKSUMTYPE="SHA-1" SIZE="5251">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:07:29" MIMETYPE="text/xml" CHECKSUM="2077d7524b63de84df651648b9db5fbe9b7527e5" CHECKSUMTYPE="SHA-1" SIZE="5251">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:07:30" MIMETYPE="text/xml"
-				CHECKSUM="cd93f1c4c502ab866eef59c3258fd2b579c14961" CHECKSUMTYPE="SHA-1" SIZE="5814">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:07:30" MIMETYPE="text/xml" CHECKSUM="cd93f1c4c502ab866eef59c3258fd2b579c14961" CHECKSUMTYPE="SHA-1" SIZE="5814">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:07:30" MIMETYPE="text/xml"
-				CHECKSUM="6a4f67a7122bcc683fea275ab7347dd7501e4ff0" CHECKSUMTYPE="SHA-1" SIZE="5189">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:07:30" MIMETYPE="text/xml" CHECKSUM="6a4f67a7122bcc683fea275ab7347dd7501e4ff0" CHECKSUMTYPE="SHA-1" SIZE="5189">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:07:30" MIMETYPE="text/xml"
-				CHECKSUM="b71f73488d554ccc7f7d509a04fba3e8340cda75" CHECKSUMTYPE="SHA-1" SIZE="5906">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:07:30" MIMETYPE="text/xml" CHECKSUM="b71f73488d554ccc7f7d509a04fba3e8340cda75" CHECKSUMTYPE="SHA-1" SIZE="5906">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:07:30" MIMETYPE="text/xml"
-				CHECKSUM="4fd6da14b4423fc0e449e7146f70d292f04e986f" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:07:30" MIMETYPE="text/xml" CHECKSUM="4fd6da14b4423fc0e449e7146f70d292f04e986f" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:07:31" MIMETYPE="text/xml"
-				CHECKSUM="a8e0e44eae995807f33320648d0f0f96e0bd43a0" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:07:31" MIMETYPE="text/xml" CHECKSUM="a8e0e44eae995807f33320648d0f0f96e0bd43a0" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T18:07:31" MIMETYPE="text/xml"
-				CHECKSUM="2e416450a028b7d0dee91b7bf93640a14d42230b" CHECKSUMTYPE="SHA-1"
-				SIZE="36405">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T18:07:31" MIMETYPE="text/xml" CHECKSUM="2e416450a028b7d0dee91b7bf93640a14d42230b" CHECKSUMTYPE="SHA-1" SIZE="36405">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T18:07:31" MIMETYPE="text/xml"
-				CHECKSUM="af97c3e6b16bb69740d22a78ac7a8856fca00a67" CHECKSUMTYPE="SHA-1" SIZE="7765">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T18:07:31" MIMETYPE="text/xml" CHECKSUM="af97c3e6b16bb69740d22a78ac7a8856fca00a67" CHECKSUMTYPE="SHA-1" SIZE="7765">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-01_01_0032.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:07:59" MIMETYPE="application/pdf"
-				CHECKSUM="e672b07069b468224cb11562057c8a6cd2aacb09" CHECKSUMTYPE="SHA-1"
-				SIZE="11404063">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/bmtnabf_1901-01-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:07:59" MIMETYPE="application/pdf" CHECKSUM="e672b07069b468224cb11562057c8a6cd2aacb09" CHECKSUMTYPE="SHA-1" SIZE="11404063">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/01_01/bmtnabf_1901-01-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3739,8 +3535,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 1 01.01.1901">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Der Jahresregent">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Der Jahresregent">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_CB00001"/>
@@ -3796,8 +3591,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c007"
-					LABEL="VER SACRUM KALENDER FÜR DAS JAHR 1901">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c007" LABEL="VER SACRUM KALENDER FÜR DAS JAHR 1901">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<seq>
@@ -3806,8 +3600,7 @@
 							</seq>
 						</fptr>
 					</div>
-					<div ID="L.1.1.5.2" TYPE="Illustration" ORDER="1" DMDID="c008"
-						LABEL="Der Jahresregent">
+					<div ID="L.1.1.5.2" TYPE="Illustration" ORDER="1" DMDID="c008" LABEL="Der Jahresregent">
 						<div ID="L.1.1.5.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00001"/>
@@ -3843,8 +3636,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="2" DMDID="c009"
-							LABEL="Salve Saturne">
+						<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="2" DMDID="c009" LABEL="Salve Saturne">
 							<div ID="L.1.1.5.3.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
@@ -3883,8 +3675,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="4" DMDID="c011"
-							LABEL="Wintermärchen">
+						<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="4" DMDID="c011" LABEL="Wintermärchen">
 							<div ID="L.1.1.5.5.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
@@ -3923,8 +3714,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="6" DMDID="c013"
-							LABEL="Frühlingserwachen">
+						<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="6" DMDID="c013" LABEL="Frühlingserwachen">
 							<div ID="L.1.1.5.7.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -3963,8 +3753,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.9" TYPE="Illustration" ORDER="8" DMDID="c015"
-							LABEL="Himmelslaunen">
+						<div ID="L.1.1.5.9" TYPE="Illustration" ORDER="8" DMDID="c015" LABEL="Himmelslaunen">
 							<div ID="L.1.1.5.9.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -4003,8 +3792,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.11" TYPE="Illustration" ORDER="10" DMDID="c017"
-							LABEL="Flatterlust">
+						<div ID="L.1.1.5.11" TYPE="Illustration" ORDER="10" DMDID="c017" LABEL="Flatterlust">
 							<div ID="L.1.1.5.11.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00001"/>
@@ -4043,8 +3831,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.13" TYPE="Illustration" ORDER="12" DMDID="c019"
-							LABEL="Landruhe">
+						<div ID="L.1.1.5.13" TYPE="Illustration" ORDER="12" DMDID="c019" LABEL="Landruhe">
 							<div ID="L.1.1.5.13.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -4083,8 +3870,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.15" TYPE="Illustration" ORDER="14" DMDID="c021"
-							LABEL="Woglinde">
+						<div ID="L.1.1.5.15" TYPE="Illustration" ORDER="14" DMDID="c021" LABEL="Woglinde">
 							<div ID="L.1.1.5.15.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
@@ -4123,8 +3909,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.17" TYPE="Illustration" ORDER="16" DMDID="c023"
-							LABEL="Gewitterlüfte">
+						<div ID="L.1.1.5.17" TYPE="Illustration" ORDER="16" DMDID="c023" LABEL="Gewitterlüfte">
 							<div ID="L.1.1.5.17.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
@@ -4147,8 +3932,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.20" TYPE="Illustration" ORDER="19" DMDID="c026"
-						LABEL="SEPTEMBER">
+					<div ID="L.1.1.5.20" TYPE="Illustration" ORDER="19" DMDID="c026" LABEL="SEPTEMBER">
 						<div ID="L.1.1.5.20.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
@@ -4164,8 +3948,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.19" TYPE="Illustration" ORDER="18" DMDID="c025"
-							LABEL="Reifesegen">
+						<div ID="L.1.1.5.19" TYPE="Illustration" ORDER="18" DMDID="c025" LABEL="Reifesegen">
 							<div ID="L.1.1.5.19.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
@@ -4204,8 +3987,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.21" TYPE="Illustration" ORDER="20" DMDID="c027"
-							LABEL="Herbstglut">
+						<div ID="L.1.1.5.21" TYPE="Illustration" ORDER="20" DMDID="c027" LABEL="Herbstglut">
 							<div ID="L.1.1.5.21.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
@@ -4228,8 +4010,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.24" TYPE="Illustration" ORDER="23" DMDID="c030"
-						LABEL="NOVEMBER">
+					<div ID="L.1.1.5.24" TYPE="Illustration" ORDER="23" DMDID="c030" LABEL="NOVEMBER">
 						<div ID="L.1.1.5.24.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00002"/>
@@ -4245,8 +4026,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00003"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.23" TYPE="Illustration" ORDER="22" DMDID="c029"
-							LABEL="Gefallenes Laub">
+						<div ID="L.1.1.5.23" TYPE="Illustration" ORDER="22" DMDID="c029" LABEL="Gefallenes Laub">
 							<div ID="L.1.1.5.23.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
@@ -4269,8 +4049,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.25" TYPE="Illustration" ORDER="24" DMDID="c031"
-						LABEL="Dank und Lebewohl">
+					<div ID="L.1.1.5.25" TYPE="Illustration" ORDER="24" DMDID="c031" LABEL="Dank und Lebewohl">
 						<div ID="L.1.1.5.25.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/01/15_01/bmtnabf_1901-01-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/01/15_01/bmtnabf_1901-01-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-01-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-01-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-01-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-01-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-01-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2677,362 +2671,180 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:53:03"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="471a20d7a0ef8f1b5432728e46511a061c8362ef"
-				CHECKSUMTYPE="SHA-1" SIZE="6157925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:53:03" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="471a20d7a0ef8f1b5432728e46511a061c8362ef" CHECKSUMTYPE="SHA-1" SIZE="6157925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:53:35"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="8d6120cd3f50370fb7dccd05a47ef83badb8ea62"
-				CHECKSUMTYPE="SHA-1" SIZE="6123727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:53:35" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="8d6120cd3f50370fb7dccd05a47ef83badb8ea62" CHECKSUMTYPE="SHA-1" SIZE="6123727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:54:08"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="75bd11709b12d4cbe6aaf98b671bde0d37187738"
-				CHECKSUMTYPE="SHA-1" SIZE="6157929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:54:08" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="75bd11709b12d4cbe6aaf98b671bde0d37187738" CHECKSUMTYPE="SHA-1" SIZE="6157929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:54:46"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a45066d6bf0de5a0befa8425095c25069fa839d1"
-				CHECKSUMTYPE="SHA-1" SIZE="6198424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:54:46" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a45066d6bf0de5a0befa8425095c25069fa839d1" CHECKSUMTYPE="SHA-1" SIZE="6198424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:55:21"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="5af6532075bc95c1f22b9ec7434217e53fa681ef"
-				CHECKSUMTYPE="SHA-1" SIZE="6142625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:55:21" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="5af6532075bc95c1f22b9ec7434217e53fa681ef" CHECKSUMTYPE="SHA-1" SIZE="6142625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:55:48"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="c70fd823f8e022fd26ec7f6540a44d883f60c6bd"
-				CHECKSUMTYPE="SHA-1" SIZE="6139864">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:55:48" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="c70fd823f8e022fd26ec7f6540a44d883f60c6bd" CHECKSUMTYPE="SHA-1" SIZE="6139864">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:56:18"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="d2b1a5189ad4c35df1c94e28b065ad967fc14568"
-				CHECKSUMTYPE="SHA-1" SIZE="6065209">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:56:18" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="d2b1a5189ad4c35df1c94e28b065ad967fc14568" CHECKSUMTYPE="SHA-1" SIZE="6065209">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:56:49"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="1bb1bc56e553e81ce9109e19dfaa0ae9219172e3"
-				CHECKSUMTYPE="SHA-1" SIZE="6174045">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:56:49" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="1bb1bc56e553e81ce9109e19dfaa0ae9219172e3" CHECKSUMTYPE="SHA-1" SIZE="6174045">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:57:19"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="8adf98d86c1ba10a580c62985b8155418ac05bd3"
-				CHECKSUMTYPE="SHA-1" SIZE="6065224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:57:19" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="8adf98d86c1ba10a580c62985b8155418ac05bd3" CHECKSUMTYPE="SHA-1" SIZE="6065224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:57:50"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="0f7b825bc56ae465520a2cbb804f59e5bd14a0a6"
-				CHECKSUMTYPE="SHA-1" SIZE="6174129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:57:50" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="0f7b825bc56ae465520a2cbb804f59e5bd14a0a6" CHECKSUMTYPE="SHA-1" SIZE="6174129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T17:58:23"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="735e97529aeb71ddbffc74677e94da94bd15d0c1"
-				CHECKSUMTYPE="SHA-1" SIZE="6089475">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T17:58:23" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="735e97529aeb71ddbffc74677e94da94bd15d0c1" CHECKSUMTYPE="SHA-1" SIZE="6089475">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T17:58:50"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="e80f9f663c70fb7a4efe771e37b5af9f0521ae13"
-				CHECKSUMTYPE="SHA-1" SIZE="6173204">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T17:58:50" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="e80f9f663c70fb7a4efe771e37b5af9f0521ae13" CHECKSUMTYPE="SHA-1" SIZE="6173204">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T17:59:20"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="2227c9de6bdfdafa1c7aa6ee0bcdcbaa78bd211e"
-				CHECKSUMTYPE="SHA-1" SIZE="6089509">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T17:59:20" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="2227c9de6bdfdafa1c7aa6ee0bcdcbaa78bd211e" CHECKSUMTYPE="SHA-1" SIZE="6089509">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:59:50"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="cbdd2a065854d3438c6aaa690c0248c6fe208cd8"
-				CHECKSUMTYPE="SHA-1" SIZE="6185810">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T17:59:50" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="cbdd2a065854d3438c6aaa690c0248c6fe208cd8" CHECKSUMTYPE="SHA-1" SIZE="6185810">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:00:23"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="141b950dfbc554429b81868df2f56ca4d70f8171"
-				CHECKSUMTYPE="SHA-1" SIZE="6066117">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:00:23" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="141b950dfbc554429b81868df2f56ca4d70f8171" CHECKSUMTYPE="SHA-1" SIZE="6066117">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:00:52"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="21fe7e28de9dce6808c762875fb486360bf7c8aa"
-				CHECKSUMTYPE="SHA-1" SIZE="6185806">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:00:52" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="21fe7e28de9dce6808c762875fb486360bf7c8aa" CHECKSUMTYPE="SHA-1" SIZE="6185806">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:01:22"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e9b1c2944b0e3b2c805d3c0600203179a4ac6171"
-				CHECKSUMTYPE="SHA-1" SIZE="6066110">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:01:22" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e9b1c2944b0e3b2c805d3c0600203179a4ac6171" CHECKSUMTYPE="SHA-1" SIZE="6066110">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:01:56"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="6d0165c38225249ef7dd47f397c920cd216670aa"
-				CHECKSUMTYPE="SHA-1" SIZE="6186425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:01:56" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="6d0165c38225249ef7dd47f397c920cd216670aa" CHECKSUMTYPE="SHA-1" SIZE="6186425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:02:28"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="407baaedcb4326df5c3522f88aa8809506f6d99c"
-				CHECKSUMTYPE="SHA-1" SIZE="6065228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:02:28" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="407baaedcb4326df5c3522f88aa8809506f6d99c" CHECKSUMTYPE="SHA-1" SIZE="6065228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:02:57"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="b0cc489c404be9a7326c09292d7e7ee24c259ac4"
-				CHECKSUMTYPE="SHA-1" SIZE="6186717">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:02:57" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="b0cc489c404be9a7326c09292d7e7ee24c259ac4" CHECKSUMTYPE="SHA-1" SIZE="6186717">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:03:29"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="8259c35d06cf0627f5b32d069e6305ff4ffac4bd"
-				CHECKSUMTYPE="SHA-1" SIZE="6065221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:03:29" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="8259c35d06cf0627f5b32d069e6305ff4ffac4bd" CHECKSUMTYPE="SHA-1" SIZE="6065221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:03:58"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="5f41ddf86c4df8384d4077e1fab4f31973bb46e0"
-				CHECKSUMTYPE="SHA-1" SIZE="6186726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:03:58" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="5f41ddf86c4df8384d4077e1fab4f31973bb46e0" CHECKSUMTYPE="SHA-1" SIZE="6186726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:04:29"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="42a2466558d29c160af60f3fe2a94424ee399713"
-				CHECKSUMTYPE="SHA-1" SIZE="6065178">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:04:29" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="42a2466558d29c160af60f3fe2a94424ee399713" CHECKSUMTYPE="SHA-1" SIZE="6065178">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:05:00"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="d3b45c9ec570a9dfc912f3d50a6b76b6c21f65fa"
-				CHECKSUMTYPE="SHA-1" SIZE="6185818">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:05:00" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="d3b45c9ec570a9dfc912f3d50a6b76b6c21f65fa" CHECKSUMTYPE="SHA-1" SIZE="6185818">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:05:28"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="343fb62d0ef7959a7d29cf099505f0f6d8d17b1c"
-				CHECKSUMTYPE="SHA-1" SIZE="6066126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:05:28" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="343fb62d0ef7959a7d29cf099505f0f6d8d17b1c" CHECKSUMTYPE="SHA-1" SIZE="6066126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:06:00"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ef5a0f60061cccb961d0e08844dda446ceb5cbe2"
-				CHECKSUMTYPE="SHA-1" SIZE="6182176">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:06:00" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ef5a0f60061cccb961d0e08844dda446ceb5cbe2" CHECKSUMTYPE="SHA-1" SIZE="6182176">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:06:30"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="e94ed553096e2494c9e100f33214cf92f965d070"
-				CHECKSUMTYPE="SHA-1" SIZE="6065225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:06:30" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="e94ed553096e2494c9e100f33214cf92f965d070" CHECKSUMTYPE="SHA-1" SIZE="6065225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:07:03"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="61f60ca083bf7c71df153fa65bd34eded1e98a28"
-				CHECKSUMTYPE="SHA-1" SIZE="6102115">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:07:03" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="61f60ca083bf7c71df153fa65bd34eded1e98a28" CHECKSUMTYPE="SHA-1" SIZE="6102115">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/delivery/bmtnabf_1901-01-15_01_0028.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:07:20" MIMETYPE="text/xml"
-				CHECKSUM="fb80750aa4451669215e76c6297e2505ef7b95e5" CHECKSUMTYPE="SHA-1" SIZE="4896">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:07:20" MIMETYPE="text/xml" CHECKSUM="fb80750aa4451669215e76c6297e2505ef7b95e5" CHECKSUMTYPE="SHA-1" SIZE="4896">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:07:20" MIMETYPE="text/xml"
-				CHECKSUM="adcadb1d477a956c0aa19cbb41825c1175f186e7" CHECKSUMTYPE="SHA-1"
-				SIZE="24745">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:07:20" MIMETYPE="text/xml" CHECKSUM="adcadb1d477a956c0aa19cbb41825c1175f186e7" CHECKSUMTYPE="SHA-1" SIZE="24745">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:07:20" MIMETYPE="text/xml"
-				CHECKSUM="ae59615701e3bc3b9042733f7814d5fa90d5a49d" CHECKSUMTYPE="SHA-1" SIZE="9819">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:07:20" MIMETYPE="text/xml" CHECKSUM="ae59615701e3bc3b9042733f7814d5fa90d5a49d" CHECKSUMTYPE="SHA-1" SIZE="9819">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:07:21" MIMETYPE="text/xml"
-				CHECKSUM="20e6d2887bb1601aa707d437afbaacb57f9dd198" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:07:21" MIMETYPE="text/xml" CHECKSUM="20e6d2887bb1601aa707d437afbaacb57f9dd198" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:07:21" MIMETYPE="text/xml"
-				CHECKSUM="b40c3fbf61932d0a8b4f35c93eba7511b10385b5" CHECKSUMTYPE="SHA-1"
-				SIZE="11283">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:07:21" MIMETYPE="text/xml" CHECKSUM="b40c3fbf61932d0a8b4f35c93eba7511b10385b5" CHECKSUMTYPE="SHA-1" SIZE="11283">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:07:21" MIMETYPE="text/xml"
-				CHECKSUM="d732923e19e5611ef3e579f4f3e3778fb2c7786e" CHECKSUMTYPE="SHA-1" SIZE="5475">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:07:21" MIMETYPE="text/xml" CHECKSUM="d732923e19e5611ef3e579f4f3e3778fb2c7786e" CHECKSUMTYPE="SHA-1" SIZE="5475">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:07:21" MIMETYPE="text/xml"
-				CHECKSUM="807782331a5fa34b5b00dcefd54fc281a7a66c56" CHECKSUMTYPE="SHA-1" SIZE="5501">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:07:21" MIMETYPE="text/xml" CHECKSUM="807782331a5fa34b5b00dcefd54fc281a7a66c56" CHECKSUMTYPE="SHA-1" SIZE="5501">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:07:22" MIMETYPE="text/xml"
-				CHECKSUM="c135f0df01f2a480fde9ee4bfd10be2ee235fec3" CHECKSUMTYPE="SHA-1" SIZE="5187">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:07:22" MIMETYPE="text/xml" CHECKSUM="c135f0df01f2a480fde9ee4bfd10be2ee235fec3" CHECKSUMTYPE="SHA-1" SIZE="5187">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:07:22" MIMETYPE="text/xml"
-				CHECKSUM="fd6a9f805b6f3aa1958df8ca91a7951e6dd6b000" CHECKSUMTYPE="SHA-1"
-				SIZE="27600">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:07:22" MIMETYPE="text/xml" CHECKSUM="fd6a9f805b6f3aa1958df8ca91a7951e6dd6b000" CHECKSUMTYPE="SHA-1" SIZE="27600">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:07:22" MIMETYPE="text/xml"
-				CHECKSUM="d017eae4756dbba50f5492447fa073020728c5d1" CHECKSUMTYPE="SHA-1"
-				SIZE="49532">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:07:22" MIMETYPE="text/xml" CHECKSUM="d017eae4756dbba50f5492447fa073020728c5d1" CHECKSUMTYPE="SHA-1" SIZE="49532">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:07:22" MIMETYPE="text/xml"
-				CHECKSUM="3f2c88d9f50c5fe4bcfd2ca1e2cd0356832a9418" CHECKSUMTYPE="SHA-1" SIZE="5115">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:07:22" MIMETYPE="text/xml" CHECKSUM="3f2c88d9f50c5fe4bcfd2ca1e2cd0356832a9418" CHECKSUMTYPE="SHA-1" SIZE="5115">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:07:23" MIMETYPE="text/xml"
-				CHECKSUM="a052044d001a70dff85a3da03db43e5d101dda8a" CHECKSUMTYPE="SHA-1" SIZE="5607">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:07:23" MIMETYPE="text/xml" CHECKSUM="a052044d001a70dff85a3da03db43e5d101dda8a" CHECKSUMTYPE="SHA-1" SIZE="5607">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:07:23" MIMETYPE="text/xml"
-				CHECKSUM="dbdb5a8d78e71897f0c0169ffc7b14e9d85fe4a5" CHECKSUMTYPE="SHA-1"
-				SIZE="49960">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:07:23" MIMETYPE="text/xml" CHECKSUM="dbdb5a8d78e71897f0c0169ffc7b14e9d85fe4a5" CHECKSUMTYPE="SHA-1" SIZE="49960">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:07:23" MIMETYPE="text/xml"
-				CHECKSUM="fd4b4a2314b0e298d15914e9f112dfcff24c2150" CHECKSUMTYPE="SHA-1" SIZE="5220">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:07:23" MIMETYPE="text/xml" CHECKSUM="fd4b4a2314b0e298d15914e9f112dfcff24c2150" CHECKSUMTYPE="SHA-1" SIZE="5220">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:07:23" MIMETYPE="text/xml"
-				CHECKSUM="4321cc29ba3227c23a03c70336e6b5261f128ec0" CHECKSUMTYPE="SHA-1"
-				SIZE="51605">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:07:23" MIMETYPE="text/xml" CHECKSUM="4321cc29ba3227c23a03c70336e6b5261f128ec0" CHECKSUMTYPE="SHA-1" SIZE="51605">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml"
-				CHECKSUM="3afba67ddecfeaf3c743e9889998fa71e8bef326" CHECKSUMTYPE="SHA-1"
-				SIZE="48569">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml" CHECKSUM="3afba67ddecfeaf3c743e9889998fa71e8bef326" CHECKSUMTYPE="SHA-1" SIZE="48569">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml"
-				CHECKSUM="4e31669ef98f8944a6c09473c50c5a3200bdca60" CHECKSUMTYPE="SHA-1" SIZE="5437">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml" CHECKSUM="4e31669ef98f8944a6c09473c50c5a3200bdca60" CHECKSUMTYPE="SHA-1" SIZE="5437">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml"
-				CHECKSUM="d2abab839ddba0aa2e2ffc034431616d4b4b26f9" CHECKSUMTYPE="SHA-1" SIZE="5104">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml" CHECKSUM="d2abab839ddba0aa2e2ffc034431616d4b4b26f9" CHECKSUMTYPE="SHA-1" SIZE="5104">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml"
-				CHECKSUM="793477f235bd4413d513e3f9a019024c1084a58f" CHECKSUMTYPE="SHA-1"
-				SIZE="18534">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:07:24" MIMETYPE="text/xml" CHECKSUM="793477f235bd4413d513e3f9a019024c1084a58f" CHECKSUMTYPE="SHA-1" SIZE="18534">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml"
-				CHECKSUM="36cf323a4f6a42b8c48e3619140c4d4b75f9654b" CHECKSUMTYPE="SHA-1"
-				SIZE="21881">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml" CHECKSUM="36cf323a4f6a42b8c48e3619140c4d4b75f9654b" CHECKSUMTYPE="SHA-1" SIZE="21881">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml"
-				CHECKSUM="6d13657de07b4f0c79a4a540eb8622dde1d3b0e9" CHECKSUMTYPE="SHA-1" SIZE="5270">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml" CHECKSUM="6d13657de07b4f0c79a4a540eb8622dde1d3b0e9" CHECKSUMTYPE="SHA-1" SIZE="5270">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml"
-				CHECKSUM="e6d9f221672a50f7ef5fa7c82e340e048c178abe" CHECKSUMTYPE="SHA-1" SIZE="5305">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml" CHECKSUM="e6d9f221672a50f7ef5fa7c82e340e048c178abe" CHECKSUMTYPE="SHA-1" SIZE="5305">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml"
-				CHECKSUM="981f970026f1f15cfdb953d0cb8ca5f99847c639" CHECKSUMTYPE="SHA-1" SIZE="5361">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:07:25" MIMETYPE="text/xml" CHECKSUM="981f970026f1f15cfdb953d0cb8ca5f99847c639" CHECKSUMTYPE="SHA-1" SIZE="5361">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml"
-				CHECKSUM="e806db55c137ed48b35d0320fa772f1d1c53d56a" CHECKSUMTYPE="SHA-1" SIZE="4140">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml" CHECKSUM="e806db55c137ed48b35d0320fa772f1d1c53d56a" CHECKSUMTYPE="SHA-1" SIZE="4140">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml"
-				CHECKSUM="d8ecc1e77d31e02edd3d4ba0ad918f2a8f15554e" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml" CHECKSUM="d8ecc1e77d31e02edd3d4ba0ad918f2a8f15554e" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml"
-				CHECKSUM="25f9d762bc055b6f2dc455b941c73b852463b1d5" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml" CHECKSUM="25f9d762bc055b6f2dc455b941c73b852463b1d5" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml"
-				CHECKSUM="c89b9b816bfc4f7ce98c212fc258c374d878e41f" CHECKSUMTYPE="SHA-1"
-				SIZE="36496">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:07:26" MIMETYPE="text/xml" CHECKSUM="c89b9b816bfc4f7ce98c212fc258c374d878e41f" CHECKSUMTYPE="SHA-1" SIZE="36496">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:07:27" MIMETYPE="text/xml"
-				CHECKSUM="491ef278956f2b9b4cc014ff472c2438b7abab5b" CHECKSUMTYPE="SHA-1" SIZE="7590">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:07:27" MIMETYPE="text/xml" CHECKSUM="491ef278956f2b9b4cc014ff472c2438b7abab5b" CHECKSUMTYPE="SHA-1" SIZE="7590">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-01-15_01_0028.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:07:53" MIMETYPE="application/pdf"
-				CHECKSUM="d0a3f1ce8a7a56d80303e731e6bce849f580a601" CHECKSUMTYPE="SHA-1"
-				SIZE="6961830">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/bmtnabf_1901-01-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:07:53" MIMETYPE="application/pdf" CHECKSUM="d0a3f1ce8a7a56d80303e731e6bce849f580a601" CHECKSUMTYPE="SHA-1" SIZE="6961830">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/01/15_01/bmtnabf_1901-01-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3323,10 +3135,8 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c007"
-					LABEL="AUS der VIII. Austeilung der Vereinigung bildender  Künstler Oesterreichs">
-					<div ID="L.1.1.5.1" TYPE="Illustration" ORDER="1" DMDID="c008"
-						LABEL="Untitled Image">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c007" LABEL="AUS der VIII. Austeilung der Vereinigung bildender  Künstler Oesterreichs">
+					<div ID="L.1.1.5.1" TYPE="Illustration" ORDER="1" DMDID="c008" LABEL="Untitled Image">
 						<div ID="L.1.1.5.1.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00002"/>
@@ -3344,8 +3154,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c009"
-						LABEL="KNIENDES KIND">
+					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c009" LABEL="KNIENDES KIND">
 						<div ID="L.1.1.5.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00003"/>
@@ -3367,8 +3176,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c010"
-						LABEL="JÜNGLING MIT WEINSCHLAUCH">
+					<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c010" LABEL="JÜNGLING MIT WEINSCHLAUCH">
 						<div ID="L.1.1.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
@@ -3390,8 +3198,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c011"
-						LABEL="JÜNGLING MIT WEINSCHLAUCH">
+					<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c011" LABEL="JÜNGLING MIT WEINSCHLAUCH">
 						<div ID="L.1.1.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -3455,26 +3262,19 @@
 								<div ID="L.1.1.9.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.9.4" TYPE="Illustration" ORDER="1" DMDID="c015"
-						LABEL="Untitled Image by Kolom. Moser OM">
+					<div ID="L.1.1.9.4" TYPE="Illustration" ORDER="1" DMDID="c015" LABEL="Untitled Image by Kolom. Moser OM">
 						<div ID="L.1.1.9.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00004"/>
@@ -3491,8 +3291,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c017"
-						LABEL="RELIQUIENTRÄGER">
+					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c017" LABEL="RELIQUIENTRÄGER">
 						<div ID="L.1.1.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -3514,8 +3313,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c018"
-						LABEL="Skizze zum Volder-monument">
+					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c018" LABEL="Skizze zum Volder-monument">
 						<div ID="L.1.1.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -3537,8 +3335,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c019"
-						LABEL="Holzschnitt aus &#34;Germinal&#34;">
+					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c019" LABEL="Holzschnitt aus &#34;Germinal&#34;">
 						<div ID="L.1.1.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
@@ -3560,8 +3357,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c020"
-						LABEL="MANN MIT HUND">
+					<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c020" LABEL="MANN MIT HUND">
 						<div ID="L.1.1.13.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -3583,8 +3379,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c021"
-						LABEL="FRAUENKOPF">
+					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c021" LABEL="FRAUENKOPF">
 						<div ID="L.1.1.14.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
@@ -3606,8 +3401,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="2" DMDID="c016"
-						LABEL="Untitled Image by Kolom. Moser OM">
+					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="2" DMDID="c016" LABEL="Untitled Image by Kolom. Moser OM">
 						<div ID="L.1.1.9.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
@@ -3624,8 +3418,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c031"
-						LABEL="Reliquienträger">
+					<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c031" LABEL="Reliquienträger">
 						<div ID="L.1.1.16.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
@@ -3674,8 +3467,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18" TYPE="Illustration" ORDER="16" DMDID="c034"
-						LABEL="Mutter mit Kindern">
+					<div ID="L.1.1.18" TYPE="Illustration" ORDER="16" DMDID="c034" LABEL="Mutter mit Kindern">
 						<div ID="L.1.1.18.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
@@ -3697,8 +3489,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.19" TYPE="Illustration" ORDER="17" DMDID="c035"
-						LABEL="Lithographie">
+					<div ID="L.1.1.19" TYPE="Illustration" ORDER="17" DMDID="c035" LABEL="Lithographie">
 						<div ID="L.1.1.19.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
@@ -3716,8 +3507,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="TextContent" ORDER="13" DMDID="c022"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.15" TYPE="TextContent" ORDER="13" DMDID="c022" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
@@ -3728,8 +3518,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00004"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.15.3" TYPE="Illustration" ORDER="1" DMDID="c023"
-						LABEL="[Initial]">
+					<div ID="L.1.1.15.3" TYPE="Illustration" ORDER="1" DMDID="c023" LABEL="[Initial]">
 						<div ID="L.1.1.15.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00008"/>
@@ -3741,15 +3530,13 @@
 							<div ID="L.1.1.15.4.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.15.4.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.15.5" TYPE="Illustration" ORDER="1" DMDID="c024"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.15.5" TYPE="Illustration" ORDER="1" DMDID="c024" LABEL="Untitled Image">
 						<div ID="L.1.1.15.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00001"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/02/01_01/bmtnabf_1901-02-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/02/01_01/bmtnabf_1901-02-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-02-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-02-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-02-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-02-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-02-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2641,361 +2635,180 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:53:40"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="f5125dfc260fb721c44145277ca76c9cd27500ff"
-				CHECKSUMTYPE="SHA-1" SIZE="6240727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:53:40" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="f5125dfc260fb721c44145277ca76c9cd27500ff" CHECKSUMTYPE="SHA-1" SIZE="6240727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:54:18"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="3bcafe24292857ba4d25ab637648d02e737365a0"
-				CHECKSUMTYPE="SHA-1" SIZE="6219125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:54:18" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="3bcafe24292857ba4d25ab637648d02e737365a0" CHECKSUMTYPE="SHA-1" SIZE="6219125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:55:01"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="6ca37b2f69c002aa117067fad0311bb32141edbc"
-				CHECKSUMTYPE="SHA-1" SIZE="6240704">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:55:01" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="6ca37b2f69c002aa117067fad0311bb32141edbc" CHECKSUMTYPE="SHA-1" SIZE="6240704">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:55:42"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="55478828cd860d0d429fc407896ad037d40928d9"
-				CHECKSUMTYPE="SHA-1" SIZE="6232625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:55:42" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="55478828cd860d0d429fc407896ad037d40928d9" CHECKSUMTYPE="SHA-1" SIZE="6232625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:56:22"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="ab5dea13168d23599d0bcf065b38a4d95790bb2a"
-				CHECKSUMTYPE="SHA-1" SIZE="6240527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:56:22" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="ab5dea13168d23599d0bcf065b38a4d95790bb2a" CHECKSUMTYPE="SHA-1" SIZE="6240527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:56:54"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="5c1edb753b7ab202a9c40419fe506821247dc152"
-				CHECKSUMTYPE="SHA-1" SIZE="6231723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:56:54" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="5c1edb753b7ab202a9c40419fe506821247dc152" CHECKSUMTYPE="SHA-1" SIZE="6231723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:57:31"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="95918fec57cf5c0575a490fee83f92c007026a4f"
-				CHECKSUMTYPE="SHA-1" SIZE="6216421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:57:31" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="95918fec57cf5c0575a490fee83f92c007026a4f" CHECKSUMTYPE="SHA-1" SIZE="6216421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:58:05"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="6f42343420a8e74b5f0cdcb28054e2cee1b0d3ee"
-				CHECKSUMTYPE="SHA-1" SIZE="6232562">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:58:05" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="6f42343420a8e74b5f0cdcb28054e2cee1b0d3ee" CHECKSUMTYPE="SHA-1" SIZE="6232562">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:58:40"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f1b822a8785757aa2f72f6b02bb5bc403e902a69"
-				CHECKSUMTYPE="SHA-1" SIZE="6216403">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:58:40" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f1b822a8785757aa2f72f6b02bb5bc403e902a69" CHECKSUMTYPE="SHA-1" SIZE="6216403">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:59:18"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="763dbd9f863d1a5a06eae83d8e26b65a625fa82c"
-				CHECKSUMTYPE="SHA-1" SIZE="6232628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:59:18" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="763dbd9f863d1a5a06eae83d8e26b65a625fa82c" CHECKSUMTYPE="SHA-1" SIZE="6232628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T17:59:52"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="c7a83ba2d9bf2f0022d119fbd61e23cd6a848da4"
-				CHECKSUMTYPE="SHA-1" SIZE="6191225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T17:59:52" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="c7a83ba2d9bf2f0022d119fbd61e23cd6a848da4" CHECKSUMTYPE="SHA-1" SIZE="6191225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:00:25"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="4dd8338faa1c179e0a76f0b62adedfce7048c545"
-				CHECKSUMTYPE="SHA-1" SIZE="6232623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:00:25" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="4dd8338faa1c179e0a76f0b62adedfce7048c545" CHECKSUMTYPE="SHA-1" SIZE="6232623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:01:01"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="3058ea48d03d9654e7017753db037e06bb25d4a2"
-				CHECKSUMTYPE="SHA-1" SIZE="6191216">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:01:01" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="3058ea48d03d9654e7017753db037e06bb25d4a2" CHECKSUMTYPE="SHA-1" SIZE="6191216">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:01:34"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="2af9670502562ed1167431d740a3216d51041368"
-				CHECKSUMTYPE="SHA-1" SIZE="6232627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:01:34" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="2af9670502562ed1167431d740a3216d51041368" CHECKSUMTYPE="SHA-1" SIZE="6232627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:02:09"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="517ad072784fb7cefd74e7efd57e57db00bd765e"
-				CHECKSUMTYPE="SHA-1" SIZE="6191229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:02:09" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="517ad072784fb7cefd74e7efd57e57db00bd765e" CHECKSUMTYPE="SHA-1" SIZE="6191229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:02:45"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ff53d654f37f2e174651d68e8cd6cca875c1a7b3"
-				CHECKSUMTYPE="SHA-1" SIZE="6232628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:02:45" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ff53d654f37f2e174651d68e8cd6cca875c1a7b3" CHECKSUMTYPE="SHA-1" SIZE="6232628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:03:20"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="d41c0a24726b94f6a919883cfa04b3f187d1c2db"
-				CHECKSUMTYPE="SHA-1" SIZE="6192128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:03:20" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="d41c0a24726b94f6a919883cfa04b3f187d1c2db" CHECKSUMTYPE="SHA-1" SIZE="6192128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:03:53"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="a3ceac5ffc986e3a9b066b2ad666f8fe6a74270a"
-				CHECKSUMTYPE="SHA-1" SIZE="6219972">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:03:53" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="a3ceac5ffc986e3a9b066b2ad666f8fe6a74270a" CHECKSUMTYPE="SHA-1" SIZE="6219972">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:04:28"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="c71a4891fc32251c8afc7d4248118a409b0e7c98"
-				CHECKSUMTYPE="SHA-1" SIZE="6192054">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:04:28" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="c71a4891fc32251c8afc7d4248118a409b0e7c98" CHECKSUMTYPE="SHA-1" SIZE="6192054">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:05:00"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="2814b0e39f0eaa69dba565106ba3992279eb5f4d"
-				CHECKSUMTYPE="SHA-1" SIZE="6219992">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:05:00" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="2814b0e39f0eaa69dba565106ba3992279eb5f4d" CHECKSUMTYPE="SHA-1" SIZE="6219992">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:05:36"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="b67490150a98850149f9bd8b06dcee15e2a748e5"
-				CHECKSUMTYPE="SHA-1" SIZE="6242502">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:05:36" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="b67490150a98850149f9bd8b06dcee15e2a748e5" CHECKSUMTYPE="SHA-1" SIZE="6242502">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:06:11"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="3eeb8397846f9ed646e44cfe8730d0bc9729721b"
-				CHECKSUMTYPE="SHA-1" SIZE="6220019">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:06:11" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="3eeb8397846f9ed646e44cfe8730d0bc9729721b" CHECKSUMTYPE="SHA-1" SIZE="6220019">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:06:47"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="5245eaa25299d6ec1565e312e94d409f63baf255"
-				CHECKSUMTYPE="SHA-1" SIZE="6242529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:06:47" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="5245eaa25299d6ec1565e312e94d409f63baf255" CHECKSUMTYPE="SHA-1" SIZE="6242529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:07:24"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="ef0ca99eeb434f3a8d0d4d46853240d419790856"
-				CHECKSUMTYPE="SHA-1" SIZE="6219852">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:07:24" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="ef0ca99eeb434f3a8d0d4d46853240d419790856" CHECKSUMTYPE="SHA-1" SIZE="6219852">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:07:56"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="4394178107026e1ab775c9386e334b5a0b5e774b"
-				CHECKSUMTYPE="SHA-1" SIZE="6242522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:07:56" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="4394178107026e1ab775c9386e334b5a0b5e774b" CHECKSUMTYPE="SHA-1" SIZE="6242522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:08:30"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="1ee3dabb6f53a07d4ecfdda881d2031115c5a8a5"
-				CHECKSUMTYPE="SHA-1" SIZE="6350527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:08:30" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="1ee3dabb6f53a07d4ecfdda881d2031115c5a8a5" CHECKSUMTYPE="SHA-1" SIZE="6350527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:09:05"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="bc406e4461e547f7fc1f99fe6faa89409dbfe44d"
-				CHECKSUMTYPE="SHA-1" SIZE="6241618">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:09:05" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="bc406e4461e547f7fc1f99fe6faa89409dbfe44d" CHECKSUMTYPE="SHA-1" SIZE="6241618">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:09:43"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="3da3992cbb224ca9f64ea7f5aacf2effe4feed5e"
-				CHECKSUMTYPE="SHA-1" SIZE="6297413">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:09:43" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="3da3992cbb224ca9f64ea7f5aacf2effe4feed5e" CHECKSUMTYPE="SHA-1" SIZE="6297413">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/delivery/bmtnabf_1901-02-01_01_0028.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:10:04" MIMETYPE="text/xml"
-				CHECKSUM="f1e7db0f4e786723426b2b2679168a45c4fd2da5" CHECKSUMTYPE="SHA-1" SIZE="5110">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:10:04" MIMETYPE="text/xml" CHECKSUM="f1e7db0f4e786723426b2b2679168a45c4fd2da5" CHECKSUMTYPE="SHA-1" SIZE="5110">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:10:04" MIMETYPE="text/xml"
-				CHECKSUM="8f80d87c1a583f0d8c844a00ef0a0f848da7b8ed" CHECKSUMTYPE="SHA-1"
-				SIZE="36146">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:10:04" MIMETYPE="text/xml" CHECKSUM="8f80d87c1a583f0d8c844a00ef0a0f848da7b8ed" CHECKSUMTYPE="SHA-1" SIZE="36146">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:10:04" MIMETYPE="text/xml"
-				CHECKSUM="7aadd3c1083cdbb184a36b9ed85cda1840208161" CHECKSUMTYPE="SHA-1" SIZE="9404">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:10:04" MIMETYPE="text/xml" CHECKSUM="7aadd3c1083cdbb184a36b9ed85cda1840208161" CHECKSUMTYPE="SHA-1" SIZE="9404">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:10:04" MIMETYPE="text/xml"
-				CHECKSUM="dad63a35cf76d5177a0eaff449b92dbad2cf4c92" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:10:04" MIMETYPE="text/xml" CHECKSUM="dad63a35cf76d5177a0eaff449b92dbad2cf4c92" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:10:05" MIMETYPE="text/xml"
-				CHECKSUM="c89f3f03b142384d0512fa99f311afa1ed1fc4c3" CHECKSUMTYPE="SHA-1" SIZE="1718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:10:05" MIMETYPE="text/xml" CHECKSUM="c89f3f03b142384d0512fa99f311afa1ed1fc4c3" CHECKSUMTYPE="SHA-1" SIZE="1718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:10:05" MIMETYPE="text/xml"
-				CHECKSUM="e6a2aa47175cdd00ae01c0c25e1c4455f4f4bb6e" CHECKSUMTYPE="SHA-1" SIZE="3608">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:10:05" MIMETYPE="text/xml" CHECKSUM="e6a2aa47175cdd00ae01c0c25e1c4455f4f4bb6e" CHECKSUMTYPE="SHA-1" SIZE="3608">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:10:05" MIMETYPE="text/xml"
-				CHECKSUM="318487b2540560888c6e6e311b80bec4e7b25370" CHECKSUMTYPE="SHA-1"
-				SIZE="19932">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:10:05" MIMETYPE="text/xml" CHECKSUM="318487b2540560888c6e6e311b80bec4e7b25370" CHECKSUMTYPE="SHA-1" SIZE="19932">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:10:05" MIMETYPE="text/xml"
-				CHECKSUM="3a21f84a4a9070382c859b2db1676fd9754468e1" CHECKSUMTYPE="SHA-1" SIZE="4430">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:10:05" MIMETYPE="text/xml" CHECKSUM="3a21f84a4a9070382c859b2db1676fd9754468e1" CHECKSUMTYPE="SHA-1" SIZE="4430">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:10:05" MIMETYPE="text/xml"
-				CHECKSUM="0359838a8594aa5dc80ea17faac4491154da52c0" CHECKSUMTYPE="SHA-1" SIZE="4441">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:10:05" MIMETYPE="text/xml" CHECKSUM="0359838a8594aa5dc80ea17faac4491154da52c0" CHECKSUMTYPE="SHA-1" SIZE="4441">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:10:06" MIMETYPE="text/xml"
-				CHECKSUM="7aba03fef8f80a9191b4692fc0c3e7f1983c7804" CHECKSUMTYPE="SHA-1"
-				SIZE="50415">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:10:06" MIMETYPE="text/xml" CHECKSUM="7aba03fef8f80a9191b4692fc0c3e7f1983c7804" CHECKSUMTYPE="SHA-1" SIZE="50415">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:10:06" MIMETYPE="text/xml"
-				CHECKSUM="1225efb9c530131aa114ed3b8b32005ccf1e2011" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:10:06" MIMETYPE="text/xml" CHECKSUM="1225efb9c530131aa114ed3b8b32005ccf1e2011" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:10:06" MIMETYPE="text/xml"
-				CHECKSUM="3af84897e3fe07445814b2ce53783898f9f5d1d0" CHECKSUMTYPE="SHA-1" SIZE="3924">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:10:06" MIMETYPE="text/xml" CHECKSUM="3af84897e3fe07445814b2ce53783898f9f5d1d0" CHECKSUMTYPE="SHA-1" SIZE="3924">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:10:06" MIMETYPE="text/xml"
-				CHECKSUM="3b36426e700a5175485939149bb4b7f5b6aea849" CHECKSUMTYPE="SHA-1"
-				SIZE="38420">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:10:06" MIMETYPE="text/xml" CHECKSUM="3b36426e700a5175485939149bb4b7f5b6aea849" CHECKSUMTYPE="SHA-1" SIZE="38420">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:10:07" MIMETYPE="text/xml"
-				CHECKSUM="0fb9d44c53842675666a5878878b2c3aeb68647a" CHECKSUMTYPE="SHA-1"
-				SIZE="29920">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:10:07" MIMETYPE="text/xml" CHECKSUM="0fb9d44c53842675666a5878878b2c3aeb68647a" CHECKSUMTYPE="SHA-1" SIZE="29920">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:10:07" MIMETYPE="text/xml"
-				CHECKSUM="1732bbc79f9317275cce85a1321773370cd75b1e" CHECKSUMTYPE="SHA-1" SIZE="4296">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:10:07" MIMETYPE="text/xml" CHECKSUM="1732bbc79f9317275cce85a1321773370cd75b1e" CHECKSUMTYPE="SHA-1" SIZE="4296">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:10:07" MIMETYPE="text/xml"
-				CHECKSUM="b5e3406f9cc60b838a569f238fff46e6a45af844" CHECKSUMTYPE="SHA-1"
-				SIZE="42591">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:10:07" MIMETYPE="text/xml" CHECKSUM="b5e3406f9cc60b838a569f238fff46e6a45af844" CHECKSUMTYPE="SHA-1" SIZE="42591">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:10:07" MIMETYPE="text/xml"
-				CHECKSUM="9ca2951301af4f8234e0d440e165d718dcbaee1f" CHECKSUMTYPE="SHA-1" SIZE="4619">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:10:07" MIMETYPE="text/xml" CHECKSUM="9ca2951301af4f8234e0d440e165d718dcbaee1f" CHECKSUMTYPE="SHA-1" SIZE="4619">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:10:08" MIMETYPE="text/xml"
-				CHECKSUM="d380c1c3394392d9e8ea5d6a2e70d9884c89c37d" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:10:08" MIMETYPE="text/xml" CHECKSUM="d380c1c3394392d9e8ea5d6a2e70d9884c89c37d" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:10:08" MIMETYPE="text/xml"
-				CHECKSUM="663abc5781295509eef8659cce69904750df25ae" CHECKSUMTYPE="SHA-1"
-				SIZE="51144">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:10:08" MIMETYPE="text/xml" CHECKSUM="663abc5781295509eef8659cce69904750df25ae" CHECKSUMTYPE="SHA-1" SIZE="51144">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:10:08" MIMETYPE="text/xml"
-				CHECKSUM="fa384665bbf30f0eca6f20f01ea73bdabfe58efc" CHECKSUMTYPE="SHA-1" SIZE="4429">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:10:08" MIMETYPE="text/xml" CHECKSUM="fa384665bbf30f0eca6f20f01ea73bdabfe58efc" CHECKSUMTYPE="SHA-1" SIZE="4429">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:10:08" MIMETYPE="text/xml"
-				CHECKSUM="41eff59a4bff04a8c720f36dcb747746e2aa8671" CHECKSUMTYPE="SHA-1" SIZE="4465">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:10:08" MIMETYPE="text/xml" CHECKSUM="41eff59a4bff04a8c720f36dcb747746e2aa8671" CHECKSUMTYPE="SHA-1" SIZE="4465">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:10:09" MIMETYPE="text/xml"
-				CHECKSUM="80a00d98c1b891bb856fc15b1499b9c442a09e77" CHECKSUMTYPE="SHA-1"
-				SIZE="27157">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:10:09" MIMETYPE="text/xml" CHECKSUM="80a00d98c1b891bb856fc15b1499b9c442a09e77" CHECKSUMTYPE="SHA-1" SIZE="27157">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:10:09" MIMETYPE="text/xml"
-				CHECKSUM="8aa46349c3805977440bb71747c7859503b22e72" CHECKSUMTYPE="SHA-1" SIZE="3885">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:10:09" MIMETYPE="text/xml" CHECKSUM="8aa46349c3805977440bb71747c7859503b22e72" CHECKSUMTYPE="SHA-1" SIZE="3885">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:10:09" MIMETYPE="text/xml"
-				CHECKSUM="f279787673781a7c8020c33a4ccd28a1df35340e" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:10:09" MIMETYPE="text/xml" CHECKSUM="f279787673781a7c8020c33a4ccd28a1df35340e" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:10:09" MIMETYPE="text/xml"
-				CHECKSUM="e9949f26204593bb149c1f71905b6d07047c333c" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:10:09" MIMETYPE="text/xml" CHECKSUM="e9949f26204593bb149c1f71905b6d07047c333c" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:10:10" MIMETYPE="text/xml"
-				CHECKSUM="aa1dcf82fbf482122e014ec4d5aa1b1470dd1b31" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:10:10" MIMETYPE="text/xml" CHECKSUM="aa1dcf82fbf482122e014ec4d5aa1b1470dd1b31" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:10:10" MIMETYPE="text/xml"
-				CHECKSUM="444b5d3262fd420a3e415061bae86c3ea6b26046" CHECKSUMTYPE="SHA-1"
-				SIZE="39520">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:10:10" MIMETYPE="text/xml" CHECKSUM="444b5d3262fd420a3e415061bae86c3ea6b26046" CHECKSUMTYPE="SHA-1" SIZE="39520">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:10:10" MIMETYPE="text/xml"
-				CHECKSUM="2d4c704ef0f95b783f5160fb3dcb450cb4736ead" CHECKSUMTYPE="SHA-1" SIZE="8278">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:10:10" MIMETYPE="text/xml" CHECKSUM="2d4c704ef0f95b783f5160fb3dcb450cb4736ead" CHECKSUMTYPE="SHA-1" SIZE="8278">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-01_01_0028.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:10:42" MIMETYPE="application/pdf"
-				CHECKSUM="d4b12deee311e59ca3d1a86b9d01e4589dadc880" CHECKSUMTYPE="SHA-1"
-				SIZE="8464701">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/bmtnabf_1901-02-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:10:42" MIMETYPE="application/pdf" CHECKSUM="d4b12deee311e59ca3d1a86b9d01e4589dadc880" CHECKSUMTYPE="SHA-1" SIZE="8464701">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/01_01/bmtnabf_1901-02-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3230,8 +3043,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 3 01.02.1901">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by F. König OM">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by F. König OM">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<seq>
@@ -3292,8 +3104,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="3" DMDID="c009"
-					LABEL="Buntpapier-Einband">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="3" DMDID="c009" LABEL="Buntpapier-Einband">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00001"/>
@@ -3310,8 +3121,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="TextContent" ORDER="4" DMDID="c010"
-					LABEL="ZEICHNUNGEN AUS DER MAPPE, DIE DEM ARCHITEKTEN J. M. OLBRICH VON SEINEN FREUNDEN ZUR ERINNERUNG AN DEN BAU DES SECESSIONS GEBÄUDES ÜBERREICHT WURDE">
+				<div ID="L.1.1.8" TYPE="TextContent" ORDER="4" DMDID="c010" LABEL="ZEICHNUNGEN AUS DER MAPPE, DIE DEM ARCHITEKTEN J. M. OLBRICH VON SEINEN FREUNDEN ZUR ERINNERUNG AN DEN BAU DES SECESSIONS GEBÄUDES ÜBERREICHT WURDE">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -3322,8 +3132,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.8.3" TYPE="Illustration" ORDER="1" DMDID="c011"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.8.3" TYPE="Illustration" ORDER="1" DMDID="c011" LABEL="Untitled Image">
 						<div ID="L.1.1.8.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00003"/>
@@ -3336,34 +3145,26 @@
 								<div ID="L.1.1.8.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="1" DMDID="c012"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="1" DMDID="c012" LABEL="Untitled Image">
 						<div ID="L.1.1.8.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="2" DMDID="c013"
-						LABEL="Bernatzik-Winter">
+					<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="2" DMDID="c013" LABEL="Bernatzik-Winter">
 						<div ID="L.1.1.8.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
@@ -3380,8 +3181,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.7" TYPE="Illustration" ORDER="3" DMDID="c014"
-						LABEL="Lenz-König">
+					<div ID="L.1.1.8.7" TYPE="Illustration" ORDER="3" DMDID="c014" LABEL="Lenz-König">
 						<div ID="L.1.1.8.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00005"/>
@@ -3398,8 +3198,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.8" TYPE="Illustration" ORDER="4" DMDID="c015"
-						LABEL="Untitled Image by F. König OM">
+					<div ID="L.1.1.8.8" TYPE="Illustration" ORDER="4" DMDID="c015" LABEL="Untitled Image by F. König OM">
 						<div ID="L.1.1.8.8.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
@@ -3412,8 +3211,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="5" DMDID="c016"
-					LABEL="Hoffmann-Gothik-Renaissance">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="5" DMDID="c016" LABEL="Hoffmann-Gothik-Renaissance">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
@@ -3430,8 +3228,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="6" DMDID="c017"
-					LABEL="Engelhart-Moll-Jettei">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="6" DMDID="c017" LABEL="Engelhart-Moll-Jettei">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -3482,15 +3279,13 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="TextContent" ORDER="9" DMDID="c020"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.13" TYPE="TextContent" ORDER="9" DMDID="c020" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.13.2" TYPE="Illustration" ORDER="1" DMDID="c021"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.13.2" TYPE="Illustration" ORDER="1" DMDID="c021" LABEL="Untitled Image">
 						<div ID="L.1.1.13.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00001"/>
@@ -3503,24 +3298,18 @@
 								<div ID="L.1.1.13.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.13.4" TYPE="Illustration" ORDER="1" DMDID="c022"
-						LABEL="Hoffmann-Moser">
+					<div ID="L.1.1.13.4" TYPE="Illustration" ORDER="1" DMDID="c022" LABEL="Hoffmann-Moser">
 						<div ID="L.1.1.13.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00005"/>
@@ -3537,8 +3326,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13.5" TYPE="Illustration" ORDER="2" DMDID="c023"
-						LABEL="Untitled Image by F. König OM">
+					<div ID="L.1.1.13.5" TYPE="Illustration" ORDER="2" DMDID="c023" LABEL="Untitled Image by F. König OM">
 						<div ID="L.1.1.13.5.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00003"/>
@@ -3585,8 +3373,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="Illustration" ORDER="11" DMDID="c027"
-					LABEL="Roller-Schwung">
+				<div ID="L.1.1.15" TYPE="Illustration" ORDER="11" DMDID="c027" LABEL="Roller-Schwung">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
@@ -3603,8 +3390,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.16" TYPE="Illustration" ORDER="12" DMDID="c028"
-					LABEL="Bernatzik-Märchensee">
+				<div ID="L.1.1.16" TYPE="Illustration" ORDER="12" DMDID="c028" LABEL="Bernatzik-Märchensee">
 					<div ID="L.1.1.16.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
@@ -3621,8 +3407,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.17" TYPE="Illustration" ORDER="13" DMDID="c029"
-					LABEL="Birkenwald-Selbstportrait">
+				<div ID="L.1.1.17" TYPE="Illustration" ORDER="13" DMDID="c029" LABEL="Birkenwald-Selbstportrait">
 					<div ID="L.1.1.17.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00001"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/02/15_01/bmtnabf_1901-02-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/02/15_01/bmtnabf_1901-02-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-02-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-02-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-02-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-02-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -51,10 +46,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-02-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2640,364 +2634,180 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:54:46"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="811956013c5ba99264e9aac648ac0f2bf89b0877"
-				CHECKSUMTYPE="SHA-1" SIZE="6297423">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T17:54:46" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="811956013c5ba99264e9aac648ac0f2bf89b0877" CHECKSUMTYPE="SHA-1" SIZE="6297423">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:55:17"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="551e753761c4ebe5d392511505cf337bf28e521a"
-				CHECKSUMTYPE="SHA-1" SIZE="6327129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T17:55:17" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="551e753761c4ebe5d392511505cf337bf28e521a" CHECKSUMTYPE="SHA-1" SIZE="6327129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:55:52"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="16bf82265a02402f2d946806da0615383f242230"
-				CHECKSUMTYPE="SHA-1" SIZE="6297408">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T17:55:52" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="16bf82265a02402f2d946806da0615383f242230" CHECKSUMTYPE="SHA-1" SIZE="6297408">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:56:27"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="410dfd3adc33842a611637396bb2ec3e46ec3941"
-				CHECKSUMTYPE="SHA-1" SIZE="6327095">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T17:56:27" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="410dfd3adc33842a611637396bb2ec3e46ec3941" CHECKSUMTYPE="SHA-1" SIZE="6327095">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:57:02"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="92776c8fedf9460f50b3c302d72377fdc7eee76e"
-				CHECKSUMTYPE="SHA-1" SIZE="6298310">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T17:57:02" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="92776c8fedf9460f50b3c302d72377fdc7eee76e" CHECKSUMTYPE="SHA-1" SIZE="6298310">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:57:33"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="dd2e0446e98612b3c9d0584e528c3a1936805aa9"
-				CHECKSUMTYPE="SHA-1" SIZE="6327127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T17:57:33" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="dd2e0446e98612b3c9d0584e528c3a1936805aa9" CHECKSUMTYPE="SHA-1" SIZE="6327127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:58:05"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="bf4261c937e2c6d483b7c532b13aa8972f7751b6"
-				CHECKSUMTYPE="SHA-1" SIZE="6296522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T17:58:05" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="bf4261c937e2c6d483b7c532b13aa8972f7751b6" CHECKSUMTYPE="SHA-1" SIZE="6296522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:58:38"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="2d47da546df426f83fd58bc5a0765d5d412c75a6"
-				CHECKSUMTYPE="SHA-1" SIZE="6362218">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T17:58:38" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="2d47da546df426f83fd58bc5a0765d5d412c75a6" CHECKSUMTYPE="SHA-1" SIZE="6362218">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:59:10"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="ee0e8d1088fd535418459889097ae662f84a9965"
-				CHECKSUMTYPE="SHA-1" SIZE="6297429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T17:59:10" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="ee0e8d1088fd535418459889097ae662f84a9965" CHECKSUMTYPE="SHA-1" SIZE="6297429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:59:43"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="ec02c1fbb657bac49e74e161e1c806f1accf1437"
-				CHECKSUMTYPE="SHA-1" SIZE="6363129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T17:59:43" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="ec02c1fbb657bac49e74e161e1c806f1accf1437" CHECKSUMTYPE="SHA-1" SIZE="6363129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:00:13"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="a9c60b78c665bb242d393461867a4fe9101e709d"
-				CHECKSUMTYPE="SHA-1" SIZE="6296529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:00:13" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="a9c60b78c665bb242d393461867a4fe9101e709d" CHECKSUMTYPE="SHA-1" SIZE="6296529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:00:46"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="40cf0186200ea753d2dce071ff2b8f6c1555505f"
-				CHECKSUMTYPE="SHA-1" SIZE="6363119">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:00:46" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="40cf0186200ea753d2dce071ff2b8f6c1555505f" CHECKSUMTYPE="SHA-1" SIZE="6363119">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:01:17"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="5dd13a40460545e6342a9f60d518bc4715b299f3"
-				CHECKSUMTYPE="SHA-1" SIZE="6297403">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:01:17" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="5dd13a40460545e6342a9f60d518bc4715b299f3" CHECKSUMTYPE="SHA-1" SIZE="6297403">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:01:48"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="9a3e93b0f9a72aee957a40aa9a26d83376ebc6b8"
-				CHECKSUMTYPE="SHA-1" SIZE="6363128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:01:48" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="9a3e93b0f9a72aee957a40aa9a26d83376ebc6b8" CHECKSUMTYPE="SHA-1" SIZE="6363128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:02:19"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="e53abbf96fb6e5427f333319bc1d693aa4699992"
-				CHECKSUMTYPE="SHA-1" SIZE="6297427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:02:19" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="e53abbf96fb6e5427f333319bc1d693aa4699992" CHECKSUMTYPE="SHA-1" SIZE="6297427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:02:53"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="0e1825a531f82ee1ecd7e3905455a2ce9dc4fcc6"
-				CHECKSUMTYPE="SHA-1" SIZE="6362223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:02:53" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="0e1825a531f82ee1ecd7e3905455a2ce9dc4fcc6" CHECKSUMTYPE="SHA-1" SIZE="6362223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:03:25"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7d2a182b9045668cf524339e7fa6a75be1b4ad32"
-				CHECKSUMTYPE="SHA-1" SIZE="6298326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:03:25" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7d2a182b9045668cf524339e7fa6a75be1b4ad32" CHECKSUMTYPE="SHA-1" SIZE="6298326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:03:56"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="f43f78c3bd522ebd4ddef9dbde029126d0739813"
-				CHECKSUMTYPE="SHA-1" SIZE="6362221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:03:56" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="f43f78c3bd522ebd4ddef9dbde029126d0739813" CHECKSUMTYPE="SHA-1" SIZE="6362221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:04:27"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="cc6d8fbae1d0e3531118dfcb9690bd65353836e3"
-				CHECKSUMTYPE="SHA-1" SIZE="6297425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:04:27" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="cc6d8fbae1d0e3531118dfcb9690bd65353836e3" CHECKSUMTYPE="SHA-1" SIZE="6297425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:05:00"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="ef0b381a08c800c022665eb89bd0e18057986c21"
-				CHECKSUMTYPE="SHA-1" SIZE="6363129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:05:00" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="ef0b381a08c800c022665eb89bd0e18057986c21" CHECKSUMTYPE="SHA-1" SIZE="6363129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:05:31"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="960264ef0918ee014f40c1e06e53b4fbc21c807d"
-				CHECKSUMTYPE="SHA-1" SIZE="6297427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:05:31" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="960264ef0918ee014f40c1e06e53b4fbc21c807d" CHECKSUMTYPE="SHA-1" SIZE="6297427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:06:02"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="f57b439a400612e9dc9be9daa3c5e29f78dcf659"
-				CHECKSUMTYPE="SHA-1" SIZE="6362223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:06:02" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="f57b439a400612e9dc9be9daa3c5e29f78dcf659" CHECKSUMTYPE="SHA-1" SIZE="6362223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:06:35"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="4f7aef1455e5b011a797072727c452f4f826a60c"
-				CHECKSUMTYPE="SHA-1" SIZE="6297427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:06:35" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="4f7aef1455e5b011a797072727c452f4f826a60c" CHECKSUMTYPE="SHA-1" SIZE="6297427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:07:06"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="2893d52634b07eab94001c6917c5128b2e7a6e9b"
-				CHECKSUMTYPE="SHA-1" SIZE="6342426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:07:06" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="2893d52634b07eab94001c6917c5128b2e7a6e9b" CHECKSUMTYPE="SHA-1" SIZE="6342426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:07:37"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="6d8a258ce3ed55463184018f57f3b96d2f2e8550"
-				CHECKSUMTYPE="SHA-1" SIZE="6297414">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:07:37" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="6d8a258ce3ed55463184018f57f3b96d2f2e8550" CHECKSUMTYPE="SHA-1" SIZE="6297414">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:08:08"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="69b77238b60ee68ede3d7c1774b03bd5e13e34da"
-				CHECKSUMTYPE="SHA-1" SIZE="6312713">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:08:08" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="69b77238b60ee68ede3d7c1774b03bd5e13e34da" CHECKSUMTYPE="SHA-1" SIZE="6312713">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:08:40"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="f33da08864d29fb9d8fdc3916d2e0505bec08c7a"
-				CHECKSUMTYPE="SHA-1" SIZE="6297427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:08:40" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="f33da08864d29fb9d8fdc3916d2e0505bec08c7a" CHECKSUMTYPE="SHA-1" SIZE="6297427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:09:14"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="a14c41831fd9d7d1e6d1fa1ad5f6264dabc41afa"
-				CHECKSUMTYPE="SHA-1" SIZE="6311823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:09:14" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="a14c41831fd9d7d1e6d1fa1ad5f6264dabc41afa" CHECKSUMTYPE="SHA-1" SIZE="6311823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/delivery/bmtnabf_1901-02-15_01_0028.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:09:32" MIMETYPE="text/xml"
-				CHECKSUM="a404a6843fb1409a684d6d8392c98f4429fb0e84" CHECKSUMTYPE="SHA-1" SIZE="4815">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:09:32" MIMETYPE="text/xml" CHECKSUM="a404a6843fb1409a684d6d8392c98f4429fb0e84" CHECKSUMTYPE="SHA-1" SIZE="4815">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:09:32" MIMETYPE="text/xml"
-				CHECKSUM="fcb1c2569306ce0d9914c51615649cfbb06d375b" CHECKSUMTYPE="SHA-1"
-				SIZE="24459">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:09:32" MIMETYPE="text/xml" CHECKSUM="fcb1c2569306ce0d9914c51615649cfbb06d375b" CHECKSUMTYPE="SHA-1" SIZE="24459">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:09:32" MIMETYPE="text/xml"
-				CHECKSUM="b3c76b07860823209976351aa5d240767ab92cec" CHECKSUMTYPE="SHA-1" SIZE="9796">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:09:32" MIMETYPE="text/xml" CHECKSUM="b3c76b07860823209976351aa5d240767ab92cec" CHECKSUMTYPE="SHA-1" SIZE="9796">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:09:33" MIMETYPE="text/xml"
-				CHECKSUM="f1cde1d5c7b693a6bd9bab6ff94f37fba35a5f08" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:09:33" MIMETYPE="text/xml" CHECKSUM="f1cde1d5c7b693a6bd9bab6ff94f37fba35a5f08" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:09:33" MIMETYPE="text/xml"
-				CHECKSUM="93a2d8acbc574ef8b1dd6125183c7ae6e9b20ca2" CHECKSUMTYPE="SHA-1" SIZE="4849">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:09:33" MIMETYPE="text/xml" CHECKSUM="93a2d8acbc574ef8b1dd6125183c7ae6e9b20ca2" CHECKSUMTYPE="SHA-1" SIZE="4849">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:09:33" MIMETYPE="text/xml"
-				CHECKSUM="cfcaddd96cc13bd761606dba51bdec69292027a8" CHECKSUMTYPE="SHA-1"
-				SIZE="40127">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:09:33" MIMETYPE="text/xml" CHECKSUM="cfcaddd96cc13bd761606dba51bdec69292027a8" CHECKSUMTYPE="SHA-1" SIZE="40127">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:09:33" MIMETYPE="text/xml"
-				CHECKSUM="74e6a76f397a1201de2b089b1f950d23de00fd51" CHECKSUMTYPE="SHA-1" SIZE="5370">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:09:33" MIMETYPE="text/xml" CHECKSUM="74e6a76f397a1201de2b089b1f950d23de00fd51" CHECKSUMTYPE="SHA-1" SIZE="5370">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:09:34" MIMETYPE="text/xml"
-				CHECKSUM="9a3132491197f120eb4fc5621092bd39675155cc" CHECKSUMTYPE="SHA-1" SIZE="5007">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:09:34" MIMETYPE="text/xml" CHECKSUM="9a3132491197f120eb4fc5621092bd39675155cc" CHECKSUMTYPE="SHA-1" SIZE="5007">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:09:35" MIMETYPE="text/xml"
-				CHECKSUM="b1968938fa81af8db6af5d4fc7306c342f0011ba" CHECKSUMTYPE="SHA-1"
-				SIZE="33063">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:09:35" MIMETYPE="text/xml" CHECKSUM="b1968938fa81af8db6af5d4fc7306c342f0011ba" CHECKSUMTYPE="SHA-1" SIZE="33063">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:09:35" MIMETYPE="text/xml"
-				CHECKSUM="5f9f6c9f626c6955562c9642506a2ca24715f2f3" CHECKSUMTYPE="SHA-1"
-				SIZE="53598">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:09:35" MIMETYPE="text/xml" CHECKSUM="5f9f6c9f626c6955562c9642506a2ca24715f2f3" CHECKSUMTYPE="SHA-1" SIZE="53598">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:09:36" MIMETYPE="text/xml"
-				CHECKSUM="5334e9ab5750decf9556588fc4ba51ba578c21ae" CHECKSUMTYPE="SHA-1"
-				SIZE="51028">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:09:36" MIMETYPE="text/xml" CHECKSUM="5334e9ab5750decf9556588fc4ba51ba578c21ae" CHECKSUMTYPE="SHA-1" SIZE="51028">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:09:37" MIMETYPE="text/xml"
-				CHECKSUM="f54e0ce4ef79ff80be3e273c2e1e59b2c6c148b9" CHECKSUMTYPE="SHA-1"
-				SIZE="50149">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:09:37" MIMETYPE="text/xml" CHECKSUM="f54e0ce4ef79ff80be3e273c2e1e59b2c6c148b9" CHECKSUMTYPE="SHA-1" SIZE="50149">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:09:38" MIMETYPE="text/xml"
-				CHECKSUM="4aa3fc6822bb34611411fef968c55a1345a940cc" CHECKSUMTYPE="SHA-1" SIZE="4740">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:09:38" MIMETYPE="text/xml" CHECKSUM="4aa3fc6822bb34611411fef968c55a1345a940cc" CHECKSUMTYPE="SHA-1" SIZE="4740">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:09:38" MIMETYPE="text/xml"
-				CHECKSUM="3e03f4f2ff4a99372dd98a6575685851bd950bfc" CHECKSUMTYPE="SHA-1" SIZE="5249">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:09:38" MIMETYPE="text/xml" CHECKSUM="3e03f4f2ff4a99372dd98a6575685851bd950bfc" CHECKSUMTYPE="SHA-1" SIZE="5249">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:09:38" MIMETYPE="text/xml"
-				CHECKSUM="f347b8bf72ba008e2f91bb160934e0d629e87628" CHECKSUMTYPE="SHA-1" SIZE="5197">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:09:38" MIMETYPE="text/xml" CHECKSUM="f347b8bf72ba008e2f91bb160934e0d629e87628" CHECKSUMTYPE="SHA-1" SIZE="5197">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:09:38" MIMETYPE="text/xml"
-				CHECKSUM="9a28f015045a4f38a8c6098a3d83ae707a549425" CHECKSUMTYPE="SHA-1" SIZE="5127">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:09:38" MIMETYPE="text/xml" CHECKSUM="9a28f015045a4f38a8c6098a3d83ae707a549425" CHECKSUMTYPE="SHA-1" SIZE="5127">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:09:39" MIMETYPE="text/xml"
-				CHECKSUM="5a7fc4f8106fb327c6ab29b058a313b5947486a0" CHECKSUMTYPE="SHA-1"
-				SIZE="51837">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:09:39" MIMETYPE="text/xml" CHECKSUM="5a7fc4f8106fb327c6ab29b058a313b5947486a0" CHECKSUMTYPE="SHA-1" SIZE="51837">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:09:39" MIMETYPE="text/xml"
-				CHECKSUM="17f02549721679ff219b7242c692ee35b23b67a3" CHECKSUMTYPE="SHA-1"
-				SIZE="49934">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:09:39" MIMETYPE="text/xml" CHECKSUM="17f02549721679ff219b7242c692ee35b23b67a3" CHECKSUMTYPE="SHA-1" SIZE="49934">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:09:40" MIMETYPE="text/xml"
-				CHECKSUM="d90409dc87f2641750dbed28fa561c036bc2404e" CHECKSUMTYPE="SHA-1" SIZE="6013">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:09:40" MIMETYPE="text/xml" CHECKSUM="d90409dc87f2641750dbed28fa561c036bc2404e" CHECKSUMTYPE="SHA-1" SIZE="6013">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:09:40" MIMETYPE="text/xml"
-				CHECKSUM="8dc12fd0bf631d439064a3c1f1df4ff367429705" CHECKSUMTYPE="SHA-1"
-				SIZE="51860">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:09:40" MIMETYPE="text/xml" CHECKSUM="8dc12fd0bf631d439064a3c1f1df4ff367429705" CHECKSUMTYPE="SHA-1" SIZE="51860">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:09:40" MIMETYPE="text/xml"
-				CHECKSUM="0fe3ec6ba4620e29581bbe265fac86fdc8adc59d" CHECKSUMTYPE="SHA-1" SIZE="5076">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:09:40" MIMETYPE="text/xml" CHECKSUM="0fe3ec6ba4620e29581bbe265fac86fdc8adc59d" CHECKSUMTYPE="SHA-1" SIZE="5076">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:09:40" MIMETYPE="text/xml"
-				CHECKSUM="0bd2ede073de897cf1cb6ffc02917f31a7d5c6d3" CHECKSUMTYPE="SHA-1" SIZE="6298">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:09:40" MIMETYPE="text/xml" CHECKSUM="0bd2ede073de897cf1cb6ffc02917f31a7d5c6d3" CHECKSUMTYPE="SHA-1" SIZE="6298">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:09:41" MIMETYPE="text/xml"
-				CHECKSUM="b405b83f7c3f7f049306a86ae0d477d07b422ea1" CHECKSUMTYPE="SHA-1"
-				SIZE="16175">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:09:41" MIMETYPE="text/xml" CHECKSUM="b405b83f7c3f7f049306a86ae0d477d07b422ea1" CHECKSUMTYPE="SHA-1" SIZE="16175">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:09:41" MIMETYPE="text/xml"
-				CHECKSUM="c5005b0cb0b5ed7082a2e9f2c5fbaf1b5775022b" CHECKSUMTYPE="SHA-1" SIZE="5206">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:09:41" MIMETYPE="text/xml" CHECKSUM="c5005b0cb0b5ed7082a2e9f2c5fbaf1b5775022b" CHECKSUMTYPE="SHA-1" SIZE="5206">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:09:41" MIMETYPE="text/xml"
-				CHECKSUM="aacede1399e777881a9743e070a803d4f69e8702" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:09:41" MIMETYPE="text/xml" CHECKSUM="aacede1399e777881a9743e070a803d4f69e8702" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:09:41" MIMETYPE="text/xml"
-				CHECKSUM="46ade5849fa7dbb84cd737086d6a66c4457ccb8d" CHECKSUMTYPE="SHA-1"
-				SIZE="32255">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:09:41" MIMETYPE="text/xml" CHECKSUM="46ade5849fa7dbb84cd737086d6a66c4457ccb8d" CHECKSUMTYPE="SHA-1" SIZE="32255">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:09:41" MIMETYPE="text/xml"
-				CHECKSUM="4a30ff8e02b96352ec133300d905f06125d4c6e9" CHECKSUMTYPE="SHA-1"
-				SIZE="36398">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:09:41" MIMETYPE="text/xml" CHECKSUM="4a30ff8e02b96352ec133300d905f06125d4c6e9" CHECKSUMTYPE="SHA-1" SIZE="36398">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:09:42" MIMETYPE="text/xml"
-				CHECKSUM="1e360a3257c58965a69f0d6eeefbbc48975a6550" CHECKSUMTYPE="SHA-1" SIZE="7775">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:09:42" MIMETYPE="text/xml" CHECKSUM="1e360a3257c58965a69f0d6eeefbbc48975a6550" CHECKSUMTYPE="SHA-1" SIZE="7775">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-02-15_01_0028.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:10:13" MIMETYPE="application/pdf"
-				CHECKSUM="4b274724325e9d26854e647deb21a7a862d2877c" CHECKSUMTYPE="SHA-1"
-				SIZE="8166327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/bmtnabf_1901-02-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:10:13" MIMETYPE="application/pdf" CHECKSUM="4b274724325e9d26854e647deb21a7a862d2877c" CHECKSUMTYPE="SHA-1" SIZE="8166327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/02/15_01/bmtnabf_1901-02-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3300,8 +3110,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c007"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c007" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00004"/>
@@ -3349,8 +3158,7 @@
 					</div>
 				</div>
 
-				<div ID="L.1.1.9" TYPE="TextContent" ORDER="7" DMDID="c011"
-					LABEL="ZUR IX AUSSTELLUNG">
+				<div ID="L.1.1.9" TYPE="TextContent" ORDER="7" DMDID="c011" LABEL="ZUR IX AUSSTELLUNG">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00004"/>
@@ -3373,24 +3181,21 @@
 							<div ID="L.1.1.9.4.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.9.4.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.9.4.1.3" TYPE="Paragraph" ORDER="3">
 								<div ID="L.1.1.9.4.1.3.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.9.4.1.4" TYPE="Paragraph" ORDER="4">
 								<div ID="L.1.1.9.4.1.4.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
 									</fptr>
 								</div>
 							</div>
@@ -3398,22 +3203,17 @@
 								<div ID="L.1.1.9.4.1.5.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c009"
-						LABEL="AUSSTELLUNGSPLACAT">
+					<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c009" LABEL="AUSSTELLUNGSPLACAT">
 						<div ID="L.1.1.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00001"/>
@@ -3435,8 +3235,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c010"
-						LABEL="KLINGER-SAAL">
+					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c010" LABEL="KLINGER-SAAL">
 						<div ID="L.1.1.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
@@ -3460,8 +3259,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="1" DMDID="c013"
-						LABEL="Untitled Image by K. Moser OM">
+					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="1" DMDID="c013" LABEL="Untitled Image by K. Moser OM">
 						<div ID="L.1.1.9.5.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00001"/>
@@ -3478,8 +3276,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c015"
-						LABEL="RAUMGESTALTUNG">
+					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c015" LABEL="RAUMGESTALTUNG">
 						<div ID="L.1.1.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -3586,8 +3383,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.6" TYPE="Illustration" ORDER="2" DMDID="c014"
-						LABEL="Untitled Image by K. Moser OM">
+					<div ID="L.1.1.9.6" TYPE="Illustration" ORDER="2" DMDID="c014" LABEL="Untitled Image by K. Moser OM">
 						<div ID="L.1.1.9.6.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00001"/>
@@ -3605,8 +3401,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c019"
-					LABEL="Aus &#34;Germinal&#34;">
+				<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c019" LABEL="Aus &#34;Germinal&#34;">
 					<div ID="L.1.1.14.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/03/01_01/bmtnabf_1901-03-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/03/01_01/bmtnabf_1901-03-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-03-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-03-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-03-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-03-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-03-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2949,367 +2943,180 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:01:33"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="77f4c0b0ed8e79da2dfb4a32732271c3f0c1ed87"
-				CHECKSUMTYPE="SHA-1" SIZE="6173206">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:01:33" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="77f4c0b0ed8e79da2dfb4a32732271c3f0c1ed87" CHECKSUMTYPE="SHA-1" SIZE="6173206">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:02:06"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="00eddeb7a1deb1dd435064f7f5614cad75205541"
-				CHECKSUMTYPE="SHA-1" SIZE="5948225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:02:06" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="00eddeb7a1deb1dd435064f7f5614cad75205541" CHECKSUMTYPE="SHA-1" SIZE="5948225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:02:44"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="887b816d4c76ce481b860fbfc9cf362aec5d1439"
-				CHECKSUMTYPE="SHA-1" SIZE="6173189">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:02:44" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="887b816d4c76ce481b860fbfc9cf362aec5d1439" CHECKSUMTYPE="SHA-1" SIZE="6173189">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:03:24"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="261e63a4737fa1b921ec005748fbb60bb627a73a"
-				CHECKSUMTYPE="SHA-1" SIZE="6185813">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:03:24" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="261e63a4737fa1b921ec005748fbb60bb627a73a" CHECKSUMTYPE="SHA-1" SIZE="6185813">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:04:03"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="6a6178a30edb6fc9a93e4c5a2f6ee425e5dd3fde"
-				CHECKSUMTYPE="SHA-1" SIZE="6145327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:04:03" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="6a6178a30edb6fc9a93e4c5a2f6ee425e5dd3fde" CHECKSUMTYPE="SHA-1" SIZE="6145327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:04:35"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="8c7d61f818c2f5e5b4e1ef70ae8605d18b0a20d0"
-				CHECKSUMTYPE="SHA-1" SIZE="6115625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:04:35" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="8c7d61f818c2f5e5b4e1ef70ae8605d18b0a20d0" CHECKSUMTYPE="SHA-1" SIZE="6115625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:05:10"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="3e5315fd5e8353d2877b3b6b32a4fc7c0ab22194"
-				CHECKSUMTYPE="SHA-1" SIZE="6152528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:05:10" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="3e5315fd5e8353d2877b3b6b32a4fc7c0ab22194" CHECKSUMTYPE="SHA-1" SIZE="6152528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:05:44"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="671a0f96eb8fb3cf8a39bcf8348f263bf2a19446"
-				CHECKSUMTYPE="SHA-1" SIZE="6115563">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:05:44" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="671a0f96eb8fb3cf8a39bcf8348f263bf2a19446" CHECKSUMTYPE="SHA-1" SIZE="6115563">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:06:17"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="c6dadc6ea9a629f0892154b40a904ec65e00c505"
-				CHECKSUMTYPE="SHA-1" SIZE="6151605">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:06:17" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="c6dadc6ea9a629f0892154b40a904ec65e00c505" CHECKSUMTYPE="SHA-1" SIZE="6151605">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:06:57"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="515b47052282328dce6814ed3965628b4fa8db5f"
-				CHECKSUMTYPE="SHA-1" SIZE="6115618">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:06:57" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="515b47052282328dce6814ed3965628b4fa8db5f" CHECKSUMTYPE="SHA-1" SIZE="6115618">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:07:32"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="aa5cb0b0ebacb473229b1c6f0878fe21d7c20726"
-				CHECKSUMTYPE="SHA-1" SIZE="6151619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:07:32" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="aa5cb0b0ebacb473229b1c6f0878fe21d7c20726" CHECKSUMTYPE="SHA-1" SIZE="6151619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:08:05"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="2761fea7992cdf3375964b8973541ec8cf2ba6de"
-				CHECKSUMTYPE="SHA-1" SIZE="6115626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:08:05" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="2761fea7992cdf3375964b8973541ec8cf2ba6de" CHECKSUMTYPE="SHA-1" SIZE="6115626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:08:38"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="0755d4d07a5c7d771fc8d6197fa6ccc5acd21b95"
-				CHECKSUMTYPE="SHA-1" SIZE="6151617">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:08:38" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="0755d4d07a5c7d771fc8d6197fa6ccc5acd21b95" CHECKSUMTYPE="SHA-1" SIZE="6151617">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:09:13"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="a47e02e6b38e1d7d1c1c85a37b97d9cd68896a6c"
-				CHECKSUMTYPE="SHA-1" SIZE="6115626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:09:13" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="a47e02e6b38e1d7d1c1c85a37b97d9cd68896a6c" CHECKSUMTYPE="SHA-1" SIZE="6115626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:09:47"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="49667865d23a33cc2344b13f2de6d2cbcbd4aafc"
-				CHECKSUMTYPE="SHA-1" SIZE="6151604">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:09:47" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="49667865d23a33cc2344b13f2de6d2cbcbd4aafc" CHECKSUMTYPE="SHA-1" SIZE="6151604">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:10:20"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="25e5ed27219c3c6d42f45c540e06c19a092e0651"
-				CHECKSUMTYPE="SHA-1" SIZE="6115622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:10:20" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="25e5ed27219c3c6d42f45c540e06c19a092e0651" CHECKSUMTYPE="SHA-1" SIZE="6115622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:10:53"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="cabfc7667c08f6386c934f0e756de36cfeebe2c2"
-				CHECKSUMTYPE="SHA-1" SIZE="6151623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:10:53" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="cabfc7667c08f6386c934f0e756de36cfeebe2c2" CHECKSUMTYPE="SHA-1" SIZE="6151623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:11:29"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="51f6ed3058dd5af10f0fe8d45707424705f7863f"
-				CHECKSUMTYPE="SHA-1" SIZE="6115628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:11:29" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="51f6ed3058dd5af10f0fe8d45707424705f7863f" CHECKSUMTYPE="SHA-1" SIZE="6115628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:12:03"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="a0e1a2b8bdde884e774e6fa92a894802fc1e4c4b"
-				CHECKSUMTYPE="SHA-1" SIZE="6152527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:12:03" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="a0e1a2b8bdde884e774e6fa92a894802fc1e4c4b" CHECKSUMTYPE="SHA-1" SIZE="6152527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:12:36"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="dee846082d9d980ecc00f0d9ee7404e076b39794"
-				CHECKSUMTYPE="SHA-1" SIZE="6115625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:12:36" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="dee846082d9d980ecc00f0d9ee7404e076b39794" CHECKSUMTYPE="SHA-1" SIZE="6115625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:13:08"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="c5c1cf324b7989dff5ee4f5a427152e71933078f"
-				CHECKSUMTYPE="SHA-1" SIZE="6152443">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:13:08" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="c5c1cf324b7989dff5ee4f5a427152e71933078f" CHECKSUMTYPE="SHA-1" SIZE="6152443">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:13:41"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="cea3aae33cbd74be44365dfec86e7ad85073c022"
-				CHECKSUMTYPE="SHA-1" SIZE="6115623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:13:41" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="cea3aae33cbd74be44365dfec86e7ad85073c022" CHECKSUMTYPE="SHA-1" SIZE="6115623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:14:15"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="65de202739ebf98e20d3175dc7a7074e60a66b2d"
-				CHECKSUMTYPE="SHA-1" SIZE="6152519">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:14:15" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="65de202739ebf98e20d3175dc7a7074e60a66b2d" CHECKSUMTYPE="SHA-1" SIZE="6152519">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:14:49"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="07eb2fcc39e5798084f5917819259a6bec4f7be2"
-				CHECKSUMTYPE="SHA-1" SIZE="6115566">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:14:49" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="07eb2fcc39e5798084f5917819259a6bec4f7be2" CHECKSUMTYPE="SHA-1" SIZE="6115566">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:15:23"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="4e7f1e177f498b9188f54ffa445dac36881c8403"
-				CHECKSUMTYPE="SHA-1" SIZE="6152527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:15:23" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="4e7f1e177f498b9188f54ffa445dac36881c8403" CHECKSUMTYPE="SHA-1" SIZE="6152527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:15:59"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ea835979b6956be3a4dd60067ecdf0fb1ef4a2d8"
-				CHECKSUMTYPE="SHA-1" SIZE="6164229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:15:59" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ea835979b6956be3a4dd60067ecdf0fb1ef4a2d8" CHECKSUMTYPE="SHA-1" SIZE="6164229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:16:36"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="6df28e04e2c01ebfc097818afe5ec3d59022ac47"
-				CHECKSUMTYPE="SHA-1" SIZE="6105729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:16:36" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="6df28e04e2c01ebfc097818afe5ec3d59022ac47" CHECKSUMTYPE="SHA-1" SIZE="6105729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:17:10"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="7d699e88bdad477d1c3288e7c73fef39c4c8bde6"
-				CHECKSUMTYPE="SHA-1" SIZE="6164220">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:17:10" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="7d699e88bdad477d1c3288e7c73fef39c4c8bde6" CHECKSUMTYPE="SHA-1" SIZE="6164220">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/delivery/bmtnabf_1901-03-01_01_0028.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:17:31" MIMETYPE="text/xml"
-				CHECKSUM="4127a7284d1c2d9e5f98651a7b94f2421d74c007" CHECKSUMTYPE="SHA-1" SIZE="5412">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:17:31" MIMETYPE="text/xml" CHECKSUM="4127a7284d1c2d9e5f98651a7b94f2421d74c007" CHECKSUMTYPE="SHA-1" SIZE="5412">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:17:31" MIMETYPE="text/xml"
-				CHECKSUM="c0df1b0cce9f33fabaf90afdbaf04f372f4c8703" CHECKSUMTYPE="SHA-1"
-				SIZE="43073">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:17:31" MIMETYPE="text/xml" CHECKSUM="c0df1b0cce9f33fabaf90afdbaf04f372f4c8703" CHECKSUMTYPE="SHA-1" SIZE="43073">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:17:31" MIMETYPE="text/xml"
-				CHECKSUM="b8a544f54eef19d74b8cf9ec174ec43a65f9484e" CHECKSUMTYPE="SHA-1" SIZE="9740">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:17:31" MIMETYPE="text/xml" CHECKSUM="b8a544f54eef19d74b8cf9ec174ec43a65f9484e" CHECKSUMTYPE="SHA-1" SIZE="9740">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:17:31" MIMETYPE="text/xml"
-				CHECKSUM="70b50143dd7624352515f94169696b8bc45fb9a0" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:17:31" MIMETYPE="text/xml" CHECKSUM="70b50143dd7624352515f94169696b8bc45fb9a0" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:17:32" MIMETYPE="text/xml"
-				CHECKSUM="bf247368a48591b60aa766000f1ce4e6a3824d19" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:17:32" MIMETYPE="text/xml" CHECKSUM="bf247368a48591b60aa766000f1ce4e6a3824d19" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:17:32" MIMETYPE="text/xml"
-				CHECKSUM="47bb54f786fbd4d610d498df969a66ee092b33c1" CHECKSUMTYPE="SHA-1" SIZE="2105">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:17:32" MIMETYPE="text/xml" CHECKSUM="47bb54f786fbd4d610d498df969a66ee092b33c1" CHECKSUMTYPE="SHA-1" SIZE="2105">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:17:32" MIMETYPE="text/xml"
-				CHECKSUM="23beea335783fb205f5c36b2109d0cd158b71e00" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:17:32" MIMETYPE="text/xml" CHECKSUM="23beea335783fb205f5c36b2109d0cd158b71e00" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:17:32" MIMETYPE="text/xml"
-				CHECKSUM="af1b744777f6c0b2e2d082e49c48114d1c2530a6" CHECKSUMTYPE="SHA-1" SIZE="3801">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:17:32" MIMETYPE="text/xml" CHECKSUM="af1b744777f6c0b2e2d082e49c48114d1c2530a6" CHECKSUMTYPE="SHA-1" SIZE="3801">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:17:33" MIMETYPE="text/xml"
-				CHECKSUM="9a25138a11b3293a0e94718c4d348cc44e79fc65" CHECKSUMTYPE="SHA-1"
-				SIZE="22992">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:17:33" MIMETYPE="text/xml" CHECKSUM="9a25138a11b3293a0e94718c4d348cc44e79fc65" CHECKSUMTYPE="SHA-1" SIZE="22992">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:17:33" MIMETYPE="text/xml"
-				CHECKSUM="ec5cd60df2e846ee55cf7c0c4a6dcb9a936abf19" CHECKSUMTYPE="SHA-1"
-				SIZE="40880">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:17:33" MIMETYPE="text/xml" CHECKSUM="ec5cd60df2e846ee55cf7c0c4a6dcb9a936abf19" CHECKSUMTYPE="SHA-1" SIZE="40880">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:17:33" MIMETYPE="text/xml"
-				CHECKSUM="4e07d435489fe37a318d4db9839fa1b0529d40a3" CHECKSUMTYPE="SHA-1"
-				SIZE="44688">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:17:33" MIMETYPE="text/xml" CHECKSUM="4e07d435489fe37a318d4db9839fa1b0529d40a3" CHECKSUMTYPE="SHA-1" SIZE="44688">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:17:33" MIMETYPE="text/xml"
-				CHECKSUM="373a295848bd3eb3f2a881bedd9ca4d5a8d3b276" CHECKSUMTYPE="SHA-1"
-				SIZE="42432">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:17:33" MIMETYPE="text/xml" CHECKSUM="373a295848bd3eb3f2a881bedd9ca4d5a8d3b276" CHECKSUMTYPE="SHA-1" SIZE="42432">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:17:34" MIMETYPE="text/xml"
-				CHECKSUM="24dc1b5a075be325e1e35cfad476d6b49db50640" CHECKSUMTYPE="SHA-1"
-				SIZE="43136">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:17:34" MIMETYPE="text/xml" CHECKSUM="24dc1b5a075be325e1e35cfad476d6b49db50640" CHECKSUMTYPE="SHA-1" SIZE="43136">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:17:34" MIMETYPE="text/xml"
-				CHECKSUM="2b24731f75d9315084c0d72704cad83b26cdafd7" CHECKSUMTYPE="SHA-1"
-				SIZE="43854">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:17:34" MIMETYPE="text/xml" CHECKSUM="2b24731f75d9315084c0d72704cad83b26cdafd7" CHECKSUMTYPE="SHA-1" SIZE="43854">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:17:34" MIMETYPE="text/xml"
-				CHECKSUM="2622274c64ca6651b50140ad1386945c1dde4229" CHECKSUMTYPE="SHA-1"
-				SIZE="45017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:17:34" MIMETYPE="text/xml" CHECKSUM="2622274c64ca6651b50140ad1386945c1dde4229" CHECKSUMTYPE="SHA-1" SIZE="45017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:17:35" MIMETYPE="text/xml"
-				CHECKSUM="8c99e7e0deb5bcb12139f9d8dd7a2b3ac243f1f2" CHECKSUMTYPE="SHA-1"
-				SIZE="44794">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:17:35" MIMETYPE="text/xml" CHECKSUM="8c99e7e0deb5bcb12139f9d8dd7a2b3ac243f1f2" CHECKSUMTYPE="SHA-1" SIZE="44794">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:17:35" MIMETYPE="text/xml"
-				CHECKSUM="960a380996b9db6d8f8fcb7debb766cedc0af279" CHECKSUMTYPE="SHA-1"
-				SIZE="40701">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:17:35" MIMETYPE="text/xml" CHECKSUM="960a380996b9db6d8f8fcb7debb766cedc0af279" CHECKSUMTYPE="SHA-1" SIZE="40701">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:17:35" MIMETYPE="text/xml"
-				CHECKSUM="ba4272289f0e4ceb8847607982437a4e0b6b2759" CHECKSUMTYPE="SHA-1"
-				SIZE="47960">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:17:35" MIMETYPE="text/xml" CHECKSUM="ba4272289f0e4ceb8847607982437a4e0b6b2759" CHECKSUMTYPE="SHA-1" SIZE="47960">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:17:35" MIMETYPE="text/xml"
-				CHECKSUM="a66673fe61a48060658def68018f1a53f3178b53" CHECKSUMTYPE="SHA-1"
-				SIZE="42834">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:17:35" MIMETYPE="text/xml" CHECKSUM="a66673fe61a48060658def68018f1a53f3178b53" CHECKSUMTYPE="SHA-1" SIZE="42834">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:17:36" MIMETYPE="text/xml"
-				CHECKSUM="1a70bdaeacdbbe13f40a2d861b9753dbbea65d40" CHECKSUMTYPE="SHA-1"
-				SIZE="27455">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:17:36" MIMETYPE="text/xml" CHECKSUM="1a70bdaeacdbbe13f40a2d861b9753dbbea65d40" CHECKSUMTYPE="SHA-1" SIZE="27455">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:17:36" MIMETYPE="text/xml"
-				CHECKSUM="13d16f295706f11cc3cc0160716b5a1d95b8c62f" CHECKSUMTYPE="SHA-1" SIZE="3747">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:17:36" MIMETYPE="text/xml" CHECKSUM="13d16f295706f11cc3cc0160716b5a1d95b8c62f" CHECKSUMTYPE="SHA-1" SIZE="3747">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:17:37" MIMETYPE="text/xml"
-				CHECKSUM="cead3caae8371af02609edbc5981a37d58cb6e0b" CHECKSUMTYPE="SHA-1" SIZE="2019">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:17:37" MIMETYPE="text/xml" CHECKSUM="cead3caae8371af02609edbc5981a37d58cb6e0b" CHECKSUMTYPE="SHA-1" SIZE="2019">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:17:38" MIMETYPE="text/xml"
-				CHECKSUM="9675b5e25a74276ff0f84d97fa03a3ae4e5f6148" CHECKSUMTYPE="SHA-1" SIZE="2406">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:17:38" MIMETYPE="text/xml" CHECKSUM="9675b5e25a74276ff0f84d97fa03a3ae4e5f6148" CHECKSUMTYPE="SHA-1" SIZE="2406">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:17:39" MIMETYPE="text/xml"
-				CHECKSUM="5cfe07bad8bc1a3d18fab0b95e7422e8e7c15390" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:17:39" MIMETYPE="text/xml" CHECKSUM="5cfe07bad8bc1a3d18fab0b95e7422e8e7c15390" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:17:39" MIMETYPE="text/xml"
-				CHECKSUM="56d95370b256efda7a4cfa25446b429f7ebe8dc9" CHECKSUMTYPE="SHA-1" SIZE="8256">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:17:39" MIMETYPE="text/xml" CHECKSUM="56d95370b256efda7a4cfa25446b429f7ebe8dc9" CHECKSUMTYPE="SHA-1" SIZE="8256">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:17:39" MIMETYPE="text/xml"
-				CHECKSUM="d9fa87bfea9bfb5f7a8854240d9463da2c725f3d" CHECKSUMTYPE="SHA-1"
-				SIZE="33813">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:17:39" MIMETYPE="text/xml" CHECKSUM="d9fa87bfea9bfb5f7a8854240d9463da2c725f3d" CHECKSUMTYPE="SHA-1" SIZE="33813">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:17:39" MIMETYPE="text/xml"
-				CHECKSUM="d7cbc98b4246096e42401408b4b5c8726953b7ba" CHECKSUMTYPE="SHA-1"
-				SIZE="32093">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:17:39" MIMETYPE="text/xml" CHECKSUM="d7cbc98b4246096e42401408b4b5c8726953b7ba" CHECKSUMTYPE="SHA-1" SIZE="32093">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:17:40" MIMETYPE="text/xml"
-				CHECKSUM="1f983022035da13a5bf718ca7c0063f16110d532" CHECKSUMTYPE="SHA-1" SIZE="7922">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:17:40" MIMETYPE="text/xml" CHECKSUM="1f983022035da13a5bf718ca7c0063f16110d532" CHECKSUMTYPE="SHA-1" SIZE="7922">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-01_01_0028.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:18:12" MIMETYPE="application/pdf"
-				CHECKSUM="6fb5764efa400dc180e0702652cb56595f2f129b" CHECKSUMTYPE="SHA-1"
-				SIZE="8507459">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/bmtnabf_1901-03-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:18:12" MIMETYPE="application/pdf" CHECKSUM="6fb5764efa400dc180e0702652cb56595f2f129b" CHECKSUMTYPE="SHA-1" SIZE="8507459">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/01_01/bmtnabf_1901-03-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3544,8 +3351,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 5 01.03.1901">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by R. Jettmar OM">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by R. Jettmar OM">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<seq>
@@ -3606,8 +3412,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="3" DMDID="c009"
-					LABEL="Untitled Image by LUDW. SIGMUNDT OM">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="3" DMDID="c009" LABEL="Untitled Image by LUDW. SIGMUNDT OM">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00001"/>
@@ -3624,15 +3429,13 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="TextContent" ORDER="4" DMDID="c010"
-					LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.8" TYPE="TextContent" ORDER="4" DMDID="c010" LABEL="MITTHEILUNGEN DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00001"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.8.2" TYPE="Illustration" ORDER="1" DMDID="c011"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.8.2" TYPE="Illustration" ORDER="1" DMDID="c011" LABEL="Untitled Image">
 						<div ID="L.1.1.8.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00002"/>
@@ -3650,8 +3453,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.8.4" TYPE="Illustration" ORDER="1" DMDID="c012"
-						LABEL="Untitled Image by L. v. Hofmann CM">
+					<div ID="L.1.1.8.4" TYPE="Illustration" ORDER="1" DMDID="c012" LABEL="Untitled Image by L. v. Hofmann CM">
 						<div ID="L.1.1.8.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
@@ -3669,8 +3471,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="TextContent" ORDER="5" DMDID="c013"
-					LABEL="FABRIK LEBENSLUSTIGER CREATUREN">
+				<div ID="L.1.1.9" TYPE="TextContent" ORDER="5" DMDID="c013" LABEL="FABRIK LEBENSLUSTIGER CREATUREN">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -3681,8 +3482,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00005"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.9.3" TYPE="Illustration" ORDER="1" DMDID="c014"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.9.3" TYPE="Illustration" ORDER="1" DMDID="c014" LABEL="Untitled Image">
 						<div ID="L.1.1.9.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00002"/>
@@ -3694,8 +3494,7 @@
 							<div ID="L.1.1.9.4.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.9.4.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
 									</fptr>
 								</div>
 							</div>
@@ -3703,64 +3502,38 @@
 								<div ID="L.1.1.9.4.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00007"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00008"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00009"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00008"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00009"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="1" DMDID="c015"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.9.5" TYPE="Illustration" ORDER="1" DMDID="c015" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.9.5.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00005"/>
@@ -3772,8 +3545,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.6" TYPE="Illustration" ORDER="2" DMDID="c016"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.9.6" TYPE="Illustration" ORDER="2" DMDID="c016" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.9.6.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00010"/>
@@ -3785,8 +3557,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.7" TYPE="Illustration" ORDER="3" DMDID="c017"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.9.7" TYPE="Illustration" ORDER="3" DMDID="c017" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.9.7.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00011"/>
@@ -3798,8 +3569,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.8" TYPE="Illustration" ORDER="4" DMDID="c018"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.9.8" TYPE="Illustration" ORDER="4" DMDID="c018" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.9.8.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00012"/>
@@ -3811,8 +3581,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.9" TYPE="Illustration" ORDER="5" DMDID="c019"
-						LABEL="Untitled Image by A. Böhm OM">
+					<div ID="L.1.1.9.9" TYPE="Illustration" ORDER="5" DMDID="c019" LABEL="Untitled Image by A. Böhm OM">
 						<div ID="L.1.1.9.9.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
@@ -3824,8 +3593,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.10" TYPE="Illustration" ORDER="6" DMDID="c020"
-						LABEL="Untitled Image by A. Roller OM">
+					<div ID="L.1.1.9.10" TYPE="Illustration" ORDER="6" DMDID="c020" LABEL="Untitled Image by A. Roller OM">
 						<div ID="L.1.1.9.10.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00004"/>
@@ -3846,8 +3614,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.9.11" TYPE="Illustration" ORDER="7" DMDID="c022"
-						LABEL="Untitled Image by F. König OM">
+					<div ID="L.1.1.9.11" TYPE="Illustration" ORDER="7" DMDID="c022" LABEL="Untitled Image by F. König OM">
 						<div ID="L.1.1.9.11.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
@@ -3868,8 +3635,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.9.12" TYPE="Illustration" ORDER="8" DMDID="c024"
-						LABEL="Untitled Image by A. Böhm OM">
+					<div ID="L.1.1.9.12" TYPE="Illustration" ORDER="8" DMDID="c024" LABEL="Untitled Image by A. Böhm OM">
 						<div ID="L.1.1.9.12.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
@@ -3881,8 +3647,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.13" TYPE="Illustration" ORDER="9" DMDID="c025"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.9.13" TYPE="Illustration" ORDER="9" DMDID="c025" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.9.13.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
@@ -3894,8 +3659,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.14" TYPE="Illustration" ORDER="10" DMDID="c026"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.9.14" TYPE="Illustration" ORDER="10" DMDID="c026" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.9.14.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
@@ -3907,8 +3671,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.15" TYPE="Illustration" ORDER="11" DMDID="c027"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.9.15" TYPE="Illustration" ORDER="11" DMDID="c027" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.9.15.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00005"/>
@@ -3920,8 +3683,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.16" TYPE="Illustration" ORDER="12" DMDID="c028"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.9.16" TYPE="Illustration" ORDER="12" DMDID="c028" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.9.16.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"/>
@@ -3933,8 +3695,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.17" TYPE="Illustration" ORDER="13" DMDID="c029"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.9.17" TYPE="Illustration" ORDER="13" DMDID="c029" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.9.17.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00005"/>
@@ -3946,8 +3707,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.18" TYPE="Illustration" ORDER="14" DMDID="c030"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.9.18" TYPE="Illustration" ORDER="14" DMDID="c030" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.9.18.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00006"/>
@@ -3959,8 +3719,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.19" TYPE="Illustration" ORDER="15" DMDID="c031"
-						LABEL="Untitled Image by Ch. Hampel">
+					<div ID="L.1.1.9.19" TYPE="Illustration" ORDER="15" DMDID="c031" LABEL="Untitled Image by Ch. Hampel">
 						<div ID="L.1.1.9.19.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
@@ -3972,8 +3731,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.20" TYPE="Illustration" ORDER="16" DMDID="c032"
-						LABEL="Untitled Image by L. Bauer OM">
+					<div ID="L.1.1.9.20" TYPE="Illustration" ORDER="16" DMDID="c032" LABEL="Untitled Image by L. Bauer OM">
 						<div ID="L.1.1.9.20.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"/>
@@ -3994,8 +3752,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.9.21" TYPE="Illustration" ORDER="17" DMDID="c034"
-						LABEL="Untitled Image by J. Hoffmann OM">
+					<div ID="L.1.1.9.21" TYPE="Illustration" ORDER="17" DMDID="c034" LABEL="Untitled Image by J. Hoffmann OM">
 						<div ID="L.1.1.9.21.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
@@ -4007,8 +3764,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.22" TYPE="Illustration" ORDER="18" DMDID="c035"
-						LABEL="Untitled Image by A. Böhm OM">
+					<div ID="L.1.1.9.22" TYPE="Illustration" ORDER="18" DMDID="c035" LABEL="Untitled Image by A. Böhm OM">
 						<div ID="L.1.1.9.22.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00004"/>
@@ -4029,8 +3785,7 @@
 							</div>
 						
 					</div>
-					<div ID="L.1.1.9.23" TYPE="Illustration" ORDER="19" DMDID="c037"
-						LABEL="Untitled Image by W. List OM">
+					<div ID="L.1.1.9.23" TYPE="Illustration" ORDER="19" DMDID="c037" LABEL="Untitled Image by W. List OM">
 						<div ID="L.1.1.9.23.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00005"/>
@@ -4042,8 +3797,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.24" TYPE="Illustration" ORDER="20" DMDID="c038"
-						LABEL="Untitled Image by L. Bauer OM">
+					<div ID="L.1.1.9.24" TYPE="Illustration" ORDER="20" DMDID="c038" LABEL="Untitled Image by L. Bauer OM">
 						<div ID="L.1.1.9.24.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00006"/>
@@ -4055,8 +3809,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.25" TYPE="Illustration" ORDER="21" DMDID="c039"
-						LABEL="Untitled Image by W. List OM">
+					<div ID="L.1.1.9.25" TYPE="Illustration" ORDER="21" DMDID="c039" LABEL="Untitled Image by W. List OM">
 						<div ID="L.1.1.9.25.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00005"/>
@@ -4068,8 +3821,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.26" TYPE="Illustration" ORDER="22" DMDID="c040"
-						LABEL="Untitled Image by W. List OM">
+					<div ID="L.1.1.9.26" TYPE="Illustration" ORDER="22" DMDID="c040" LABEL="Untitled Image by W. List OM">
 						<div ID="L.1.1.9.26.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00006"/>
@@ -4081,8 +3833,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.27" TYPE="Illustration" ORDER="23" DMDID="c041"
-						LABEL="Untitled Image by A. Böhm OM">
+					<div ID="L.1.1.9.27" TYPE="Illustration" ORDER="23" DMDID="c041" LABEL="Untitled Image by A. Böhm OM">
 						<div ID="L.1.1.9.27.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00006"/>
@@ -4094,8 +3845,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9.28" TYPE="Illustration" ORDER="24" DMDID="c042"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.9.28" TYPE="Illustration" ORDER="24" DMDID="c042" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.9.28.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00007"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/03/15_01/bmtnabf_1901-03-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/03/15_01/bmtnabf_1901-03-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-03-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-03-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-03-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-03-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-03-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2760,356 +2754,180 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:01:58"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="714eb8de0b1b86ee4d098feca1f410156f3e756e"
-				CHECKSUMTYPE="SHA-1" SIZE="6159724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:01:58" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="714eb8de0b1b86ee4d098feca1f410156f3e756e" CHECKSUMTYPE="SHA-1" SIZE="6159724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:02:33"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="d9d612a4fb989961e99089ab454e29b87de86026"
-				CHECKSUMTYPE="SHA-1" SIZE="6161526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:02:33" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="d9d612a4fb989961e99089ab454e29b87de86026" CHECKSUMTYPE="SHA-1" SIZE="6161526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:03:10"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="885769ecb816e3a3b46f91839229f1a12eab16e6"
-				CHECKSUMTYPE="SHA-1" SIZE="6159722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:03:10" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="885769ecb816e3a3b46f91839229f1a12eab16e6" CHECKSUMTYPE="SHA-1" SIZE="6159722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:03:53"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="01aef715f3a5d510a3ccf2af4fd1e4ce65fe62d0"
-				CHECKSUMTYPE="SHA-1" SIZE="6161510">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:03:53" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="01aef715f3a5d510a3ccf2af4fd1e4ce65fe62d0" CHECKSUMTYPE="SHA-1" SIZE="6161510">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:04:35"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="cf253adad7068345d3f7cb51657211d7241d601f"
-				CHECKSUMTYPE="SHA-1" SIZE="6159724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:04:35" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="cf253adad7068345d3f7cb51657211d7241d601f" CHECKSUMTYPE="SHA-1" SIZE="6159724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:05:06"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="80b0abd6839e64f56e250583f0cb59764fb1afae"
-				CHECKSUMTYPE="SHA-1" SIZE="6160606">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:05:06" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="80b0abd6839e64f56e250583f0cb59764fb1afae" CHECKSUMTYPE="SHA-1" SIZE="6160606">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:05:44"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="67c6aa91045c2031c216002f472282b0d94250ed"
-				CHECKSUMTYPE="SHA-1" SIZE="6159708">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:05:44" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="67c6aa91045c2031c216002f472282b0d94250ed" CHECKSUMTYPE="SHA-1" SIZE="6159708">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:06:17"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a99b01fbfbf7fd7d1f33c297ca99457b68c0d625"
-				CHECKSUMTYPE="SHA-1" SIZE="6206525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:06:17" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a99b01fbfbf7fd7d1f33c297ca99457b68c0d625" CHECKSUMTYPE="SHA-1" SIZE="6206525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:06:56"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="75159516a68a649441737a3bde946113c16b9c65"
-				CHECKSUMTYPE="SHA-1" SIZE="6101209">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:06:56" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="75159516a68a649441737a3bde946113c16b9c65" CHECKSUMTYPE="SHA-1" SIZE="6101209">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:07:32"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="4513099131ba1e3e2062020d19de45a2225341ea"
-				CHECKSUMTYPE="SHA-1" SIZE="6207408">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:07:32" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="4513099131ba1e3e2062020d19de45a2225341ea" CHECKSUMTYPE="SHA-1" SIZE="6207408">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:08:05"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="dae7431eec77f14e4e79a2fb3ce06a192ae11e3f"
-				CHECKSUMTYPE="SHA-1" SIZE="6101176">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:08:05" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="dae7431eec77f14e4e79a2fb3ce06a192ae11e3f" CHECKSUMTYPE="SHA-1" SIZE="6101176">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:08:36"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="a87847bfd9e1c899dc213436656880299d5c6d03"
-				CHECKSUMTYPE="SHA-1" SIZE="6207423">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:08:36" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="a87847bfd9e1c899dc213436656880299d5c6d03" CHECKSUMTYPE="SHA-1" SIZE="6207423">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:09:09"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="72565b3a89f570e43c473ac70638318ce947f798"
-				CHECKSUMTYPE="SHA-1" SIZE="6101225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:09:09" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="72565b3a89f570e43c473ac70638318ce947f798" CHECKSUMTYPE="SHA-1" SIZE="6101225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:09:42"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="47c53b5f88d74c39380b917c2e96ebe76666cb45"
-				CHECKSUMTYPE="SHA-1" SIZE="6207360">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:09:42" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="47c53b5f88d74c39380b917c2e96ebe76666cb45" CHECKSUMTYPE="SHA-1" SIZE="6207360">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:10:17"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="61314637d44eb24af7a0c5fe6520b8fd0a519a3b"
-				CHECKSUMTYPE="SHA-1" SIZE="6100321">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:10:17" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="61314637d44eb24af7a0c5fe6520b8fd0a519a3b" CHECKSUMTYPE="SHA-1" SIZE="6100321">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:10:53"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="2b9bac5d329fc762cd30cb2c1499eabd1fa7d29b"
-				CHECKSUMTYPE="SHA-1" SIZE="6207428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:10:53" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="2b9bac5d329fc762cd30cb2c1499eabd1fa7d29b" CHECKSUMTYPE="SHA-1" SIZE="6207428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:11:30"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="0be67273a28352e6b64c67603999aecdc9c8a594"
-				CHECKSUMTYPE="SHA-1" SIZE="6100323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:11:30" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="0be67273a28352e6b64c67603999aecdc9c8a594" CHECKSUMTYPE="SHA-1" SIZE="6100323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:12:07"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="205e25d394928fb9f24882ece821f7fcd97c4871"
-				CHECKSUMTYPE="SHA-1" SIZE="6207417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:12:07" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="205e25d394928fb9f24882ece821f7fcd97c4871" CHECKSUMTYPE="SHA-1" SIZE="6207417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:12:42"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="0d04814004d50c8316e9e8a95e65f725d2341755"
-				CHECKSUMTYPE="SHA-1" SIZE="6100307">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:12:42" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="0d04814004d50c8316e9e8a95e65f725d2341755" CHECKSUMTYPE="SHA-1" SIZE="6100307">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:13:17"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="253579d280e2427738f12dbe2eb79f59a25d2477"
-				CHECKSUMTYPE="SHA-1" SIZE="6207395">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:13:17" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="253579d280e2427738f12dbe2eb79f59a25d2477" CHECKSUMTYPE="SHA-1" SIZE="6207395">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:13:50"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="ec52821aad7d9d60e985c7852d29a097cca9fd95"
-				CHECKSUMTYPE="SHA-1" SIZE="6101223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:13:50" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="ec52821aad7d9d60e985c7852d29a097cca9fd95" CHECKSUMTYPE="SHA-1" SIZE="6101223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:14:25"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="647bc3ec75ee5456ec862de416aa44af76dffa8a"
-				CHECKSUMTYPE="SHA-1" SIZE="6207422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:14:25" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="647bc3ec75ee5456ec862de416aa44af76dffa8a" CHECKSUMTYPE="SHA-1" SIZE="6207422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:14:57"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="12c375dd56dba00de871d160318d705122cdeb33"
-				CHECKSUMTYPE="SHA-1" SIZE="6101217">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:14:57" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="12c375dd56dba00de871d160318d705122cdeb33" CHECKSUMTYPE="SHA-1" SIZE="6101217">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:15:30"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="1dd131a09d4e8508fe28af98d5a5f1c501983d56"
-				CHECKSUMTYPE="SHA-1" SIZE="6207417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:15:30" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="1dd131a09d4e8508fe28af98d5a5f1c501983d56" CHECKSUMTYPE="SHA-1" SIZE="6207417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:16:05"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="f85f2f5409c22a5f91591f42d626ffc315b02b21"
-				CHECKSUMTYPE="SHA-1" SIZE="6101227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:16:05" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="f85f2f5409c22a5f91591f42d626ffc315b02b21" CHECKSUMTYPE="SHA-1" SIZE="6101227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:16:37"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="25d43f3e46f261a5baff02b6f70c4a5ff59d9132"
-				CHECKSUMTYPE="SHA-1" SIZE="6256920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:16:37" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="25d43f3e46f261a5baff02b6f70c4a5ff59d9132" CHECKSUMTYPE="SHA-1" SIZE="6256920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:17:11"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="cbbbe8569d596b10364142b13a5151a54db31016"
-				CHECKSUMTYPE="SHA-1" SIZE="6031924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:17:11" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="cbbbe8569d596b10364142b13a5151a54db31016" CHECKSUMTYPE="SHA-1" SIZE="6031924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:17:49"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="5d631d24d1e747a94dff01a0edc9ca950015f80e"
-				CHECKSUMTYPE="SHA-1" SIZE="6184926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:17:49" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="5d631d24d1e747a94dff01a0edc9ca950015f80e" CHECKSUMTYPE="SHA-1" SIZE="6184926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/delivery/bmtnabf_1901-03-15_01_0028.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:18:10" MIMETYPE="text/xml"
-				CHECKSUM="e779ec763ca77fed33808437680dad5d010a97a2" CHECKSUMTYPE="SHA-1" SIZE="5004">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:18:10" MIMETYPE="text/xml" CHECKSUM="e779ec763ca77fed33808437680dad5d010a97a2" CHECKSUMTYPE="SHA-1" SIZE="5004">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:18:10" MIMETYPE="text/xml"
-				CHECKSUM="985164904cba36676733c665e65be5aa2790fadb" CHECKSUMTYPE="SHA-1"
-				SIZE="24586">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:18:10" MIMETYPE="text/xml" CHECKSUM="985164904cba36676733c665e65be5aa2790fadb" CHECKSUMTYPE="SHA-1" SIZE="24586">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:18:11" MIMETYPE="text/xml"
-				CHECKSUM="d973213deac6353d6b0ebb1e3dbe255443e22931" CHECKSUMTYPE="SHA-1"
-				SIZE="10158">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:18:11" MIMETYPE="text/xml" CHECKSUM="d973213deac6353d6b0ebb1e3dbe255443e22931" CHECKSUMTYPE="SHA-1" SIZE="10158">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:18:11" MIMETYPE="text/xml"
-				CHECKSUM="3e6fe07e2bc88c784f22e2a3814c5a1d0bc49e8b" CHECKSUMTYPE="SHA-1" SIZE="2001">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:18:11" MIMETYPE="text/xml" CHECKSUM="3e6fe07e2bc88c784f22e2a3814c5a1d0bc49e8b" CHECKSUMTYPE="SHA-1" SIZE="2001">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:18:11" MIMETYPE="text/xml"
-				CHECKSUM="961f1b1e10d9f9c8716cf7433baa910f9d075d9c" CHECKSUMTYPE="SHA-1" SIZE="2397">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:18:11" MIMETYPE="text/xml" CHECKSUM="961f1b1e10d9f9c8716cf7433baa910f9d075d9c" CHECKSUMTYPE="SHA-1" SIZE="2397">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:18:11" MIMETYPE="text/xml"
-				CHECKSUM="9ada9f666d3dec0165ee71236e2f86d4fc9f51bd" CHECKSUMTYPE="SHA-1" SIZE="2397">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:18:11" MIMETYPE="text/xml" CHECKSUM="9ada9f666d3dec0165ee71236e2f86d4fc9f51bd" CHECKSUMTYPE="SHA-1" SIZE="2397">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:18:12" MIMETYPE="text/xml"
-				CHECKSUM="d07aed0c00ffa00e346ae7c9aa205a524d51a9f7" CHECKSUMTYPE="SHA-1" SIZE="2009">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:18:12" MIMETYPE="text/xml" CHECKSUM="d07aed0c00ffa00e346ae7c9aa205a524d51a9f7" CHECKSUMTYPE="SHA-1" SIZE="2009">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:18:12" MIMETYPE="text/xml"
-				CHECKSUM="1cec6b5e5c23f02c048232e69d765927bf1eb609" CHECKSUMTYPE="SHA-1" SIZE="4893">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:18:12" MIMETYPE="text/xml" CHECKSUM="1cec6b5e5c23f02c048232e69d765927bf1eb609" CHECKSUMTYPE="SHA-1" SIZE="4893">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:18:12" MIMETYPE="text/xml"
-				CHECKSUM="ea195625b396faf1d135034fd01967f9acaa9e78" CHECKSUMTYPE="SHA-1" SIZE="7985">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:18:12" MIMETYPE="text/xml" CHECKSUM="ea195625b396faf1d135034fd01967f9acaa9e78" CHECKSUMTYPE="SHA-1" SIZE="7985">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:18:12" MIMETYPE="text/xml"
-				CHECKSUM="664d3fd37dffdf268cfe53b49869cd83408ac3f4" CHECKSUMTYPE="SHA-1" SIZE="3742">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:18:12" MIMETYPE="text/xml" CHECKSUM="664d3fd37dffdf268cfe53b49869cd83408ac3f4" CHECKSUMTYPE="SHA-1" SIZE="3742">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:18:13" MIMETYPE="text/xml"
-				CHECKSUM="ba445b6628e906f5f57fde8e33b21e5607b48ff7" CHECKSUMTYPE="SHA-1" SIZE="3805">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:18:13" MIMETYPE="text/xml" CHECKSUM="ba445b6628e906f5f57fde8e33b21e5607b48ff7" CHECKSUMTYPE="SHA-1" SIZE="3805">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:18:13" MIMETYPE="text/xml"
-				CHECKSUM="955a506ddfd97f4dce15742736bb14cd75bfc0a3" CHECKSUMTYPE="SHA-1" SIZE="4040">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:18:13" MIMETYPE="text/xml" CHECKSUM="955a506ddfd97f4dce15742736bb14cd75bfc0a3" CHECKSUMTYPE="SHA-1" SIZE="4040">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:18:13" MIMETYPE="text/xml"
-				CHECKSUM="3544a64c9a6acd6c4c9d8fe8112da2e8251c4633" CHECKSUMTYPE="SHA-1" SIZE="3794">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:18:13" MIMETYPE="text/xml" CHECKSUM="3544a64c9a6acd6c4c9d8fe8112da2e8251c4633" CHECKSUMTYPE="SHA-1" SIZE="3794">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:18:13" MIMETYPE="text/xml"
-				CHECKSUM="39bf088862e2d4a5f6ca6bfc114a2bc067b0f38e" CHECKSUMTYPE="SHA-1" SIZE="3743">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:18:13" MIMETYPE="text/xml" CHECKSUM="39bf088862e2d4a5f6ca6bfc114a2bc067b0f38e" CHECKSUMTYPE="SHA-1" SIZE="3743">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:18:13" MIMETYPE="text/xml"
-				CHECKSUM="fb070740e5b19360c1a0b8957087902fb2f0b9e6" CHECKSUMTYPE="SHA-1" SIZE="4041">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:18:13" MIMETYPE="text/xml" CHECKSUM="fb070740e5b19360c1a0b8957087902fb2f0b9e6" CHECKSUMTYPE="SHA-1" SIZE="4041">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:18:14" MIMETYPE="text/xml"
-				CHECKSUM="7858a5a4d8f045ef8a18373aa49be1255d4d9a58" CHECKSUMTYPE="SHA-1" SIZE="3747">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:18:14" MIMETYPE="text/xml" CHECKSUM="7858a5a4d8f045ef8a18373aa49be1255d4d9a58" CHECKSUMTYPE="SHA-1" SIZE="3747">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:18:14" MIMETYPE="text/xml"
-				CHECKSUM="7319234c1d436d1669d8955903d096222ec3bc53" CHECKSUMTYPE="SHA-1" SIZE="3804">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:18:14" MIMETYPE="text/xml" CHECKSUM="7319234c1d436d1669d8955903d096222ec3bc53" CHECKSUMTYPE="SHA-1" SIZE="3804">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:18:14" MIMETYPE="text/xml"
-				CHECKSUM="1ebfbfb3a850581c8510330bcafd748e7333cf60" CHECKSUMTYPE="SHA-1" SIZE="3732">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:18:14" MIMETYPE="text/xml" CHECKSUM="1ebfbfb3a850581c8510330bcafd748e7333cf60" CHECKSUMTYPE="SHA-1" SIZE="3732">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:18:14" MIMETYPE="text/xml"
-				CHECKSUM="3982c12d4f8659c842320965d2ba5b08ecf7fd42" CHECKSUMTYPE="SHA-1" SIZE="3797">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:18:14" MIMETYPE="text/xml" CHECKSUM="3982c12d4f8659c842320965d2ba5b08ecf7fd42" CHECKSUMTYPE="SHA-1" SIZE="3797">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:18:15" MIMETYPE="text/xml"
-				CHECKSUM="6fa274b02169dc9d65a493c9fe16cef36ffcb502" CHECKSUMTYPE="SHA-1" SIZE="3738">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:18:15" MIMETYPE="text/xml" CHECKSUM="6fa274b02169dc9d65a493c9fe16cef36ffcb502" CHECKSUMTYPE="SHA-1" SIZE="3738">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:18:15" MIMETYPE="text/xml"
-				CHECKSUM="c7beeb298c0ab96d08c8674154c299acb2312d6a" CHECKSUMTYPE="SHA-1" SIZE="3982">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:18:15" MIMETYPE="text/xml" CHECKSUM="c7beeb298c0ab96d08c8674154c299acb2312d6a" CHECKSUMTYPE="SHA-1" SIZE="3982">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:18:15" MIMETYPE="text/xml"
-				CHECKSUM="aded7f24fe5f0f6f5d99c0c3ccc5cbaedd17f0ae" CHECKSUMTYPE="SHA-1" SIZE="3745">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:18:15" MIMETYPE="text/xml" CHECKSUM="aded7f24fe5f0f6f5d99c0c3ccc5cbaedd17f0ae" CHECKSUMTYPE="SHA-1" SIZE="3745">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:18:15" MIMETYPE="text/xml"
-				CHECKSUM="2885f804ea48b04d8761e3807fb50bb9c850a33c" CHECKSUMTYPE="SHA-1" SIZE="3803">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:18:15" MIMETYPE="text/xml" CHECKSUM="2885f804ea48b04d8761e3807fb50bb9c850a33c" CHECKSUMTYPE="SHA-1" SIZE="3803">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:18:16" MIMETYPE="text/xml"
-				CHECKSUM="4c6a569a9355d6b55cd7d21a8997667aeefd9ca1" CHECKSUMTYPE="SHA-1" SIZE="3791">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:18:16" MIMETYPE="text/xml" CHECKSUM="4c6a569a9355d6b55cd7d21a8997667aeefd9ca1" CHECKSUMTYPE="SHA-1" SIZE="3791">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:18:16" MIMETYPE="text/xml"
-				CHECKSUM="65a08fc39e8175763c828807a70b6674747ef63c" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:18:16" MIMETYPE="text/xml" CHECKSUM="65a08fc39e8175763c828807a70b6674747ef63c" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:18:16" MIMETYPE="text/xml"
-				CHECKSUM="5b528d64192425b3ccf6764e09d0fa3ea3cb53d4" CHECKSUMTYPE="SHA-1"
-				SIZE="33285">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:18:16" MIMETYPE="text/xml" CHECKSUM="5b528d64192425b3ccf6764e09d0fa3ea3cb53d4" CHECKSUMTYPE="SHA-1" SIZE="33285">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:18:16" MIMETYPE="text/xml"
-				CHECKSUM="50b74a45ca218c07677f74d2e1a01c9130d75657" CHECKSUMTYPE="SHA-1"
-				SIZE="39030">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:18:16" MIMETYPE="text/xml" CHECKSUM="50b74a45ca218c07677f74d2e1a01c9130d75657" CHECKSUMTYPE="SHA-1" SIZE="39030">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:18:17" MIMETYPE="text/xml"
-				CHECKSUM="0dc19e747f89e1f58fc19fd427e993606b13a226" CHECKSUMTYPE="SHA-1" SIZE="7590">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:18:17" MIMETYPE="text/xml" CHECKSUM="0dc19e747f89e1f58fc19fd427e993606b13a226" CHECKSUMTYPE="SHA-1" SIZE="7590">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-03-15_01_0028.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:18:43" MIMETYPE="application/pdf"
-				CHECKSUM="7f0d79e25c2a0a4279a32a559bcc94bcdb08f1b4" CHECKSUMTYPE="SHA-1"
-				SIZE="7503151">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/bmtnabf_1901-03-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:18:43" MIMETYPE="application/pdf" CHECKSUM="7f0d79e25c2a0a4279a32a559bcc94bcdb08f1b4" CHECKSUMTYPE="SHA-1" SIZE="7503151">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/03/15_01/bmtnabf_1901-03-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3344,8 +3162,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 6 15.03.1901">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by GUSTAV KLIMT OM">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by GUSTAV KLIMT OM">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_CB00001"/>
@@ -3408,10 +3225,8 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="TextContent" ORDER="5" DMDID="c009"
-					LABEL="BEWEGUNGSTUDIEN ZUR &#34;MEDICIN&#34; VON GUSTAV KLIMT.">
-					<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c008"
-						LABEL="&#34;DIE MEDICIN&#34; DECKENBILD">
+				<div ID="L.1.1.7" TYPE="TextContent" ORDER="5" DMDID="c009" LABEL="BEWEGUNGSTUDIEN ZUR &#34;MEDICIN&#34; VON GUSTAV KLIMT.">
+					<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c008" LABEL="&#34;DIE MEDICIN&#34; DECKENBILD">
 						<div ID="L.1.1.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
@@ -3451,8 +3266,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="1" DMDID="c011"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="1" DMDID="c011" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.7.3.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
@@ -3464,8 +3278,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c012"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c012" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.8.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -3477,8 +3290,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c013"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c013" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.9.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -3490,8 +3302,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c014"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c014" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.10.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -3504,8 +3315,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.10.3" TYPE="Illustration" ORDER="2" DMDID="c015"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.10.3" TYPE="Illustration" ORDER="2" DMDID="c015" LABEL="Untitled Image">
 							<div ID="L.1.1.10.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00002"/>
@@ -3513,8 +3323,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c016"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c016" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.11.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -3526,8 +3335,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c017"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c017" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.12.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
@@ -3539,8 +3347,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c018"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c018" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.13.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -3553,8 +3360,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.13.3" TYPE="Illustration" ORDER="2" DMDID="c019"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.13.3" TYPE="Illustration" ORDER="2" DMDID="c019" LABEL="Untitled Image">
 							<div ID="L.1.1.13.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00002"/>
@@ -3562,8 +3368,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c020"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c020" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.14.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -3575,8 +3380,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c021"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c021" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.15.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -3588,8 +3392,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c022"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c022" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.16.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
@@ -3601,8 +3404,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17" TYPE="Illustration" ORDER="15" DMDID="c023"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.17" TYPE="Illustration" ORDER="15" DMDID="c023" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.17.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
@@ -3614,8 +3416,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18" TYPE="Illustration" ORDER="16" DMDID="c024"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.18" TYPE="Illustration" ORDER="16" DMDID="c024" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.18.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
@@ -3627,8 +3428,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.19" TYPE="Illustration" ORDER="17" DMDID="c025"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.19" TYPE="Illustration" ORDER="17" DMDID="c025" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.19.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
@@ -3641,8 +3441,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="2" DMDID="c026"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.19.3" TYPE="Illustration" ORDER="2" DMDID="c026" LABEL="Untitled Image">
 							<div ID="L.1.1.19.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_CB00002"/>
@@ -3650,8 +3449,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.20" TYPE="Illustration" ORDER="18" DMDID="c027"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.20" TYPE="Illustration" ORDER="18" DMDID="c027" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.20.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
@@ -3663,8 +3461,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.21" TYPE="Illustration" ORDER="19" DMDID="c028"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.21" TYPE="Illustration" ORDER="19" DMDID="c028" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.21.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
@@ -3676,8 +3473,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.22" TYPE="Illustration" ORDER="20" DMDID="c029"
-						LABEL="Untitled Image by GUSTAV KLIMT OM">
+					<div ID="L.1.1.22" TYPE="Illustration" ORDER="20" DMDID="c029" LABEL="Untitled Image by GUSTAV KLIMT OM">
 						<div ID="L.1.1.22.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/04/01_01/bmtnabf_1901-04-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/04/01_01/bmtnabf_1901-04-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-04-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-04-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-04-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1901/04/15_01/bmtnabf_1901-04-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/04/15_01/bmtnabf_1901-04-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-04-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-04-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-04-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-04-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-04-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2577,310 +2571,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:09:06"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a339328257e595e383d3b86cc0daf22680190c4e"
-				CHECKSUMTYPE="SHA-1" SIZE="6238029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:09:06" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a339328257e595e383d3b86cc0daf22680190c4e" CHECKSUMTYPE="SHA-1" SIZE="6238029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:09:38"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="0127e75254e15262335f01f5097a03a1b29fbb9d"
-				CHECKSUMTYPE="SHA-1" SIZE="6203827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:09:38" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="0127e75254e15262335f01f5097a03a1b29fbb9d" CHECKSUMTYPE="SHA-1" SIZE="6203827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:10:11"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="9323fc740a53f7940ae54717119334e41a27daff"
-				CHECKSUMTYPE="SHA-1" SIZE="6238919">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:10:11" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="9323fc740a53f7940ae54717119334e41a27daff" CHECKSUMTYPE="SHA-1" SIZE="6238919">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:10:42"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="433314cc4f36cae702151092d6d023b05e25b020"
-				CHECKSUMTYPE="SHA-1" SIZE="6204707">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:10:42" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="433314cc4f36cae702151092d6d023b05e25b020" CHECKSUMTYPE="SHA-1" SIZE="6204707">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:11:16"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="192ccef163792072f5f1e6469db7c92d78b20ad9"
-				CHECKSUMTYPE="SHA-1" SIZE="6238924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:11:16" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="192ccef163792072f5f1e6469db7c92d78b20ad9" CHECKSUMTYPE="SHA-1" SIZE="6238924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:11:48"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="9619ed65feed440b1af16a269aa9f0a491e0c1fb"
-				CHECKSUMTYPE="SHA-1" SIZE="6235329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:11:48" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="9619ed65feed440b1af16a269aa9f0a491e0c1fb" CHECKSUMTYPE="SHA-1" SIZE="6235329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:12:20"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="eb9571d139f6648dc4bb445fe6534866bf4b69b4"
-				CHECKSUMTYPE="SHA-1" SIZE="6230821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:12:20" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="eb9571d139f6648dc4bb445fe6534866bf4b69b4" CHECKSUMTYPE="SHA-1" SIZE="6230821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:12:53"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="6d717916e81d1f67c0d2ab78db66807cc5bf8f36"
-				CHECKSUMTYPE="SHA-1" SIZE="6235320">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:12:53" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="6d717916e81d1f67c0d2ab78db66807cc5bf8f36" CHECKSUMTYPE="SHA-1" SIZE="6235320">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:13:24"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f59d1008d83ef27131b58709048cab324e0a4237"
-				CHECKSUMTYPE="SHA-1" SIZE="6230821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:13:24" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f59d1008d83ef27131b58709048cab324e0a4237" CHECKSUMTYPE="SHA-1" SIZE="6230821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:13:59"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="3db81e693d6ae91532b1eb80ba9e7f3832aa1351"
-				CHECKSUMTYPE="SHA-1" SIZE="6290224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:13:59" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="3db81e693d6ae91532b1eb80ba9e7f3832aa1351" CHECKSUMTYPE="SHA-1" SIZE="6290224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:14:30"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="953247e178627b06cb8ba0166be34b4a654045b7"
-				CHECKSUMTYPE="SHA-1" SIZE="6178626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:14:30" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="953247e178627b06cb8ba0166be34b4a654045b7" CHECKSUMTYPE="SHA-1" SIZE="6178626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:15:00"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="ae8fba24d6f5b2ca70ceae284bcc2f2fd988393e"
-				CHECKSUMTYPE="SHA-1" SIZE="6290215">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:15:00" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="ae8fba24d6f5b2ca70ceae284bcc2f2fd988393e" CHECKSUMTYPE="SHA-1" SIZE="6290215">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:15:31"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="5f52605ded83b574f8c8953168d8abc34f088238"
-				CHECKSUMTYPE="SHA-1" SIZE="6178617">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:15:31" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="5f52605ded83b574f8c8953168d8abc34f088238" CHECKSUMTYPE="SHA-1" SIZE="6178617">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:16:01"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="0efb6332a445516852eb68d223b166a9eb914acb"
-				CHECKSUMTYPE="SHA-1" SIZE="6290212">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:16:01" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="0efb6332a445516852eb68d223b166a9eb914acb" CHECKSUMTYPE="SHA-1" SIZE="6290212">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:16:34"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="ead311d6762f627fe8f28ca206edefddcca3ad7d"
-				CHECKSUMTYPE="SHA-1" SIZE="6178599">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:16:34" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="ead311d6762f627fe8f28ca206edefddcca3ad7d" CHECKSUMTYPE="SHA-1" SIZE="6178599">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:17:07"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d995d6a180852b5a0732715148a19956800bcb6c"
-				CHECKSUMTYPE="SHA-1" SIZE="6290228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:17:07" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d995d6a180852b5a0732715148a19956800bcb6c" CHECKSUMTYPE="SHA-1" SIZE="6290228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:17:41"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="5c9e613e0e2ddd885a2055d4e153bc9948fe99d4"
-				CHECKSUMTYPE="SHA-1" SIZE="6178622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:17:41" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="5c9e613e0e2ddd885a2055d4e153bc9948fe99d4" CHECKSUMTYPE="SHA-1" SIZE="6178622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:18:11"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="ddbc9786532f644868978b459edb77ea9b1f093a"
-				CHECKSUMTYPE="SHA-1" SIZE="6290218">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:18:11" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="ddbc9786532f644868978b459edb77ea9b1f093a" CHECKSUMTYPE="SHA-1" SIZE="6290218">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:18:42"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="ee0cc9cef9c5efeaac2f1602f3e9b0026a1c6c63"
-				CHECKSUMTYPE="SHA-1" SIZE="6178628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:18:42" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="ee0cc9cef9c5efeaac2f1602f3e9b0026a1c6c63" CHECKSUMTYPE="SHA-1" SIZE="6178628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:19:16"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="d4763f36aa66e83be4cb51ddf260c6a0bb8a6586"
-				CHECKSUMTYPE="SHA-1" SIZE="6290225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:19:16" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="d4763f36aa66e83be4cb51ddf260c6a0bb8a6586" CHECKSUMTYPE="SHA-1" SIZE="6290225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:19:49"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="5f91eb7d7b548067185de04fe235d634cd4f6a1b"
-				CHECKSUMTYPE="SHA-1" SIZE="6178610">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:19:49" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="5f91eb7d7b548067185de04fe235d634cd4f6a1b" CHECKSUMTYPE="SHA-1" SIZE="6178610">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:20:18"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="42df7a648fba1d0621d5290250210e707a8c709a"
-				CHECKSUMTYPE="SHA-1" SIZE="6290227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:20:18" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="42df7a648fba1d0621d5290250210e707a8c709a" CHECKSUMTYPE="SHA-1" SIZE="6290227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:20:48"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="41a1405f38fa772bfb4edee8288aaa6b03dda333"
-				CHECKSUMTYPE="SHA-1" SIZE="6178629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:20:48" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="41a1405f38fa772bfb4edee8288aaa6b03dda333" CHECKSUMTYPE="SHA-1" SIZE="6178629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:21:23"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="45ead7b7869ba565553756646da44e49b3b387f9"
-				CHECKSUMTYPE="SHA-1" SIZE="6290224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:21:23" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="45ead7b7869ba565553756646da44e49b3b387f9" CHECKSUMTYPE="SHA-1" SIZE="6290224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/delivery/bmtnabf_1901-04-15_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:21:41" MIMETYPE="text/xml"
-				CHECKSUM="c0cb36015a32a920f4a386d325a08fcae2b29ed7" CHECKSUMTYPE="SHA-1" SIZE="4560">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:21:41" MIMETYPE="text/xml" CHECKSUM="c0cb36015a32a920f4a386d325a08fcae2b29ed7" CHECKSUMTYPE="SHA-1" SIZE="4560">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:21:41" MIMETYPE="text/xml"
-				CHECKSUM="4a6386770a99cbcd88b19fe0c9f14dce6914abbf" CHECKSUMTYPE="SHA-1"
-				SIZE="26118">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:21:41" MIMETYPE="text/xml" CHECKSUM="4a6386770a99cbcd88b19fe0c9f14dce6914abbf" CHECKSUMTYPE="SHA-1" SIZE="26118">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:21:41" MIMETYPE="text/xml"
-				CHECKSUM="a3572abbe90f7372dab431e8d5fffc1b6edb057a" CHECKSUMTYPE="SHA-1" SIZE="9841">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:21:41" MIMETYPE="text/xml" CHECKSUM="a3572abbe90f7372dab431e8d5fffc1b6edb057a" CHECKSUMTYPE="SHA-1" SIZE="9841">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:21:41" MIMETYPE="text/xml"
-				CHECKSUM="89fabeb0e12da8565c614fba64f9db99b4667281" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:21:41" MIMETYPE="text/xml" CHECKSUM="89fabeb0e12da8565c614fba64f9db99b4667281" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:21:42" MIMETYPE="text/xml"
-				CHECKSUM="59e2780ce969e0f4fcb16e71f40a22d582336746" CHECKSUMTYPE="SHA-1" SIZE="5704">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:21:42" MIMETYPE="text/xml" CHECKSUM="59e2780ce969e0f4fcb16e71f40a22d582336746" CHECKSUMTYPE="SHA-1" SIZE="5704">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:21:42" MIMETYPE="text/xml"
-				CHECKSUM="08daa961336bcb3b83113626650d422c391e2973" CHECKSUMTYPE="SHA-1" SIZE="4914">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:21:42" MIMETYPE="text/xml" CHECKSUM="08daa961336bcb3b83113626650d422c391e2973" CHECKSUMTYPE="SHA-1" SIZE="4914">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:21:42" MIMETYPE="text/xml"
-				CHECKSUM="0a13a8db0a09465f5b4b0fac544666e31eb53d47" CHECKSUMTYPE="SHA-1"
-				SIZE="36173">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:21:42" MIMETYPE="text/xml" CHECKSUM="0a13a8db0a09465f5b4b0fac544666e31eb53d47" CHECKSUMTYPE="SHA-1" SIZE="36173">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:21:42" MIMETYPE="text/xml"
-				CHECKSUM="f2b80e9100b21421dedad775917af2417207ef9b" CHECKSUMTYPE="SHA-1" SIZE="5314">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:21:42" MIMETYPE="text/xml" CHECKSUM="f2b80e9100b21421dedad775917af2417207ef9b" CHECKSUMTYPE="SHA-1" SIZE="5314">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:21:43" MIMETYPE="text/xml"
-				CHECKSUM="3e653b9f27e23974292d35a43cea2d372fbd25d4" CHECKSUMTYPE="SHA-1" SIZE="5794">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:21:43" MIMETYPE="text/xml" CHECKSUM="3e653b9f27e23974292d35a43cea2d372fbd25d4" CHECKSUMTYPE="SHA-1" SIZE="5794">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:21:43" MIMETYPE="text/xml"
-				CHECKSUM="0a4ab2c148997d88f02dace36b409911b8e0e8ab" CHECKSUMTYPE="SHA-1" SIZE="6964">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:21:43" MIMETYPE="text/xml" CHECKSUM="0a4ab2c148997d88f02dace36b409911b8e0e8ab" CHECKSUMTYPE="SHA-1" SIZE="6964">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:21:43" MIMETYPE="text/xml"
-				CHECKSUM="18ca91e8cbd041c9231c6e51b7607df738e2b318" CHECKSUMTYPE="SHA-1" SIZE="7120">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:21:43" MIMETYPE="text/xml" CHECKSUM="18ca91e8cbd041c9231c6e51b7607df738e2b318" CHECKSUMTYPE="SHA-1" SIZE="7120">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:21:43" MIMETYPE="text/xml"
-				CHECKSUM="6b6868fceccc5a6272f7a9a534ecce376068f60d" CHECKSUMTYPE="SHA-1"
-				SIZE="13932">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:21:43" MIMETYPE="text/xml" CHECKSUM="6b6868fceccc5a6272f7a9a534ecce376068f60d" CHECKSUMTYPE="SHA-1" SIZE="13932">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:21:44" MIMETYPE="text/xml"
-				CHECKSUM="a5e6407c22529a5bd4687aedd2d76873e5b9bfde" CHECKSUMTYPE="SHA-1" SIZE="9590">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:21:44" MIMETYPE="text/xml" CHECKSUM="a5e6407c22529a5bd4687aedd2d76873e5b9bfde" CHECKSUMTYPE="SHA-1" SIZE="9590">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:21:44" MIMETYPE="text/xml"
-				CHECKSUM="db0ed33ef5fb7fdbc053931d4698cdf116175925" CHECKSUMTYPE="SHA-1"
-				SIZE="10388">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:21:44" MIMETYPE="text/xml" CHECKSUM="db0ed33ef5fb7fdbc053931d4698cdf116175925" CHECKSUMTYPE="SHA-1" SIZE="10388">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:21:45" MIMETYPE="text/xml"
-				CHECKSUM="2a2a980d1f17ba79db25769a5deca9859b59dda9" CHECKSUMTYPE="SHA-1" SIZE="5797">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:21:45" MIMETYPE="text/xml" CHECKSUM="2a2a980d1f17ba79db25769a5deca9859b59dda9" CHECKSUMTYPE="SHA-1" SIZE="5797">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:21:45" MIMETYPE="text/xml"
-				CHECKSUM="c8ffb4f59871fe9c08b9f86d7300821ffa52e749" CHECKSUMTYPE="SHA-1" SIZE="5872">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:21:45" MIMETYPE="text/xml" CHECKSUM="c8ffb4f59871fe9c08b9f86d7300821ffa52e749" CHECKSUMTYPE="SHA-1" SIZE="5872">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:21:45" MIMETYPE="text/xml"
-				CHECKSUM="6cfa8150496c971b72be620c4090d581db4a70e8" CHECKSUMTYPE="SHA-1" SIZE="6786">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:21:45" MIMETYPE="text/xml" CHECKSUM="6cfa8150496c971b72be620c4090d581db4a70e8" CHECKSUMTYPE="SHA-1" SIZE="6786">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:21:46" MIMETYPE="text/xml"
-				CHECKSUM="2200afa7c0b17b3635778725a8cffe6cf625b87d" CHECKSUMTYPE="SHA-1" SIZE="5335">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:21:46" MIMETYPE="text/xml" CHECKSUM="2200afa7c0b17b3635778725a8cffe6cf625b87d" CHECKSUMTYPE="SHA-1" SIZE="5335">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:21:46" MIMETYPE="text/xml"
-				CHECKSUM="b2988965665b2a1e380fcfa15b701bf85169a398" CHECKSUMTYPE="SHA-1" SIZE="6149">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:21:46" MIMETYPE="text/xml" CHECKSUM="b2988965665b2a1e380fcfa15b701bf85169a398" CHECKSUMTYPE="SHA-1" SIZE="6149">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:21:46" MIMETYPE="text/xml"
-				CHECKSUM="38eb48b81b7e2839e5a3d14c4e900bce0428d250" CHECKSUMTYPE="SHA-1" SIZE="6919">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:21:46" MIMETYPE="text/xml" CHECKSUM="38eb48b81b7e2839e5a3d14c4e900bce0428d250" CHECKSUMTYPE="SHA-1" SIZE="6919">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:21:47" MIMETYPE="text/xml"
-				CHECKSUM="83eb992fe8e0b63fdc819f7c24a3477c226d5f18" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:21:47" MIMETYPE="text/xml" CHECKSUM="83eb992fe8e0b63fdc819f7c24a3477c226d5f18" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:21:47" MIMETYPE="text/xml"
-				CHECKSUM="5e280b969addd5dc13b6f6092c0df6a6882735d3" CHECKSUMTYPE="SHA-1"
-				SIZE="32557">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:21:47" MIMETYPE="text/xml" CHECKSUM="5e280b969addd5dc13b6f6092c0df6a6882735d3" CHECKSUMTYPE="SHA-1" SIZE="32557">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:21:47" MIMETYPE="text/xml"
-				CHECKSUM="748c9280767fb567089ab64c96ca49f5765f543e" CHECKSUMTYPE="SHA-1"
-				SIZE="38668">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:21:47" MIMETYPE="text/xml" CHECKSUM="748c9280767fb567089ab64c96ca49f5765f543e" CHECKSUMTYPE="SHA-1" SIZE="38668">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:21:48" MIMETYPE="text/xml"
-				CHECKSUM="39c0d3f79d69ec765dfa2c265757f855f38a8fa8" CHECKSUMTYPE="SHA-1" SIZE="7955">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:21:48" MIMETYPE="text/xml" CHECKSUM="39c0d3f79d69ec765dfa2c265757f855f38a8fa8" CHECKSUMTYPE="SHA-1" SIZE="7955">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-04-15_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:22:09" MIMETYPE="application/pdf"
-				CHECKSUM="8e10c04ffa085905c1f421525a36567cc29a8e21" CHECKSUMTYPE="SHA-1"
-				SIZE="7249780">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/bmtnabf_1901-04-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:22:09" MIMETYPE="application/pdf" CHECKSUM="8e10c04ffa085905c1f421525a36567cc29a8e21" CHECKSUMTYPE="SHA-1" SIZE="7249780">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/04/15_01/bmtnabf_1901-04-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3144,8 +2984,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c007"
-					LABEL="ZEICHNUNGEN UND ENTWURFE">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c007" LABEL="ZEICHNUNGEN UND ENTWURFE">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -3167,8 +3006,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c008"
-					LABEL="Decorative Landschaft">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c008" LABEL="Decorative Landschaft">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00001"/>
@@ -3196,8 +3034,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00001"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.7.2" TYPE="Illustration" ORDER="1" DMDID="c010"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.2" TYPE="Illustration" ORDER="1" DMDID="c010" LABEL="Untitled Image">
 						<div ID="L.1.1.7.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00002"/>
@@ -3222,8 +3059,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="1" DMDID="c011"
-						LABEL="Untitled Image by J. M. Auchentaller OM">
+					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="1" DMDID="c011" LABEL="Untitled Image by J. M. Auchentaller OM">
 						<div ID="L.1.1.7.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
@@ -3263,8 +3099,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c013"
-					LABEL="Motiv für ein Flächenmuster">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c013" LABEL="Motiv für ein Flächenmuster">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -3286,8 +3121,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c014"
-					LABEL="Entwurf zu einem Stoffmuster">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c014" LABEL="Entwurf zu einem Stoffmuster">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -3309,8 +3143,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="GH-222-1" TYPE="TextContent" ORDER="1" DMDID="c015a"
-					LABEL="IN SILBER GETRIEBEN">
+				<div ID="GH-222-1" TYPE="TextContent" ORDER="1" DMDID="c015a" LABEL="IN SILBER GETRIEBEN">
 					<div ID="L.1.1.11.3.2" TYPE="Caption">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
@@ -3333,8 +3166,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c016"
-						LABEL="BONBONNIERE, MIT EMAIL">
+					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c016" LABEL="BONBONNIERE, MIT EMAIL">
 						<div ID="L.1.1.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -3368,8 +3200,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c018"
-						LABEL="HALSSCHLIESSEN">
+					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c018" LABEL="HALSSCHLIESSEN">
 						<div ID="L.1.1.14.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00006"/>
@@ -3397,8 +3228,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c020"
-						LABEL="GÜRTELSCHNALLE">
+					<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c020" LABEL="GÜRTELSCHNALLE">
 						<div ID="L.1.1.15.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -3410,8 +3240,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c021"
-						LABEL="GÜRTELSCHNALLE">
+					<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c021" LABEL="GÜRTELSCHNALLE">
 						<div ID="L.1.1.16.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
@@ -3423,8 +3252,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17" TYPE="Illustration" ORDER="15" DMDID="c022"
-						LABEL="STOCKGRIFF">
+					<div ID="L.1.1.17" TYPE="Illustration" ORDER="15" DMDID="c022" LABEL="STOCKGRIFF">
 						<div ID="L.1.1.17.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
@@ -3446,8 +3274,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.18" TYPE="Illustration" ORDER="16" DMDID="c023"
-						LABEL="BONBONNIÈRE">
+					<div ID="L.1.1.18" TYPE="Illustration" ORDER="16" DMDID="c023" LABEL="BONBONNIÈRE">
 						<div ID="L.1.1.18.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
@@ -3465,8 +3292,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.19" TYPE="Illustration" ORDER="17" DMDID="c024"
-					LABEL="ASCHENSCHALE AUS FARBIGEM GLAS, SILBERMONTIERT">
+				<div ID="L.1.1.19" TYPE="Illustration" ORDER="17" DMDID="c024" LABEL="ASCHENSCHALE AUS FARBIGEM GLAS, SILBERMONTIERT">
 					<div ID="L.1.1.19.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
@@ -3488,8 +3314,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.20" TYPE="Illustration" ORDER="18" DMDID="c025"
-					LABEL="Entwurf zu einem Stoffmuster">
+				<div ID="L.1.1.20" TYPE="Illustration" ORDER="18" DMDID="c025" LABEL="Entwurf zu einem Stoffmuster">
 					<div ID="L.1.1.20.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -3511,8 +3336,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.21" TYPE="Illustration" ORDER="19" DMDID="c026"
-					LABEL="Burg Liechtenstein bei Wien">
+				<div ID="L.1.1.21" TYPE="Illustration" ORDER="19" DMDID="c026" LABEL="Burg Liechtenstein bei Wien">
 					<div ID="L.1.1.21.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -3534,8 +3358,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.22" TYPE="Illustration" ORDER="20" DMDID="c027"
-					LABEL="Studie zu einem Flächenmuster">
+				<div ID="L.1.1.22" TYPE="Illustration" ORDER="20" DMDID="c027" LABEL="Studie zu einem Flächenmuster">
 					<div ID="L.1.1.22.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -3579,8 +3402,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.24" TYPE="Illustration" ORDER="22" DMDID="c029"
-					LABEL="Studie zu einem Placatin 3 Farben">
+				<div ID="L.1.1.24" TYPE="Illustration" ORDER="22" DMDID="c029" LABEL="Studie zu einem Placatin 3 Farben">
 					<div ID="L.1.1.24.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
@@ -3602,8 +3424,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.25" TYPE="Illustration" ORDER="23" DMDID="c030"
-					LABEL="Musikzimmer im Hause des Herrn G. A. Sch.">
+				<div ID="L.1.1.25" TYPE="Illustration" ORDER="23" DMDID="c030" LABEL="Musikzimmer im Hause des Herrn G. A. Sch.">
 					<div ID="L.1.1.25.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/05/01_01/bmtnabf_1901-05-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/05/01_01/bmtnabf_1901-05-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-05-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-05-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-05-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-05-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-05-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2034,263 +2028,132 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:09:17"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="906fc816e9f5733857d920270a136ad4487c5f66"
-				CHECKSUMTYPE="SHA-1" SIZE="6115607">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:09:17" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="906fc816e9f5733857d920270a136ad4487c5f66" CHECKSUMTYPE="SHA-1" SIZE="6115607">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:09:47"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="31321a211bc3e379e6d609d7e24a0f3541d4b47d"
-				CHECKSUMTYPE="SHA-1" SIZE="6031924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:09:47" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="31321a211bc3e379e6d609d7e24a0f3541d4b47d" CHECKSUMTYPE="SHA-1" SIZE="6031924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:10:17"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="2de62a62e75b4fbaab33c1daf882919b5bdbe8fe"
-				CHECKSUMTYPE="SHA-1" SIZE="6114698">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:10:17" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="2de62a62e75b4fbaab33c1daf882919b5bdbe8fe" CHECKSUMTYPE="SHA-1" SIZE="6114698">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:10:52"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="794908826adfc6c4420c6147a377b28087f54a9c"
-				CHECKSUMTYPE="SHA-1" SIZE="6136322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:10:52" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="794908826adfc6c4420c6147a377b28087f54a9c" CHECKSUMTYPE="SHA-1" SIZE="6136322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:11:24"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2e86b263a1110869e4bc387b0575bb763fb580f6"
-				CHECKSUMTYPE="SHA-1" SIZE="6097628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:11:24" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2e86b263a1110869e4bc387b0575bb763fb580f6" CHECKSUMTYPE="SHA-1" SIZE="6097628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:11:54"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="227856685ab25c28a89a90c3addda54c106ff812"
-				CHECKSUMTYPE="SHA-1" SIZE="6100324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:11:54" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="227856685ab25c28a89a90c3addda54c106ff812" CHECKSUMTYPE="SHA-1" SIZE="6100324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:12:25"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="313d982fa08982ae3b41d402acad131bc649e541"
-				CHECKSUMTYPE="SHA-1" SIZE="6097621">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:12:25" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="313d982fa08982ae3b41d402acad131bc649e541" CHECKSUMTYPE="SHA-1" SIZE="6097621">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:12:56"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="0da68aefefd60c8e4f339062b5cf93d550b6de0c"
-				CHECKSUMTYPE="SHA-1" SIZE="6100320">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:12:56" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="0da68aefefd60c8e4f339062b5cf93d550b6de0c" CHECKSUMTYPE="SHA-1" SIZE="6100320">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:13:27"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="68d6056db41e5e26c1cd0536a2d9c5f22b799200"
-				CHECKSUMTYPE="SHA-1" SIZE="6097625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:13:27" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="68d6056db41e5e26c1cd0536a2d9c5f22b799200" CHECKSUMTYPE="SHA-1" SIZE="6097625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:13:59"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="f326022d740deb296d922ad4a60c7934461998d4"
-				CHECKSUMTYPE="SHA-1" SIZE="6100328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:13:59" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="f326022d740deb296d922ad4a60c7934461998d4" CHECKSUMTYPE="SHA-1" SIZE="6100328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:14:33"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="7d23dfd15a1d4c344e946d403700a3253a2197b9"
-				CHECKSUMTYPE="SHA-1" SIZE="6035234">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:14:33" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="7d23dfd15a1d4c344e946d403700a3253a2197b9" CHECKSUMTYPE="SHA-1" SIZE="6035234">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:15:03"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="c714216c43fbb84c1eef58edfc4d0609b4ea032b"
-				CHECKSUMTYPE="SHA-1" SIZE="6100323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:15:03" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="c714216c43fbb84c1eef58edfc4d0609b4ea032b" CHECKSUMTYPE="SHA-1" SIZE="6100323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:15:33"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="b4eebccf00cd91eb975fcf419a7cc8a630869e8e"
-				CHECKSUMTYPE="SHA-1" SIZE="6035517">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:15:33" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="b4eebccf00cd91eb975fcf419a7cc8a630869e8e" CHECKSUMTYPE="SHA-1" SIZE="6035517">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:16:04"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="01ce23165366f3c69a48c28204cb530c619c41bc"
-				CHECKSUMTYPE="SHA-1" SIZE="6100323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:16:04" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="01ce23165366f3c69a48c28204cb530c619c41bc" CHECKSUMTYPE="SHA-1" SIZE="6100323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:16:34"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="84ff8460b66fb2f8c8694ff588ee252aae2d36ed"
-				CHECKSUMTYPE="SHA-1" SIZE="6035522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:16:34" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="84ff8460b66fb2f8c8694ff588ee252aae2d36ed" CHECKSUMTYPE="SHA-1" SIZE="6035522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:17:07"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ec52025199980671486b368996fb3a0308cbcb5b"
-				CHECKSUMTYPE="SHA-1" SIZE="6101223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:17:07" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ec52025199980671486b368996fb3a0308cbcb5b" CHECKSUMTYPE="SHA-1" SIZE="6101223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:17:42"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="46d629eb2b816483d92a54258a3af4d66c26a75a"
-				CHECKSUMTYPE="SHA-1" SIZE="6035521">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:17:42" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="46d629eb2b816483d92a54258a3af4d66c26a75a" CHECKSUMTYPE="SHA-1" SIZE="6035521">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:18:10"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="9440498b40e1d79b9ff8ad196fb33c85829b97e7"
-				CHECKSUMTYPE="SHA-1" SIZE="6101228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:18:10" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="9440498b40e1d79b9ff8ad196fb33c85829b97e7" CHECKSUMTYPE="SHA-1" SIZE="6101228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:18:43"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="c3627bcc68bba50c2a8b60f8cb6cc68270c66394"
-				CHECKSUMTYPE="SHA-1" SIZE="5977028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:18:43" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="c3627bcc68bba50c2a8b60f8cb6cc68270c66394" CHECKSUMTYPE="SHA-1" SIZE="5977028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:19:13"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="1b13093a6e997b1ddb4dd0324eae2fb0478e90ff"
-				CHECKSUMTYPE="SHA-1" SIZE="6100318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:19:13" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="1b13093a6e997b1ddb4dd0324eae2fb0478e90ff" CHECKSUMTYPE="SHA-1" SIZE="6100318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/delivery/bmtnabf_1901-05-01_01_0020.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:19:30" MIMETYPE="text/xml"
-				CHECKSUM="dacf20293d470f7758b7d76b03281461a28fdb7d" CHECKSUMTYPE="SHA-1" SIZE="4786">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:19:30" MIMETYPE="text/xml" CHECKSUM="dacf20293d470f7758b7d76b03281461a28fdb7d" CHECKSUMTYPE="SHA-1" SIZE="4786">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:19:31" MIMETYPE="text/xml"
-				CHECKSUM="fc9377317368b656b4d7bcd7dcc9a49e0e200786" CHECKSUMTYPE="SHA-1"
-				SIZE="43151">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:19:31" MIMETYPE="text/xml" CHECKSUM="fc9377317368b656b4d7bcd7dcc9a49e0e200786" CHECKSUMTYPE="SHA-1" SIZE="43151">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:19:31" MIMETYPE="text/xml"
-				CHECKSUM="0e3e17dea794ecc5fe4b79c8ca0e5d9ad71eb13d" CHECKSUMTYPE="SHA-1" SIZE="9564">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:19:31" MIMETYPE="text/xml" CHECKSUM="0e3e17dea794ecc5fe4b79c8ca0e5d9ad71eb13d" CHECKSUMTYPE="SHA-1" SIZE="9564">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:19:32" MIMETYPE="text/xml"
-				CHECKSUM="6b3156529bf5b57e51b051c5fff0772c3fb83522" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:19:32" MIMETYPE="text/xml" CHECKSUM="6b3156529bf5b57e51b051c5fff0772c3fb83522" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:19:32" MIMETYPE="text/xml"
-				CHECKSUM="757cdef52effd0f455a76e5a54253ecf2ffeebbc" CHECKSUMTYPE="SHA-1" SIZE="8024">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:19:32" MIMETYPE="text/xml" CHECKSUM="757cdef52effd0f455a76e5a54253ecf2ffeebbc" CHECKSUMTYPE="SHA-1" SIZE="8024">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:19:33" MIMETYPE="text/xml"
-				CHECKSUM="8e840e8ed707de72cbebaee6b2f7ccb80b60c28d" CHECKSUMTYPE="SHA-1" SIZE="6227">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:19:33" MIMETYPE="text/xml" CHECKSUM="8e840e8ed707de72cbebaee6b2f7ccb80b60c28d" CHECKSUMTYPE="SHA-1" SIZE="6227">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:19:33" MIMETYPE="text/xml"
-				CHECKSUM="7ffd51e7269284d4f0874c93d29f74a08b57796a" CHECKSUMTYPE="SHA-1"
-				SIZE="45651">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:19:33" MIMETYPE="text/xml" CHECKSUM="7ffd51e7269284d4f0874c93d29f74a08b57796a" CHECKSUMTYPE="SHA-1" SIZE="45651">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:19:33" MIMETYPE="text/xml"
-				CHECKSUM="5acf11a1efb96deeca3f61d202585da31c267fd7" CHECKSUMTYPE="SHA-1"
-				SIZE="42789">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:19:33" MIMETYPE="text/xml" CHECKSUM="5acf11a1efb96deeca3f61d202585da31c267fd7" CHECKSUMTYPE="SHA-1" SIZE="42789">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:19:34" MIMETYPE="text/xml"
-				CHECKSUM="528ec80279339e98c48463d45a5243b4a55e2f1a" CHECKSUMTYPE="SHA-1" SIZE="6403">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:19:34" MIMETYPE="text/xml" CHECKSUM="528ec80279339e98c48463d45a5243b4a55e2f1a" CHECKSUMTYPE="SHA-1" SIZE="6403">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:19:34" MIMETYPE="text/xml"
-				CHECKSUM="2d791d74d86fdf2ca4e4bbd7a12c540490eb8f03" CHECKSUMTYPE="SHA-1" SIZE="6422">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:19:34" MIMETYPE="text/xml" CHECKSUM="2d791d74d86fdf2ca4e4bbd7a12c540490eb8f03" CHECKSUMTYPE="SHA-1" SIZE="6422">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:19:34" MIMETYPE="text/xml"
-				CHECKSUM="861e9337cef9fd8a2063a005dfcfbe69352109f2" CHECKSUMTYPE="SHA-1" SIZE="6472">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:19:34" MIMETYPE="text/xml" CHECKSUM="861e9337cef9fd8a2063a005dfcfbe69352109f2" CHECKSUMTYPE="SHA-1" SIZE="6472">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:19:34" MIMETYPE="text/xml"
-				CHECKSUM="2eca72e4f6f715498081cd61699009c2afc00ecd" CHECKSUMTYPE="SHA-1" SIZE="5361">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:19:34" MIMETYPE="text/xml" CHECKSUM="2eca72e4f6f715498081cd61699009c2afc00ecd" CHECKSUMTYPE="SHA-1" SIZE="5361">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:19:35" MIMETYPE="text/xml"
-				CHECKSUM="207aa0649b052f3642d853ca8f04bfc8d7a8f5b3" CHECKSUMTYPE="SHA-1"
-				SIZE="48660">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:19:35" MIMETYPE="text/xml" CHECKSUM="207aa0649b052f3642d853ca8f04bfc8d7a8f5b3" CHECKSUMTYPE="SHA-1" SIZE="48660">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:19:35" MIMETYPE="text/xml"
-				CHECKSUM="60bd6cf5909b7f59d6d00e860a699153ec1bb81f" CHECKSUMTYPE="SHA-1"
-				SIZE="40731">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:19:35" MIMETYPE="text/xml" CHECKSUM="60bd6cf5909b7f59d6d00e860a699153ec1bb81f" CHECKSUMTYPE="SHA-1" SIZE="40731">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:19:35" MIMETYPE="text/xml"
-				CHECKSUM="de59514d3121d963850c339061db00ce1919dc22" CHECKSUMTYPE="SHA-1" SIZE="5564">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:19:35" MIMETYPE="text/xml" CHECKSUM="de59514d3121d963850c339061db00ce1919dc22" CHECKSUMTYPE="SHA-1" SIZE="5564">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:19:35" MIMETYPE="text/xml"
-				CHECKSUM="8b48f487fff8417a5505a6acf475735d14cb7735" CHECKSUMTYPE="SHA-1" SIZE="8467">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:19:35" MIMETYPE="text/xml" CHECKSUM="8b48f487fff8417a5505a6acf475735d14cb7735" CHECKSUMTYPE="SHA-1" SIZE="8467">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:19:36" MIMETYPE="text/xml"
-				CHECKSUM="2daac308522d5e634bd348ba7cd50f6a5117d51c" CHECKSUMTYPE="SHA-1" SIZE="8800">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:19:36" MIMETYPE="text/xml" CHECKSUM="2daac308522d5e634bd348ba7cd50f6a5117d51c" CHECKSUMTYPE="SHA-1" SIZE="8800">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:19:36" MIMETYPE="text/xml"
-				CHECKSUM="22327bbcea2254a720c1ed1dc5a9e6b9e4e73ecf" CHECKSUMTYPE="SHA-1"
-				SIZE="34492">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:19:36" MIMETYPE="text/xml" CHECKSUM="22327bbcea2254a720c1ed1dc5a9e6b9e4e73ecf" CHECKSUMTYPE="SHA-1" SIZE="34492">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:19:36" MIMETYPE="text/xml"
-				CHECKSUM="97810a88725ae8cb91a3f40c9cd0575cedd73f34" CHECKSUMTYPE="SHA-1"
-				SIZE="30287">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:19:36" MIMETYPE="text/xml" CHECKSUM="97810a88725ae8cb91a3f40c9cd0575cedd73f34" CHECKSUMTYPE="SHA-1" SIZE="30287">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:19:36" MIMETYPE="text/xml"
-				CHECKSUM="919a15abbd438d9e2ea500495fdaebb6398eff29" CHECKSUMTYPE="SHA-1" SIZE="7763">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:19:36" MIMETYPE="text/xml" CHECKSUM="919a15abbd438d9e2ea500495fdaebb6398eff29" CHECKSUMTYPE="SHA-1" SIZE="7763">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-01_01_0020.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:19:59" MIMETYPE="application/pdf"
-				CHECKSUM="06cfde1a8323db53719540656f552fd450d20bc0" CHECKSUMTYPE="SHA-1"
-				SIZE="5564898">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/bmtnabf_1901-05-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:19:59" MIMETYPE="application/pdf" CHECKSUM="06cfde1a8323db53719540656f552fd450d20bc0" CHECKSUMTYPE="SHA-1" SIZE="5564898">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/01_01/bmtnabf_1901-05-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2517,15 +2380,13 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c007"
-					LABEL="AUS DER ZEHNTEN AUSSTELLUNG DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS &#34;SECESSION&#34;">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c007" LABEL="AUS DER ZEHNTEN AUSSTELLUNG DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS &#34;SECESSION&#34;">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c007a"
-						LABEL="Raumausgestaltung">
+					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c007a" LABEL="Raumausgestaltung">
 						<div ID="L.1.1.5.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00001"/>
@@ -2549,8 +2410,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c009"
-						LABEL="Raumausgestaltung">
+					<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c009" LABEL="Raumausgestaltung">
 						<div ID="L.1.1.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
@@ -2572,8 +2432,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c024"
-						LABEL="Raumausgestaltung">
+					<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c024" LABEL="Raumausgestaltung">
 						<div ID="L.1.1.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -2595,8 +2454,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c025"
-						LABEL="Raumausgestaltung">
+					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c025" LABEL="Raumausgestaltung">
 						<div ID="L.1.1.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -2618,8 +2476,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c026"
-						LABEL="Raumausgestaltung">
+					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c026" LABEL="Raumausgestaltung">
 						<div ID="L.1.1.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -2641,8 +2498,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c027"
-						LABEL="Raumausgestaltung">
+					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c027" LABEL="Raumausgestaltung">
 						<div ID="L.1.1.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -2664,8 +2520,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c028"
-						LABEL="Raumausgestaltung">
+					<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c028" LABEL="Raumausgestaltung">
 						<div ID="L.1.1.13.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -2716,8 +2571,7 @@
 								<div ID="L.1.1.14.4.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.14.4.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"/>
 										</fptr>
 									</div>
 								</div>
@@ -2725,8 +2579,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="TextContent" ORDER="5" DMDID="c010"
-					LABEL="MALEREI UNSERER ZEIT">
+				<div ID="L.1.1.7" TYPE="TextContent" ORDER="5" DMDID="c010" LABEL="MALEREI UNSERER ZEIT">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -2745,18 +2598,15 @@
 								<div ID="L.1.1.7.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="1" DMDID="c012"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="1" DMDID="c012" LABEL="Buchschmuck">
 						<div ID="L.1.1.7.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
@@ -2796,8 +2646,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="TextContent" ORDER="6" DMDID="c017"
-					LABEL="O ÜBER DAS DECKENGEMÄLDE &#34;DIE MEDICIN&#34; VON GUSTAV KLIMT">
+				<div ID="L.1.1.8" TYPE="TextContent" ORDER="6" DMDID="c017" LABEL="O ÜBER DAS DECKENGEMÄLDE &#34;DIE MEDICIN&#34; VON GUSTAV KLIMT">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00003"/>
@@ -2821,26 +2670,19 @@
 								<div ID="L.1.1.8.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00005"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="1" DMDID="c019"
-						LABEL="Buchschmuck. Für V. S. gez">
+					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="1" DMDID="c019" LABEL="Buchschmuck. Für V. S. gez">
 						<div ID="L.1.1.8.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00007"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/05/15_01/bmtnabf_1901-05-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/05/15_01/bmtnabf_1901-05-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-05-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-05-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-05-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-05-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-05-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2634,361 +2628,180 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:09:56"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="cd16858365306a5fbc7d6e59d38f85efdc0b2122"
-				CHECKSUMTYPE="SHA-1" SIZE="6109306">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:09:56" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="cd16858365306a5fbc7d6e59d38f85efdc0b2122" CHECKSUMTYPE="SHA-1" SIZE="6109306">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:10:30"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="2c6441c09e958b48ee14675c12cc310b9f4fa7b6"
-				CHECKSUMTYPE="SHA-1" SIZE="6121029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:10:30" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="2c6441c09e958b48ee14675c12cc310b9f4fa7b6" CHECKSUMTYPE="SHA-1" SIZE="6121029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:11:05"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c54259d2244e17dd0a2b4ef71b9bb8d71164af70"
-				CHECKSUMTYPE="SHA-1" SIZE="6109328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:11:05" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c54259d2244e17dd0a2b4ef71b9bb8d71164af70" CHECKSUMTYPE="SHA-1" SIZE="6109328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:11:45"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="7467e143c6d6178ff9244480a8e24a0d170bc359"
-				CHECKSUMTYPE="SHA-1" SIZE="6121004">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:11:45" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="7467e143c6d6178ff9244480a8e24a0d170bc359" CHECKSUMTYPE="SHA-1" SIZE="6121004">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:12:24"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="405dc285ff2250473ca31c621781904fb3a2d48d"
-				CHECKSUMTYPE="SHA-1" SIZE="6109328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:12:24" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="405dc285ff2250473ca31c621781904fb3a2d48d" CHECKSUMTYPE="SHA-1" SIZE="6109328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:13:00"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="b8f13b702716e9c2537b727f21fa32c6afa78fa0"
-				CHECKSUMTYPE="SHA-1" SIZE="6121017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:13:00" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="b8f13b702716e9c2537b727f21fa32c6afa78fa0" CHECKSUMTYPE="SHA-1" SIZE="6121017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:13:34"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="9562c14503cccea5b0d458f0acbd269687a36282"
-				CHECKSUMTYPE="SHA-1" SIZE="6109328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:13:34" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="9562c14503cccea5b0d458f0acbd269687a36282" CHECKSUMTYPE="SHA-1" SIZE="6109328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:14:07"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="6ec0f767c40528c9d6b4336d6d5dcb4a60b17b49"
-				CHECKSUMTYPE="SHA-1" SIZE="6121021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:14:07" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="6ec0f767c40528c9d6b4336d6d5dcb4a60b17b49" CHECKSUMTYPE="SHA-1" SIZE="6121021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:14:45"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="bcf9c052ecca7f184394f247b3dcceb8d5fb12f0"
-				CHECKSUMTYPE="SHA-1" SIZE="6081417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:14:45" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="bcf9c052ecca7f184394f247b3dcceb8d5fb12f0" CHECKSUMTYPE="SHA-1" SIZE="6081417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:15:23"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="b26010302d4f44790af9a618d5760de3e266342c"
-				CHECKSUMTYPE="SHA-1" SIZE="6120983">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:15:23" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="b26010302d4f44790af9a618d5760de3e266342c" CHECKSUMTYPE="SHA-1" SIZE="6120983">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:16:00"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="b909b161319560a3703764703c6fd31a5a1a5b4d"
-				CHECKSUMTYPE="SHA-1" SIZE="6081429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:16:00" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="b909b161319560a3703764703c6fd31a5a1a5b4d" CHECKSUMTYPE="SHA-1" SIZE="6081429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:16:36"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="37c533d4cc8c4932ff69ff43cf3fe41123e8e099"
-				CHECKSUMTYPE="SHA-1" SIZE="6121029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:16:36" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="37c533d4cc8c4932ff69ff43cf3fe41123e8e099" CHECKSUMTYPE="SHA-1" SIZE="6121029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:17:06"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="0e7e10e0f274878348c2f02e5780e9cea5440a9a"
-				CHECKSUMTYPE="SHA-1" SIZE="6081429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:17:06" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="0e7e10e0f274878348c2f02e5780e9cea5440a9a" CHECKSUMTYPE="SHA-1" SIZE="6081429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:17:45"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="b3d8bc88d4bdf77074f28ec15a9f741a544d277f"
-				CHECKSUMTYPE="SHA-1" SIZE="6121028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:17:45" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="b3d8bc88d4bdf77074f28ec15a9f741a544d277f" CHECKSUMTYPE="SHA-1" SIZE="6121028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:18:18"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="0fc273fa2b9e30bfc237632528edbd9bec666257"
-				CHECKSUMTYPE="SHA-1" SIZE="6081425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:18:18" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="0fc273fa2b9e30bfc237632528edbd9bec666257" CHECKSUMTYPE="SHA-1" SIZE="6081425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:18:52"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="469a772aedbc9868bef42fc1539806573b69f0ef"
-				CHECKSUMTYPE="SHA-1" SIZE="6121026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:18:52" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="469a772aedbc9868bef42fc1539806573b69f0ef" CHECKSUMTYPE="SHA-1" SIZE="6121026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:19:29"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="863237abbbab14cf9b038e3850a0b19c96005b26"
-				CHECKSUMTYPE="SHA-1" SIZE="6081426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:19:29" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="863237abbbab14cf9b038e3850a0b19c96005b26" CHECKSUMTYPE="SHA-1" SIZE="6081426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:20:03"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="524c232ff51e1512a207bbb7c414f72cee92e0a4"
-				CHECKSUMTYPE="SHA-1" SIZE="6121013">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:20:03" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="524c232ff51e1512a207bbb7c414f72cee92e0a4" CHECKSUMTYPE="SHA-1" SIZE="6121013">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:20:39"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="67cf9410fa37c84056a523144b91b2374477720d"
-				CHECKSUMTYPE="SHA-1" SIZE="6081427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:20:39" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="67cf9410fa37c84056a523144b91b2374477720d" CHECKSUMTYPE="SHA-1" SIZE="6081427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:21:15"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="fce908b8f5780f796650e68d9a6b020a5aac9540"
-				CHECKSUMTYPE="SHA-1" SIZE="6121012">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:21:15" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="fce908b8f5780f796650e68d9a6b020a5aac9540" CHECKSUMTYPE="SHA-1" SIZE="6121012">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:21:51"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="5551272fdda73ccdb6f99dfc30d1f3115b71376a"
-				CHECKSUMTYPE="SHA-1" SIZE="6081428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:21:51" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="5551272fdda73ccdb6f99dfc30d1f3115b71376a" CHECKSUMTYPE="SHA-1" SIZE="6081428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:22:25"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="710ace84dce8cae2dfb71aa57b5d54c3d6f786db"
-				CHECKSUMTYPE="SHA-1" SIZE="6121028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:22:25" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="710ace84dce8cae2dfb71aa57b5d54c3d6f786db" CHECKSUMTYPE="SHA-1" SIZE="6121028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:22:58"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="d3ee2b9b838d6e3d7b7441b14d6720ede44181e4"
-				CHECKSUMTYPE="SHA-1" SIZE="6081408">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:22:58" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="d3ee2b9b838d6e3d7b7441b14d6720ede44181e4" CHECKSUMTYPE="SHA-1" SIZE="6081408">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:23:32"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="744b135244dd93d66462206a5242d66efef20537"
-				CHECKSUMTYPE="SHA-1" SIZE="6120992">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:23:32" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="744b135244dd93d66462206a5242d66efef20537" CHECKSUMTYPE="SHA-1" SIZE="6120992">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:24:07"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="facc49519eaf00bdad3534c4ff9c96992e0358d4"
-				CHECKSUMTYPE="SHA-1" SIZE="6081427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:24:07" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="facc49519eaf00bdad3534c4ff9c96992e0358d4" CHECKSUMTYPE="SHA-1" SIZE="6081427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:24:40"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="4eca6b5f5a21b4d62dbe6157b5b3e28cb7fcbe24"
-				CHECKSUMTYPE="SHA-1" SIZE="6121028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:24:40" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="4eca6b5f5a21b4d62dbe6157b5b3e28cb7fcbe24" CHECKSUMTYPE="SHA-1" SIZE="6121028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:25:13"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="925c3ad4d2f39635159d9d3703fe62ef87aa9165"
-				CHECKSUMTYPE="SHA-1" SIZE="6081428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:25:13" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="925c3ad4d2f39635159d9d3703fe62ef87aa9165" CHECKSUMTYPE="SHA-1" SIZE="6081428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:25:49"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="c129af101bb3df161e59f3cb7c5fd4ccca2dd3dd"
-				CHECKSUMTYPE="SHA-1" SIZE="6121020">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:25:49" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="c129af101bb3df161e59f3cb7c5fd4ccca2dd3dd" CHECKSUMTYPE="SHA-1" SIZE="6121020">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/delivery/bmtnabf_1901-05-15_01_0028.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:26:08" MIMETYPE="text/xml"
-				CHECKSUM="0f0cb51b97b659ec89fc7385b847167d468e838d" CHECKSUMTYPE="SHA-1" SIZE="5061">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:26:08" MIMETYPE="text/xml" CHECKSUM="0f0cb51b97b659ec89fc7385b847167d468e838d" CHECKSUMTYPE="SHA-1" SIZE="5061">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:26:08" MIMETYPE="text/xml"
-				CHECKSUM="7da6bc1eb2dd11105bf9b86a1c8201d480e2715f" CHECKSUMTYPE="SHA-1"
-				SIZE="37934">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:26:08" MIMETYPE="text/xml" CHECKSUM="7da6bc1eb2dd11105bf9b86a1c8201d480e2715f" CHECKSUMTYPE="SHA-1" SIZE="37934">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:26:09" MIMETYPE="text/xml"
-				CHECKSUM="31b1125b619d5eb5e29decbb927c674b1363a17d" CHECKSUMTYPE="SHA-1" SIZE="9867">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:26:09" MIMETYPE="text/xml" CHECKSUM="31b1125b619d5eb5e29decbb927c674b1363a17d" CHECKSUMTYPE="SHA-1" SIZE="9867">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:26:09" MIMETYPE="text/xml"
-				CHECKSUM="9a6c50bd2f60f0e1cf284a2d2af9c4207cfedf0b" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:26:09" MIMETYPE="text/xml" CHECKSUM="9a6c50bd2f60f0e1cf284a2d2af9c4207cfedf0b" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:26:09" MIMETYPE="text/xml"
-				CHECKSUM="ea3afb857a9e68a6752bde2dbd5fb1ae9592f7e0" CHECKSUMTYPE="SHA-1" SIZE="5193">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:26:09" MIMETYPE="text/xml" CHECKSUM="ea3afb857a9e68a6752bde2dbd5fb1ae9592f7e0" CHECKSUMTYPE="SHA-1" SIZE="5193">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:26:10" MIMETYPE="text/xml"
-				CHECKSUM="3b7af4a60decd6ae0ffb924bef99870fc816c99f" CHECKSUMTYPE="SHA-1"
-				SIZE="25519">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:26:10" MIMETYPE="text/xml" CHECKSUM="3b7af4a60decd6ae0ffb924bef99870fc816c99f" CHECKSUMTYPE="SHA-1" SIZE="25519">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:26:10" MIMETYPE="text/xml"
-				CHECKSUM="4291aebf9d29879f4291b4baee5852db16929878" CHECKSUMTYPE="SHA-1" SIZE="2009">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:26:10" MIMETYPE="text/xml" CHECKSUM="4291aebf9d29879f4291b4baee5852db16929878" CHECKSUMTYPE="SHA-1" SIZE="2009">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:26:10" MIMETYPE="text/xml"
-				CHECKSUM="310fb1da34ad19ac13aa1c165e6a50759bcd733f" CHECKSUMTYPE="SHA-1" SIZE="9357">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:26:10" MIMETYPE="text/xml" CHECKSUM="310fb1da34ad19ac13aa1c165e6a50759bcd733f" CHECKSUMTYPE="SHA-1" SIZE="9357">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:26:10" MIMETYPE="text/xml"
-				CHECKSUM="bb3346eeccb2068a2881561f53f15537cf43c417" CHECKSUMTYPE="SHA-1" SIZE="2001">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:26:10" MIMETYPE="text/xml" CHECKSUM="bb3346eeccb2068a2881561f53f15537cf43c417" CHECKSUMTYPE="SHA-1" SIZE="2001">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:26:10" MIMETYPE="text/xml"
-				CHECKSUM="b0c1ad4fbd441d4a1447e12e663ea2f2d7fa9c67" CHECKSUMTYPE="SHA-1" SIZE="3595">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:26:10" MIMETYPE="text/xml" CHECKSUM="b0c1ad4fbd441d4a1447e12e663ea2f2d7fa9c67" CHECKSUMTYPE="SHA-1" SIZE="3595">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:26:11" MIMETYPE="text/xml"
-				CHECKSUM="9ad8848a50d0e0fa995c8cf38879cbfe8c8bcc74" CHECKSUMTYPE="SHA-1"
-				SIZE="34893">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:26:11" MIMETYPE="text/xml" CHECKSUM="9ad8848a50d0e0fa995c8cf38879cbfe8c8bcc74" CHECKSUMTYPE="SHA-1" SIZE="34893">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:26:11" MIMETYPE="text/xml"
-				CHECKSUM="ee30fd44555a7e2a38258a34ae435b19d75fb08b" CHECKSUMTYPE="SHA-1"
-				SIZE="49715">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:26:11" MIMETYPE="text/xml" CHECKSUM="ee30fd44555a7e2a38258a34ae435b19d75fb08b" CHECKSUMTYPE="SHA-1" SIZE="49715">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:26:11" MIMETYPE="text/xml"
-				CHECKSUM="19484b3709b0990e760d7bb1386285bec4e6ee26" CHECKSUMTYPE="SHA-1" SIZE="4909">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:26:11" MIMETYPE="text/xml" CHECKSUM="19484b3709b0990e760d7bb1386285bec4e6ee26" CHECKSUMTYPE="SHA-1" SIZE="4909">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:26:11" MIMETYPE="text/xml"
-				CHECKSUM="4ca535fb5ff1b555722bfa4afaaf9a8bd7c4195f" CHECKSUMTYPE="SHA-1"
-				SIZE="39662">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:26:11" MIMETYPE="text/xml" CHECKSUM="4ca535fb5ff1b555722bfa4afaaf9a8bd7c4195f" CHECKSUMTYPE="SHA-1" SIZE="39662">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:26:12" MIMETYPE="text/xml"
-				CHECKSUM="91cd617bfe9c80a0f074a38ca2d7b532ed750f94" CHECKSUMTYPE="SHA-1" SIZE="4864">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:26:12" MIMETYPE="text/xml" CHECKSUM="91cd617bfe9c80a0f074a38ca2d7b532ed750f94" CHECKSUMTYPE="SHA-1" SIZE="4864">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:26:12" MIMETYPE="text/xml"
-				CHECKSUM="4b02b5803740ed338354a5f501978eeff7496050" CHECKSUMTYPE="SHA-1" SIZE="5678">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:26:12" MIMETYPE="text/xml" CHECKSUM="4b02b5803740ed338354a5f501978eeff7496050" CHECKSUMTYPE="SHA-1" SIZE="5678">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:26:12" MIMETYPE="text/xml"
-				CHECKSUM="6a264b71c4c0237513a080100f7ebabb9b4394fd" CHECKSUMTYPE="SHA-1"
-				SIZE="50334">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:26:12" MIMETYPE="text/xml" CHECKSUM="6a264b71c4c0237513a080100f7ebabb9b4394fd" CHECKSUMTYPE="SHA-1" SIZE="50334">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:26:12" MIMETYPE="text/xml"
-				CHECKSUM="7a093fb9ca3a0a93a8ed54381d9c1bf11b605e9a" CHECKSUMTYPE="SHA-1"
-				SIZE="33729">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:26:12" MIMETYPE="text/xml" CHECKSUM="7a093fb9ca3a0a93a8ed54381d9c1bf11b605e9a" CHECKSUMTYPE="SHA-1" SIZE="33729">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:26:13" MIMETYPE="text/xml"
-				CHECKSUM="bd4d0080b53b8c7f65811af2dd91c7a700062089" CHECKSUMTYPE="SHA-1" SIZE="4046">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:26:13" MIMETYPE="text/xml" CHECKSUM="bd4d0080b53b8c7f65811af2dd91c7a700062089" CHECKSUMTYPE="SHA-1" SIZE="4046">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:26:13" MIMETYPE="text/xml"
-				CHECKSUM="e0a5200cc72e1f057a4c66f39722e8b927b4bf9d" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:26:13" MIMETYPE="text/xml" CHECKSUM="e0a5200cc72e1f057a4c66f39722e8b927b4bf9d" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:26:13" MIMETYPE="text/xml"
-				CHECKSUM="af501c3164b5e0701ccab36da5a32b2e03e95066" CHECKSUMTYPE="SHA-1" SIZE="2406">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:26:13" MIMETYPE="text/xml" CHECKSUM="af501c3164b5e0701ccab36da5a32b2e03e95066" CHECKSUMTYPE="SHA-1" SIZE="2406">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:26:13" MIMETYPE="text/xml"
-				CHECKSUM="b8505bff06436f38dda6638a2aaf84d7c0a2a1f6" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:26:13" MIMETYPE="text/xml" CHECKSUM="b8505bff06436f38dda6638a2aaf84d7c0a2a1f6" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:26:14" MIMETYPE="text/xml"
-				CHECKSUM="3837326d04065ec7ee045815e2b69c7556ff638e" CHECKSUMTYPE="SHA-1" SIZE="4827">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:26:14" MIMETYPE="text/xml" CHECKSUM="3837326d04065ec7ee045815e2b69c7556ff638e" CHECKSUMTYPE="SHA-1" SIZE="4827">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:26:14" MIMETYPE="text/xml"
-				CHECKSUM="67e6a0a0deedc26e18a5591e06f3f8177aa0ab94" CHECKSUMTYPE="SHA-1" SIZE="5261">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:26:14" MIMETYPE="text/xml" CHECKSUM="67e6a0a0deedc26e18a5591e06f3f8177aa0ab94" CHECKSUMTYPE="SHA-1" SIZE="5261">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:26:14" MIMETYPE="text/xml"
-				CHECKSUM="243f3610e83731e3f6d70c00116368de58b9c377" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:26:14" MIMETYPE="text/xml" CHECKSUM="243f3610e83731e3f6d70c00116368de58b9c377" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:26:14" MIMETYPE="text/xml"
-				CHECKSUM="458d37cbb580a458e6599c8504f70053098081c6" CHECKSUMTYPE="SHA-1"
-				SIZE="33905">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:26:14" MIMETYPE="text/xml" CHECKSUM="458d37cbb580a458e6599c8504f70053098081c6" CHECKSUMTYPE="SHA-1" SIZE="33905">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:26:15" MIMETYPE="text/xml"
-				CHECKSUM="01bf661ad869728d05cdb439c786304d231f11fd" CHECKSUMTYPE="SHA-1"
-				SIZE="35640">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:26:15" MIMETYPE="text/xml" CHECKSUM="01bf661ad869728d05cdb439c786304d231f11fd" CHECKSUMTYPE="SHA-1" SIZE="35640">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:26:15" MIMETYPE="text/xml"
-				CHECKSUM="30640c4cbf0f45fa42d625e54bb95f74d2618caf" CHECKSUMTYPE="SHA-1" SIZE="8114">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:26:15" MIMETYPE="text/xml" CHECKSUM="30640c4cbf0f45fa42d625e54bb95f74d2618caf" CHECKSUMTYPE="SHA-1" SIZE="8114">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-05-15_01_0028.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:26:44" MIMETYPE="application/pdf"
-				CHECKSUM="6804619f65e0da6c21d5ff2458fa454224b6f30e" CHECKSUMTYPE="SHA-1"
-				SIZE="7935041">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/bmtnabf_1901-05-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:26:44" MIMETYPE="application/pdf" CHECKSUM="6804619f65e0da6c21d5ff2458fa454224b6f30e" CHECKSUMTYPE="SHA-1" SIZE="7935041">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/05/15_01/bmtnabf_1901-05-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3223,8 +3036,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 10 15.05.1901">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by J. V. Krämer OM">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by J. V. Krämer OM">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_CB00001"/>
@@ -3308,8 +3120,7 @@
 					</div>
 				</div>
 				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c008" LABEL="Untitled text">
-					<div ID="L.1.1.6.1" TYPE="Illustration" ORDER="1" DMDID="c009"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.6.1" TYPE="Illustration" ORDER="1" DMDID="c009" LABEL="Untitled Image">
 						<div ID="L.1.1.6.1.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_CB00002"/>
@@ -3322,20 +3133,16 @@
 								<div ID="L.1.1.6.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00001"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00001"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.3" TYPE="Illustration" ORDER="1" DMDID="c010"
-						LABEL="Für V. S. gez">
+					<div ID="L.1.1.6.3" TYPE="Illustration" ORDER="1" DMDID="c010" LABEL="Für V. S. gez">
 						<div ID="L.1.1.6.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00004"/>
@@ -3370,8 +3177,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="1" DMDID="c012"
-						LABEL="Untitled Image by J. V. KRÄMER OM">
+					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="1" DMDID="c012" LABEL="Untitled Image by J. V. KRÄMER OM">
 						<div ID="L.1.1.7.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00001"/>
@@ -3384,8 +3190,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="TextContent" ORDER="6" DMDID="c013"
-					LABEL="Untitled text by J. V. KRÄMER">
+				<div ID="L.1.1.8" TYPE="TextContent" ORDER="6" DMDID="c013" LABEL="Untitled text by J. V. KRÄMER">
 					<div ID="L.1.1.8.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"/>
@@ -3403,8 +3208,7 @@
 							<div ID="L.1.1.8.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.8.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
 									</fptr>
 								</div>
 							</div>
@@ -3412,28 +3216,20 @@
 								<div ID="L.1.1.8.3.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.8.4" TYPE="Illustration" ORDER="1" DMDID="c015"
-						LABEL="Schneefelder am grossen Hermon">
+					<div ID="L.1.1.8.4" TYPE="Illustration" ORDER="1" DMDID="c015" LABEL="Schneefelder am grossen Hermon">
 						<div ID="L.1.1.8.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
@@ -3450,8 +3246,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="2" DMDID="c016"
-						LABEL="Jericho - 1900">
+					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="2" DMDID="c016" LABEL="Jericho - 1900">
 						<div ID="L.1.1.8.5.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
@@ -3463,8 +3258,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="3" DMDID="c017"
-						LABEL="&#34;Sakum&#34; &#34;Balanites aegyptiaca&#34; &#34;Christusdorn&#34;">
+					<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="3" DMDID="c017" LABEL="&#34;Sakum&#34; &#34;Balanites aegyptiaca&#34; &#34;Christusdorn&#34;">
 						<div ID="L.1.1.8.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00005"/>
@@ -3482,8 +3276,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c018"
-					LABEL="Am Brunnen zu Bitir">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c018" LABEL="Am Brunnen zu Bitir">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -3500,8 +3293,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c019"
-					LABEL="Reproduction nach einer Kreidezeichnung">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c019" LABEL="Reproduction nach einer Kreidezeichnung">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -3518,8 +3310,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c020"
-					LABEL="Heilige Bäume vom Haram esch-Scherif in Jerusalem">
+				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c020" LABEL="Heilige Bäume vom Haram esch-Scherif in Jerusalem">
 					<div ID="L.1.1.11.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -3536,8 +3327,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c021"
-					LABEL="BEDUINE AUS DEM OST-JORDANLAND">
+				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c021" LABEL="BEDUINE AUS DEM OST-JORDANLAND">
 					<div ID="L.1.1.12.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00001"/>
@@ -3554,8 +3344,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c022"
-					LABEL="Abend am Nil. Assuan">
+				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c022" LABEL="Abend am Nil. Assuan">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/06/01_01/bmtnabf_1901-06-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/06/01_01/bmtnabf_1901-06-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-06-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-06-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-06-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-06-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-06-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3811,323 +3805,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:11:37"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="ff551dde1e2c76acc74b80f41828fe0e030915cd"
-				CHECKSUMTYPE="SHA-1" SIZE="6220028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:11:37" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="ff551dde1e2c76acc74b80f41828fe0e030915cd" CHECKSUMTYPE="SHA-1" SIZE="6220028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:12:09"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="6e12293cc4ae95f6cd8aa51454cb10a0bec11596"
-				CHECKSUMTYPE="SHA-1" SIZE="6186725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:12:09" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="6e12293cc4ae95f6cd8aa51454cb10a0bec11596" CHECKSUMTYPE="SHA-1" SIZE="6186725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:12:44"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="8c1ba8b75edce7e3fd10758536f190ad8d1fddfc"
-				CHECKSUMTYPE="SHA-1" SIZE="6342428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:12:44" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="8c1ba8b75edce7e3fd10758536f190ad8d1fddfc" CHECKSUMTYPE="SHA-1" SIZE="6342428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:13:18"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="1cbabeab1bd698672ec3ba487af9559bfd7e607c"
-				CHECKSUMTYPE="SHA-1" SIZE="6187628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:13:18" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="1cbabeab1bd698672ec3ba487af9559bfd7e607c" CHECKSUMTYPE="SHA-1" SIZE="6187628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:13:52"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="f12520f6679ccfdcfb734d003b5220f896eccee6"
-				CHECKSUMTYPE="SHA-1" SIZE="6127322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:13:52" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="f12520f6679ccfdcfb734d003b5220f896eccee6" CHECKSUMTYPE="SHA-1" SIZE="6127322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:14:23"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="c3c7c3e4a9cc165f8365a057236dca0c304fe3bf"
-				CHECKSUMTYPE="SHA-1" SIZE="6218228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:14:23" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="c3c7c3e4a9cc165f8365a057236dca0c304fe3bf" CHECKSUMTYPE="SHA-1" SIZE="6218228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:14:54"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="c70b57b8d07992e75da44dcd532125d26d975ecc"
-				CHECKSUMTYPE="SHA-1" SIZE="6152519">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:14:54" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="c70b57b8d07992e75da44dcd532125d26d975ecc" CHECKSUMTYPE="SHA-1" SIZE="6152519">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:15:24"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="1183557e741cd929a39d8f44c833a2e8f6010377"
-				CHECKSUMTYPE="SHA-1" SIZE="6218227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:15:24" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="1183557e741cd929a39d8f44c833a2e8f6010377" CHECKSUMTYPE="SHA-1" SIZE="6218227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:15:56"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="a6f926ddd096b231c340292e4f2ed5d6f13f9fc1"
-				CHECKSUMTYPE="SHA-1" SIZE="6153420">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:15:56" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="a6f926ddd096b231c340292e4f2ed5d6f13f9fc1" CHECKSUMTYPE="SHA-1" SIZE="6153420">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:16:25"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="b17bbc8bb40fd5d78bbcc83dadc25a5a920d8aab"
-				CHECKSUMTYPE="SHA-1" SIZE="6219128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:16:25" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="b17bbc8bb40fd5d78bbcc83dadc25a5a920d8aab" CHECKSUMTYPE="SHA-1" SIZE="6219128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:16:57"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="94b70e5ac82e81afc898abf91b41c2d9343d1c78"
-				CHECKSUMTYPE="SHA-1" SIZE="6152520">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:16:57" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="94b70e5ac82e81afc898abf91b41c2d9343d1c78" CHECKSUMTYPE="SHA-1" SIZE="6152520">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:17:29"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="b143e669cbf79e4b9b2c15cdd3a61b555b54042c"
-				CHECKSUMTYPE="SHA-1" SIZE="6218224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:17:29" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="b143e669cbf79e4b9b2c15cdd3a61b555b54042c" CHECKSUMTYPE="SHA-1" SIZE="6218224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:18:01"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="06d96f98e9c61f13b83359a147b9f869c26f1b5c"
-				CHECKSUMTYPE="SHA-1" SIZE="6152527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:18:01" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="06d96f98e9c61f13b83359a147b9f869c26f1b5c" CHECKSUMTYPE="SHA-1" SIZE="6152527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:18:31"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="e15a1c7f6a172c9cdd19dbfda312f929fbb38482"
-				CHECKSUMTYPE="SHA-1" SIZE="6218228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:18:31" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="e15a1c7f6a172c9cdd19dbfda312f929fbb38482" CHECKSUMTYPE="SHA-1" SIZE="6218228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:19:03"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="81df8d8e2c1c829e01a6b94b0753efdeff405fd6"
-				CHECKSUMTYPE="SHA-1" SIZE="6152525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:19:03" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="81df8d8e2c1c829e01a6b94b0753efdeff405fd6" CHECKSUMTYPE="SHA-1" SIZE="6152525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:19:35"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="cd7e0c4667f5d278caaef788583391a614fb6533"
-				CHECKSUMTYPE="SHA-1" SIZE="6218216">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:19:35" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="cd7e0c4667f5d278caaef788583391a614fb6533" CHECKSUMTYPE="SHA-1" SIZE="6218216">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:20:04"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="f750d3d121a6cb2be4b1bcb1e134222d48f32bb5"
-				CHECKSUMTYPE="SHA-1" SIZE="6152512">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:20:04" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="f750d3d121a6cb2be4b1bcb1e134222d48f32bb5" CHECKSUMTYPE="SHA-1" SIZE="6152512">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:20:34"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="5ef4f2db5ee72b971622e4b1aa8b7184fe1ef055"
-				CHECKSUMTYPE="SHA-1" SIZE="6218227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:20:34" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="5ef4f2db5ee72b971622e4b1aa8b7184fe1ef055" CHECKSUMTYPE="SHA-1" SIZE="6218227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:21:04"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7b05a943392dedf59c8da60658082e68b0a76941"
-				CHECKSUMTYPE="SHA-1" SIZE="6152521">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:21:04" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7b05a943392dedf59c8da60658082e68b0a76941" CHECKSUMTYPE="SHA-1" SIZE="6152521">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:21:34"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="9bcd93112844f61e82c30b4a64cd86bcf6b52303"
-				CHECKSUMTYPE="SHA-1" SIZE="6218227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:21:34" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="9bcd93112844f61e82c30b4a64cd86bcf6b52303" CHECKSUMTYPE="SHA-1" SIZE="6218227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:22:05"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="486158b4ae194efccead1be0cfc624374915333b"
-				CHECKSUMTYPE="SHA-1" SIZE="6152408">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:22:05" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="486158b4ae194efccead1be0cfc624374915333b" CHECKSUMTYPE="SHA-1" SIZE="6152408">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:22:36"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="fedea085e01799a563bf4be60c1948a07dd0d04b"
-				CHECKSUMTYPE="SHA-1" SIZE="6279427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:22:36" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="fedea085e01799a563bf4be60c1948a07dd0d04b" CHECKSUMTYPE="SHA-1" SIZE="6279427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:23:05"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="b83cc4a9f1a58d63e257d9dbf002b1ec836e70f9"
-				CHECKSUMTYPE="SHA-1" SIZE="6152522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:23:05" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="b83cc4a9f1a58d63e257d9dbf002b1ec836e70f9" CHECKSUMTYPE="SHA-1" SIZE="6152522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:23:36"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="264b74b3f7b1f76cff8bba40fbad86e9b5963f73"
-				CHECKSUMTYPE="SHA-1" SIZE="6279333">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:23:36" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="264b74b3f7b1f76cff8bba40fbad86e9b5963f73" CHECKSUMTYPE="SHA-1" SIZE="6279333">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/delivery/bmtnabf_1901-06-01_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:23:55" MIMETYPE="text/xml"
-				CHECKSUM="feda27d3248af2e531cc40f7d2bf849056c1ff6b" CHECKSUMTYPE="SHA-1" SIZE="4848">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:23:55" MIMETYPE="text/xml" CHECKSUM="feda27d3248af2e531cc40f7d2bf849056c1ff6b" CHECKSUMTYPE="SHA-1" SIZE="4848">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:23:55" MIMETYPE="text/xml"
-				CHECKSUM="6d8e39de49e7c5367337d3f30881f02ce0c17b43" CHECKSUMTYPE="SHA-1"
-				SIZE="37648">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:23:55" MIMETYPE="text/xml" CHECKSUM="6d8e39de49e7c5367337d3f30881f02ce0c17b43" CHECKSUMTYPE="SHA-1" SIZE="37648">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:23:55" MIMETYPE="text/xml"
-				CHECKSUM="ddaf6cc46f42b0c609b4d9b237365fba39c68e7c" CHECKSUMTYPE="SHA-1" SIZE="9997">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:23:55" MIMETYPE="text/xml" CHECKSUM="ddaf6cc46f42b0c609b4d9b237365fba39c68e7c" CHECKSUMTYPE="SHA-1" SIZE="9997">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:23:56" MIMETYPE="text/xml"
-				CHECKSUM="bd2403c2475e039e2e229ead1122c04387fcdc8c" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:23:56" MIMETYPE="text/xml" CHECKSUM="bd2403c2475e039e2e229ead1122c04387fcdc8c" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:23:56" MIMETYPE="text/xml"
-				CHECKSUM="bbd381f1392a5106278c3cf6c0b6648a931b9fcc" CHECKSUMTYPE="SHA-1"
-				SIZE="37062">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:23:56" MIMETYPE="text/xml" CHECKSUM="bbd381f1392a5106278c3cf6c0b6648a931b9fcc" CHECKSUMTYPE="SHA-1" SIZE="37062">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:23:56" MIMETYPE="text/xml"
-				CHECKSUM="9346c1f7e183524b57152d539b1e75c0f64a8faf" CHECKSUMTYPE="SHA-1"
-				SIZE="36938">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:23:56" MIMETYPE="text/xml" CHECKSUM="9346c1f7e183524b57152d539b1e75c0f64a8faf" CHECKSUMTYPE="SHA-1" SIZE="36938">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:23:56" MIMETYPE="text/xml"
-				CHECKSUM="dd386149a562cc0f7f389126561e0e64e76dfc24" CHECKSUMTYPE="SHA-1"
-				SIZE="40624">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:23:56" MIMETYPE="text/xml" CHECKSUM="dd386149a562cc0f7f389126561e0e64e76dfc24" CHECKSUMTYPE="SHA-1" SIZE="40624">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:23:57" MIMETYPE="text/xml"
-				CHECKSUM="ab5adc816f55135c0822782f9aa07824f9b89578" CHECKSUMTYPE="SHA-1"
-				SIZE="39157">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:23:57" MIMETYPE="text/xml" CHECKSUM="ab5adc816f55135c0822782f9aa07824f9b89578" CHECKSUMTYPE="SHA-1" SIZE="39157">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:23:57" MIMETYPE="text/xml"
-				CHECKSUM="56a11ea44544ff7fa2d24f686ba0d440b99afe76" CHECKSUMTYPE="SHA-1"
-				SIZE="37953">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:23:57" MIMETYPE="text/xml" CHECKSUM="56a11ea44544ff7fa2d24f686ba0d440b99afe76" CHECKSUMTYPE="SHA-1" SIZE="37953">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:23:57" MIMETYPE="text/xml"
-				CHECKSUM="4a9058246518f680096f5ed8367c09192aa07d39" CHECKSUMTYPE="SHA-1"
-				SIZE="42316">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:23:57" MIMETYPE="text/xml" CHECKSUM="4a9058246518f680096f5ed8367c09192aa07d39" CHECKSUMTYPE="SHA-1" SIZE="42316">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:23:57" MIMETYPE="text/xml"
-				CHECKSUM="c471aec5b357556ec0b87983564aa4a583c1e835" CHECKSUMTYPE="SHA-1"
-				SIZE="41057">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:23:57" MIMETYPE="text/xml" CHECKSUM="c471aec5b357556ec0b87983564aa4a583c1e835" CHECKSUMTYPE="SHA-1" SIZE="41057">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:23:58" MIMETYPE="text/xml"
-				CHECKSUM="28037d861bf6b965b4a9f0dd9b63d6f8f9eeb33f" CHECKSUMTYPE="SHA-1"
-				SIZE="37467">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:23:58" MIMETYPE="text/xml" CHECKSUM="28037d861bf6b965b4a9f0dd9b63d6f8f9eeb33f" CHECKSUMTYPE="SHA-1" SIZE="37467">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:23:58" MIMETYPE="text/xml"
-				CHECKSUM="4f48d5883f98c72d0d394d4483a98c922d06fc09" CHECKSUMTYPE="SHA-1"
-				SIZE="37123">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:23:58" MIMETYPE="text/xml" CHECKSUM="4f48d5883f98c72d0d394d4483a98c922d06fc09" CHECKSUMTYPE="SHA-1" SIZE="37123">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:23:58" MIMETYPE="text/xml"
-				CHECKSUM="ee8a904bcc06220d38fa1f28a946d503b0595930" CHECKSUMTYPE="SHA-1"
-				SIZE="42682">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:23:58" MIMETYPE="text/xml" CHECKSUM="ee8a904bcc06220d38fa1f28a946d503b0595930" CHECKSUMTYPE="SHA-1" SIZE="42682">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:23:59" MIMETYPE="text/xml"
-				CHECKSUM="27a972c5e050504399459ea639b0932006ac9d5e" CHECKSUMTYPE="SHA-1"
-				SIZE="41015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:23:59" MIMETYPE="text/xml" CHECKSUM="27a972c5e050504399459ea639b0932006ac9d5e" CHECKSUMTYPE="SHA-1" SIZE="41015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:23:59" MIMETYPE="text/xml"
-				CHECKSUM="0d990342d44220b8ccbab5cbe3f924d42cdcb1f8" CHECKSUMTYPE="SHA-1"
-				SIZE="36754">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:23:59" MIMETYPE="text/xml" CHECKSUM="0d990342d44220b8ccbab5cbe3f924d42cdcb1f8" CHECKSUMTYPE="SHA-1" SIZE="36754">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:23:59" MIMETYPE="text/xml"
-				CHECKSUM="da2d8962adab2629a1c2b1305ca6507aedf89273" CHECKSUMTYPE="SHA-1"
-				SIZE="38606">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:23:59" MIMETYPE="text/xml" CHECKSUM="da2d8962adab2629a1c2b1305ca6507aedf89273" CHECKSUMTYPE="SHA-1" SIZE="38606">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:23:59" MIMETYPE="text/xml"
-				CHECKSUM="0807d6b8c971239faae81ac5d6b4ce7df641d85a" CHECKSUMTYPE="SHA-1"
-				SIZE="42868">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:23:59" MIMETYPE="text/xml" CHECKSUM="0807d6b8c971239faae81ac5d6b4ce7df641d85a" CHECKSUMTYPE="SHA-1" SIZE="42868">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:24:00" MIMETYPE="text/xml"
-				CHECKSUM="7937a34992ac7f21bdd698d2dbe112b3a3fbf848" CHECKSUMTYPE="SHA-1"
-				SIZE="39160">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:24:00" MIMETYPE="text/xml" CHECKSUM="7937a34992ac7f21bdd698d2dbe112b3a3fbf848" CHECKSUMTYPE="SHA-1" SIZE="39160">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:24:00" MIMETYPE="text/xml"
-				CHECKSUM="e19ad2408f99351bfcb683c9e443198bd4fb877a" CHECKSUMTYPE="SHA-1"
-				SIZE="39918">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:24:00" MIMETYPE="text/xml" CHECKSUM="e19ad2408f99351bfcb683c9e443198bd4fb877a" CHECKSUMTYPE="SHA-1" SIZE="39918">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:24:00" MIMETYPE="text/xml"
-				CHECKSUM="d887e3f198af9c45aefad3ce7f8a1c2857b9782c" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:24:00" MIMETYPE="text/xml" CHECKSUM="d887e3f198af9c45aefad3ce7f8a1c2857b9782c" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:24:00" MIMETYPE="text/xml"
-				CHECKSUM="a0dc8e749c6677b4ea6570d66bb5f4e52590c651" CHECKSUMTYPE="SHA-1"
-				SIZE="31625">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:24:00" MIMETYPE="text/xml" CHECKSUM="a0dc8e749c6677b4ea6570d66bb5f4e52590c651" CHECKSUMTYPE="SHA-1" SIZE="31625">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:24:00" MIMETYPE="text/xml"
-				CHECKSUM="0696c8362b802ba45cbe9731d16fb5ad0a264829" CHECKSUMTYPE="SHA-1"
-				SIZE="31684">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:24:00" MIMETYPE="text/xml" CHECKSUM="0696c8362b802ba45cbe9731d16fb5ad0a264829" CHECKSUMTYPE="SHA-1" SIZE="31684">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:24:01" MIMETYPE="text/xml"
-				CHECKSUM="bb46978c225821f9d9880da9b0a00ce450c632a1" CHECKSUMTYPE="SHA-1" SIZE="7431">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:24:01" MIMETYPE="text/xml" CHECKSUM="bb46978c225821f9d9880da9b0a00ce450c632a1" CHECKSUMTYPE="SHA-1" SIZE="7431">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-01_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:24:29" MIMETYPE="application/pdf"
-				CHECKSUM="824651b2498d6ad82b449df19aba1cbfc67288eb" CHECKSUMTYPE="SHA-1"
-				SIZE="7317587">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/bmtnabf_1901-06-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:24:29" MIMETYPE="application/pdf" CHECKSUM="824651b2498d6ad82b449df19aba1cbfc67288eb" CHECKSUMTYPE="SHA-1" SIZE="7317587">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/01_01/bmtnabf_1901-06-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -4418,8 +4245,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="1" DMDID="c009"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.5.4" TYPE="Illustration" ORDER="1" DMDID="c009" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.5.4.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00001"/>
@@ -4432,16 +4258,14 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.4.3" TYPE="Illustration" ORDER="2" DMDID="c010"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.5.4.3" TYPE="Illustration" ORDER="2" DMDID="c010" LABEL="Untitled Image">
 							<div ID="L.1.1.5.4.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.4.5" TYPE="Illustration" ORDER="4" DMDID="c012"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.5.4.5" TYPE="Illustration" ORDER="4" DMDID="c012" LABEL="Untitled Image">
 							<div ID="L.1.1.5.4.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00004"/>
@@ -4461,8 +4285,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00006"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.6.3" TYPE="Illustration" ORDER="1" DMDID="c014"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.6.3" TYPE="Illustration" ORDER="1" DMDID="c014" LABEL="Untitled Image">
 						<div ID="L.1.1.6.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00003"/>
@@ -4475,62 +4298,37 @@
 								<div ID="L.1.1.6.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00005"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="1" DMDID="c015"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="1" DMDID="c015" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.5.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00003"/>
@@ -4543,8 +4341,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.5.3" TYPE="Illustration" ORDER="2" DMDID="c016"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.5.3" TYPE="Illustration" ORDER="2" DMDID="c016" LABEL="Untitled Image">
 							<div ID="L.1.1.6.5.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_CB00002"/>
@@ -4552,8 +4349,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.6" TYPE="Illustration" ORDER="2" DMDID="c017"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.6" TYPE="Illustration" ORDER="2" DMDID="c017" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.6.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00001"/>
@@ -4566,40 +4362,35 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.6.3" TYPE="Illustration" ORDER="2" DMDID="c018"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.6.3" TYPE="Illustration" ORDER="2" DMDID="c018" LABEL="Untitled Image">
 							<div ID="L.1.1.6.6.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.6.4" TYPE="Illustration" ORDER="3" DMDID="c019"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.6.4" TYPE="Illustration" ORDER="3" DMDID="c019" LABEL="Untitled Image">
 							<div ID="L.1.1.6.6.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.6.5" TYPE="Illustration" ORDER="4" DMDID="c020"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.6.5" TYPE="Illustration" ORDER="4" DMDID="c020" LABEL="Untitled Image">
 							<div ID="L.1.1.6.6.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.6.6" TYPE="Illustration" ORDER="5" DMDID="c021"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.6.6" TYPE="Illustration" ORDER="5" DMDID="c021" LABEL="Untitled Image">
 							<div ID="L.1.1.6.6.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00005"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.6.7" TYPE="Illustration" ORDER="6" DMDID="c022"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.6.7" TYPE="Illustration" ORDER="6" DMDID="c022" LABEL="Untitled Image">
 							<div ID="L.1.1.6.6.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00006"/>
@@ -4607,8 +4398,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.7" TYPE="Illustration" ORDER="3" DMDID="c023"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.7" TYPE="Illustration" ORDER="3" DMDID="c023" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.7.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00001"/>
@@ -4621,48 +4411,42 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.7.3" TYPE="Illustration" ORDER="2" DMDID="c024"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.7.3" TYPE="Illustration" ORDER="2" DMDID="c024" LABEL="Untitled Image">
 							<div ID="L.1.1.6.7.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.7.4" TYPE="Illustration" ORDER="3" DMDID="c025"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.7.4" TYPE="Illustration" ORDER="3" DMDID="c025" LABEL="Untitled Image">
 							<div ID="L.1.1.6.7.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.7.5" TYPE="Illustration" ORDER="4" DMDID="c026"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.7.5" TYPE="Illustration" ORDER="4" DMDID="c026" LABEL="Untitled Image">
 							<div ID="L.1.1.6.7.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.7.6" TYPE="Illustration" ORDER="5" DMDID="c027"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.7.6" TYPE="Illustration" ORDER="5" DMDID="c027" LABEL="Untitled Image">
 							<div ID="L.1.1.6.7.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00005"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.7.7" TYPE="Illustration" ORDER="6" DMDID="c028"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.7.7" TYPE="Illustration" ORDER="6" DMDID="c028" LABEL="Untitled Image">
 							<div ID="L.1.1.6.7.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00006"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.7.8" TYPE="Illustration" ORDER="7" DMDID="c029"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.7.8" TYPE="Illustration" ORDER="7" DMDID="c029" LABEL="Untitled Image">
 							<div ID="L.1.1.6.7.8.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00007"/>
@@ -4670,8 +4454,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.8" TYPE="Illustration" ORDER="4" DMDID="c030"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.8" TYPE="Illustration" ORDER="4" DMDID="c030" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.8.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
@@ -4684,56 +4467,49 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.8.3" TYPE="Illustration" ORDER="2" DMDID="c031"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.8.3" TYPE="Illustration" ORDER="2" DMDID="c031" LABEL="Untitled Image">
 							<div ID="L.1.1.6.8.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.8.4" TYPE="Illustration" ORDER="3" DMDID="c032"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.8.4" TYPE="Illustration" ORDER="3" DMDID="c032" LABEL="Untitled Image">
 							<div ID="L.1.1.6.8.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.8.5" TYPE="Illustration" ORDER="4" DMDID="c033"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.8.5" TYPE="Illustration" ORDER="4" DMDID="c033" LABEL="Untitled Image">
 							<div ID="L.1.1.6.8.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.8.6" TYPE="Illustration" ORDER="5" DMDID="c034"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.8.6" TYPE="Illustration" ORDER="5" DMDID="c034" LABEL="Untitled Image">
 							<div ID="L.1.1.6.8.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00005"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.8.7" TYPE="Illustration" ORDER="6" DMDID="c035"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.8.7" TYPE="Illustration" ORDER="6" DMDID="c035" LABEL="Untitled Image">
 							<div ID="L.1.1.6.8.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00006"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.8.8" TYPE="Illustration" ORDER="7" DMDID="c036"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.8.8" TYPE="Illustration" ORDER="7" DMDID="c036" LABEL="Untitled Image">
 							<div ID="L.1.1.6.8.8.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00007"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.8.9" TYPE="Illustration" ORDER="8" DMDID="c037"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.8.9" TYPE="Illustration" ORDER="8" DMDID="c037" LABEL="Untitled Image">
 							<div ID="L.1.1.6.8.9.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00008"/>
@@ -4741,8 +4517,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.9" TYPE="Illustration" ORDER="5" DMDID="c038"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.9" TYPE="Illustration" ORDER="5" DMDID="c038" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.9.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00001"/>
@@ -4755,32 +4530,28 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.9.3" TYPE="Illustration" ORDER="2" DMDID="c039"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.9.3" TYPE="Illustration" ORDER="2" DMDID="c039" LABEL="Untitled Image">
 							<div ID="L.1.1.6.9.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.9.4" TYPE="Illustration" ORDER="3" DMDID="c040"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.9.4" TYPE="Illustration" ORDER="3" DMDID="c040" LABEL="Untitled Image">
 							<div ID="L.1.1.6.9.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.9.5" TYPE="Illustration" ORDER="4" DMDID="c041"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.9.5" TYPE="Illustration" ORDER="4" DMDID="c041" LABEL="Untitled Image">
 							<div ID="L.1.1.6.9.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.9.6" TYPE="Illustration" ORDER="5" DMDID="c042"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.9.6" TYPE="Illustration" ORDER="5" DMDID="c042" LABEL="Untitled Image">
 							<div ID="L.1.1.6.9.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00005"/>
@@ -4788,8 +4559,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.10" TYPE="Illustration" ORDER="6" DMDID="c043"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.10" TYPE="Illustration" ORDER="6" DMDID="c043" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.10.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
@@ -4802,40 +4572,35 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.10.3" TYPE="Illustration" ORDER="2" DMDID="c044"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.10.3" TYPE="Illustration" ORDER="2" DMDID="c044" LABEL="Untitled Image">
 							<div ID="L.1.1.6.10.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.10.4" TYPE="Illustration" ORDER="3" DMDID="c045"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.10.4" TYPE="Illustration" ORDER="3" DMDID="c045" LABEL="Untitled Image">
 							<div ID="L.1.1.6.10.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.10.5" TYPE="Illustration" ORDER="4" DMDID="c046"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.10.5" TYPE="Illustration" ORDER="4" DMDID="c046" LABEL="Untitled Image">
 							<div ID="L.1.1.6.10.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.10.6" TYPE="Illustration" ORDER="5" DMDID="c047"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.10.6" TYPE="Illustration" ORDER="5" DMDID="c047" LABEL="Untitled Image">
 							<div ID="L.1.1.6.10.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00005"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.10.7" TYPE="Illustration" ORDER="6" DMDID="c048"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.10.7" TYPE="Illustration" ORDER="6" DMDID="c048" LABEL="Untitled Image">
 							<div ID="L.1.1.6.10.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00006"/>
@@ -4843,8 +4608,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.11" TYPE="Illustration" ORDER="7" DMDID="c049"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.11" TYPE="Illustration" ORDER="7" DMDID="c049" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.11.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
@@ -4857,56 +4621,49 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.11.3" TYPE="Illustration" ORDER="2" DMDID="c050"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.11.3" TYPE="Illustration" ORDER="2" DMDID="c050" LABEL="Untitled Image">
 							<div ID="L.1.1.6.11.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.11.4" TYPE="Illustration" ORDER="3" DMDID="c051"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.11.4" TYPE="Illustration" ORDER="3" DMDID="c051" LABEL="Untitled Image">
 							<div ID="L.1.1.6.11.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.11.5" TYPE="Illustration" ORDER="4" DMDID="c052"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.11.5" TYPE="Illustration" ORDER="4" DMDID="c052" LABEL="Untitled Image">
 							<div ID="L.1.1.6.11.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.11.6" TYPE="Illustration" ORDER="5" DMDID="c053"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.11.6" TYPE="Illustration" ORDER="5" DMDID="c053" LABEL="Untitled Image">
 							<div ID="L.1.1.6.11.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00005"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.11.7" TYPE="Illustration" ORDER="6" DMDID="c054"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.11.7" TYPE="Illustration" ORDER="6" DMDID="c054" LABEL="Untitled Image">
 							<div ID="L.1.1.6.11.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00006"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.11.8" TYPE="Illustration" ORDER="7" DMDID="c055"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.11.8" TYPE="Illustration" ORDER="7" DMDID="c055" LABEL="Untitled Image">
 							<div ID="L.1.1.6.11.8.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00007"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.11.9" TYPE="Illustration" ORDER="8" DMDID="c056"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.11.9" TYPE="Illustration" ORDER="8" DMDID="c056" LABEL="Untitled Image">
 							<div ID="L.1.1.6.11.9.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00008"/>
@@ -4914,8 +4671,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.12" TYPE="Illustration" ORDER="8" DMDID="c057"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.12" TYPE="Illustration" ORDER="8" DMDID="c057" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.12.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00001"/>
@@ -4928,24 +4684,21 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.12.3" TYPE="Illustration" ORDER="2" DMDID="c058"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.12.3" TYPE="Illustration" ORDER="2" DMDID="c058" LABEL="Untitled Image">
 							<div ID="L.1.1.6.12.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.12.4" TYPE="Illustration" ORDER="3" DMDID="c059"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.12.4" TYPE="Illustration" ORDER="3" DMDID="c059" LABEL="Untitled Image">
 							<div ID="L.1.1.6.12.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.12.5" TYPE="Illustration" ORDER="4" DMDID="c060"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.12.5" TYPE="Illustration" ORDER="4" DMDID="c060" LABEL="Untitled Image">
 							<div ID="L.1.1.6.12.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00004"/>
@@ -4953,8 +4706,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.13" TYPE="Illustration" ORDER="9" DMDID="c061"
-						LABEL="Untitled Image by Gez. v. Dt. Hans Przibram">
+					<div ID="L.1.1.6.13" TYPE="Illustration" ORDER="9" DMDID="c061" LABEL="Untitled Image by Gez. v. Dt. Hans Przibram">
 						<div ID="L.1.1.6.13.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00001"/>
@@ -4967,40 +4719,35 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.13.3" TYPE="Illustration" ORDER="2" DMDID="c062"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.13.3" TYPE="Illustration" ORDER="2" DMDID="c062" LABEL="Untitled Image">
 							<div ID="L.1.1.6.13.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.13.4" TYPE="Illustration" ORDER="3" DMDID="c063"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.13.4" TYPE="Illustration" ORDER="3" DMDID="c063" LABEL="Untitled Image">
 							<div ID="L.1.1.6.13.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.13.5" TYPE="Illustration" ORDER="4" DMDID="c064"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.13.5" TYPE="Illustration" ORDER="4" DMDID="c064" LABEL="Untitled Image">
 							<div ID="L.1.1.6.13.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.13.6" TYPE="Illustration" ORDER="5" DMDID="c065"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.13.6" TYPE="Illustration" ORDER="5" DMDID="c065" LABEL="Untitled Image">
 							<div ID="L.1.1.6.13.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00005"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.13.7" TYPE="Illustration" ORDER="6" DMDID="c066"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.13.7" TYPE="Illustration" ORDER="6" DMDID="c066" LABEL="Untitled Image">
 							<div ID="L.1.1.6.13.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00006"/>
@@ -5008,8 +4755,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.14" TYPE="Illustration" ORDER="10" DMDID="c067"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.14" TYPE="Illustration" ORDER="10" DMDID="c067" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.14.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"/>
@@ -5022,40 +4768,35 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.14.3" TYPE="Illustration" ORDER="2" DMDID="c068"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.14.3" TYPE="Illustration" ORDER="2" DMDID="c068" LABEL="Untitled Image">
 							<div ID="L.1.1.6.14.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.14.4" TYPE="Illustration" ORDER="3" DMDID="c069"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.14.4" TYPE="Illustration" ORDER="3" DMDID="c069" LABEL="Untitled Image">
 							<div ID="L.1.1.6.14.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.14.5" TYPE="Illustration" ORDER="4" DMDID="c070"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.14.5" TYPE="Illustration" ORDER="4" DMDID="c070" LABEL="Untitled Image">
 							<div ID="L.1.1.6.14.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.14.6" TYPE="Illustration" ORDER="5" DMDID="c071"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.14.6" TYPE="Illustration" ORDER="5" DMDID="c071" LABEL="Untitled Image">
 							<div ID="L.1.1.6.14.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00005"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.14.7" TYPE="Illustration" ORDER="6" DMDID="c072"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.14.7" TYPE="Illustration" ORDER="6" DMDID="c072" LABEL="Untitled Image">
 							<div ID="L.1.1.6.14.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00006"/>
@@ -5063,8 +4804,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.15" TYPE="Illustration" ORDER="11" DMDID="c073"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.15" TYPE="Illustration" ORDER="11" DMDID="c073" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.15.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00001"/>
@@ -5077,40 +4817,35 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.15.3" TYPE="Illustration" ORDER="2" DMDID="c074"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.15.3" TYPE="Illustration" ORDER="2" DMDID="c074" LABEL="Untitled Image">
 							<div ID="L.1.1.6.15.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.15.4" TYPE="Illustration" ORDER="3" DMDID="c075"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.15.4" TYPE="Illustration" ORDER="3" DMDID="c075" LABEL="Untitled Image">
 							<div ID="L.1.1.6.15.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.15.5" TYPE="Illustration" ORDER="4" DMDID="c076"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.15.5" TYPE="Illustration" ORDER="4" DMDID="c076" LABEL="Untitled Image">
 							<div ID="L.1.1.6.15.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.15.6" TYPE="Illustration" ORDER="5" DMDID="c077"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.15.6" TYPE="Illustration" ORDER="5" DMDID="c077" LABEL="Untitled Image">
 							<div ID="L.1.1.6.15.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00005"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.15.7" TYPE="Illustration" ORDER="6" DMDID="c078"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.15.7" TYPE="Illustration" ORDER="6" DMDID="c078" LABEL="Untitled Image">
 							<div ID="L.1.1.6.15.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00006"/>
@@ -5118,8 +4853,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.16" TYPE="Illustration" ORDER="12" DMDID="c079"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.16" TYPE="Illustration" ORDER="12" DMDID="c079" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.16.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
@@ -5132,24 +4866,21 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.16.3" TYPE="Illustration" ORDER="2" DMDID="c080"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.16.3" TYPE="Illustration" ORDER="2" DMDID="c080" LABEL="Untitled Image">
 							<div ID="L.1.1.6.16.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.16.4" TYPE="Illustration" ORDER="3" DMDID="c081"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.16.4" TYPE="Illustration" ORDER="3" DMDID="c081" LABEL="Untitled Image">
 							<div ID="L.1.1.6.16.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.16.5" TYPE="Illustration" ORDER="4" DMDID="c082"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.16.5" TYPE="Illustration" ORDER="4" DMDID="c082" LABEL="Untitled Image">
 							<div ID="L.1.1.6.16.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_CB00004"/>
@@ -5157,8 +4888,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.17" TYPE="Illustration" ORDER="13" DMDID="c083"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.17" TYPE="Illustration" ORDER="13" DMDID="c083" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.17.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00001"/>
@@ -5171,40 +4901,35 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.17.3" TYPE="Illustration" ORDER="2" DMDID="c084"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.17.3" TYPE="Illustration" ORDER="2" DMDID="c084" LABEL="Untitled Image">
 							<div ID="L.1.1.6.17.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.17.4" TYPE="Illustration" ORDER="3" DMDID="c085"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.17.4" TYPE="Illustration" ORDER="3" DMDID="c085" LABEL="Untitled Image">
 							<div ID="L.1.1.6.17.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.17.5" TYPE="Illustration" ORDER="4" DMDID="c086"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.17.5" TYPE="Illustration" ORDER="4" DMDID="c086" LABEL="Untitled Image">
 							<div ID="L.1.1.6.17.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.17.6" TYPE="Illustration" ORDER="5" DMDID="c087"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.17.6" TYPE="Illustration" ORDER="5" DMDID="c087" LABEL="Untitled Image">
 							<div ID="L.1.1.6.17.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00005"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.17.7" TYPE="Illustration" ORDER="6" DMDID="c088"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.17.7" TYPE="Illustration" ORDER="6" DMDID="c088" LABEL="Untitled Image">
 							<div ID="L.1.1.6.17.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00006"/>
@@ -5212,8 +4937,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.18" TYPE="Illustration" ORDER="14" DMDID="c089"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.18" TYPE="Illustration" ORDER="14" DMDID="c089" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.18.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
@@ -5226,48 +4950,42 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.18.3" TYPE="Illustration" ORDER="2" DMDID="c090"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.18.3" TYPE="Illustration" ORDER="2" DMDID="c090" LABEL="Untitled Image">
 							<div ID="L.1.1.6.18.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.18.4" TYPE="Illustration" ORDER="3" DMDID="c091"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.18.4" TYPE="Illustration" ORDER="3" DMDID="c091" LABEL="Untitled Image">
 							<div ID="L.1.1.6.18.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.18.5" TYPE="Illustration" ORDER="4" DMDID="c092"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.18.5" TYPE="Illustration" ORDER="4" DMDID="c092" LABEL="Untitled Image">
 							<div ID="L.1.1.6.18.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00005"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.18.6" TYPE="Illustration" ORDER="5" DMDID="c093"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.18.6" TYPE="Illustration" ORDER="5" DMDID="c093" LABEL="Untitled Image">
 							<div ID="L.1.1.6.18.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00006"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.18.7" TYPE="Illustration" ORDER="6" DMDID="c094"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.18.7" TYPE="Illustration" ORDER="6" DMDID="c094" LABEL="Untitled Image">
 							<div ID="L.1.1.6.18.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00007"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.18.8" TYPE="Illustration" ORDER="7" DMDID="c095"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.18.8" TYPE="Illustration" ORDER="7" DMDID="c095" LABEL="Untitled Image">
 							<div ID="L.1.1.6.18.8.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00001"/>
@@ -5275,8 +4993,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.19" TYPE="Illustration" ORDER="15" DMDID="c096"
-						LABEL="Untitled Image by Dr. Hans Przibram">
+					<div ID="L.1.1.6.19" TYPE="Illustration" ORDER="15" DMDID="c096" LABEL="Untitled Image by Dr. Hans Przibram">
 						<div ID="L.1.1.6.19.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00001"/>
@@ -5289,72 +5006,63 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.19.3" TYPE="Illustration" ORDER="2" DMDID="c097"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.19.3" TYPE="Illustration" ORDER="2" DMDID="c097" LABEL="Untitled Image">
 							<div ID="L.1.1.6.19.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00004"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.19.4" TYPE="Illustration" ORDER="3" DMDID="c098"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.19.4" TYPE="Illustration" ORDER="3" DMDID="c098" LABEL="Untitled Image">
 							<div ID="L.1.1.6.19.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00002"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.19.5" TYPE="Illustration" ORDER="4" DMDID="c099"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.19.5" TYPE="Illustration" ORDER="4" DMDID="c099" LABEL="Untitled Image">
 							<div ID="L.1.1.6.19.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00005"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.19.6" TYPE="Illustration" ORDER="5" DMDID="c100"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.19.6" TYPE="Illustration" ORDER="5" DMDID="c100" LABEL="Untitled Image">
 							<div ID="L.1.1.6.19.6.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00006"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.19.7" TYPE="Illustration" ORDER="6" DMDID="c101"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.19.7" TYPE="Illustration" ORDER="6" DMDID="c101" LABEL="Untitled Image">
 							<div ID="L.1.1.6.19.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00007"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.19.8" TYPE="Illustration" ORDER="7" DMDID="c102"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.19.8" TYPE="Illustration" ORDER="7" DMDID="c102" LABEL="Untitled Image">
 							<div ID="L.1.1.6.19.8.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00008"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.19.9" TYPE="Illustration" ORDER="8" DMDID="c103"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.19.9" TYPE="Illustration" ORDER="8" DMDID="c103" LABEL="Untitled Image">
 							<div ID="L.1.1.6.19.9.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00009"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.19.10" TYPE="Illustration" ORDER="9" DMDID="c104"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.19.10" TYPE="Illustration" ORDER="9" DMDID="c104" LABEL="Untitled Image">
 							<div ID="L.1.1.6.19.10.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00010"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.6.19.11" TYPE="Illustration" ORDER="10" DMDID="c105"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.6.19.11" TYPE="Illustration" ORDER="10" DMDID="c105" LABEL="Untitled Image">
 							<div ID="L.1.1.6.19.11.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00003"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/06/15_01/bmtnabf_1901-06-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/06/15_01/bmtnabf_1901-06-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-06-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-06-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-06-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-06-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-06-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -1976,263 +1970,132 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:13:10"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="f7a050cbd472b7bfe89523acd351a7e4523b79df"
-				CHECKSUMTYPE="SHA-1" SIZE="6108428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:13:10" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="f7a050cbd472b7bfe89523acd351a7e4523b79df" CHECKSUMTYPE="SHA-1" SIZE="6108428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:13:42"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="2309ea2940a599ca194f0df3fe3e48c53dfb3f65"
-				CHECKSUMTYPE="SHA-1" SIZE="5977923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:13:42" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="2309ea2940a599ca194f0df3fe3e48c53dfb3f65" CHECKSUMTYPE="SHA-1" SIZE="5977923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:14:19"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="7f4f98e72ce86a78cf865902a9b7450ed117fab8"
-				CHECKSUMTYPE="SHA-1" SIZE="6108417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:14:19" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="7f4f98e72ce86a78cf865902a9b7450ed117fab8" CHECKSUMTYPE="SHA-1" SIZE="6108417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:14:59"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="c8d92d18db8b5b758b08e2798de218ccea8e5843"
-				CHECKSUMTYPE="SHA-1" SIZE="5977921">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:14:59" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="c8d92d18db8b5b758b08e2798de218ccea8e5843" CHECKSUMTYPE="SHA-1" SIZE="5977921">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:15:36"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="ac554b8107474532a3226aac708adb6fb13ead09"
-				CHECKSUMTYPE="SHA-1" SIZE="6136270">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:15:36" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="ac554b8107474532a3226aac708adb6fb13ead09" CHECKSUMTYPE="SHA-1" SIZE="6136270">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:16:12"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="c160a09116e3cf935f0b60f25b4a06c3fab2b5b6"
-				CHECKSUMTYPE="SHA-1" SIZE="5977922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:16:12" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="c160a09116e3cf935f0b60f25b4a06c3fab2b5b6" CHECKSUMTYPE="SHA-1" SIZE="5977922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:16:46"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="d133bb696abb5d712c8e06ffaa4a2b90f2f1d036"
-				CHECKSUMTYPE="SHA-1" SIZE="6117407">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:16:46" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="d133bb696abb5d712c8e06ffaa4a2b90f2f1d036" CHECKSUMTYPE="SHA-1" SIZE="6117407">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:17:23"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="d8e838a04a282a68a32d3d7f69cd145c361d93c9"
-				CHECKSUMTYPE="SHA-1" SIZE="6091296">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:17:23" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="d8e838a04a282a68a32d3d7f69cd145c361d93c9" CHECKSUMTYPE="SHA-1" SIZE="6091296">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:17:56"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="ae05647f1a3c58e120beb3f508f30ac81e2bbd46"
-				CHECKSUMTYPE="SHA-1" SIZE="6117416">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:17:56" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="ae05647f1a3c58e120beb3f508f30ac81e2bbd46" CHECKSUMTYPE="SHA-1" SIZE="6117416">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:18:29"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="30ac267637b56a39e7807abed27aee9c90092e91"
-				CHECKSUMTYPE="SHA-1" SIZE="6062510">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:18:29" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="30ac267637b56a39e7807abed27aee9c90092e91" CHECKSUMTYPE="SHA-1" SIZE="6062510">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:19:02"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="7d648c4bc2a95b4b420e7392d69a88a157f9501f"
-				CHECKSUMTYPE="SHA-1" SIZE="6087717">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:19:02" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="7d648c4bc2a95b4b420e7392d69a88a157f9501f" CHECKSUMTYPE="SHA-1" SIZE="6087717">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:19:38"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="bae6403ea7eee39f8d5332be20b8b78dc3cfdb4d"
-				CHECKSUMTYPE="SHA-1" SIZE="6074926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:19:38" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="bae6403ea7eee39f8d5332be20b8b78dc3cfdb4d" CHECKSUMTYPE="SHA-1" SIZE="6074926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:20:17"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="92a8ee1e68e27582ed7639d404788a01b065e00e"
-				CHECKSUMTYPE="SHA-1" SIZE="6052607">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:20:17" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="92a8ee1e68e27582ed7639d404788a01b065e00e" CHECKSUMTYPE="SHA-1" SIZE="6052607">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:20:53"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="3355cbf50744b03cac99da058d6c6c0093492868"
-				CHECKSUMTYPE="SHA-1" SIZE="6075109">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:20:53" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="3355cbf50744b03cac99da058d6c6c0093492868" CHECKSUMTYPE="SHA-1" SIZE="6075109">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:21:29"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="3b33b3aefaca415e4f7e4c73c964dd2c56345092"
-				CHECKSUMTYPE="SHA-1" SIZE="6052624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:21:29" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="3b33b3aefaca415e4f7e4c73c964dd2c56345092" CHECKSUMTYPE="SHA-1" SIZE="6052624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:22:02"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="cbc128c531e885631d30a07883d4c915c61ee718"
-				CHECKSUMTYPE="SHA-1" SIZE="6075122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:22:02" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="cbc128c531e885631d30a07883d4c915c61ee718" CHECKSUMTYPE="SHA-1" SIZE="6075122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:22:35"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="f80cecbba1ddd05221a14de08b1f9bbb08f39ee9"
-				CHECKSUMTYPE="SHA-1" SIZE="6052386">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:22:35" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="f80cecbba1ddd05221a14de08b1f9bbb08f39ee9" CHECKSUMTYPE="SHA-1" SIZE="6052386">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:23:07"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="99bc96d47703cd07a05999c69709023ce352c3e8"
-				CHECKSUMTYPE="SHA-1" SIZE="5922124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:23:07" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="99bc96d47703cd07a05999c69709023ce352c3e8" CHECKSUMTYPE="SHA-1" SIZE="5922124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:23:41"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="0c878fc1e7e71cb518c7d9584c1262eb39055a3e"
-				CHECKSUMTYPE="SHA-1" SIZE="5833025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:23:41" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="0c878fc1e7e71cb518c7d9584c1262eb39055a3e" CHECKSUMTYPE="SHA-1" SIZE="5833025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:24:16"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="68fb9fca44f5bdeab106fbd274709688b273fbdd"
-				CHECKSUMTYPE="SHA-1" SIZE="6141721">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:24:16" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="68fb9fca44f5bdeab106fbd274709688b273fbdd" CHECKSUMTYPE="SHA-1" SIZE="6141721">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/delivery/bmtnabf_1901-06-15_01_0020.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:24:34" MIMETYPE="text/xml"
-				CHECKSUM="7c2beb0021bebff6c6b2497751c32003c6a42c29" CHECKSUMTYPE="SHA-1" SIZE="4756">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:24:34" MIMETYPE="text/xml" CHECKSUM="7c2beb0021bebff6c6b2497751c32003c6a42c29" CHECKSUMTYPE="SHA-1" SIZE="4756">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:24:34" MIMETYPE="text/xml"
-				CHECKSUM="a72493a22155fd8e1050fee4f8bef723d51feca7" CHECKSUMTYPE="SHA-1"
-				SIZE="28753">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:24:34" MIMETYPE="text/xml" CHECKSUM="a72493a22155fd8e1050fee4f8bef723d51feca7" CHECKSUMTYPE="SHA-1" SIZE="28753">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:24:34" MIMETYPE="text/xml"
-				CHECKSUM="f77471c11321a197e1de818054e456b05790361e" CHECKSUMTYPE="SHA-1"
-				SIZE="10082">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:24:34" MIMETYPE="text/xml" CHECKSUM="f77471c11321a197e1de818054e456b05790361e" CHECKSUMTYPE="SHA-1" SIZE="10082">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:24:35" MIMETYPE="text/xml"
-				CHECKSUM="a8a1352ccd6420678bbb1f56d284097eb9d3e858" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:24:35" MIMETYPE="text/xml" CHECKSUM="a8a1352ccd6420678bbb1f56d284097eb9d3e858" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:24:35" MIMETYPE="text/xml"
-				CHECKSUM="a8b9baefec662d05648b759824b261b349097970" CHECKSUMTYPE="SHA-1" SIZE="4895">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:24:35" MIMETYPE="text/xml" CHECKSUM="a8b9baefec662d05648b759824b261b349097970" CHECKSUMTYPE="SHA-1" SIZE="4895">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:24:35" MIMETYPE="text/xml"
-				CHECKSUM="5b290fd83006f0c29e7a2b32bf2a3b6959fbb3ed" CHECKSUMTYPE="SHA-1"
-				SIZE="38892">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:24:35" MIMETYPE="text/xml" CHECKSUM="5b290fd83006f0c29e7a2b32bf2a3b6959fbb3ed" CHECKSUMTYPE="SHA-1" SIZE="38892">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:24:35" MIMETYPE="text/xml"
-				CHECKSUM="7b756e40c2f494e810e757e2a4dc0ee7ddfa441e" CHECKSUMTYPE="SHA-1" SIZE="4206">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:24:35" MIMETYPE="text/xml" CHECKSUM="7b756e40c2f494e810e757e2a4dc0ee7ddfa441e" CHECKSUMTYPE="SHA-1" SIZE="4206">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:24:36" MIMETYPE="text/xml"
-				CHECKSUM="0208a992ab78e358936db7b4a49f184172b997c9" CHECKSUMTYPE="SHA-1" SIZE="4248">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:24:36" MIMETYPE="text/xml" CHECKSUM="0208a992ab78e358936db7b4a49f184172b997c9" CHECKSUMTYPE="SHA-1" SIZE="4248">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:24:36" MIMETYPE="text/xml"
-				CHECKSUM="1e04eb966c191ccd70e82192a69c178a206b41b4" CHECKSUMTYPE="SHA-1" SIZE="4209">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:24:36" MIMETYPE="text/xml" CHECKSUM="1e04eb966c191ccd70e82192a69c178a206b41b4" CHECKSUMTYPE="SHA-1" SIZE="4209">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:24:36" MIMETYPE="text/xml"
-				CHECKSUM="65a8c585f99b64626746312978535fadbaff29d2" CHECKSUMTYPE="SHA-1" SIZE="4201">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:24:36" MIMETYPE="text/xml" CHECKSUM="65a8c585f99b64626746312978535fadbaff29d2" CHECKSUMTYPE="SHA-1" SIZE="4201">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:24:36" MIMETYPE="text/xml"
-				CHECKSUM="b649aef08af47747945b9c5c22105c90d6c699ef" CHECKSUMTYPE="SHA-1" SIZE="4132">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:24:36" MIMETYPE="text/xml" CHECKSUM="b649aef08af47747945b9c5c22105c90d6c699ef" CHECKSUMTYPE="SHA-1" SIZE="4132">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:24:36" MIMETYPE="text/xml"
-				CHECKSUM="30c232fea057cde978a9ef9d2a7c54c791948e54" CHECKSUMTYPE="SHA-1" SIZE="4127">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:24:36" MIMETYPE="text/xml" CHECKSUM="30c232fea057cde978a9ef9d2a7c54c791948e54" CHECKSUMTYPE="SHA-1" SIZE="4127">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:24:37" MIMETYPE="text/xml"
-				CHECKSUM="c8a32d033b6f8cc50c2c52b720883e14cb77ad15" CHECKSUMTYPE="SHA-1" SIZE="4138">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:24:37" MIMETYPE="text/xml" CHECKSUM="c8a32d033b6f8cc50c2c52b720883e14cb77ad15" CHECKSUMTYPE="SHA-1" SIZE="4138">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:24:37" MIMETYPE="text/xml"
-				CHECKSUM="092908747b7f87d2fa6c47177c2afc5aa87c5e65" CHECKSUMTYPE="SHA-1" SIZE="4200">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:24:37" MIMETYPE="text/xml" CHECKSUM="092908747b7f87d2fa6c47177c2afc5aa87c5e65" CHECKSUMTYPE="SHA-1" SIZE="4200">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:24:37" MIMETYPE="text/xml"
-				CHECKSUM="91aa32e3cf4c69607cd18f16c3ffe24972d1debc" CHECKSUMTYPE="SHA-1"
-				SIZE="25260">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:24:37" MIMETYPE="text/xml" CHECKSUM="91aa32e3cf4c69607cd18f16c3ffe24972d1debc" CHECKSUMTYPE="SHA-1" SIZE="25260">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:24:37" MIMETYPE="text/xml"
-				CHECKSUM="1ce61439ca94591ebe6252834a68d7f4cea437a6" CHECKSUMTYPE="SHA-1"
-				SIZE="35868">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:24:37" MIMETYPE="text/xml" CHECKSUM="1ce61439ca94591ebe6252834a68d7f4cea437a6" CHECKSUMTYPE="SHA-1" SIZE="35868">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:24:38" MIMETYPE="text/xml"
-				CHECKSUM="a4123c4dd4d78c31baad26f023f94e6a93f9832f" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:24:38" MIMETYPE="text/xml" CHECKSUM="a4123c4dd4d78c31baad26f023f94e6a93f9832f" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:24:38" MIMETYPE="text/xml"
-				CHECKSUM="1e8f8f9fd3a4c8e1d1d59712434c796ab7110c4e" CHECKSUMTYPE="SHA-1"
-				SIZE="32759">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:24:38" MIMETYPE="text/xml" CHECKSUM="1e8f8f9fd3a4c8e1d1d59712434c796ab7110c4e" CHECKSUMTYPE="SHA-1" SIZE="32759">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:24:38" MIMETYPE="text/xml"
-				CHECKSUM="d2a5a5ec1e231f40b909e3e7c1e773f302b5a45c" CHECKSUMTYPE="SHA-1"
-				SIZE="38826">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:24:38" MIMETYPE="text/xml" CHECKSUM="d2a5a5ec1e231f40b909e3e7c1e773f302b5a45c" CHECKSUMTYPE="SHA-1" SIZE="38826">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:24:39" MIMETYPE="text/xml"
-				CHECKSUM="cd57263a636c5a318ff10d357c2e38fb6a554c84" CHECKSUMTYPE="SHA-1" SIZE="8281">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:24:39" MIMETYPE="text/xml" CHECKSUM="cd57263a636c5a318ff10d357c2e38fb6a554c84" CHECKSUMTYPE="SHA-1" SIZE="8281">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-06-15_01_0020.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:24:57" MIMETYPE="application/pdf"
-				CHECKSUM="818f76898a3967efc8d2c400e6645b364c22c1aa" CHECKSUMTYPE="SHA-1"
-				SIZE="6791456">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/bmtnabf_1901-06-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:24:57" MIMETYPE="application/pdf" CHECKSUM="818f76898a3967efc8d2c400e6645b364c22c1aa" CHECKSUMTYPE="SHA-1" SIZE="6791456">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/06/15_01/bmtnabf_1901-06-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2403,8 +2266,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 12 15.06.1901">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by A. HÄNISCH OM">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by A. HÄNISCH OM">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_CB00001"/>
@@ -2460,8 +2322,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c007"
-					LABEL="Untitled Image by A. Hänisch OM">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c007" LABEL="Untitled Image by A. Hänisch OM">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -2639,8 +2500,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="TextContent" ORDER="13" DMDID="c018"
-					LABEL="X. AUSSTELLUNG DER VEREINIGUNG VOM 15. MÄRZ BIS 12. MAI 1901. LISTE DER VERKAUFTEN WERKE">
+				<div ID="L.1.1.15" TYPE="TextContent" ORDER="13" DMDID="c018" LABEL="X. AUSSTELLUNG DER VEREINIGUNG VOM 15. MÄRZ BIS 12. MAI 1901. LISTE DER VERKAUFTEN WERKE">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -2651,16 +2511,14 @@
 							<div ID="L.1.1.15.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.15.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.15.2.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.15.2.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"/>
 									</fptr>
 								</div>
 							</div>
@@ -2681,8 +2539,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.15.3" TYPE="Illustration" ORDER="1" DMDID="c019"
-						LABEL="Untitled Image by A. Hänisch OM">
+					<div ID="L.1.1.15.3" TYPE="Illustration" ORDER="1" DMDID="c019" LABEL="Untitled Image by A. Hänisch OM">
 						<div ID="L.1.1.15.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00005"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/07/01_01/bmtnabf_1901-07-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/07/01_01/bmtnabf_1901-07-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-07-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-07-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-07-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-07-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-07-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2295,291 +2289,144 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:16:54"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="73b25e95f52b4de7ba044a82a665c393a342e4f2"
-				CHECKSUMTYPE="SHA-1" SIZE="6216428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:16:54" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="73b25e95f52b4de7ba044a82a665c393a342e4f2" CHECKSUMTYPE="SHA-1" SIZE="6216428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:17:28"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="bbbf23edbfe3bc41b6c955ec399e5607cf955a43"
-				CHECKSUMTYPE="SHA-1" SIZE="6147126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:17:28" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="bbbf23edbfe3bc41b6c955ec399e5607cf955a43" CHECKSUMTYPE="SHA-1" SIZE="6147126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:18:03"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="79b9ece392073dac510694a0f24342370e9c6416"
-				CHECKSUMTYPE="SHA-1" SIZE="6216429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:18:03" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="79b9ece392073dac510694a0f24342370e9c6416" CHECKSUMTYPE="SHA-1" SIZE="6216429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:18:36"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="c651a2f6b5a83afc67f518b0fcb3a9040aa5d6bd"
-				CHECKSUMTYPE="SHA-1" SIZE="6192124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:18:36" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="c651a2f6b5a83afc67f518b0fcb3a9040aa5d6bd" CHECKSUMTYPE="SHA-1" SIZE="6192124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:19:09"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="e56141f499c6729527537b62b00f4cd1e766dd02"
-				CHECKSUMTYPE="SHA-1" SIZE="6123700">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:19:09" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="e56141f499c6729527537b62b00f4cd1e766dd02" CHECKSUMTYPE="SHA-1" SIZE="6123700">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:19:40"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="4c8b1ca2567a2f85a4ed5b922b5756147d15a3e7"
-				CHECKSUMTYPE="SHA-1" SIZE="6192121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:19:40" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="4c8b1ca2567a2f85a4ed5b922b5756147d15a3e7" CHECKSUMTYPE="SHA-1" SIZE="6192121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:20:09"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="33944089434cce373cd6332f6dee1fcc842e4160"
-				CHECKSUMTYPE="SHA-1" SIZE="6123728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:20:09" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="33944089434cce373cd6332f6dee1fcc842e4160" CHECKSUMTYPE="SHA-1" SIZE="6123728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:20:39"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="60c966195fd75e35cd0bc76b8b3137a28f9d3807"
-				CHECKSUMTYPE="SHA-1" SIZE="6184009">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:20:39" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="60c966195fd75e35cd0bc76b8b3137a28f9d3807" CHECKSUMTYPE="SHA-1" SIZE="6184009">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:21:09"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="66676813d69d802353f81a8796ae7d24910a85dc"
-				CHECKSUMTYPE="SHA-1" SIZE="6089526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:21:09" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="66676813d69d802353f81a8796ae7d24910a85dc" CHECKSUMTYPE="SHA-1" SIZE="6089526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:21:39"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="7a2ca4833f5a27301af9a48ad5a76218af4f6440"
-				CHECKSUMTYPE="SHA-1" SIZE="6184029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:21:39" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="7a2ca4833f5a27301af9a48ad5a76218af4f6440" CHECKSUMTYPE="SHA-1" SIZE="6184029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:22:09"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="4f1ccc83a9e5d9aea755ce7364247d77f236434b"
-				CHECKSUMTYPE="SHA-1" SIZE="6089521">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:22:09" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="4f1ccc83a9e5d9aea755ce7364247d77f236434b" CHECKSUMTYPE="SHA-1" SIZE="6089521">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:22:39"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="154e82c31cd8e5bee241e05467229dabc9d069e5"
-				CHECKSUMTYPE="SHA-1" SIZE="6214628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:22:39" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="154e82c31cd8e5bee241e05467229dabc9d069e5" CHECKSUMTYPE="SHA-1" SIZE="6214628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:23:10"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="b86fa634e4ffac2bf29f43b2e636d793ef5cfdbc"
-				CHECKSUMTYPE="SHA-1" SIZE="6089518">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:23:10" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="b86fa634e4ffac2bf29f43b2e636d793ef5cfdbc" CHECKSUMTYPE="SHA-1" SIZE="6089518">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:23:39"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="2ca725592898e09276600b1eaa53996d9c6e2685"
-				CHECKSUMTYPE="SHA-1" SIZE="6214580">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:23:39" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="2ca725592898e09276600b1eaa53996d9c6e2685" CHECKSUMTYPE="SHA-1" SIZE="6214580">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:24:11"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="338d7128a48f6397dd29f28f49b0e204928e3283"
-				CHECKSUMTYPE="SHA-1" SIZE="6090427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:24:11" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="338d7128a48f6397dd29f28f49b0e204928e3283" CHECKSUMTYPE="SHA-1" SIZE="6090427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:24:41"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="a3496dbe88a6a764bf7092ae045e384f5e9726cc"
-				CHECKSUMTYPE="SHA-1" SIZE="6214627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:24:41" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="a3496dbe88a6a764bf7092ae045e384f5e9726cc" CHECKSUMTYPE="SHA-1" SIZE="6214627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:25:11"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="3dc1d08a4d3263bcd87559b9c8ea899c1db87f26"
-				CHECKSUMTYPE="SHA-1" SIZE="6091289">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:25:11" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="3dc1d08a4d3263bcd87559b9c8ea899c1db87f26" CHECKSUMTYPE="SHA-1" SIZE="6091289">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:25:42"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="5a3525ffa8c9311ce701ccc2141605d0883e9211"
-				CHECKSUMTYPE="SHA-1" SIZE="6182224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:25:42" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="5a3525ffa8c9311ce701ccc2141605d0883e9211" CHECKSUMTYPE="SHA-1" SIZE="6182224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:26:11"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="92296b20a2a09a0b79370be087c63dac3d96e139"
-				CHECKSUMTYPE="SHA-1" SIZE="6088618">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:26:11" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="92296b20a2a09a0b79370be087c63dac3d96e139" CHECKSUMTYPE="SHA-1" SIZE="6088618">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:26:40"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="fe661f7a920dba299e6d395ccb60ec4325a34695"
-				CHECKSUMTYPE="SHA-1" SIZE="6259629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:26:40" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="fe661f7a920dba299e6d395ccb60ec4325a34695" CHECKSUMTYPE="SHA-1" SIZE="6259629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:27:12"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="e3b1c73ffb2b35164fe6067d9ef8de90677c9ac1"
-				CHECKSUMTYPE="SHA-1" SIZE="5995924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:27:12" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="e3b1c73ffb2b35164fe6067d9ef8de90677c9ac1" CHECKSUMTYPE="SHA-1" SIZE="5995924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:27:43"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="7667421580f9e08c6fd65444428e1c232e8ee4c4"
-				CHECKSUMTYPE="SHA-1" SIZE="6179528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:27:43" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="7667421580f9e08c6fd65444428e1c232e8ee4c4" CHECKSUMTYPE="SHA-1" SIZE="6179528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/delivery/bmtnabf_1901-07-01_01_0022.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:28:01" MIMETYPE="text/xml"
-				CHECKSUM="5d7f4398dbc4ef5915c6a80304e06202cb077849" CHECKSUMTYPE="SHA-1" SIZE="5165">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:28:01" MIMETYPE="text/xml" CHECKSUM="5d7f4398dbc4ef5915c6a80304e06202cb077849" CHECKSUMTYPE="SHA-1" SIZE="5165">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:28:02" MIMETYPE="text/xml"
-				CHECKSUM="9bd4d4f60b483ffc9b3ee2e2e76257c63a54c441" CHECKSUMTYPE="SHA-1"
-				SIZE="41780">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:28:02" MIMETYPE="text/xml" CHECKSUM="9bd4d4f60b483ffc9b3ee2e2e76257c63a54c441" CHECKSUMTYPE="SHA-1" SIZE="41780">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:28:02" MIMETYPE="text/xml"
-				CHECKSUM="794933d9476803dcfbc0e61a88504f715e21c9a3" CHECKSUMTYPE="SHA-1" SIZE="9845">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:28:02" MIMETYPE="text/xml" CHECKSUM="794933d9476803dcfbc0e61a88504f715e21c9a3" CHECKSUMTYPE="SHA-1" SIZE="9845">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:28:02" MIMETYPE="text/xml"
-				CHECKSUM="f6aedc9d6c843b19ec616b5fbf3d286f6756d33c" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:28:02" MIMETYPE="text/xml" CHECKSUM="f6aedc9d6c843b19ec616b5fbf3d286f6756d33c" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:28:02" MIMETYPE="text/xml"
-				CHECKSUM="3263d741f14c84ae7fc9b30c61938d786b3d37b2" CHECKSUMTYPE="SHA-1" SIZE="5924">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:28:02" MIMETYPE="text/xml" CHECKSUM="3263d741f14c84ae7fc9b30c61938d786b3d37b2" CHECKSUMTYPE="SHA-1" SIZE="5924">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:28:03" MIMETYPE="text/xml"
-				CHECKSUM="ad6355a0465a86475fb1859b94b71a4fb284cca5" CHECKSUMTYPE="SHA-1" SIZE="9295">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:28:03" MIMETYPE="text/xml" CHECKSUM="ad6355a0465a86475fb1859b94b71a4fb284cca5" CHECKSUMTYPE="SHA-1" SIZE="9295">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:28:03" MIMETYPE="text/xml"
-				CHECKSUM="0082625132acebaca08e81c6a000b4ca3a27b850" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:28:03" MIMETYPE="text/xml" CHECKSUM="0082625132acebaca08e81c6a000b4ca3a27b850" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:28:03" MIMETYPE="text/xml"
-				CHECKSUM="f773497d140f2e4c802765ca65d270d34802def1" CHECKSUMTYPE="SHA-1" SIZE="3674">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:28:03" MIMETYPE="text/xml" CHECKSUM="f773497d140f2e4c802765ca65d270d34802def1" CHECKSUMTYPE="SHA-1" SIZE="3674">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:28:03" MIMETYPE="text/xml"
-				CHECKSUM="efefa30283804fc16dcbc915e4c038ad16fb23ca" CHECKSUMTYPE="SHA-1"
-				SIZE="23903">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:28:03" MIMETYPE="text/xml" CHECKSUM="efefa30283804fc16dcbc915e4c038ad16fb23ca" CHECKSUMTYPE="SHA-1" SIZE="23903">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:28:03" MIMETYPE="text/xml"
-				CHECKSUM="5e16d0227f2ad4458f898891b98ef38c8866c0da" CHECKSUMTYPE="SHA-1"
-				SIZE="22269">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:28:03" MIMETYPE="text/xml" CHECKSUM="5e16d0227f2ad4458f898891b98ef38c8866c0da" CHECKSUMTYPE="SHA-1" SIZE="22269">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:28:04" MIMETYPE="text/xml"
-				CHECKSUM="9cb84ce7ce6196cedf2262caef37eee5b9458687" CHECKSUMTYPE="SHA-1"
-				SIZE="31459">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:28:04" MIMETYPE="text/xml" CHECKSUM="9cb84ce7ce6196cedf2262caef37eee5b9458687" CHECKSUMTYPE="SHA-1" SIZE="31459">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:28:04" MIMETYPE="text/xml"
-				CHECKSUM="0534d93d259c1e7c0826e277f799c6b51b821e6b" CHECKSUMTYPE="SHA-1" SIZE="8107">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:28:04" MIMETYPE="text/xml" CHECKSUM="0534d93d259c1e7c0826e277f799c6b51b821e6b" CHECKSUMTYPE="SHA-1" SIZE="8107">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:28:04" MIMETYPE="text/xml"
-				CHECKSUM="71f9d830dd8c223d929084a19a8f927ad59e0d43" CHECKSUMTYPE="SHA-1" SIZE="8492">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:28:04" MIMETYPE="text/xml" CHECKSUM="71f9d830dd8c223d929084a19a8f927ad59e0d43" CHECKSUMTYPE="SHA-1" SIZE="8492">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:28:04" MIMETYPE="text/xml"
-				CHECKSUM="9b3b7cd151925bbbce0a2cf1202eeed0a5388c4c" CHECKSUMTYPE="SHA-1"
-				SIZE="20136">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:28:04" MIMETYPE="text/xml" CHECKSUM="9b3b7cd151925bbbce0a2cf1202eeed0a5388c4c" CHECKSUMTYPE="SHA-1" SIZE="20136">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:28:05" MIMETYPE="text/xml"
-				CHECKSUM="df30ec410e4eeec7804319ac0b1eb11cbd6db85f" CHECKSUMTYPE="SHA-1"
-				SIZE="22741">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:28:05" MIMETYPE="text/xml" CHECKSUM="df30ec410e4eeec7804319ac0b1eb11cbd6db85f" CHECKSUMTYPE="SHA-1" SIZE="22741">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:28:05" MIMETYPE="text/xml"
-				CHECKSUM="e17c57216d4e777f12317d8d688f329beefb4dbb" CHECKSUMTYPE="SHA-1"
-				SIZE="23395">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:28:05" MIMETYPE="text/xml" CHECKSUM="e17c57216d4e777f12317d8d688f329beefb4dbb" CHECKSUMTYPE="SHA-1" SIZE="23395">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:28:05" MIMETYPE="text/xml"
-				CHECKSUM="95b64212e418961237637282ece902e6bf14d82b" CHECKSUMTYPE="SHA-1"
-				SIZE="22837">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:28:05" MIMETYPE="text/xml" CHECKSUM="95b64212e418961237637282ece902e6bf14d82b" CHECKSUMTYPE="SHA-1" SIZE="22837">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:28:05" MIMETYPE="text/xml"
-				CHECKSUM="20b949d3280e5130d5f5c3a9a33bd7122c8dfa75" CHECKSUMTYPE="SHA-1"
-				SIZE="24579">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:28:05" MIMETYPE="text/xml" CHECKSUM="20b949d3280e5130d5f5c3a9a33bd7122c8dfa75" CHECKSUMTYPE="SHA-1" SIZE="24579">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:28:06" MIMETYPE="text/xml"
-				CHECKSUM="f265dfa2b095c74576f04181275de6c48a9b9f90" CHECKSUMTYPE="SHA-1" SIZE="2014">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:28:06" MIMETYPE="text/xml" CHECKSUM="f265dfa2b095c74576f04181275de6c48a9b9f90" CHECKSUMTYPE="SHA-1" SIZE="2014">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:28:06" MIMETYPE="text/xml"
-				CHECKSUM="02db04091b05a488390ec78ca9a3b4f006813397" CHECKSUMTYPE="SHA-1"
-				SIZE="33309">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:28:06" MIMETYPE="text/xml" CHECKSUM="02db04091b05a488390ec78ca9a3b4f006813397" CHECKSUMTYPE="SHA-1" SIZE="33309">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:28:06" MIMETYPE="text/xml"
-				CHECKSUM="ddcd8ba90a931097629cfce2635ce0f85f6b29ae" CHECKSUMTYPE="SHA-1"
-				SIZE="31304">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:28:06" MIMETYPE="text/xml" CHECKSUM="ddcd8ba90a931097629cfce2635ce0f85f6b29ae" CHECKSUMTYPE="SHA-1" SIZE="31304">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:28:06" MIMETYPE="text/xml"
-				CHECKSUM="2f7bf5f2b5510f7c0ff8ba0571beeb6bafb35a88" CHECKSUMTYPE="SHA-1" SIZE="8276">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:28:06" MIMETYPE="text/xml" CHECKSUM="2f7bf5f2b5510f7c0ff8ba0571beeb6bafb35a88" CHECKSUMTYPE="SHA-1" SIZE="8276">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-01_01_0022.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:28:34" MIMETYPE="application/pdf"
-				CHECKSUM="63373b6c18bab33c99d7a0af3a3576a561f59003" CHECKSUMTYPE="SHA-1"
-				SIZE="5964431">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/bmtnabf_1901-07-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:28:34" MIMETYPE="application/pdf" CHECKSUM="63373b6c18bab33c99d7a0af3a3576a561f59003" CHECKSUMTYPE="SHA-1" SIZE="5964431">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/01_01/bmtnabf_1901-07-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2766,8 +2613,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 13 01.07.1901">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by Max Benirschke">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by Max Benirschke">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<seq>
@@ -2906,16 +2752,14 @@
 								<div ID="L.1.1.7.9.3.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.7.9.3.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
 										</fptr>
 									</div>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7.10" TYPE="TextContent" ORDER="2" DMDID="c011"
-						LABEL="REGENABEND">
+					<div ID="L.1.1.7.10" TYPE="TextContent" ORDER="2" DMDID="c011" LABEL="REGENABEND">
 						<div ID="L.1.1.7.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -2931,24 +2775,21 @@
 								<div ID="L.1.1.7.10.3.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.7.10.3.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00004"/>
 										</fptr>
 									</div>
 								</div>
 								<div ID="L.1.1.7.10.3.1.2" TYPE="Paragraph" ORDER="2">
 									<div ID="L.1.1.7.10.3.1.2.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
 										</fptr>
 									</div>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7.11" TYPE="TextContent" ORDER="3" DMDID="c012"
-						LABEL="MONDENSCHEIN">
+					<div ID="L.1.1.7.11" TYPE="TextContent" ORDER="3" DMDID="c012" LABEL="MONDENSCHEIN">
 						<div ID="L.1.1.7.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -2964,24 +2805,21 @@
 								<div ID="L.1.1.7.11.3.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.7.11.3.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
 										</fptr>
 									</div>
 								</div>
 								<div ID="L.1.1.7.11.3.1.2" TYPE="Paragraph" ORDER="2">
 									<div ID="L.1.1.7.11.3.1.2.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
 										</fptr>
 									</div>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7.12" TYPE="TextContent" ORDER="4" DMDID="c013"
-						LABEL="NACHTSCHWÄRMER">
+					<div ID="L.1.1.7.12" TYPE="TextContent" ORDER="4" DMDID="c013" LABEL="NACHTSCHWÄRMER">
 						<div ID="L.1.1.7.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
@@ -2997,16 +2835,14 @@
 								<div ID="L.1.1.7.12.3.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.7.12.3.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
 										</fptr>
 									</div>
 								</div>
 								<div ID="L.1.1.7.12.3.1.2" TYPE="Paragraph" ORDER="2">
 									<div ID="L.1.1.7.12.3.1.2.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
 										</fptr>
 									</div>
 								</div>
@@ -3029,16 +2865,14 @@
 								<div ID="L.1.1.7.13.3.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.7.13.3.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"/>
 										</fptr>
 									</div>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7.14" TYPE="TextContent" ORDER="6" DMDID="c015"
-						LABEL="TULPENBLATT">
+					<div ID="L.1.1.7.14" TYPE="TextContent" ORDER="6" DMDID="c015" LABEL="TULPENBLATT">
 						<div ID="L.1.1.7.14.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -3054,8 +2888,7 @@
 								<div ID="L.1.1.7.14.3.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.7.14.3.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
 										</fptr>
 									</div>
 								</div>
@@ -3078,16 +2911,14 @@
 								<div ID="L.1.1.7.15.3.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.7.15.3.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
 										</fptr>
 									</div>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.7.16" TYPE="Illustration" ORDER="8" DMDID="c017"
-						LABEL="Für V. S. gez">
+					<div ID="L.1.1.7.16" TYPE="Illustration" ORDER="8" DMDID="c017" LABEL="Für V. S. gez">
 						<div ID="L.1.1.7.16.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00010"/>
@@ -3104,8 +2935,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.17" TYPE="Illustration" ORDER="9" DMDID="c018"
-						LABEL="Für V. S. gez">
+					<div ID="L.1.1.7.17" TYPE="Illustration" ORDER="9" DMDID="c018" LABEL="Für V. S. gez">
 						<div ID="L.1.1.7.17.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00005"/>
@@ -3122,8 +2952,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.18" TYPE="Illustration" ORDER="10" DMDID="c019"
-						LABEL="Für V. S. gez">
+					<div ID="L.1.1.7.18" TYPE="Illustration" ORDER="10" DMDID="c019" LABEL="Für V. S. gez">
 						<div ID="L.1.1.7.18.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00005"/>
@@ -3140,8 +2969,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.19" TYPE="Illustration" ORDER="11" DMDID="c020"
-						LABEL="Für V. S. gez">
+					<div ID="L.1.1.7.19" TYPE="Illustration" ORDER="11" DMDID="c020" LABEL="Für V. S. gez">
 						<div ID="L.1.1.7.19.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
@@ -3158,8 +2986,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.20" TYPE="Illustration" ORDER="12" DMDID="c021"
-						LABEL="Für V. S. gez">
+					<div ID="L.1.1.7.20" TYPE="Illustration" ORDER="12" DMDID="c021" LABEL="Für V. S. gez">
 						<div ID="L.1.1.7.20.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00004"/>
@@ -3176,8 +3003,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.21" TYPE="Illustration" ORDER="13" DMDID="c022"
-						LABEL="Für V. S. gez">
+					<div ID="L.1.1.7.21" TYPE="Illustration" ORDER="13" DMDID="c022" LABEL="Für V. S. gez">
 						<div ID="L.1.1.7.21.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
@@ -3194,8 +3020,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.22" TYPE="Illustration" ORDER="14" DMDID="c023"
-						LABEL="Für V. S. gez">
+					<div ID="L.1.1.7.22" TYPE="Illustration" ORDER="14" DMDID="c023" LABEL="Für V. S. gez">
 						<div ID="L.1.1.7.22.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
@@ -3212,8 +3037,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.23" TYPE="Illustration" ORDER="15" DMDID="c024"
-						LABEL="Für V. S. gez">
+					<div ID="L.1.1.7.23" TYPE="Illustration" ORDER="15" DMDID="c024" LABEL="Für V. S. gez">
 						<div ID="L.1.1.7.23.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"/>
@@ -3230,8 +3054,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.24" TYPE="Illustration" ORDER="16" DMDID="c025"
-						LABEL="Für V. S. gez">
+					<div ID="L.1.1.7.24" TYPE="Illustration" ORDER="16" DMDID="c025" LABEL="Für V. S. gez">
 						<div ID="L.1.1.7.24.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00005"/>
@@ -3248,8 +3071,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.25" TYPE="Illustration" ORDER="17" DMDID="c026"
-						LABEL="Für V. S. gez">
+					<div ID="L.1.1.7.25" TYPE="Illustration" ORDER="17" DMDID="c026" LABEL="Für V. S. gez">
 						<div ID="L.1.1.7.25.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00005"/>
@@ -3282,8 +3104,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.7.26" TYPE="Illustration" ORDER="18" DMDID="c029"
-						LABEL="Untitled Image by Max Benirschke">
+					<div ID="L.1.1.7.26" TYPE="Illustration" ORDER="18" DMDID="c029" LABEL="Untitled Image by Max Benirschke">
 						<div ID="L.1.1.7.26.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00005"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/07/15_01/bmtnabf_1901-07-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/07/15_01/bmtnabf_1901-07-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-07-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-07-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-07-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-07-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-07-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2249,315 +2243,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:20:29"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="1afbbe1b15af9afb7cf06341ddc367acfc316ab5"
-				CHECKSUMTYPE="SHA-1" SIZE="6199325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:20:29" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="1afbbe1b15af9afb7cf06341ddc367acfc316ab5" CHECKSUMTYPE="SHA-1" SIZE="6199325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:21:04"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="1a616908fc38c7c2b33541ab1074edb606f89571"
-				CHECKSUMTYPE="SHA-1" SIZE="5977927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:21:04" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="1a616908fc38c7c2b33541ab1074edb606f89571" CHECKSUMTYPE="SHA-1" SIZE="5977927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:21:40"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="007f5043cb67794231f21c0346512c7e095e5294"
-				CHECKSUMTYPE="SHA-1" SIZE="6199317">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:21:40" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="007f5043cb67794231f21c0346512c7e095e5294" CHECKSUMTYPE="SHA-1" SIZE="6199317">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:22:19"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="d3cbbac73e9db8c182733592787133c028338ad1"
-				CHECKSUMTYPE="SHA-1" SIZE="5977918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:22:19" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="d3cbbac73e9db8c182733592787133c028338ad1" CHECKSUMTYPE="SHA-1" SIZE="5977918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:22:57"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="1161a44c3a89c56785471cd43b6421f354d13d33"
-				CHECKSUMTYPE="SHA-1" SIZE="6146226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:22:57" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="1161a44c3a89c56785471cd43b6421f354d13d33" CHECKSUMTYPE="SHA-1" SIZE="6146226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:23:29"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="739da7420f505e17471d846f177d38a7f9265f48"
-				CHECKSUMTYPE="SHA-1" SIZE="6090376">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:23:29" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="739da7420f505e17471d846f177d38a7f9265f48" CHECKSUMTYPE="SHA-1" SIZE="6090376">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:24:01"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="c027228e5761955079a3fdfbf19b1b0ce6994952"
-				CHECKSUMTYPE="SHA-1" SIZE="6146224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:24:01" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="c027228e5761955079a3fdfbf19b1b0ce6994952" CHECKSUMTYPE="SHA-1" SIZE="6146224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:24:36"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="60bcad51c4d73d8e837014cad4540a7dd48aa972"
-				CHECKSUMTYPE="SHA-1" SIZE="6089508">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:24:36" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="60bcad51c4d73d8e837014cad4540a7dd48aa972" CHECKSUMTYPE="SHA-1" SIZE="6089508">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:25:09"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="d15abde4592c6ba1325d688b94c5d54344e7a35e"
-				CHECKSUMTYPE="SHA-1" SIZE="6146210">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:25:09" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="d15abde4592c6ba1325d688b94c5d54344e7a35e" CHECKSUMTYPE="SHA-1" SIZE="6146210">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:25:44"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="bcb728d1390e651a7b460b69beae3aaa9a12dc5d"
-				CHECKSUMTYPE="SHA-1" SIZE="6089528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:25:44" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="bcb728d1390e651a7b460b69beae3aaa9a12dc5d" CHECKSUMTYPE="SHA-1" SIZE="6089528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:26:18"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f4ee758874d65d105fc45c1fd3b961006f883cfb"
-				CHECKSUMTYPE="SHA-1" SIZE="6146224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:26:18" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f4ee758874d65d105fc45c1fd3b961006f883cfb" CHECKSUMTYPE="SHA-1" SIZE="6146224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:26:51"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="d771665b8970041db4d8270ce4324f7d51e2ec73"
-				CHECKSUMTYPE="SHA-1" SIZE="6089518">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:26:51" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="d771665b8970041db4d8270ce4324f7d51e2ec73" CHECKSUMTYPE="SHA-1" SIZE="6089518">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:27:26"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="709458a45b17abf38187588f5ad854f76de49218"
-				CHECKSUMTYPE="SHA-1" SIZE="6146229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:27:26" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="709458a45b17abf38187588f5ad854f76de49218" CHECKSUMTYPE="SHA-1" SIZE="6146229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:28:04"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="2a424570b9f7d39507ff504aac054ed0b21600c6"
-				CHECKSUMTYPE="SHA-1" SIZE="6121027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:28:04" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="2a424570b9f7d39507ff504aac054ed0b21600c6" CHECKSUMTYPE="SHA-1" SIZE="6121027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:28:37"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="aa21341c3b1bb41e89b069eb388ff6b53075a674"
-				CHECKSUMTYPE="SHA-1" SIZE="6146226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:28:37" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="aa21341c3b1bb41e89b069eb388ff6b53075a674" CHECKSUMTYPE="SHA-1" SIZE="6146226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:29:10"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ddc368e00aa26b6539b68b9c0bf066367232c3d3"
-				CHECKSUMTYPE="SHA-1" SIZE="6121018">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:29:10" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ddc368e00aa26b6539b68b9c0bf066367232c3d3" CHECKSUMTYPE="SHA-1" SIZE="6121018">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:29:43"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="443ffdc32bc96355e33df80a2806f2bffbfae1aa"
-				CHECKSUMTYPE="SHA-1" SIZE="6151619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:29:43" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="443ffdc32bc96355e33df80a2806f2bffbfae1aa" CHECKSUMTYPE="SHA-1" SIZE="6151619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:30:16"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="03a679f77e411cb68e09ea4370bd55be2a91d7ef"
-				CHECKSUMTYPE="SHA-1" SIZE="6121026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:30:16" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="03a679f77e411cb68e09ea4370bd55be2a91d7ef" CHECKSUMTYPE="SHA-1" SIZE="6121026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:30:50"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="bde2aa24b8cabd8ba539c40e9ec25445523f683b"
-				CHECKSUMTYPE="SHA-1" SIZE="6151626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:30:50" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="bde2aa24b8cabd8ba539c40e9ec25445523f683b" CHECKSUMTYPE="SHA-1" SIZE="6151626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:31:24"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="1addb63dd56fc98884b1fb8cb5ef30b02ba5926d"
-				CHECKSUMTYPE="SHA-1" SIZE="6121007">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:31:24" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="1addb63dd56fc98884b1fb8cb5ef30b02ba5926d" CHECKSUMTYPE="SHA-1" SIZE="6121007">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:31:56"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="88227c130bb9c739a52017ec06c90947a622e346"
-				CHECKSUMTYPE="SHA-1" SIZE="6151619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:31:56" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="88227c130bb9c739a52017ec06c90947a622e346" CHECKSUMTYPE="SHA-1" SIZE="6151619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:32:29"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="15ce9e12e561204abba7e7df441d3544efc54e40"
-				CHECKSUMTYPE="SHA-1" SIZE="6266824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:32:29" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="15ce9e12e561204abba7e7df441d3544efc54e40" CHECKSUMTYPE="SHA-1" SIZE="6266824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:33:05"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="195e49807a2d1c0a14aa0fb7b879085f9e9f2e96"
-				CHECKSUMTYPE="SHA-1" SIZE="6040929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:33:05" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="195e49807a2d1c0a14aa0fb7b879085f9e9f2e96" CHECKSUMTYPE="SHA-1" SIZE="6040929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:33:40"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="20208eead67586a356729fd3fb3ef64ad2140b4e"
-				CHECKSUMTYPE="SHA-1" SIZE="6228112">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:33:40" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="20208eead67586a356729fd3fb3ef64ad2140b4e" CHECKSUMTYPE="SHA-1" SIZE="6228112">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/delivery/bmtnabf_1901-07-15_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:34:00" MIMETYPE="text/xml"
-				CHECKSUM="fb656d2de375a46074f7d4b81f3a9de03f020b57" CHECKSUMTYPE="SHA-1" SIZE="5038">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:34:00" MIMETYPE="text/xml" CHECKSUM="fb656d2de375a46074f7d4b81f3a9de03f020b57" CHECKSUMTYPE="SHA-1" SIZE="5038">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:34:01" MIMETYPE="text/xml"
-				CHECKSUM="b9e6a82c3ea99d582e47fbf12c546e632b5b1458" CHECKSUMTYPE="SHA-1"
-				SIZE="28079">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:34:01" MIMETYPE="text/xml" CHECKSUM="b9e6a82c3ea99d582e47fbf12c546e632b5b1458" CHECKSUMTYPE="SHA-1" SIZE="28079">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:34:01" MIMETYPE="text/xml"
-				CHECKSUM="cd83d289d960c38764ce3b25115f7f32672c0b5c" CHECKSUMTYPE="SHA-1" SIZE="9415">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:34:01" MIMETYPE="text/xml" CHECKSUM="cd83d289d960c38764ce3b25115f7f32672c0b5c" CHECKSUMTYPE="SHA-1" SIZE="9415">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:34:01" MIMETYPE="text/xml"
-				CHECKSUM="26b3fc90b56b68a195015560f648d39ab853a0e5" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:34:01" MIMETYPE="text/xml" CHECKSUM="26b3fc90b56b68a195015560f648d39ab853a0e5" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:34:01" MIMETYPE="text/xml"
-				CHECKSUM="b2cd975344bd0c1339ee4c58948498aba2c8c560" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:34:01" MIMETYPE="text/xml" CHECKSUM="b2cd975344bd0c1339ee4c58948498aba2c8c560" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:34:02" MIMETYPE="text/xml"
-				CHECKSUM="b4faa08f2df77e62ab5e82eaa2855812fc6ac9a2" CHECKSUMTYPE="SHA-1" SIZE="2117">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:34:02" MIMETYPE="text/xml" CHECKSUM="b4faa08f2df77e62ab5e82eaa2855812fc6ac9a2" CHECKSUMTYPE="SHA-1" SIZE="2117">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:34:02" MIMETYPE="text/xml"
-				CHECKSUM="7cdd772e600838abf5434982be7d02e40fc39c5e" CHECKSUMTYPE="SHA-1"
-				SIZE="33638">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:34:02" MIMETYPE="text/xml" CHECKSUM="7cdd772e600838abf5434982be7d02e40fc39c5e" CHECKSUMTYPE="SHA-1" SIZE="33638">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:34:02" MIMETYPE="text/xml"
-				CHECKSUM="68270bf2bf5d47eed1846373430b377205b91948" CHECKSUMTYPE="SHA-1"
-				SIZE="54073">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:34:02" MIMETYPE="text/xml" CHECKSUM="68270bf2bf5d47eed1846373430b377205b91948" CHECKSUMTYPE="SHA-1" SIZE="54073">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:34:02" MIMETYPE="text/xml"
-				CHECKSUM="429802d22deb632e115349575f961d21d89cad2d" CHECKSUMTYPE="SHA-1"
-				SIZE="54499">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:34:02" MIMETYPE="text/xml" CHECKSUM="429802d22deb632e115349575f961d21d89cad2d" CHECKSUMTYPE="SHA-1" SIZE="54499">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:34:03" MIMETYPE="text/xml"
-				CHECKSUM="31e91093e7b65d1c93ad60613b7fd20fb35225e2" CHECKSUMTYPE="SHA-1" SIZE="4635">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:34:03" MIMETYPE="text/xml" CHECKSUM="31e91093e7b65d1c93ad60613b7fd20fb35225e2" CHECKSUMTYPE="SHA-1" SIZE="4635">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:34:03" MIMETYPE="text/xml"
-				CHECKSUM="61ffe08d3701b9ed5982a0ad0256fe8a98cd3cda" CHECKSUMTYPE="SHA-1"
-				SIZE="42444">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:34:03" MIMETYPE="text/xml" CHECKSUM="61ffe08d3701b9ed5982a0ad0256fe8a98cd3cda" CHECKSUMTYPE="SHA-1" SIZE="42444">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:34:03" MIMETYPE="text/xml"
-				CHECKSUM="59eca2e2157e8912155f625b5267304423b8ef5e" CHECKSUMTYPE="SHA-1" SIZE="4766">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:34:03" MIMETYPE="text/xml" CHECKSUM="59eca2e2157e8912155f625b5267304423b8ef5e" CHECKSUMTYPE="SHA-1" SIZE="4766">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:34:03" MIMETYPE="text/xml"
-				CHECKSUM="6e0da081ae19f32819d17a7d4bc64dbf572afdde" CHECKSUMTYPE="SHA-1" SIZE="4721">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:34:03" MIMETYPE="text/xml" CHECKSUM="6e0da081ae19f32819d17a7d4bc64dbf572afdde" CHECKSUMTYPE="SHA-1" SIZE="4721">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:34:04" MIMETYPE="text/xml"
-				CHECKSUM="b0f20ec912548d68099e340294104b6acfcfaa47" CHECKSUMTYPE="SHA-1"
-				SIZE="43757">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:34:04" MIMETYPE="text/xml" CHECKSUM="b0f20ec912548d68099e340294104b6acfcfaa47" CHECKSUMTYPE="SHA-1" SIZE="43757">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:34:04" MIMETYPE="text/xml"
-				CHECKSUM="af39caf238a8fce16907408ddccbeb9b6564d490" CHECKSUMTYPE="SHA-1" SIZE="4652">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:34:04" MIMETYPE="text/xml" CHECKSUM="af39caf238a8fce16907408ddccbeb9b6564d490" CHECKSUMTYPE="SHA-1" SIZE="4652">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:34:04" MIMETYPE="text/xml"
-				CHECKSUM="f2830915c2909d1d46f649459f899449958b2daa" CHECKSUMTYPE="SHA-1"
-				SIZE="31337">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:34:04" MIMETYPE="text/xml" CHECKSUM="f2830915c2909d1d46f649459f899449958b2daa" CHECKSUMTYPE="SHA-1" SIZE="31337">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:34:04" MIMETYPE="text/xml"
-				CHECKSUM="c30a274b50ca2a8e31bb1068c48ed88f30d28e9e" CHECKSUMTYPE="SHA-1"
-				SIZE="54159">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:34:04" MIMETYPE="text/xml" CHECKSUM="c30a274b50ca2a8e31bb1068c48ed88f30d28e9e" CHECKSUMTYPE="SHA-1" SIZE="54159">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:34:05" MIMETYPE="text/xml"
-				CHECKSUM="3773706ce397044d6ae36abd9922f6da8c3ddf8a" CHECKSUMTYPE="SHA-1"
-				SIZE="53399">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:34:05" MIMETYPE="text/xml" CHECKSUM="3773706ce397044d6ae36abd9922f6da8c3ddf8a" CHECKSUMTYPE="SHA-1" SIZE="53399">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:34:05" MIMETYPE="text/xml"
-				CHECKSUM="65286839d1bf69c5924915309da563c1ac0d301e" CHECKSUMTYPE="SHA-1" SIZE="2414">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:34:05" MIMETYPE="text/xml" CHECKSUM="65286839d1bf69c5924915309da563c1ac0d301e" CHECKSUMTYPE="SHA-1" SIZE="2414">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:34:05" MIMETYPE="text/xml"
-				CHECKSUM="c3cba23f1b8e78ad0224fcfba9de25d6aef6f488" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:34:05" MIMETYPE="text/xml" CHECKSUM="c3cba23f1b8e78ad0224fcfba9de25d6aef6f488" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:34:05" MIMETYPE="text/xml"
-				CHECKSUM="15b7ffaf4ef7018eba585a8828f2552e90b68c93" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:34:05" MIMETYPE="text/xml" CHECKSUM="15b7ffaf4ef7018eba585a8828f2552e90b68c93" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:34:06" MIMETYPE="text/xml"
-				CHECKSUM="33d401b3d0718e089c3407603f81bafae26cb17d" CHECKSUMTYPE="SHA-1"
-				SIZE="34889">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:34:06" MIMETYPE="text/xml" CHECKSUM="33d401b3d0718e089c3407603f81bafae26cb17d" CHECKSUMTYPE="SHA-1" SIZE="34889">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:34:06" MIMETYPE="text/xml"
-				CHECKSUM="08ceae135284ac0a4b15607fa6bf9d484bf1f12a" CHECKSUMTYPE="SHA-1"
-				SIZE="38696">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:34:06" MIMETYPE="text/xml" CHECKSUM="08ceae135284ac0a4b15607fa6bf9d484bf1f12a" CHECKSUMTYPE="SHA-1" SIZE="38696">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:34:06" MIMETYPE="text/xml"
-				CHECKSUM="e083590f97c6dacb03126b80e4019136279fae6c" CHECKSUMTYPE="SHA-1" SIZE="7578">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:34:06" MIMETYPE="text/xml" CHECKSUM="e083590f97c6dacb03126b80e4019136279fae6c" CHECKSUMTYPE="SHA-1" SIZE="7578">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-07-15_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:34:36" MIMETYPE="application/pdf"
-				CHECKSUM="43b5bcddc47ba9e3dbc2c96fc00a5781567b36b9" CHECKSUMTYPE="SHA-1"
-				SIZE="6623430">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/bmtnabf_1901-07-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:34:36" MIMETYPE="application/pdf" CHECKSUM="43b5bcddc47ba9e3dbc2c96fc00a5781567b36b9" CHECKSUMTYPE="SHA-1" SIZE="6623430">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/07/15_01/bmtnabf_1901-07-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2760,8 +2595,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 14 15.07.1901">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by Friedr. König OM">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by Friedr. König OM">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_CB00001"/>
@@ -2834,8 +2668,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c008"
-					LABEL="BRIEF AN DIE SECESSION">
+				<div ID="L.1.1.6" TYPE="TextContent" ORDER="4" DMDID="c008" LABEL="BRIEF AN DIE SECESSION">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -2859,38 +2692,25 @@
 								<div ID="L.1.1.6.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="1" DMDID="c010"
-						LABEL="Untitled Image by Friedr. König OM">
+					<div ID="L.1.1.6.5" TYPE="Illustration" ORDER="1" DMDID="c010" LABEL="Untitled Image by Friedr. König OM">
 						<div ID="L.1.1.6.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
@@ -2912,8 +2732,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.6" TYPE="Illustration" ORDER="2" DMDID="c011"
-						LABEL="Untitled Image by Friedr. König OM">
+					<div ID="L.1.1.6.6" TYPE="Illustration" ORDER="2" DMDID="c011" LABEL="Untitled Image by Friedr. König OM">
 						<div ID="L.1.1.6.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00005"/>
@@ -2930,8 +2749,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.7" TYPE="Illustration" ORDER="3" DMDID="c012"
-						LABEL="Untitled Image by Friedr. König OM">
+					<div ID="L.1.1.6.7" TYPE="Illustration" ORDER="3" DMDID="c012" LABEL="Untitled Image by Friedr. König OM">
 						<div ID="L.1.1.6.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00005"/>
@@ -2948,8 +2766,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.6.8" TYPE="Illustration" ORDER="4" DMDID="c013"
-						LABEL="Untitled Image by Friedr. König OM">
+					<div ID="L.1.1.6.8" TYPE="Illustration" ORDER="4" DMDID="c013" LABEL="Untitled Image by Friedr. König OM">
 						<div ID="L.1.1.6.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
@@ -2967,8 +2784,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c014"
-					LABEL="Untitled Image by Friedr. König OM">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c014" LABEL="Untitled Image by Friedr. König OM">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -2985,8 +2801,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c015"
-					LABEL="Untitled Image by Friedr. König OM">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c015" LABEL="Untitled Image by Friedr. König OM">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -3003,8 +2818,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c016"
-					LABEL="Untitled Image by Friedr. König OM">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c016" LABEL="Untitled Image by Friedr. König OM">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -3021,8 +2835,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c017"
-					LABEL="Untitled Image by Friedr. König OM">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c017" LABEL="Untitled Image by Friedr. König OM">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -3039,8 +2852,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="Illustration" ORDER="1" DMDID="c018"
-					LABEL="Untitled Image by K">
+				<div ID="L.1.1.11" TYPE="Illustration" ORDER="1" DMDID="c018" LABEL="Untitled Image by K">
 					<div ID="L.1.1.11.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00001"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/08/01_01/bmtnabf_1901-08-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/08/01_01/bmtnabf_1901-08-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-08-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-08-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-08-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1901/08/15_01/bmtnabf_1901-08-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/08/15_01/bmtnabf_1901-08-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-08-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-08-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-08-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-08-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-08-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2766,392 +2760,192 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:21:06"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="807aab2d79493df978ccfe2266fc182e47001d37"
-				CHECKSUMTYPE="SHA-1" SIZE="6180411">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:21:06" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="807aab2d79493df978ccfe2266fc182e47001d37" CHECKSUMTYPE="SHA-1" SIZE="6180411">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:21:39"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="2ed8ae00bd04407e509e6d2844b59a114c177fd7"
-				CHECKSUMTYPE="SHA-1" SIZE="5986028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:21:39" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="2ed8ae00bd04407e509e6d2844b59a114c177fd7" CHECKSUMTYPE="SHA-1" SIZE="5986028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:22:11"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="b7a5783ea8d3c07ab5b299a7e62b777882fd9a19"
-				CHECKSUMTYPE="SHA-1" SIZE="6207427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:22:11" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="b7a5783ea8d3c07ab5b299a7e62b777882fd9a19" CHECKSUMTYPE="SHA-1" SIZE="6207427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:22:44"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="fee60f98f388110a5af18b41ee96b1fd9943637b"
-				CHECKSUMTYPE="SHA-1" SIZE="5986929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:22:44" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="fee60f98f388110a5af18b41ee96b1fd9943637b" CHECKSUMTYPE="SHA-1" SIZE="5986929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:23:17"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="7c8499b65118eea85e0e9b67a3d628900d26fab5"
-				CHECKSUMTYPE="SHA-1" SIZE="6207426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:23:17" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="7c8499b65118eea85e0e9b67a3d628900d26fab5" CHECKSUMTYPE="SHA-1" SIZE="6207426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:23:50"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="75051fa1b7e99c7732137776c93c6036a3c7dcbf"
-				CHECKSUMTYPE="SHA-1" SIZE="6054421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:23:50" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="75051fa1b7e99c7732137776c93c6036a3c7dcbf" CHECKSUMTYPE="SHA-1" SIZE="6054421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:24:20"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="1df5b0ca1c2b9d6a9d839adbb08323eb6e8efe6b"
-				CHECKSUMTYPE="SHA-1" SIZE="6206496">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:24:20" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="1df5b0ca1c2b9d6a9d839adbb08323eb6e8efe6b" CHECKSUMTYPE="SHA-1" SIZE="6206496">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:24:49"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="c5d2131b0f9bc8c47b4f1f8061c2efae59496891"
-				CHECKSUMTYPE="SHA-1" SIZE="6111092">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:24:49" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="c5d2131b0f9bc8c47b4f1f8061c2efae59496891" CHECKSUMTYPE="SHA-1" SIZE="6111092">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:25:18"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="285a7a83c97d233d59e345cfda47451d355d37b3"
-				CHECKSUMTYPE="SHA-1" SIZE="6149822">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:25:18" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="285a7a83c97d233d59e345cfda47451d355d37b3" CHECKSUMTYPE="SHA-1" SIZE="6149822">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:25:47"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="87beb43e6868f8ba72be2cda344ccb2af6ac834c"
-				CHECKSUMTYPE="SHA-1" SIZE="6111125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:25:47" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="87beb43e6868f8ba72be2cda344ccb2af6ac834c" CHECKSUMTYPE="SHA-1" SIZE="6111125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:26:20"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="e545a67e4005cb926875d7a7e044d55de7b21d5c"
-				CHECKSUMTYPE="SHA-1" SIZE="6149818">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:26:20" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="e545a67e4005cb926875d7a7e044d55de7b21d5c" CHECKSUMTYPE="SHA-1" SIZE="6149818">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:26:48"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="369874c012e63548ff92b6f28e78d285f5f23c16"
-				CHECKSUMTYPE="SHA-1" SIZE="6111120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:26:48" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="369874c012e63548ff92b6f28e78d285f5f23c16" CHECKSUMTYPE="SHA-1" SIZE="6111120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:27:21"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="708620f7f73915a09faf21e9fe751fc6e66701ca"
-				CHECKSUMTYPE="SHA-1" SIZE="6109321">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:27:21" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="708620f7f73915a09faf21e9fe751fc6e66701ca" CHECKSUMTYPE="SHA-1" SIZE="6109321">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:27:53"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="20452bae87441c488477103d0f50b9aa5ae666e7"
-				CHECKSUMTYPE="SHA-1" SIZE="6110215">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:27:53" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="20452bae87441c488477103d0f50b9aa5ae666e7" CHECKSUMTYPE="SHA-1" SIZE="6110215">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:28:23"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="6cce44a24cb4c9377ddd79884a30fd9006ae4b2d"
-				CHECKSUMTYPE="SHA-1" SIZE="6109282">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:28:23" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="6cce44a24cb4c9377ddd79884a30fd9006ae4b2d" CHECKSUMTYPE="SHA-1" SIZE="6109282">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:28:55"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="9b8dc9866f01bd3804f66cbb57a5b2b2b9e62af5"
-				CHECKSUMTYPE="SHA-1" SIZE="6110219">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:28:55" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="9b8dc9866f01bd3804f66cbb57a5b2b2b9e62af5" CHECKSUMTYPE="SHA-1" SIZE="6110219">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:29:26"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7c1ba0effa99e59751556ba482b1a2be1cd90ef2"
-				CHECKSUMTYPE="SHA-1" SIZE="6109329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:29:26" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7c1ba0effa99e59751556ba482b1a2be1cd90ef2" CHECKSUMTYPE="SHA-1" SIZE="6109329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:29:56"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="ee080f055c102abeeeee1d7b8471f386598b9ac1"
-				CHECKSUMTYPE="SHA-1" SIZE="6111127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:29:56" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="ee080f055c102abeeeee1d7b8471f386598b9ac1" CHECKSUMTYPE="SHA-1" SIZE="6111127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:30:28"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="dbc33ee2aa84d64e4d780529a515dacc8623b3c5"
-				CHECKSUMTYPE="SHA-1" SIZE="6109329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:30:28" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="dbc33ee2aa84d64e4d780529a515dacc8623b3c5" CHECKSUMTYPE="SHA-1" SIZE="6109329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:31:02"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="31560f77d410edc1ed3b109aec100e8a71d3ef85"
-				CHECKSUMTYPE="SHA-1" SIZE="6110183">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:31:02" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="31560f77d410edc1ed3b109aec100e8a71d3ef85" CHECKSUMTYPE="SHA-1" SIZE="6110183">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:31:34"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="9e19a33bc96e781a5ef0fb75163f65cc86205485"
-				CHECKSUMTYPE="SHA-1" SIZE="6109320">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:31:34" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="9e19a33bc96e781a5ef0fb75163f65cc86205485" CHECKSUMTYPE="SHA-1" SIZE="6109320">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:32:05"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="0b374f56f23d4207f8453884a45a3b039d20fe30"
-				CHECKSUMTYPE="SHA-1" SIZE="6110224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:32:05" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="0b374f56f23d4207f8453884a45a3b039d20fe30" CHECKSUMTYPE="SHA-1" SIZE="6110224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:32:35"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="fb6a9ccf8460efc5c17bc49a2952b79b439e6f6b"
-				CHECKSUMTYPE="SHA-1" SIZE="6109315">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:32:35" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="fb6a9ccf8460efc5c17bc49a2952b79b439e6f6b" CHECKSUMTYPE="SHA-1" SIZE="6109315">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:33:06"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f9396dc30b011accc2cbe3642d19026e09cbf8ed"
-				CHECKSUMTYPE="SHA-1" SIZE="6110209">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:33:06" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f9396dc30b011accc2cbe3642d19026e09cbf8ed" CHECKSUMTYPE="SHA-1" SIZE="6110209">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:33:38"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="ea01f507e47f54b04d2de2e4b760e1153fdd6ea1"
-				CHECKSUMTYPE="SHA-1" SIZE="6109328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:33:38" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="ea01f507e47f54b04d2de2e4b760e1153fdd6ea1" CHECKSUMTYPE="SHA-1" SIZE="6109328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:34:09"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ff22d7d94bf64adc3a56f7bab0c7de40350cc465"
-				CHECKSUMTYPE="SHA-1" SIZE="6111120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:34:09" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ff22d7d94bf64adc3a56f7bab0c7de40350cc465" CHECKSUMTYPE="SHA-1" SIZE="6111120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:34:41"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="9ca73a32ffc3b22c9947328f07845833734dbb1b"
-				CHECKSUMTYPE="SHA-1" SIZE="6110229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:34:41" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="9ca73a32ffc3b22c9947328f07845833734dbb1b" CHECKSUMTYPE="SHA-1" SIZE="6110229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:35:10"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="83874b274692e37c1d09d6ee4697a8dc153fdfaf"
-				CHECKSUMTYPE="SHA-1" SIZE="6274023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:35:10" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="83874b274692e37c1d09d6ee4697a8dc153fdfaf" CHECKSUMTYPE="SHA-1" SIZE="6274023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:35:42"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="3478ba4a771f708304b3500966b4183c49290bd7"
-				CHECKSUMTYPE="SHA-1" SIZE="5902327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:35:42" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="3478ba4a771f708304b3500966b4183c49290bd7" CHECKSUMTYPE="SHA-1" SIZE="5902327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:36:14"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="f5f34e153f79f31d5511496cc0f1d0ad59ed8b55"
-				CHECKSUMTYPE="SHA-1" SIZE="6220028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:36:14" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="f5f34e153f79f31d5511496cc0f1d0ad59ed8b55" CHECKSUMTYPE="SHA-1" SIZE="6220028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/delivery/bmtnabf_1901-08-15_01_0030.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:36:33" MIMETYPE="text/xml"
-				CHECKSUM="db65355038a9a468525f98038bd3e6652c2fa7b4" CHECKSUMTYPE="SHA-1" SIZE="4905">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:36:33" MIMETYPE="text/xml" CHECKSUM="db65355038a9a468525f98038bd3e6652c2fa7b4" CHECKSUMTYPE="SHA-1" SIZE="4905">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:36:33" MIMETYPE="text/xml"
-				CHECKSUM="06812d5c0aedd96daa7eebe66d646d15ff2cf243" CHECKSUMTYPE="SHA-1"
-				SIZE="34525">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:36:33" MIMETYPE="text/xml" CHECKSUM="06812d5c0aedd96daa7eebe66d646d15ff2cf243" CHECKSUMTYPE="SHA-1" SIZE="34525">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:36:33" MIMETYPE="text/xml"
-				CHECKSUM="7a8a7e6f32159cdf7f21afeee6691f827105e651" CHECKSUMTYPE="SHA-1" SIZE="9990">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:36:33" MIMETYPE="text/xml" CHECKSUM="7a8a7e6f32159cdf7f21afeee6691f827105e651" CHECKSUMTYPE="SHA-1" SIZE="9990">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:36:34" MIMETYPE="text/xml"
-				CHECKSUM="81da469135719d765a0ad616091312313e523127" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:36:34" MIMETYPE="text/xml" CHECKSUM="81da469135719d765a0ad616091312313e523127" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:36:34" MIMETYPE="text/xml"
-				CHECKSUM="e74bfb9dd2fc28303d2eafb33f49750502b8a012" CHECKSUMTYPE="SHA-1"
-				SIZE="13659">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:36:34" MIMETYPE="text/xml" CHECKSUM="e74bfb9dd2fc28303d2eafb33f49750502b8a012" CHECKSUMTYPE="SHA-1" SIZE="13659">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:36:34" MIMETYPE="text/xml"
-				CHECKSUM="54ebf0bb970e3ae5378ab83fb9625c1371b6573f" CHECKSUMTYPE="SHA-1" SIZE="2010">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:36:34" MIMETYPE="text/xml" CHECKSUM="54ebf0bb970e3ae5378ab83fb9625c1371b6573f" CHECKSUMTYPE="SHA-1" SIZE="2010">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:36:34" MIMETYPE="text/xml"
-				CHECKSUM="673226fbf856ae6145ae2398058b13922eeefe83" CHECKSUMTYPE="SHA-1" SIZE="4599">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:36:34" MIMETYPE="text/xml" CHECKSUM="673226fbf856ae6145ae2398058b13922eeefe83" CHECKSUMTYPE="SHA-1" SIZE="4599">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:36:35" MIMETYPE="text/xml"
-				CHECKSUM="5532d08a3b16ddb47406ff9f58906fca3eb88db7" CHECKSUMTYPE="SHA-1" SIZE="3852">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:36:35" MIMETYPE="text/xml" CHECKSUM="5532d08a3b16ddb47406ff9f58906fca3eb88db7" CHECKSUMTYPE="SHA-1" SIZE="3852">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:36:35" MIMETYPE="text/xml"
-				CHECKSUM="d85ab1f053b1dce9d50e12b84d72ba711b0528b9" CHECKSUMTYPE="SHA-1"
-				SIZE="44559">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:36:35" MIMETYPE="text/xml" CHECKSUM="d85ab1f053b1dce9d50e12b84d72ba711b0528b9" CHECKSUMTYPE="SHA-1" SIZE="44559">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:36:35" MIMETYPE="text/xml"
-				CHECKSUM="69bf9e662cf8687f476d0674e688970ecb88cecf" CHECKSUMTYPE="SHA-1" SIZE="9138">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:36:35" MIMETYPE="text/xml" CHECKSUM="69bf9e662cf8687f476d0674e688970ecb88cecf" CHECKSUMTYPE="SHA-1" SIZE="9138">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:36:35" MIMETYPE="text/xml"
-				CHECKSUM="ab6ad76103e9d21f04731a2c8c79b3e724ca3736" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:36:35" MIMETYPE="text/xml" CHECKSUM="ab6ad76103e9d21f04731a2c8c79b3e724ca3736" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:36:35" MIMETYPE="text/xml"
-				CHECKSUM="eaab0089ccc0a4751e281b62a172bc125ef775a7" CHECKSUMTYPE="SHA-1" SIZE="2402">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:36:35" MIMETYPE="text/xml" CHECKSUM="eaab0089ccc0a4751e281b62a172bc125ef775a7" CHECKSUMTYPE="SHA-1" SIZE="2402">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:36:36" MIMETYPE="text/xml"
-				CHECKSUM="5d7a2cda1994092cff28bcf808d7bfc351b485d6" CHECKSUMTYPE="SHA-1" SIZE="2023">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:36:36" MIMETYPE="text/xml" CHECKSUM="5d7a2cda1994092cff28bcf808d7bfc351b485d6" CHECKSUMTYPE="SHA-1" SIZE="2023">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:36:36" MIMETYPE="text/xml"
-				CHECKSUM="d5d16a89e8785c242803dbf544c80b79c69400f9" CHECKSUMTYPE="SHA-1" SIZE="4167">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:36:36" MIMETYPE="text/xml" CHECKSUM="d5d16a89e8785c242803dbf544c80b79c69400f9" CHECKSUMTYPE="SHA-1" SIZE="4167">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:36:36" MIMETYPE="text/xml"
-				CHECKSUM="06f48757b5df378bece1836d172823fd48ba079e" CHECKSUMTYPE="SHA-1"
-				SIZE="53570">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:36:36" MIMETYPE="text/xml" CHECKSUM="06f48757b5df378bece1836d172823fd48ba079e" CHECKSUMTYPE="SHA-1" SIZE="53570">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:36:36" MIMETYPE="text/xml"
-				CHECKSUM="1bdb258faa6d5bc85b74cc9ae52c73f16f7831cc" CHECKSUMTYPE="SHA-1"
-				SIZE="19173">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:36:36" MIMETYPE="text/xml" CHECKSUM="1bdb258faa6d5bc85b74cc9ae52c73f16f7831cc" CHECKSUMTYPE="SHA-1" SIZE="19173">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:36:37" MIMETYPE="text/xml"
-				CHECKSUM="0b42267122fcb27a08819019931c735c7acdf971" CHECKSUMTYPE="SHA-1"
-				SIZE="19632">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:36:37" MIMETYPE="text/xml" CHECKSUM="0b42267122fcb27a08819019931c735c7acdf971" CHECKSUMTYPE="SHA-1" SIZE="19632">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:36:37" MIMETYPE="text/xml"
-				CHECKSUM="292385122e40f37170fa3c7e7ff69bab003fd42c" CHECKSUMTYPE="SHA-1"
-				SIZE="46459">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:36:37" MIMETYPE="text/xml" CHECKSUM="292385122e40f37170fa3c7e7ff69bab003fd42c" CHECKSUMTYPE="SHA-1" SIZE="46459">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:36:37" MIMETYPE="text/xml"
-				CHECKSUM="bba0ef5cf85626958da216ea1f1a8ba539898067" CHECKSUMTYPE="SHA-1"
-				SIZE="16333">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:36:37" MIMETYPE="text/xml" CHECKSUM="bba0ef5cf85626958da216ea1f1a8ba539898067" CHECKSUMTYPE="SHA-1" SIZE="16333">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:36:37" MIMETYPE="text/xml"
-				CHECKSUM="c42179e018661f7f71322d09b961db09283923e7" CHECKSUMTYPE="SHA-1"
-				SIZE="15490">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:36:37" MIMETYPE="text/xml" CHECKSUM="c42179e018661f7f71322d09b961db09283923e7" CHECKSUMTYPE="SHA-1" SIZE="15490">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:36:38" MIMETYPE="text/xml"
-				CHECKSUM="dc9c992ca2fe1a4906d225ddf89785fd8a7aad0f" CHECKSUMTYPE="SHA-1"
-				SIZE="17053">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:36:38" MIMETYPE="text/xml" CHECKSUM="dc9c992ca2fe1a4906d225ddf89785fd8a7aad0f" CHECKSUMTYPE="SHA-1" SIZE="17053">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:36:38" MIMETYPE="text/xml"
-				CHECKSUM="68fea7bc699b7e864d1c41040b77cc354c33092e" CHECKSUMTYPE="SHA-1"
-				SIZE="52158">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:36:38" MIMETYPE="text/xml" CHECKSUM="68fea7bc699b7e864d1c41040b77cc354c33092e" CHECKSUMTYPE="SHA-1" SIZE="52158">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:36:39" MIMETYPE="text/xml"
-				CHECKSUM="f8e15cf1d8a38f32356d60ab2856b70088209511" CHECKSUMTYPE="SHA-1"
-				SIZE="23604">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:36:39" MIMETYPE="text/xml" CHECKSUM="f8e15cf1d8a38f32356d60ab2856b70088209511" CHECKSUMTYPE="SHA-1" SIZE="23604">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:36:40" MIMETYPE="text/xml"
-				CHECKSUM="0bea48dc85936fb1ad5446fed9baf1b02d4529c0" CHECKSUMTYPE="SHA-1"
-				SIZE="49753">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:36:40" MIMETYPE="text/xml" CHECKSUM="0bea48dc85936fb1ad5446fed9baf1b02d4529c0" CHECKSUMTYPE="SHA-1" SIZE="49753">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:36:40" MIMETYPE="text/xml"
-				CHECKSUM="147287421e908f5e8af24d7e55684a3d14be468f" CHECKSUMTYPE="SHA-1"
-				SIZE="16143">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:36:40" MIMETYPE="text/xml" CHECKSUM="147287421e908f5e8af24d7e55684a3d14be468f" CHECKSUMTYPE="SHA-1" SIZE="16143">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:36:40" MIMETYPE="text/xml"
-				CHECKSUM="02a5d4ea4ed009110c49f8ba794f2309067a44e3" CHECKSUMTYPE="SHA-1" SIZE="4291">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:36:40" MIMETYPE="text/xml" CHECKSUM="02a5d4ea4ed009110c49f8ba794f2309067a44e3" CHECKSUMTYPE="SHA-1" SIZE="4291">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:36:41" MIMETYPE="text/xml"
-				CHECKSUM="edb9a28d80e23b938296bc9a51525a0349a203d4" CHECKSUMTYPE="SHA-1" SIZE="2014">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:36:41" MIMETYPE="text/xml" CHECKSUM="edb9a28d80e23b938296bc9a51525a0349a203d4" CHECKSUMTYPE="SHA-1" SIZE="2014">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:36:41" MIMETYPE="text/xml"
-				CHECKSUM="9677d1bef15cb802f9177e3e9f9b310ec86cf02d" CHECKSUMTYPE="SHA-1"
-				SIZE="33708">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:36:41" MIMETYPE="text/xml" CHECKSUM="9677d1bef15cb802f9177e3e9f9b310ec86cf02d" CHECKSUMTYPE="SHA-1" SIZE="33708">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:36:41" MIMETYPE="text/xml"
-				CHECKSUM="ed770bb0857652b2dc182b73f7d9ed91325727da" CHECKSUMTYPE="SHA-1"
-				SIZE="38767">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:36:41" MIMETYPE="text/xml" CHECKSUM="ed770bb0857652b2dc182b73f7d9ed91325727da" CHECKSUMTYPE="SHA-1" SIZE="38767">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:36:41" MIMETYPE="text/xml"
-				CHECKSUM="3d399f56a37acb7155e67362848476117bb9c7db" CHECKSUMTYPE="SHA-1" SIZE="8115">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:36:41" MIMETYPE="text/xml" CHECKSUM="3d399f56a37acb7155e67362848476117bb9c7db" CHECKSUMTYPE="SHA-1" SIZE="8115">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-08-15_01_0030.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:37:13" MIMETYPE="application/pdf"
-				CHECKSUM="2e808c639686daf5a7cb33f34db86ed1da38338f" CHECKSUMTYPE="SHA-1"
-				SIZE="9056632">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/bmtnabf_1901-08-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:37:13" MIMETYPE="application/pdf" CHECKSUM="2e808c639686daf5a7cb33f34db86ed1da38338f" CHECKSUMTYPE="SHA-1" SIZE="9056632">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/08/15_01/bmtnabf_1901-08-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3402,8 +3196,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 16 15.08.1901">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by WILHELM LAAGE">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by WILHELM LAAGE">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_CB00001"/>
@@ -3471,10 +3264,8 @@
 								<div ID="L.1.1.5.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3499,40 +3290,26 @@
 								<div ID="L.1.1.8.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c008"
-						LABEL="DURCH DIE HEIDE">
+					<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c008" LABEL="DURCH DIE HEIDE">
 						<div ID="L.1.1.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -3605,8 +3382,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="2" DMDID="c013"
-						LABEL="Sonne überm Meer">
+					<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="2" DMDID="c013" LABEL="Sonne überm Meer">
 						<div ID="L.1.1.8.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
@@ -3650,8 +3426,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.8" TYPE="Illustration" ORDER="4" DMDID="c016"
-						LABEL="Tod und Leben">
+					<div ID="L.1.1.8.8" TYPE="Illustration" ORDER="4" DMDID="c016" LABEL="Tod und Leben">
 						<div ID="L.1.1.8.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
@@ -3673,8 +3448,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.9" TYPE="Illustration" ORDER="5" DMDID="c017"
-						LABEL="Frühlingstag">
+					<div ID="L.1.1.8.9" TYPE="Illustration" ORDER="5" DMDID="c017" LABEL="Frühlingstag">
 						<div ID="L.1.1.8.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
@@ -3696,8 +3470,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.10" TYPE="Illustration" ORDER="6" DMDID="c018"
-						LABEL="Nachtstille">
+					<div ID="L.1.1.8.10" TYPE="Illustration" ORDER="6" DMDID="c018" LABEL="Nachtstille">
 						<div ID="L.1.1.8.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00003"/>
@@ -3719,8 +3492,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.11" TYPE="Illustration" ORDER="7" DMDID="c019"
-						LABEL="Badeplatz am Meer">
+					<div ID="L.1.1.8.11" TYPE="Illustration" ORDER="7" DMDID="c019" LABEL="Badeplatz am Meer">
 						<div ID="L.1.1.8.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
@@ -3742,8 +3514,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.12" TYPE="Illustration" ORDER="8" DMDID="c020"
-						LABEL="Untitled Image by Wilhelm Laage">
+					<div ID="L.1.1.8.12" TYPE="Illustration" ORDER="8" DMDID="c020" LABEL="Untitled Image by Wilhelm Laage">
 						<div ID="L.1.1.8.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00004"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/09/01_01/bmtnabf_1901-09-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/09/01_01/bmtnabf_1901-09-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-09-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-09-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-09-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-09-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-09-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2592,309 +2586,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:26:07"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="5f61adb6dfabb97f6b7a17c297c1f39432fa23e4"
-				CHECKSUMTYPE="SHA-1" SIZE="6094016">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:26:07" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="5f61adb6dfabb97f6b7a17c297c1f39432fa23e4" CHECKSUMTYPE="SHA-1" SIZE="6094016">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:26:42"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="be2a006759fcf736e9dc74003f4e1625fe76f34a"
-				CHECKSUMTYPE="SHA-1" SIZE="5995028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:26:42" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="be2a006759fcf736e9dc74003f4e1625fe76f34a" CHECKSUMTYPE="SHA-1" SIZE="5995028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:27:13"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="42af3a8d9fdbd40d5f6a907f1847c8ce30beb6d7"
-				CHECKSUMTYPE="SHA-1" SIZE="6128228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:27:13" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="42af3a8d9fdbd40d5f6a907f1847c8ce30beb6d7" CHECKSUMTYPE="SHA-1" SIZE="6128228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:27:48"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="b48a32f219199db0b6384fbe4ece74cf35b89203"
-				CHECKSUMTYPE="SHA-1" SIZE="5995920">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:27:48" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="b48a32f219199db0b6384fbe4ece74cf35b89203" CHECKSUMTYPE="SHA-1" SIZE="5995920">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:28:22"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="28e2719fe2baa751d2f3a844c370f2f62fc03611"
-				CHECKSUMTYPE="SHA-1" SIZE="6036417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:28:22" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="28e2719fe2baa751d2f3a844c370f2f62fc03611" CHECKSUMTYPE="SHA-1" SIZE="6036417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:28:51"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="20e66d10fc6cd171ef7dd57a9f54bd5d7f50f5f1"
-				CHECKSUMTYPE="SHA-1" SIZE="6047971">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:28:51" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="20e66d10fc6cd171ef7dd57a9f54bd5d7f50f5f1" CHECKSUMTYPE="SHA-1" SIZE="6047971">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:29:23"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="bd2f8b29f3d6eb1b53f62e930754d79535296e44"
-				CHECKSUMTYPE="SHA-1" SIZE="6061606">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:29:23" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="bd2f8b29f3d6eb1b53f62e930754d79535296e44" CHECKSUMTYPE="SHA-1" SIZE="6061606">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:29:53"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="75259ef67e9b1b56def25f15e8c1ba3c39494675"
-				CHECKSUMTYPE="SHA-1" SIZE="6048065">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:29:53" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="75259ef67e9b1b56def25f15e8c1ba3c39494675" CHECKSUMTYPE="SHA-1" SIZE="6048065">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:30:22"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="2daa7f487455061b55de951421ac01acdc9793dc"
-				CHECKSUMTYPE="SHA-1" SIZE="6058876">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:30:22" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="2daa7f487455061b55de951421ac01acdc9793dc" CHECKSUMTYPE="SHA-1" SIZE="6058876">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:30:53"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="0b4d7768c8f38c769801eba8a00199fc452c7a73"
-				CHECKSUMTYPE="SHA-1" SIZE="6047229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:30:53" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="0b4d7768c8f38c769801eba8a00199fc452c7a73" CHECKSUMTYPE="SHA-1" SIZE="6047229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:31:26"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="518224c314f68a704acda4aa742ee54494e031f2"
-				CHECKSUMTYPE="SHA-1" SIZE="6060729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:31:26" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="518224c314f68a704acda4aa742ee54494e031f2" CHECKSUMTYPE="SHA-1" SIZE="6060729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:31:55"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="6139e0fdc5fa3cccfc9e10a1ab9ad68e76ed5cc2"
-				CHECKSUMTYPE="SHA-1" SIZE="6047210">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:31:55" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="6139e0fdc5fa3cccfc9e10a1ab9ad68e76ed5cc2" CHECKSUMTYPE="SHA-1" SIZE="6047210">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:32:27"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="e1c0cb0f8978b190093b2a67a43d4539266c6c15"
-				CHECKSUMTYPE="SHA-1" SIZE="6060728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:32:27" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="e1c0cb0f8978b190093b2a67a43d4539266c6c15" CHECKSUMTYPE="SHA-1" SIZE="6060728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:33:00"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="19552aa75a2dad9c937eb0cf2928e4384cc5e63c"
-				CHECKSUMTYPE="SHA-1" SIZE="6048122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:33:00" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="19552aa75a2dad9c937eb0cf2928e4384cc5e63c" CHECKSUMTYPE="SHA-1" SIZE="6048122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:33:34"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="14e7ad00ca0644bca61a7ce196bd54941ca45f10"
-				CHECKSUMTYPE="SHA-1" SIZE="6060577">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:33:34" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="14e7ad00ca0644bca61a7ce196bd54941ca45f10" CHECKSUMTYPE="SHA-1" SIZE="6060577">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:34:05"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="711d928ca98dac0d3c1fa5c1d60a9d1a1856d418"
-				CHECKSUMTYPE="SHA-1" SIZE="6075747">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:34:05" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="711d928ca98dac0d3c1fa5c1d60a9d1a1856d418" CHECKSUMTYPE="SHA-1" SIZE="6075747">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:34:36"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="1e72c9421a8896c79c94e8aeadff521f90c32dcf"
-				CHECKSUMTYPE="SHA-1" SIZE="6060688">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:34:36" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="1e72c9421a8896c79c94e8aeadff521f90c32dcf" CHECKSUMTYPE="SHA-1" SIZE="6060688">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:35:07"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="8049cec908cff63ffcb7e07aaf6d5806552b668e"
-				CHECKSUMTYPE="SHA-1" SIZE="6076022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:35:07" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="8049cec908cff63ffcb7e07aaf6d5806552b668e" CHECKSUMTYPE="SHA-1" SIZE="6076022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:35:40"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="b427f3ff2d14b8a5f9036c76b5c42a31ebca7f86"
-				CHECKSUMTYPE="SHA-1" SIZE="6060715">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:35:40" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="b427f3ff2d14b8a5f9036c76b5c42a31ebca7f86" CHECKSUMTYPE="SHA-1" SIZE="6060715">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:36:08"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="2cadef61644fff8e59e1a4131181f8217e80644a"
-				CHECKSUMTYPE="SHA-1" SIZE="6076024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:36:08" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="2cadef61644fff8e59e1a4131181f8217e80644a" CHECKSUMTYPE="SHA-1" SIZE="6076024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:36:41"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="4d1c5ddac6896e7300d845f17e7a0ae289c0f11e"
-				CHECKSUMTYPE="SHA-1" SIZE="6060718">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:36:41" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="4d1c5ddac6896e7300d845f17e7a0ae289c0f11e" CHECKSUMTYPE="SHA-1" SIZE="6060718">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:37:12"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="15f6944bc5beddf38f1a08e5048911388cfb71f8"
-				CHECKSUMTYPE="SHA-1" SIZE="6099429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:37:12" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="15f6944bc5beddf38f1a08e5048911388cfb71f8" CHECKSUMTYPE="SHA-1" SIZE="6099429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:37:40"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="f1f636dd11d202717fe9e0155d08ee957d5fcf00"
-				CHECKSUMTYPE="SHA-1" SIZE="6060726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:37:40" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="f1f636dd11d202717fe9e0155d08ee957d5fcf00" CHECKSUMTYPE="SHA-1" SIZE="6060726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:38:11"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="117161fcee87ce8912eeb62fc4d7734a87b5cd4a"
-				CHECKSUMTYPE="SHA-1" SIZE="6099401">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:38:11" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="117161fcee87ce8912eeb62fc4d7734a87b5cd4a" CHECKSUMTYPE="SHA-1" SIZE="6099401">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/delivery/bmtnabf_1901-09-01_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:38:31" MIMETYPE="text/xml"
-				CHECKSUM="c7784bcdc725b3888ca1b652681a829d315732d9" CHECKSUMTYPE="SHA-1" SIZE="4730">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:38:31" MIMETYPE="text/xml" CHECKSUM="c7784bcdc725b3888ca1b652681a829d315732d9" CHECKSUMTYPE="SHA-1" SIZE="4730">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:38:31" MIMETYPE="text/xml"
-				CHECKSUM="87fe981b84a34f7f7918cd6bb5454f7f673f3bc9" CHECKSUMTYPE="SHA-1"
-				SIZE="40198">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:38:31" MIMETYPE="text/xml" CHECKSUM="87fe981b84a34f7f7918cd6bb5454f7f673f3bc9" CHECKSUMTYPE="SHA-1" SIZE="40198">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:38:31" MIMETYPE="text/xml"
-				CHECKSUM="8809cfe5e1f4f622b358124e638b15fdcbef5c3f" CHECKSUMTYPE="SHA-1" SIZE="9482">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:38:31" MIMETYPE="text/xml" CHECKSUM="8809cfe5e1f4f622b358124e638b15fdcbef5c3f" CHECKSUMTYPE="SHA-1" SIZE="9482">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:38:32" MIMETYPE="text/xml"
-				CHECKSUM="643f7f53fb925f3de8ce808874a7638d8b172f39" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:38:32" MIMETYPE="text/xml" CHECKSUM="643f7f53fb925f3de8ce808874a7638d8b172f39" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:38:32" MIMETYPE="text/xml"
-				CHECKSUM="ee64c86606a5eede90e0a9fa611f2631a01e03af" CHECKSUMTYPE="SHA-1" SIZE="6578">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:38:32" MIMETYPE="text/xml" CHECKSUM="ee64c86606a5eede90e0a9fa611f2631a01e03af" CHECKSUMTYPE="SHA-1" SIZE="6578">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:38:32" MIMETYPE="text/xml"
-				CHECKSUM="7c9f5305a316df41c0c3d264afa605a0e5b6cb5e" CHECKSUMTYPE="SHA-1" SIZE="4447">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:38:32" MIMETYPE="text/xml" CHECKSUM="7c9f5305a316df41c0c3d264afa605a0e5b6cb5e" CHECKSUMTYPE="SHA-1" SIZE="4447">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:38:32" MIMETYPE="text/xml"
-				CHECKSUM="d4cbb04106182538fb20ea59d7042efb94fe0235" CHECKSUMTYPE="SHA-1" SIZE="5520">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:38:32" MIMETYPE="text/xml" CHECKSUM="d4cbb04106182538fb20ea59d7042efb94fe0235" CHECKSUMTYPE="SHA-1" SIZE="5520">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:38:32" MIMETYPE="text/xml"
-				CHECKSUM="41e69d89590b4c8c58bde766e7cdf0bc71d3ed1f" CHECKSUMTYPE="SHA-1" SIZE="6901">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:38:32" MIMETYPE="text/xml" CHECKSUM="41e69d89590b4c8c58bde766e7cdf0bc71d3ed1f" CHECKSUMTYPE="SHA-1" SIZE="6901">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:38:33" MIMETYPE="text/xml"
-				CHECKSUM="59affc4eb09d00c25844c94fdb3d7ced96afd8cc" CHECKSUMTYPE="SHA-1" SIZE="7001">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:38:33" MIMETYPE="text/xml" CHECKSUM="59affc4eb09d00c25844c94fdb3d7ced96afd8cc" CHECKSUMTYPE="SHA-1" SIZE="7001">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:38:33" MIMETYPE="text/xml"
-				CHECKSUM="bb383bca90decd04fa7ddfb3334ee99dc01fce2e" CHECKSUMTYPE="SHA-1" SIZE="5271">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:38:33" MIMETYPE="text/xml" CHECKSUM="bb383bca90decd04fa7ddfb3334ee99dc01fce2e" CHECKSUMTYPE="SHA-1" SIZE="5271">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:38:33" MIMETYPE="text/xml"
-				CHECKSUM="6582dbae7bc5a0425fbb6d79412a5975821452b9" CHECKSUMTYPE="SHA-1" SIZE="4955">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:38:33" MIMETYPE="text/xml" CHECKSUM="6582dbae7bc5a0425fbb6d79412a5975821452b9" CHECKSUMTYPE="SHA-1" SIZE="4955">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:38:34" MIMETYPE="text/xml"
-				CHECKSUM="2d8229ef6625dfa6894212bc6a7ba30ec134149a" CHECKSUMTYPE="SHA-1" SIZE="3004">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:38:34" MIMETYPE="text/xml" CHECKSUM="2d8229ef6625dfa6894212bc6a7ba30ec134149a" CHECKSUMTYPE="SHA-1" SIZE="3004">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:38:35" MIMETYPE="text/xml"
-				CHECKSUM="65717a29e5c0b1016afdf6ce5ad4814879e5891d" CHECKSUMTYPE="SHA-1" SIZE="5073">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:38:35" MIMETYPE="text/xml" CHECKSUM="65717a29e5c0b1016afdf6ce5ad4814879e5891d" CHECKSUMTYPE="SHA-1" SIZE="5073">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:38:35" MIMETYPE="text/xml"
-				CHECKSUM="6e2374703bdc11c74d426a4e4342e90bc7fa6f18" CHECKSUMTYPE="SHA-1" SIZE="7181">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:38:35" MIMETYPE="text/xml" CHECKSUM="6e2374703bdc11c74d426a4e4342e90bc7fa6f18" CHECKSUMTYPE="SHA-1" SIZE="7181">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:38:36" MIMETYPE="text/xml"
-				CHECKSUM="02a18802da765b0733e582e722e742553bb9e62a" CHECKSUMTYPE="SHA-1" SIZE="5487">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:38:36" MIMETYPE="text/xml" CHECKSUM="02a18802da765b0733e582e722e742553bb9e62a" CHECKSUMTYPE="SHA-1" SIZE="5487">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:38:36" MIMETYPE="text/xml"
-				CHECKSUM="fe2ae27719c3ad7b71f23b6af70731d7da2c4449" CHECKSUMTYPE="SHA-1" SIZE="7484">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:38:36" MIMETYPE="text/xml" CHECKSUM="fe2ae27719c3ad7b71f23b6af70731d7da2c4449" CHECKSUMTYPE="SHA-1" SIZE="7484">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:38:36" MIMETYPE="text/xml"
-				CHECKSUM="96293295b705b14adaf3d63f6d99810fb31b09e3" CHECKSUMTYPE="SHA-1" SIZE="5822">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:38:36" MIMETYPE="text/xml" CHECKSUM="96293295b705b14adaf3d63f6d99810fb31b09e3" CHECKSUMTYPE="SHA-1" SIZE="5822">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:38:36" MIMETYPE="text/xml"
-				CHECKSUM="20836a5e188d89471a530bbe71d017442fb7b3ea" CHECKSUMTYPE="SHA-1" SIZE="5601">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:38:36" MIMETYPE="text/xml" CHECKSUM="20836a5e188d89471a530bbe71d017442fb7b3ea" CHECKSUMTYPE="SHA-1" SIZE="5601">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:38:37" MIMETYPE="text/xml"
-				CHECKSUM="f8a36fca1295077ad7d5901ebd2c6b533c09b28c" CHECKSUMTYPE="SHA-1"
-				SIZE="22187">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:38:37" MIMETYPE="text/xml" CHECKSUM="f8a36fca1295077ad7d5901ebd2c6b533c09b28c" CHECKSUMTYPE="SHA-1" SIZE="22187">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:38:37" MIMETYPE="text/xml"
-				CHECKSUM="840dd5cc83b7208541d2c031e0bdb40f21f68c46" CHECKSUMTYPE="SHA-1"
-				SIZE="12914">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:38:37" MIMETYPE="text/xml" CHECKSUM="840dd5cc83b7208541d2c031e0bdb40f21f68c46" CHECKSUMTYPE="SHA-1" SIZE="12914">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:38:37" MIMETYPE="text/xml"
-				CHECKSUM="c97e9a2a9d4a4d129b6533766c714950737671e5" CHECKSUMTYPE="SHA-1" SIZE="8607">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:38:37" MIMETYPE="text/xml" CHECKSUM="c97e9a2a9d4a4d129b6533766c714950737671e5" CHECKSUMTYPE="SHA-1" SIZE="8607">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:38:37" MIMETYPE="text/xml"
-				CHECKSUM="45565f9b616bbdbfa635bad0f063529a22b6ac1e" CHECKSUMTYPE="SHA-1"
-				SIZE="33673">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:38:37" MIMETYPE="text/xml" CHECKSUM="45565f9b616bbdbfa635bad0f063529a22b6ac1e" CHECKSUMTYPE="SHA-1" SIZE="33673">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:38:38" MIMETYPE="text/xml"
-				CHECKSUM="05e0565f444e2d58e97e6aef2ea93e2c8be1f28e" CHECKSUMTYPE="SHA-1"
-				SIZE="30466">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:38:38" MIMETYPE="text/xml" CHECKSUM="05e0565f444e2d58e97e6aef2ea93e2c8be1f28e" CHECKSUMTYPE="SHA-1" SIZE="30466">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:38:38" MIMETYPE="text/xml"
-				CHECKSUM="77b3df09a754147b0e8e36b8ccf7897c8d4cb429" CHECKSUMTYPE="SHA-1" SIZE="8456">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:38:38" MIMETYPE="text/xml" CHECKSUM="77b3df09a754147b0e8e36b8ccf7897c8d4cb429" CHECKSUMTYPE="SHA-1" SIZE="8456">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-09-01_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:39:03" MIMETYPE="application/pdf"
-				CHECKSUM="3c81df6c52b9b2b3a97637a98b909635f656e233" CHECKSUMTYPE="SHA-1"
-				SIZE="7324255">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/bmtnabf_1901-09-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:39:03" MIMETYPE="application/pdf" CHECKSUM="3c81df6c52b9b2b3a97637a98b909635f656e233" CHECKSUMTYPE="SHA-1" SIZE="7324255">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/09/01_01/bmtnabf_1901-09-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3097,8 +2938,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 17 01.09.1901">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by F. v. MYRBACH">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by F. v. MYRBACH">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_CB00001"/>
@@ -3149,8 +2989,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c007"
-					LABEL="STUDIEN UND ENTWÜRFE VON F. v. MYRBACH">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c007" LABEL="STUDIEN UND ENTWÜRFE VON F. v. MYRBACH">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -3174,8 +3013,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00004"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c008"
-						LABEL="Untitled Image by F. v. Myrbach OM">
+					<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c008" LABEL="Untitled Image by F. v. Myrbach OM">
 						<div ID="L.1.1.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00001"/>
@@ -3192,8 +3030,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c009"
-						LABEL="STUDIEN ZU ILLUSTRATIONEN FÜR &#34;ERZHERZOG ALBRECHT&#34;">
+					<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c009" LABEL="STUDIEN ZU ILLUSTRATIONEN FÜR &#34;ERZHERZOG ALBRECHT&#34;">
 						<div ID="L.1.1.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -3210,8 +3047,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c010"
-						LABEL="AUS DEM PALAIS DE JUSTICE IN PARIS">
+					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c010" LABEL="AUS DEM PALAIS DE JUSTICE IN PARIS">
 						<div ID="L.1.1.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
@@ -3245,8 +3081,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c012"
-						LABEL="AUS DER POLICE CORRECTIONELLE IN PARIS">
+					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c012" LABEL="AUS DER POLICE CORRECTIONELLE IN PARIS">
 						<div ID="L.1.1.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00001"/>
@@ -3263,8 +3098,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c013"
-						LABEL="STUDIE FÜR &#34;LIFE OF NAPOLEON&#34;">
+					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c013" LABEL="STUDIE FÜR &#34;LIFE OF NAPOLEON&#34;">
 						<div ID="L.1.1.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
@@ -3281,8 +3115,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c014"
-						LABEL="RUE DU FAU-BOURG ST. DENIS 1884">
+					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c014" LABEL="RUE DU FAU-BOURG ST. DENIS 1884">
 						<div ID="L.1.1.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -3299,8 +3132,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c015"
-						LABEL="MARIAHILFER-STRASSE IN WIEN. 1897">
+					<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c015" LABEL="MARIAHILFER-STRASSE IN WIEN. 1897">
 						<div ID="L.1.1.13.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -3317,8 +3149,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c016"
-						LABEL="STUDIEN ZU &#34;AVENTURES DE GUERRE&#34;">
+					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c016" LABEL="STUDIEN ZU &#34;AVENTURES DE GUERRE&#34;">
 						<div ID="L.1.1.14.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -3336,8 +3167,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.14.4" TYPE="Illustration" ORDER="2" DMDID="c017"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.14.4" TYPE="Illustration" ORDER="2" DMDID="c017" LABEL="Untitled Image">
 							<div ID="L.1.1.14.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00001"/>
@@ -3345,8 +3175,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c018"
-						LABEL="SCHUHPUTZER">
+					<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c018" LABEL="SCHUHPUTZER">
 						<div ID="L.1.1.15.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
@@ -3363,8 +3192,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c019"
-						LABEL="STUDIE FRANZÖSISCHER PIONNIER 1809 ZU &#34;LIFE OF NAPOLEON&#34;">
+					<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c019" LABEL="STUDIE FRANZÖSISCHER PIONNIER 1809 ZU &#34;LIFE OF NAPOLEON&#34;">
 						<div ID="L.1.1.16.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
@@ -3381,8 +3209,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.17" TYPE="Illustration" ORDER="15" DMDID="c020"
-						LABEL="STUDIE FRANZÖSISCHER VOLONTAIRE VON 1793">
+					<div ID="L.1.1.17" TYPE="Illustration" ORDER="15" DMDID="c020" LABEL="STUDIE FRANZÖSISCHER VOLONTAIRE VON 1793">
 						<div ID="L.1.1.17.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -3400,8 +3227,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.17.4" TYPE="Illustration" ORDER="2" DMDID="c021"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.17.4" TYPE="Illustration" ORDER="2" DMDID="c021" LABEL="Untitled Image">
 							<div ID="L.1.1.17.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00002"/>
@@ -3409,8 +3235,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.18" TYPE="Illustration" ORDER="16" DMDID="c022"
-						LABEL="STUDIE ZU EINEM AQUARELL &#34;SCHLACHT BEI LEIPZIG&#34;">
+					<div ID="L.1.1.18" TYPE="Illustration" ORDER="16" DMDID="c022" LABEL="STUDIE ZU EINEM AQUARELL &#34;SCHLACHT BEI LEIPZIG&#34;">
 						<div ID="L.1.1.18.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -3445,16 +3270,14 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.19.4" TYPE="Illustration" ORDER="2" DMDID="c024"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.19.4" TYPE="Illustration" ORDER="2" DMDID="c024" LABEL="Untitled Image">
 							<div ID="L.1.1.19.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00003"/>
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.19.5" TYPE="Illustration" ORDER="3" DMDID="c025"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.19.5" TYPE="Illustration" ORDER="3" DMDID="c025" LABEL="Untitled Image">
 							<div ID="L.1.1.19.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00004"/>
@@ -3462,8 +3285,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.20" TYPE="Illustration" ORDER="18" DMDID="c026"
-						LABEL="STUDIE ZU EINEM AQUARELL &#34;SCHLACHT BEI LEIPZIG&#34;">
+					<div ID="L.1.1.20" TYPE="Illustration" ORDER="18" DMDID="c026" LABEL="STUDIE ZU EINEM AQUARELL &#34;SCHLACHT BEI LEIPZIG&#34;">
 						<div ID="L.1.1.20.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -3481,8 +3303,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.20.4" TYPE="Illustration" ORDER="2" DMDID="c027"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.20.4" TYPE="Illustration" ORDER="2" DMDID="c027" LABEL="Untitled Image">
 							<div ID="L.1.1.20.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_CB00002"/>
@@ -3492,8 +3313,7 @@
 					</div>
 				</div>
 
-				<div ID="L.1.1.21" TYPE="Illustration" ORDER="19" DMDID="c028"
-					LABEL="STUDIE ZU EINEM AQUARELL &#34;LIFE OF NAPOLEON&#34;">
+				<div ID="L.1.1.21" TYPE="Illustration" ORDER="19" DMDID="c028" LABEL="STUDIE ZU EINEM AQUARELL &#34;LIFE OF NAPOLEON&#34;">
 					<div ID="L.1.1.21.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
@@ -3521,8 +3341,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00005"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.22.3" TYPE="Illustration" ORDER="1" DMDID="c030"
-						LABEL="[Initial]">
+					<div ID="L.1.1.22.3" TYPE="Illustration" ORDER="1" DMDID="c030" LABEL="[Initial]">
 						<div ID="L.1.1.22.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00003"/>
@@ -3534,23 +3353,20 @@
 							<div ID="L.1.1.22.4.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.22.4.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.22.4.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.22.4.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.22.5" TYPE="Illustration" ORDER="1" DMDID="c031"
-						LABEL="Untitled Image by F. v. Myrbach OM">
+					<div ID="L.1.1.22.5" TYPE="Illustration" ORDER="1" DMDID="c031" LABEL="Untitled Image by F. v. Myrbach OM">
 						<div ID="L.1.1.22.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00006"/>
@@ -3568,8 +3384,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.22.5.4" TYPE="Illustration" ORDER="2" DMDID="c032"
-							LABEL="Untitled Image">
+						<div ID="L.1.1.22.5.4" TYPE="Illustration" ORDER="2" DMDID="c032" LABEL="Untitled Image">
 							<div ID="L.1.1.22.5.4.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00002"/>
@@ -3594,15 +3409,13 @@
 							<div ID="L.1.1.23.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.23.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.23.4" TYPE="Illustration" ORDER="1" DMDID="c034"
-						LABEL="Untitled Image by R. Jettmar OM">
+					<div ID="L.1.1.23.4" TYPE="Illustration" ORDER="1" DMDID="c034" LABEL="Untitled Image by R. Jettmar OM">
 						<div ID="L.1.1.23.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00004"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/10/01_01/bmtnabf_1901-10-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/10/01_01/bmtnabf_1901-10-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-10-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-10-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-10-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-10-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-10-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 
@@ -3065,420 +3059,204 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:26:44"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="9b824d0de89b6403f90f6f015c085ce4cc777804"
-				CHECKSUMTYPE="SHA-1" SIZE="6130026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:26:44" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="9b824d0de89b6403f90f6f015c085ce4cc777804" CHECKSUMTYPE="SHA-1" SIZE="6130026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:27:19"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="065b4f67586fe0c6d8ec8c88bb14c353ffbd0d5f"
-				CHECKSUMTYPE="SHA-1" SIZE="5985129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:27:19" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="065b4f67586fe0c6d8ec8c88bb14c353ffbd0d5f" CHECKSUMTYPE="SHA-1" SIZE="5985129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:27:56"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="b69b7ffd54afab61f1a426ab01245eb367ecad79"
-				CHECKSUMTYPE="SHA-1" SIZE="6130909">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:27:56" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="b69b7ffd54afab61f1a426ab01245eb367ecad79" CHECKSUMTYPE="SHA-1" SIZE="6130909">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:28:34"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="7dde8b79b735d788914ef8b2c8ae586812be3229"
-				CHECKSUMTYPE="SHA-1" SIZE="5986026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:28:34" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="7dde8b79b735d788914ef8b2c8ae586812be3229" CHECKSUMTYPE="SHA-1" SIZE="5986026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:29:13"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="0f5fc08f8b16860a788bc393d9a193885ab97df2"
-				CHECKSUMTYPE="SHA-1" SIZE="6130926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:29:13" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="0f5fc08f8b16860a788bc393d9a193885ab97df2" CHECKSUMTYPE="SHA-1" SIZE="6130926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:29:47"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="1aa44a5ec7ece4f7dc675f14ea81859205a2237d"
-				CHECKSUMTYPE="SHA-1" SIZE="6120108">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:29:47" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="1aa44a5ec7ece4f7dc675f14ea81859205a2237d" CHECKSUMTYPE="SHA-1" SIZE="6120108">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:30:21"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="3fee6b9d1fdd7e00618e5f2201136caac686ac10"
-				CHECKSUMTYPE="SHA-1" SIZE="6080522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:30:21" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="3fee6b9d1fdd7e00618e5f2201136caac686ac10" CHECKSUMTYPE="SHA-1" SIZE="6080522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:30:54"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="6ab2d1015a61c9799b86b82828e4110f9d00d996"
-				CHECKSUMTYPE="SHA-1" SIZE="6121026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:30:54" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="6ab2d1015a61c9799b86b82828e4110f9d00d996" CHECKSUMTYPE="SHA-1" SIZE="6121026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:31:30"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="98e8337e6899d01e7f8b6183815685c308c52e60"
-				CHECKSUMTYPE="SHA-1" SIZE="6079627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:31:30" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="98e8337e6899d01e7f8b6183815685c308c52e60" CHECKSUMTYPE="SHA-1" SIZE="6079627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:32:02"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="a40c2ea0ec2652c35db662aaeae9be2a4d904ffa"
-				CHECKSUMTYPE="SHA-1" SIZE="6147115">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:32:02" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="a40c2ea0ec2652c35db662aaeae9be2a4d904ffa" CHECKSUMTYPE="SHA-1" SIZE="6147115">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:32:36"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f8ed70b262e2cd55ec325237690d350a0dddecfe"
-				CHECKSUMTYPE="SHA-1" SIZE="6056221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:32:36" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f8ed70b262e2cd55ec325237690d350a0dddecfe" CHECKSUMTYPE="SHA-1" SIZE="6056221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:33:08"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="a257f8aac39c6cde977462a01b11e975e6b9f1e7"
-				CHECKSUMTYPE="SHA-1" SIZE="6147126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:33:08" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="a257f8aac39c6cde977462a01b11e975e6b9f1e7" CHECKSUMTYPE="SHA-1" SIZE="6147126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:33:41"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="72614ce4615988a3dc82df1fa65d3aaad1d952c0"
-				CHECKSUMTYPE="SHA-1" SIZE="6042729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:33:41" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="72614ce4615988a3dc82df1fa65d3aaad1d952c0" CHECKSUMTYPE="SHA-1" SIZE="6042729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:34:13"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="c60b66692b666ca2ca843697771c4d351ba4368d"
-				CHECKSUMTYPE="SHA-1" SIZE="6147127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:34:13" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="c60b66692b666ca2ca843697771c4d351ba4368d" CHECKSUMTYPE="SHA-1" SIZE="6147127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:34:44"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="02ff190e75a81eb5efb06282fb9969ac7fc2a1ec"
-				CHECKSUMTYPE="SHA-1" SIZE="6042728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:34:44" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="02ff190e75a81eb5efb06282fb9969ac7fc2a1ec" CHECKSUMTYPE="SHA-1" SIZE="6042728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:35:18"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ea3e46312b19e18690a2ed66ae95d82baf645b6f"
-				CHECKSUMTYPE="SHA-1" SIZE="6147125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:35:18" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ea3e46312b19e18690a2ed66ae95d82baf645b6f" CHECKSUMTYPE="SHA-1" SIZE="6147125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:35:50"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="ec82cbf2c5fdfeb433d9d25e0e42cbeeca378c55"
-				CHECKSUMTYPE="SHA-1" SIZE="6042720">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:35:50" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="ec82cbf2c5fdfeb433d9d25e0e42cbeeca378c55" CHECKSUMTYPE="SHA-1" SIZE="6042720">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:36:24"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="7320ad97dfbec37a6ebe17d771f2f9d2cddbd801"
-				CHECKSUMTYPE="SHA-1" SIZE="6147122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:36:24" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="7320ad97dfbec37a6ebe17d771f2f9d2cddbd801" CHECKSUMTYPE="SHA-1" SIZE="6147122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:36:59"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="8c942d4f10613390da1eebc1e35605b049cd0696"
-				CHECKSUMTYPE="SHA-1" SIZE="6069727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:36:59" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="8c942d4f10613390da1eebc1e35605b049cd0696" CHECKSUMTYPE="SHA-1" SIZE="6069727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:37:36"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="01e74df28cc1a57e7033687dce7db482f2e5846c"
-				CHECKSUMTYPE="SHA-1" SIZE="6147117">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:37:36" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="01e74df28cc1a57e7033687dce7db482f2e5846c" CHECKSUMTYPE="SHA-1" SIZE="6147117">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:38:12"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="5b5bf252534d08683c6bae172a0e377ba54fd300"
-				CHECKSUMTYPE="SHA-1" SIZE="6085924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:38:12" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="5b5bf252534d08683c6bae172a0e377ba54fd300" CHECKSUMTYPE="SHA-1" SIZE="6085924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:38:46"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="45a038a70351fcb3a209cd327a628e7f738df678"
-				CHECKSUMTYPE="SHA-1" SIZE="6147109">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:38:46" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="45a038a70351fcb3a209cd327a628e7f738df678" CHECKSUMTYPE="SHA-1" SIZE="6147109">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:39:21"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="1d10d4280008e2933bbd5c16bd639e69d6d344a0"
-				CHECKSUMTYPE="SHA-1" SIZE="6074216">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:39:21" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="1d10d4280008e2933bbd5c16bd639e69d6d344a0" CHECKSUMTYPE="SHA-1" SIZE="6074216">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:39:55"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f7ca2323cfd27928f6c4e1e79aa230bef40bd2dd"
-				CHECKSUMTYPE="SHA-1" SIZE="6147129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:39:55" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f7ca2323cfd27928f6c4e1e79aa230bef40bd2dd" CHECKSUMTYPE="SHA-1" SIZE="6147129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:40:25"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="b649dddc3bcf629a075894c189bb6870c4b8a8fc"
-				CHECKSUMTYPE="SHA-1" SIZE="6074216">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:40:25" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="b649dddc3bcf629a075894c189bb6870c4b8a8fc" CHECKSUMTYPE="SHA-1" SIZE="6074216">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:41:01"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="8bd6e338d98e07e97fa425e057156a8f28fb2eca"
-				CHECKSUMTYPE="SHA-1" SIZE="6147083">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:41:01" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="8bd6e338d98e07e97fa425e057156a8f28fb2eca" CHECKSUMTYPE="SHA-1" SIZE="6147083">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:41:36"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="bae3abd53227c47ff3b74f884d17f80ff93b0d68"
-				CHECKSUMTYPE="SHA-1" SIZE="6074228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:41:36" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="bae3abd53227c47ff3b74f884d17f80ff93b0d68" CHECKSUMTYPE="SHA-1" SIZE="6074228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:42:13"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="242f0965c7d1cd2dab0fd1aa070533528491f75f"
-				CHECKSUMTYPE="SHA-1" SIZE="6118295">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:42:13" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="242f0965c7d1cd2dab0fd1aa070533528491f75f" CHECKSUMTYPE="SHA-1" SIZE="6118295">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:42:45"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="96188d615b9cd2b3d5f1ed602fcc0287cd57d104"
-				CHECKSUMTYPE="SHA-1" SIZE="6073327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:42:45" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="96188d615b9cd2b3d5f1ed602fcc0287cd57d104" CHECKSUMTYPE="SHA-1" SIZE="6073327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:43:20"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="b2da857d1bcaba865ee3cf66b74060aa78d97c24"
-				CHECKSUMTYPE="SHA-1" SIZE="6204718">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:43:20" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="b2da857d1bcaba865ee3cf66b74060aa78d97c24" CHECKSUMTYPE="SHA-1" SIZE="6204718">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T18:43:55"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="167130c50359d02345685d0534d071134034d6f8"
-				CHECKSUMTYPE="SHA-1" SIZE="5980629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T18:43:55" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="167130c50359d02345685d0534d071134034d6f8" CHECKSUMTYPE="SHA-1" SIZE="5980629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T18:44:32"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="c4621f14c8dd2532a9823a4f9a0f25a981b9193d"
-				CHECKSUMTYPE="SHA-1" SIZE="6085918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T18:44:32" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="c4621f14c8dd2532a9823a4f9a0f25a981b9193d" CHECKSUMTYPE="SHA-1" SIZE="6085918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/delivery/bmtnabf_1901-10-01_01_0032.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:44:50" MIMETYPE="text/xml"
-				CHECKSUM="a7e657d3981bb5bc7a5239a0308535d298873439" CHECKSUMTYPE="SHA-1" SIZE="4899">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:44:50" MIMETYPE="text/xml" CHECKSUM="a7e657d3981bb5bc7a5239a0308535d298873439" CHECKSUMTYPE="SHA-1" SIZE="4899">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:44:51" MIMETYPE="text/xml"
-				CHECKSUM="b1cc5913f11bde328f797a2982065d1ab1f0817a" CHECKSUMTYPE="SHA-1"
-				SIZE="53464">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:44:51" MIMETYPE="text/xml" CHECKSUM="b1cc5913f11bde328f797a2982065d1ab1f0817a" CHECKSUMTYPE="SHA-1" SIZE="53464">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:44:51" MIMETYPE="text/xml"
-				CHECKSUM="5b6dfe34d8c684ec2719cd0708410e5bffb3852b" CHECKSUMTYPE="SHA-1" SIZE="9905">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:44:51" MIMETYPE="text/xml" CHECKSUM="5b6dfe34d8c684ec2719cd0708410e5bffb3852b" CHECKSUMTYPE="SHA-1" SIZE="9905">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:44:51" MIMETYPE="text/xml"
-				CHECKSUM="af28a35e83ac0f748799324a42f07afa0370c3e0" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:44:51" MIMETYPE="text/xml" CHECKSUM="af28a35e83ac0f748799324a42f07afa0370c3e0" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:44:51" MIMETYPE="text/xml"
-				CHECKSUM="f52005dc49e1cf40d14ceeb90b0654e7884188e2" CHECKSUMTYPE="SHA-1"
-				SIZE="27568">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:44:51" MIMETYPE="text/xml" CHECKSUM="f52005dc49e1cf40d14ceeb90b0654e7884188e2" CHECKSUMTYPE="SHA-1" SIZE="27568">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:44:52" MIMETYPE="text/xml"
-				CHECKSUM="902f3e11f3967a92540532e94f9b37bb4d3281e7" CHECKSUMTYPE="SHA-1"
-				SIZE="34317">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:44:52" MIMETYPE="text/xml" CHECKSUM="902f3e11f3967a92540532e94f9b37bb4d3281e7" CHECKSUMTYPE="SHA-1" SIZE="34317">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:44:52" MIMETYPE="text/xml"
-				CHECKSUM="c79ecb848d972705966b4f4eebd82ca448c79cde" CHECKSUMTYPE="SHA-1"
-				SIZE="27158">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:44:52" MIMETYPE="text/xml" CHECKSUM="c79ecb848d972705966b4f4eebd82ca448c79cde" CHECKSUMTYPE="SHA-1" SIZE="27158">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:44:52" MIMETYPE="text/xml"
-				CHECKSUM="845839c290229e93e845c39390ba35740fb90015" CHECKSUMTYPE="SHA-1"
-				SIZE="27593">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:44:52" MIMETYPE="text/xml" CHECKSUM="845839c290229e93e845c39390ba35740fb90015" CHECKSUMTYPE="SHA-1" SIZE="27593">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:44:52" MIMETYPE="text/xml"
-				CHECKSUM="672d489d5b5587104a54b073702cdd504fe6bf42" CHECKSUMTYPE="SHA-1"
-				SIZE="28314">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:44:52" MIMETYPE="text/xml" CHECKSUM="672d489d5b5587104a54b073702cdd504fe6bf42" CHECKSUMTYPE="SHA-1" SIZE="28314">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:44:53" MIMETYPE="text/xml"
-				CHECKSUM="09e4061fc2cebc27ff6b6d80e8d63088452f96a2" CHECKSUMTYPE="SHA-1"
-				SIZE="26844">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:44:53" MIMETYPE="text/xml" CHECKSUM="09e4061fc2cebc27ff6b6d80e8d63088452f96a2" CHECKSUMTYPE="SHA-1" SIZE="26844">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:44:53" MIMETYPE="text/xml"
-				CHECKSUM="0612da1c7ceb6ee25e27a1b091efe63f2ffd05ec" CHECKSUMTYPE="SHA-1"
-				SIZE="30248">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:44:53" MIMETYPE="text/xml" CHECKSUM="0612da1c7ceb6ee25e27a1b091efe63f2ffd05ec" CHECKSUMTYPE="SHA-1" SIZE="30248">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:44:53" MIMETYPE="text/xml"
-				CHECKSUM="8b23cd9cf35ead86591750854379de247ad859ce" CHECKSUMTYPE="SHA-1"
-				SIZE="28680">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:44:53" MIMETYPE="text/xml" CHECKSUM="8b23cd9cf35ead86591750854379de247ad859ce" CHECKSUMTYPE="SHA-1" SIZE="28680">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:44:53" MIMETYPE="text/xml"
-				CHECKSUM="2073d9b79b668a2b1e8d5081907c7452ac4a9ad7" CHECKSUMTYPE="SHA-1"
-				SIZE="38023">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:44:53" MIMETYPE="text/xml" CHECKSUM="2073d9b79b668a2b1e8d5081907c7452ac4a9ad7" CHECKSUMTYPE="SHA-1" SIZE="38023">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:44:54" MIMETYPE="text/xml"
-				CHECKSUM="99c2973987435efac6c6d9ae0c43b00de420f81b" CHECKSUMTYPE="SHA-1"
-				SIZE="30242">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:44:54" MIMETYPE="text/xml" CHECKSUM="99c2973987435efac6c6d9ae0c43b00de420f81b" CHECKSUMTYPE="SHA-1" SIZE="30242">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:44:54" MIMETYPE="text/xml"
-				CHECKSUM="49351fbb1f89c647c19f79822213356364d7016d" CHECKSUMTYPE="SHA-1"
-				SIZE="30569">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:44:54" MIMETYPE="text/xml" CHECKSUM="49351fbb1f89c647c19f79822213356364d7016d" CHECKSUMTYPE="SHA-1" SIZE="30569">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:44:54" MIMETYPE="text/xml"
-				CHECKSUM="73a779fc8ed8d20326caa38cfa53734a949b9759" CHECKSUMTYPE="SHA-1"
-				SIZE="29225">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:44:54" MIMETYPE="text/xml" CHECKSUM="73a779fc8ed8d20326caa38cfa53734a949b9759" CHECKSUMTYPE="SHA-1" SIZE="29225">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:44:54" MIMETYPE="text/xml"
-				CHECKSUM="f1a98474a385a8ad75f00808dc22f06198289aaa" CHECKSUMTYPE="SHA-1"
-				SIZE="30190">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:44:54" MIMETYPE="text/xml" CHECKSUM="f1a98474a385a8ad75f00808dc22f06198289aaa" CHECKSUMTYPE="SHA-1" SIZE="30190">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:44:55" MIMETYPE="text/xml"
-				CHECKSUM="2920db40b05fbb4f34c6e3e718e6da018db275c9" CHECKSUMTYPE="SHA-1"
-				SIZE="21550">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:44:55" MIMETYPE="text/xml" CHECKSUM="2920db40b05fbb4f34c6e3e718e6da018db275c9" CHECKSUMTYPE="SHA-1" SIZE="21550">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:44:55" MIMETYPE="text/xml"
-				CHECKSUM="8a8b072000fbe4539b3aa6dcdc3bdffbd2b1de5d" CHECKSUMTYPE="SHA-1"
-				SIZE="31411">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:44:55" MIMETYPE="text/xml" CHECKSUM="8a8b072000fbe4539b3aa6dcdc3bdffbd2b1de5d" CHECKSUMTYPE="SHA-1" SIZE="31411">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:44:55" MIMETYPE="text/xml"
-				CHECKSUM="f3dd1e72519dab7fb1066e0f2d6a86650dde2ffa" CHECKSUMTYPE="SHA-1"
-				SIZE="12989">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:44:55" MIMETYPE="text/xml" CHECKSUM="f3dd1e72519dab7fb1066e0f2d6a86650dde2ffa" CHECKSUMTYPE="SHA-1" SIZE="12989">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:44:55" MIMETYPE="text/xml"
-				CHECKSUM="e805c575a0c2b0c91ad43fd1ba72a93ce5ea6b07" CHECKSUMTYPE="SHA-1" SIZE="4176">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:44:55" MIMETYPE="text/xml" CHECKSUM="e805c575a0c2b0c91ad43fd1ba72a93ce5ea6b07" CHECKSUMTYPE="SHA-1" SIZE="4176">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:44:56" MIMETYPE="text/xml"
-				CHECKSUM="63ad0c312b75b76f15125de9ed58ee8cd7786d2b" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:44:56" MIMETYPE="text/xml" CHECKSUM="63ad0c312b75b76f15125de9ed58ee8cd7786d2b" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:44:56" MIMETYPE="text/xml"
-				CHECKSUM="9fa0f3f534df4a850a595a3c549453d6c4fd674f" CHECKSUMTYPE="SHA-1" SIZE="2406">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:44:56" MIMETYPE="text/xml" CHECKSUM="9fa0f3f534df4a850a595a3c549453d6c4fd674f" CHECKSUMTYPE="SHA-1" SIZE="2406">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:44:56" MIMETYPE="text/xml"
-				CHECKSUM="6930b9ddc38f9a91c4811709dd9bc5a519961d1c" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:44:56" MIMETYPE="text/xml" CHECKSUM="6930b9ddc38f9a91c4811709dd9bc5a519961d1c" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:44:56" MIMETYPE="text/xml"
-				CHECKSUM="8aba2a08314fbcdac75b97b7a2357a56c16d55fb" CHECKSUMTYPE="SHA-1" SIZE="4357">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:44:56" MIMETYPE="text/xml" CHECKSUM="8aba2a08314fbcdac75b97b7a2357a56c16d55fb" CHECKSUMTYPE="SHA-1" SIZE="4357">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:44:57" MIMETYPE="text/xml"
-				CHECKSUM="d7a9e8f62ab1dee1ac03c4816177cdb658c3811f" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:44:57" MIMETYPE="text/xml" CHECKSUM="d7a9e8f62ab1dee1ac03c4816177cdb658c3811f" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:44:57" MIMETYPE="text/xml"
-				CHECKSUM="4c8173161a0df157b29c48b42ae41dc16028cc13" CHECKSUMTYPE="SHA-1" SIZE="2406">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:44:57" MIMETYPE="text/xml" CHECKSUM="4c8173161a0df157b29c48b42ae41dc16028cc13" CHECKSUMTYPE="SHA-1" SIZE="2406">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:44:57" MIMETYPE="text/xml"
-				CHECKSUM="dcc12835a1411888fdee439a2bb6baeb8045727f" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:44:57" MIMETYPE="text/xml" CHECKSUM="dcc12835a1411888fdee439a2bb6baeb8045727f" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:44:57" MIMETYPE="text/xml"
-				CHECKSUM="713cef7422104f0ba4e6b37927c04a92d4497000" CHECKSUMTYPE="SHA-1"
-				SIZE="22727">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:44:57" MIMETYPE="text/xml" CHECKSUM="713cef7422104f0ba4e6b37927c04a92d4497000" CHECKSUMTYPE="SHA-1" SIZE="22727">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:44:57" MIMETYPE="text/xml"
-				CHECKSUM="b266217ab75dc45639398180a7bb597dd30391a9" CHECKSUMTYPE="SHA-1"
-				SIZE="33315">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:44:57" MIMETYPE="text/xml" CHECKSUM="b266217ab75dc45639398180a7bb597dd30391a9" CHECKSUMTYPE="SHA-1" SIZE="33315">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T18:44:58" MIMETYPE="text/xml"
-				CHECKSUM="ce8ac23d20d326180527e09d967cfe2b51fa770e" CHECKSUMTYPE="SHA-1"
-				SIZE="38399">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T18:44:58" MIMETYPE="text/xml" CHECKSUM="ce8ac23d20d326180527e09d967cfe2b51fa770e" CHECKSUMTYPE="SHA-1" SIZE="38399">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T18:44:58" MIMETYPE="text/xml"
-				CHECKSUM="46b21a0614fb24ea39498a177da340d25acf599d" CHECKSUMTYPE="SHA-1" SIZE="8283">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T18:44:58" MIMETYPE="text/xml" CHECKSUM="46b21a0614fb24ea39498a177da340d25acf599d" CHECKSUMTYPE="SHA-1" SIZE="8283">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-10-01_01_0032.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:45:42" MIMETYPE="application/pdf"
-				CHECKSUM="ccd7d6c811cc662135a6a9fe6b3731cc33fc4064" CHECKSUMTYPE="SHA-1"
-				SIZE="8513818">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/bmtnabf_1901-10-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:45:42" MIMETYPE="application/pdf" CHECKSUM="ccd7d6c811cc662135a6a9fe6b3731cc33fc4064" CHECKSUMTYPE="SHA-1" SIZE="8513818">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/10/01_01/bmtnabf_1901-10-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3746,8 +3524,7 @@
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 1 01.10.1901">
 				<div ID="L.1.1.2" TYPE="PublicationInfo" LABEL="Publication Information">
-					<div ID="L.1.1.2.1" TYPE="Illustration" ORDER="1" DMDID="c005"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.2.1" TYPE="Illustration" ORDER="1" DMDID="c005" LABEL="Untitled Image">
 						<div ID="L.1.1.2.1.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_CB00001"/>
@@ -3795,34 +3572,29 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.3" TYPE="TextContent" ORDER="2" DMDID="c006"
-					LABEL="Hat die Pauke auch ein Loch...">
-					<div ID="L.1.1.3.1" TYPE="Illustration" ORDER="1" DMDID="c007"
-						LABEL="Untitled Image">
+				<div ID="L.1.1.3" TYPE="TextContent" ORDER="2" DMDID="c006" LABEL="Hat die Pauke auch ein Loch...">
+					<div ID="L.1.1.3.1" TYPE="Illustration" ORDER="1" DMDID="c007" LABEL="Untitled Image">
 						<div ID="L.1.1.3.1.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00003" BEGIN="P3_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.2" TYPE="Illustration" ORDER="2" DMDID="c008"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.2" TYPE="Illustration" ORDER="2" DMDID="c008" LABEL="Untitled Image">
 						<div ID="L.1.1.3.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.3" TYPE="Illustration" ORDER="3" DMDID="c009"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.3" TYPE="Illustration" ORDER="3" DMDID="c009" LABEL="Untitled Image">
 						<div ID="L.1.1.3.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.4" TYPE="Illustration" ORDER="4" DMDID="c010"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.4" TYPE="Illustration" ORDER="4" DMDID="c010" LABEL="Untitled Image">
 						<div ID="L.1.1.3.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_CB00001"/>
@@ -3834,240 +3606,210 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.5" TYPE="Illustration" ORDER="5" DMDID="c011"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.5" TYPE="Illustration" ORDER="5" DMDID="c011" LABEL="Untitled Image">
 						<div ID="L.1.1.3.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.6" TYPE="Illustration" ORDER="6" DMDID="c012"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.6" TYPE="Illustration" ORDER="6" DMDID="c012" LABEL="Untitled Image">
 						<div ID="L.1.1.3.6.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.7" TYPE="Illustration" ORDER="7" DMDID="c013"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.7" TYPE="Illustration" ORDER="7" DMDID="c013" LABEL="Untitled Image">
 						<div ID="L.1.1.3.7.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.8" TYPE="Illustration" ORDER="8" DMDID="c014"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.8" TYPE="Illustration" ORDER="8" DMDID="c014" LABEL="Untitled Image">
 						<div ID="L.1.1.3.8.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.9" TYPE="Illustration" ORDER="9" DMDID="c015"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.9" TYPE="Illustration" ORDER="9" DMDID="c015" LABEL="Untitled Image">
 						<div ID="L.1.1.3.9.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.10" TYPE="Illustration" ORDER="10" DMDID="c016"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.10" TYPE="Illustration" ORDER="10" DMDID="c016" LABEL="Untitled Image">
 						<div ID="L.1.1.3.10.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.11" TYPE="Illustration" ORDER="11" DMDID="c017"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.11" TYPE="Illustration" ORDER="11" DMDID="c017" LABEL="Untitled Image">
 						<div ID="L.1.1.3.11.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.12" TYPE="Illustration" ORDER="12" DMDID="c018"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.12" TYPE="Illustration" ORDER="12" DMDID="c018" LABEL="Untitled Image">
 						<div ID="L.1.1.3.12.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.13" TYPE="Illustration" ORDER="13" DMDID="c019"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.13" TYPE="Illustration" ORDER="13" DMDID="c019" LABEL="Untitled Image">
 						<div ID="L.1.1.3.13.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.14" TYPE="Illustration" ORDER="14" DMDID="c020"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.14" TYPE="Illustration" ORDER="14" DMDID="c020" LABEL="Untitled Image">
 						<div ID="L.1.1.3.14.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.15" TYPE="Illustration" ORDER="15" DMDID="c021"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.15" TYPE="Illustration" ORDER="15" DMDID="c021" LABEL="Untitled Image">
 						<div ID="L.1.1.3.15.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.16" TYPE="Illustration" ORDER="16" DMDID="c022"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.16" TYPE="Illustration" ORDER="16" DMDID="c022" LABEL="Untitled Image">
 						<div ID="L.1.1.3.16.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.17" TYPE="Illustration" ORDER="17" DMDID="c023"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.17" TYPE="Illustration" ORDER="17" DMDID="c023" LABEL="Untitled Image">
 						<div ID="L.1.1.3.17.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.18" TYPE="Illustration" ORDER="18" DMDID="c024"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.18" TYPE="Illustration" ORDER="18" DMDID="c024" LABEL="Untitled Image">
 						<div ID="L.1.1.3.18.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.19" TYPE="Illustration" ORDER="19" DMDID="c025"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.19" TYPE="Illustration" ORDER="19" DMDID="c025" LABEL="Untitled Image">
 						<div ID="L.1.1.3.19.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.20" TYPE="Illustration" ORDER="20" DMDID="c026"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.20" TYPE="Illustration" ORDER="20" DMDID="c026" LABEL="Untitled Image">
 						<div ID="L.1.1.3.20.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.21" TYPE="Illustration" ORDER="21" DMDID="c027"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.21" TYPE="Illustration" ORDER="21" DMDID="c027" LABEL="Untitled Image">
 						<div ID="L.1.1.3.21.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.22" TYPE="Illustration" ORDER="22" DMDID="c028"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.22" TYPE="Illustration" ORDER="22" DMDID="c028" LABEL="Untitled Image">
 						<div ID="L.1.1.3.22.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.23" TYPE="Illustration" ORDER="23" DMDID="c029"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.23" TYPE="Illustration" ORDER="23" DMDID="c029" LABEL="Untitled Image">
 						<div ID="L.1.1.3.23.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.3.24" TYPE="Illustration" ORDER="24" DMDID="c030"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.3.24" TYPE="Illustration" ORDER="24" DMDID="c030" LABEL="Untitled Image">
 						<div ID="L.1.1.3.24.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.2" TYPE="Illustration" ORDER="25" DMDID="c032"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.4.2" TYPE="Illustration" ORDER="25" DMDID="c032" LABEL="Untitled Image">
 						<div ID="L.1.1.4.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.2" TYPE="Illustration" ORDER="26" DMDID="c036"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.2" TYPE="Illustration" ORDER="26" DMDID="c036" LABEL="Untitled Image">
 						<div ID="L.1.1.7.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="27" DMDID="c037"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="27" DMDID="c037" LABEL="Untitled Image">
 						<div ID="L.1.1.7.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="28" DMDID="c038"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="28" DMDID="c038" LABEL="Untitled Image">
 						<div ID="L.1.1.7.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.5" TYPE="Illustration" ORDER="29" DMDID="c039"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.5" TYPE="Illustration" ORDER="29" DMDID="c039" LABEL="Untitled Image">
 						<div ID="L.1.1.7.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.6" TYPE="Illustration" ORDER="30" DMDID="c040"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.6" TYPE="Illustration" ORDER="30" DMDID="c040" LABEL="Untitled Image">
 						<div ID="L.1.1.7.6.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.7" TYPE="Illustration" ORDER="31" DMDID="c041"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.7" TYPE="Illustration" ORDER="31" DMDID="c041" LABEL="Untitled Image">
 						<div ID="L.1.1.7.7.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.8" TYPE="Illustration" ORDER="32" DMDID="c042"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.8" TYPE="Illustration" ORDER="32" DMDID="c042" LABEL="Untitled Image">
 						<div ID="L.1.1.7.8.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.9" TYPE="Illustration" ORDER="33" DMDID="c043"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.9" TYPE="Illustration" ORDER="33" DMDID="c043" LABEL="Untitled Image">
 						<div ID="L.1.1.7.9.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00002"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.10" TYPE="Illustration" ORDER="34" DMDID="c044"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.10" TYPE="Illustration" ORDER="34" DMDID="c044" LABEL="Untitled Image">
 						<div ID="L.1.1.7.10.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00003"/>
@@ -4121,48 +3863,42 @@
 							<div ID="L.1.1.3.25.1.7" TYPE="Paragraph" ORDER="7">
 								<div ID="L.1.1.3.25.1.7.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.3.25.1.8" TYPE="Paragraph" ORDER="8">
 								<div ID="L.1.1.3.25.1.8.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.3.25.1.9" TYPE="Paragraph" ORDER="9">
 								<div ID="L.1.1.3.25.1.9.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.3.25.1.10" TYPE="Paragraph" ORDER="10">
 								<div ID="L.1.1.3.25.1.10.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.3.25.1.11" TYPE="Paragraph" ORDER="11">
 								<div ID="L.1.1.3.25.1.11.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.3.25.1.12" TYPE="Paragraph" ORDER="12">
 								<div ID="L.1.1.3.25.1.12.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
 									</fptr>
 								</div>
 							</div>
@@ -4170,10 +3906,8 @@
 								<div ID="L.1.1.4.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4182,10 +3916,8 @@
 								<div ID="L.1.1.5.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00005"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4194,10 +3926,8 @@
 								<div ID="L.1.1.6.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00007"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4207,10 +3937,8 @@
 
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00008"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00009"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00008"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00009"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4218,48 +3946,42 @@
 							<div ID="L.1.1.7.11.1.2" TYPE="Paragraph" ORDER="17">
 								<div ID="L.1.1.7.11.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.7.11.1.3" TYPE="Paragraph" ORDER="18">
 								<div ID="L.1.1.7.11.1.3.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.7.11.1.4" TYPE="Paragraph" ORDER="19">
 								<div ID="L.1.1.7.11.1.4.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.7.11.1.5" TYPE="Paragraph" ORDER="20">
 								<div ID="L.1.1.7.11.1.5.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.7.11.1.6" TYPE="Paragraph" ORDER="21">
 								<div ID="L.1.1.7.11.1.6.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.7.11.1.7" TYPE="Paragraph" ORDER="22">
 								<div ID="L.1.1.7.11.1.7.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
 									</fptr>
 								</div>
 							</div>
@@ -4288,8 +4010,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="TextContent" ORDER="7" DMDID="c046"
-					LABEL="AUS DER BRONZEZEIT">
+				<div ID="L.1.1.8" TYPE="TextContent" ORDER="7" DMDID="c046" LABEL="AUS DER BRONZEZEIT">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00001"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/10/15_01/bmtnabf_1901-10-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/10/15_01/bmtnabf_1901-10-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-10-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-10-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-10-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1901/11/01_01/bmtnabf_1901-11-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/11/01_01/bmtnabf_1901-11-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-11-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-11-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-11-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-11-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-11-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2794,368 +2788,180 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:29:14"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="ab57ef35bf53d94d85f81add3fa30086933753d0"
-				CHECKSUMTYPE="SHA-1" SIZE="6266827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:29:14" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="ab57ef35bf53d94d85f81add3fa30086933753d0" CHECKSUMTYPE="SHA-1" SIZE="6266827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:29:51"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="86cd1284ce0715c22737f5770f65352572a4fef7"
-				CHECKSUMTYPE="SHA-1" SIZE="6150727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:29:51" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="86cd1284ce0715c22737f5770f65352572a4fef7" CHECKSUMTYPE="SHA-1" SIZE="6150727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:30:29"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c784789e189090d3aa8665cc80ba9063ad15bf65"
-				CHECKSUMTYPE="SHA-1" SIZE="6266815">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:30:29" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c784789e189090d3aa8665cc80ba9063ad15bf65" CHECKSUMTYPE="SHA-1" SIZE="6266815">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:31:07"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="68e1846f3ae119944cc9504e1b5f3ab780f9b005"
-				CHECKSUMTYPE="SHA-1" SIZE="6267722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:31:07" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="68e1846f3ae119944cc9504e1b5f3ab780f9b005" CHECKSUMTYPE="SHA-1" SIZE="6267722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:31:48"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2d20f63a628461f7f66a273f99882bcb715f56da"
-				CHECKSUMTYPE="SHA-1" SIZE="6064301">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:31:48" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2d20f63a628461f7f66a273f99882bcb715f56da" CHECKSUMTYPE="SHA-1" SIZE="6064301">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:32:25"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="c86253ac60dd8e1187a4001b6d97995860c727ab"
-				CHECKSUMTYPE="SHA-1" SIZE="6201128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:32:25" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="c86253ac60dd8e1187a4001b6d97995860c727ab" CHECKSUMTYPE="SHA-1" SIZE="6201128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:33:01"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="60a9ac470c82df7d7fe67e2f1784dfefca5c386c"
-				CHECKSUMTYPE="SHA-1" SIZE="6131807">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:33:01" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="60a9ac470c82df7d7fe67e2f1784dfefca5c386c" CHECKSUMTYPE="SHA-1" SIZE="6131807">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:33:35"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a3a4db41c7ffd83e95b57d2e870b3f8fabfa6a34"
-				CHECKSUMTYPE="SHA-1" SIZE="6201124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:33:35" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a3a4db41c7ffd83e95b57d2e870b3f8fabfa6a34" CHECKSUMTYPE="SHA-1" SIZE="6201124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:34:15"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="7d32258fb4ec2f54fdea8cc372bd6765b5fb0707"
-				CHECKSUMTYPE="SHA-1" SIZE="6107506">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:34:15" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="7d32258fb4ec2f54fdea8cc372bd6765b5fb0707" CHECKSUMTYPE="SHA-1" SIZE="6107506">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:34:51"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="c782ec3f447b26a292c48e89a28a46a5f15bfc62"
-				CHECKSUMTYPE="SHA-1" SIZE="6201122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:34:51" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="c782ec3f447b26a292c48e89a28a46a5f15bfc62" CHECKSUMTYPE="SHA-1" SIZE="6201122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:35:24"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="a3a5e146ddb681ee7336dcc4307a836031329380"
-				CHECKSUMTYPE="SHA-1" SIZE="6107523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:35:24" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="a3a5e146ddb681ee7336dcc4307a836031329380" CHECKSUMTYPE="SHA-1" SIZE="6107523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:35:59"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="b95c8d030196484f57232de857e96000f2a80669"
-				CHECKSUMTYPE="SHA-1" SIZE="6201046">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:35:59" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="b95c8d030196484f57232de857e96000f2a80669" CHECKSUMTYPE="SHA-1" SIZE="6201046">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:36:37"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="6e77beca360847ff1fd0e7658271ca365343c133"
-				CHECKSUMTYPE="SHA-1" SIZE="6090428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:36:37" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="6e77beca360847ff1fd0e7658271ca365343c133" CHECKSUMTYPE="SHA-1" SIZE="6090428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:37:14"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="3549234ceb1797319f45d419c5fe88407b32fde7"
-				CHECKSUMTYPE="SHA-1" SIZE="6201119">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:37:14" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="3549234ceb1797319f45d419c5fe88407b32fde7" CHECKSUMTYPE="SHA-1" SIZE="6201119">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:37:46"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="0a4c7ed9cbdbeedcfb2ba5ab0b752efc9c2167a8"
-				CHECKSUMTYPE="SHA-1" SIZE="6092211">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:37:46" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="0a4c7ed9cbdbeedcfb2ba5ab0b752efc9c2167a8" CHECKSUMTYPE="SHA-1" SIZE="6092211">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:38:18"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="46065099d16b31a5395a1e7bd054e83561d3762c"
-				CHECKSUMTYPE="SHA-1" SIZE="6214629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:38:18" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="46065099d16b31a5395a1e7bd054e83561d3762c" CHECKSUMTYPE="SHA-1" SIZE="6214629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:38:50"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="1be78b646f7c245b48747f4cb869f522ec19a896"
-				CHECKSUMTYPE="SHA-1" SIZE="6062529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:38:50" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="1be78b646f7c245b48747f4cb869f522ec19a896" CHECKSUMTYPE="SHA-1" SIZE="6062529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:39:24"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="91d2a427a089f7bfaf04317601231f56d957d2d6"
-				CHECKSUMTYPE="SHA-1" SIZE="6246059">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:39:24" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="91d2a427a089f7bfaf04317601231f56d957d2d6" CHECKSUMTYPE="SHA-1" SIZE="6246059">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:40:02"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="cbcff434350a8249e2b96de1e4ffaba8bf6500ad"
-				CHECKSUMTYPE="SHA-1" SIZE="6024728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:40:02" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="cbcff434350a8249e2b96de1e4ffaba8bf6500ad" CHECKSUMTYPE="SHA-1" SIZE="6024728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:40:37"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="20349d6dc2645ed74129b2cbd226c3ee9df51560"
-				CHECKSUMTYPE="SHA-1" SIZE="6245199">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:40:37" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="20349d6dc2645ed74129b2cbd226c3ee9df51560" CHECKSUMTYPE="SHA-1" SIZE="6245199">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:41:14"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="2777b34b274799274b0cccaf4d56b7c7e7d36315"
-				CHECKSUMTYPE="SHA-1" SIZE="6058024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:41:14" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="2777b34b274799274b0cccaf4d56b7c7e7d36315" CHECKSUMTYPE="SHA-1" SIZE="6058024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:41:45"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="0a0c3bc8bd7f634212b9a20d39e1c9d3a65f6f79"
-				CHECKSUMTYPE="SHA-1" SIZE="6247028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:41:45" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="0a0c3bc8bd7f634212b9a20d39e1c9d3a65f6f79" CHECKSUMTYPE="SHA-1" SIZE="6247028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:42:20"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="f2cca7158909e1b7979cfa92aad8b3ce540a327b"
-				CHECKSUMTYPE="SHA-1" SIZE="6058028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:42:20" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="f2cca7158909e1b7979cfa92aad8b3ce540a327b" CHECKSUMTYPE="SHA-1" SIZE="6058028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:42:55"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="0fbac69aec1aaf2a2e3211c1eed5dc6c4358ad3b"
-				CHECKSUMTYPE="SHA-1" SIZE="6246113">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:42:55" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="0fbac69aec1aaf2a2e3211c1eed5dc6c4358ad3b" CHECKSUMTYPE="SHA-1" SIZE="6246113">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:43:30"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="b027b88ac2f546648238d22a89df77ff57f836f3"
-				CHECKSUMTYPE="SHA-1" SIZE="6058023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:43:30" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="b027b88ac2f546648238d22a89df77ff57f836f3" CHECKSUMTYPE="SHA-1" SIZE="6058023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:44:05"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="2b50b36e15147beb3b047d95cce885da47497022"
-				CHECKSUMTYPE="SHA-1" SIZE="6246129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:44:05" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="2b50b36e15147beb3b047d95cce885da47497022" CHECKSUMTYPE="SHA-1" SIZE="6246129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:44:40"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="04a61756667be6ac5d311964c25e014c1f0ca8b9"
-				CHECKSUMTYPE="SHA-1" SIZE="6106621">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:44:40" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="04a61756667be6ac5d311964c25e014c1f0ca8b9" CHECKSUMTYPE="SHA-1" SIZE="6106621">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:45:16"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="18f436511f45de5c1b7602cb703c44824546aa8c"
-				CHECKSUMTYPE="SHA-1" SIZE="6258719">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:45:16" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="18f436511f45de5c1b7602cb703c44824546aa8c" CHECKSUMTYPE="SHA-1" SIZE="6258719">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/delivery/bmtnabf_1901-11-01_01_0028.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:45:36" MIMETYPE="text/xml"
-				CHECKSUM="03585bfcc84a541e07570886468f3ab5c2d0854f" CHECKSUMTYPE="SHA-1" SIZE="5028">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:45:36" MIMETYPE="text/xml" CHECKSUM="03585bfcc84a541e07570886468f3ab5c2d0854f" CHECKSUMTYPE="SHA-1" SIZE="5028">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml"
-				CHECKSUM="7e2f4ecb15195cec0e0c0078ec42a09288df4cdd" CHECKSUMTYPE="SHA-1"
-				SIZE="46663">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml" CHECKSUM="7e2f4ecb15195cec0e0c0078ec42a09288df4cdd" CHECKSUMTYPE="SHA-1" SIZE="46663">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml"
-				CHECKSUM="dda938a7d30e158475c04f39dc9dceb863485937" CHECKSUMTYPE="SHA-1" SIZE="9487">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml" CHECKSUM="dda938a7d30e158475c04f39dc9dceb863485937" CHECKSUMTYPE="SHA-1" SIZE="9487">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml"
-				CHECKSUM="b31f4e7853b4a41e0efde20691f3d5f7d182fe97" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml" CHECKSUM="b31f4e7853b4a41e0efde20691f3d5f7d182fe97" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml"
-				CHECKSUM="c6d18d6dfa9691688f6274a9f2c1fb2e4557f4dd" CHECKSUMTYPE="SHA-1" SIZE="6392">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml" CHECKSUM="c6d18d6dfa9691688f6274a9f2c1fb2e4557f4dd" CHECKSUMTYPE="SHA-1" SIZE="6392">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml"
-				CHECKSUM="b38f207677b6985c923d34f5cc45fff19a8f0a40" CHECKSUMTYPE="SHA-1" SIZE="8483">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml" CHECKSUM="b38f207677b6985c923d34f5cc45fff19a8f0a40" CHECKSUMTYPE="SHA-1" SIZE="8483">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml"
-				CHECKSUM="70532711c5c70ec5de1e891b147430f787cf1188" CHECKSUMTYPE="SHA-1" SIZE="8569">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml" CHECKSUM="70532711c5c70ec5de1e891b147430f787cf1188" CHECKSUMTYPE="SHA-1" SIZE="8569">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml"
-				CHECKSUM="98cb88b9fcc740c65f132e9f48adaec32f48952e" CHECKSUMTYPE="SHA-1" SIZE="4753">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml" CHECKSUM="98cb88b9fcc740c65f132e9f48adaec32f48952e" CHECKSUMTYPE="SHA-1" SIZE="4753">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml"
-				CHECKSUM="c65bd61fa78504a9277dcccc479a97569375767b" CHECKSUMTYPE="SHA-1"
-				SIZE="33821">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml" CHECKSUM="c65bd61fa78504a9277dcccc479a97569375767b" CHECKSUMTYPE="SHA-1" SIZE="33821">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml"
-				CHECKSUM="7038036287548a31e634ae3d25a25fde18e5488b" CHECKSUMTYPE="SHA-1"
-				SIZE="30723">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml" CHECKSUM="7038036287548a31e634ae3d25a25fde18e5488b" CHECKSUMTYPE="SHA-1" SIZE="30723">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml"
-				CHECKSUM="caa835e6244c72f34a5987f234e904bb367be5a5" CHECKSUMTYPE="SHA-1"
-				SIZE="32912">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml" CHECKSUM="caa835e6244c72f34a5987f234e904bb367be5a5" CHECKSUMTYPE="SHA-1" SIZE="32912">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml"
-				CHECKSUM="cdddbb6a966ba048f823531b9aba7ef9fe9ae95e" CHECKSUMTYPE="SHA-1" SIZE="4668">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml" CHECKSUM="cdddbb6a966ba048f823531b9aba7ef9fe9ae95e" CHECKSUMTYPE="SHA-1" SIZE="4668">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml"
-				CHECKSUM="29e8b9363f7ea32ec707c693960f085f834019cc" CHECKSUMTYPE="SHA-1"
-				SIZE="20108">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml" CHECKSUM="29e8b9363f7ea32ec707c693960f085f834019cc" CHECKSUMTYPE="SHA-1" SIZE="20108">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml"
-				CHECKSUM="c2794adf73606432079d4a63a558639247731609" CHECKSUMTYPE="SHA-1"
-				SIZE="33222">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml" CHECKSUM="c2794adf73606432079d4a63a558639247731609" CHECKSUMTYPE="SHA-1" SIZE="33222">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml"
-				CHECKSUM="4f78b01b1de44f543ce6b3fe7bf461d7bb72b452" CHECKSUMTYPE="SHA-1"
-				SIZE="27633">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml" CHECKSUM="4f78b01b1de44f543ce6b3fe7bf461d7bb72b452" CHECKSUMTYPE="SHA-1" SIZE="27633">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml"
-				CHECKSUM="29463788e2c62f77de07d24fdcb48b9015b555fa" CHECKSUMTYPE="SHA-1"
-				SIZE="28534">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml" CHECKSUM="29463788e2c62f77de07d24fdcb48b9015b555fa" CHECKSUMTYPE="SHA-1" SIZE="28534">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml"
-				CHECKSUM="c4e01c90fe2e70453b10191a2ff8a5df0bfa4f92" CHECKSUMTYPE="SHA-1"
-				SIZE="13933">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml" CHECKSUM="c4e01c90fe2e70453b10191a2ff8a5df0bfa4f92" CHECKSUMTYPE="SHA-1" SIZE="13933">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml"
-				CHECKSUM="4094031bd77f10fc001a13bcc6642da5a1de3c17" CHECKSUMTYPE="SHA-1" SIZE="4780">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml" CHECKSUM="4094031bd77f10fc001a13bcc6642da5a1de3c17" CHECKSUMTYPE="SHA-1" SIZE="4780">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml"
-				CHECKSUM="86e609fc4d65710594e4e27cab3e4ec858ec77e9" CHECKSUMTYPE="SHA-1"
-				SIZE="33411">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml" CHECKSUM="86e609fc4d65710594e4e27cab3e4ec858ec77e9" CHECKSUMTYPE="SHA-1" SIZE="33411">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml"
-				CHECKSUM="2050a0a2f1dd63d7e17e3f70224b3a418d40c126" CHECKSUMTYPE="SHA-1"
-				SIZE="46316">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml" CHECKSUM="2050a0a2f1dd63d7e17e3f70224b3a418d40c126" CHECKSUMTYPE="SHA-1" SIZE="46316">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml"
-				CHECKSUM="80a9875d1f935616cbee0af2e10949e0a1d5ccde" CHECKSUMTYPE="SHA-1"
-				SIZE="40728">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml" CHECKSUM="80a9875d1f935616cbee0af2e10949e0a1d5ccde" CHECKSUMTYPE="SHA-1" SIZE="40728">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml"
-				CHECKSUM="b0b56f50c02546f2bf2e0f1beffe2cb0e941fb8c" CHECKSUMTYPE="SHA-1"
-				SIZE="35031">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml" CHECKSUM="b0b56f50c02546f2bf2e0f1beffe2cb0e941fb8c" CHECKSUMTYPE="SHA-1" SIZE="35031">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml"
-				CHECKSUM="beade9b775dc4ced59205335204c2b19f90c4270" CHECKSUMTYPE="SHA-1"
-				SIZE="28827">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml" CHECKSUM="beade9b775dc4ced59205335204c2b19f90c4270" CHECKSUMTYPE="SHA-1" SIZE="28827">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml"
-				CHECKSUM="f8c419bcd5d46a797ec0b683c47692dd8da98835" CHECKSUMTYPE="SHA-1" SIZE="5266">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml" CHECKSUM="f8c419bcd5d46a797ec0b683c47692dd8da98835" CHECKSUMTYPE="SHA-1" SIZE="5266">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml"
-				CHECKSUM="552d0454442d1a814a1e6e2b86019d9a3509ed43" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml" CHECKSUM="552d0454442d1a814a1e6e2b86019d9a3509ed43" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:45:43" MIMETYPE="text/xml"
-				CHECKSUM="011846ebec555ca98053be1c7519eefd1fb2705a" CHECKSUMTYPE="SHA-1"
-				SIZE="34007">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:45:43" MIMETYPE="text/xml" CHECKSUM="011846ebec555ca98053be1c7519eefd1fb2705a" CHECKSUMTYPE="SHA-1" SIZE="34007">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:45:43" MIMETYPE="text/xml"
-				CHECKSUM="698ee62ec6e3bf8c49db85d4bcb9121f54220fad" CHECKSUMTYPE="SHA-1"
-				SIZE="39474">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:45:43" MIMETYPE="text/xml" CHECKSUM="698ee62ec6e3bf8c49db85d4bcb9121f54220fad" CHECKSUMTYPE="SHA-1" SIZE="39474">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:45:43" MIMETYPE="text/xml"
-				CHECKSUM="764f08b41870d26b3a912a5a271f46db6e169cd5" CHECKSUMTYPE="SHA-1" SIZE="7761">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:45:43" MIMETYPE="text/xml" CHECKSUM="764f08b41870d26b3a912a5a271f46db6e169cd5" CHECKSUMTYPE="SHA-1" SIZE="7761">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-01_01_0028.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:46:15" MIMETYPE="application/pdf"
-				CHECKSUM="92b699c7cb108bd8ba4bcb9484f485bc0cf4b7d5" CHECKSUMTYPE="SHA-1"
-				SIZE="8960514">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/bmtnabf_1901-11-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:46:15" MIMETYPE="application/pdf" CHECKSUM="92b699c7cb108bd8ba4bcb9484f485bc0cf4b7d5" CHECKSUMTYPE="SHA-1" SIZE="8960514">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/01_01/bmtnabf_1901-11-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3390,8 +3196,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 21 01.11.1901">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by A. Roller OM">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by A. Roller OM">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_CB00001"/>
@@ -3481,8 +3286,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.4" TYPE="TextContent" ORDER="1" DMDID="c008"
-						LABEL="VORFRÜHLING">
+					<div ID="L.1.1.5.4" TYPE="TextContent" ORDER="1" DMDID="c008" LABEL="VORFRÜHLING">
 						<div ID="L.1.1.5.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00001"/>
@@ -3493,32 +3297,28 @@
 								<div ID="L.1.1.5.4.2.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.5.4.2.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
 										</fptr>
 									</div>
 								</div>
 								<div ID="L.1.1.5.4.2.1.2" TYPE="Paragraph" ORDER="2">
 									<div ID="L.1.1.5.4.2.1.2.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
 										</fptr>
 									</div>
 								</div>
 								<div ID="L.1.1.5.4.2.1.3" TYPE="Paragraph" ORDER="3">
 									<div ID="L.1.1.5.4.2.1.3.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
 										</fptr>
 									</div>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.5" TYPE="TextContent" ORDER="2" DMDID="c009"
-						LABEL="IN HERBSTLICHEN ALLEEN">
+					<div ID="L.1.1.5.5" TYPE="TextContent" ORDER="2" DMDID="c009" LABEL="IN HERBSTLICHEN ALLEEN">
 						<div ID="L.1.1.5.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00001"/>
@@ -3529,8 +3329,7 @@
 								<div ID="L.1.1.5.5.2.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.5.5.2.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
 										</fptr>
 									</div>
 								</div>
@@ -3538,14 +3337,10 @@
 									<div ID="L.1.1.5.5.2.1.2.1" TYPE="Text">
 										<fptr>
 											<seq>
-												<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-												<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-												<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-												<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
+												<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+												<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+												<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+												<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
 											</seq>
 										</fptr>
 									</div>
@@ -3553,8 +3348,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.6" TYPE="TextContent" ORDER="3" DMDID="c010"
-						LABEL="WINTER-SEELE">
+					<div ID="L.1.1.5.6" TYPE="TextContent" ORDER="3" DMDID="c010" LABEL="WINTER-SEELE">
 						<div ID="L.1.1.5.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00001"/>
@@ -3565,8 +3359,7 @@
 								<div ID="L.1.1.5.6.2.1.1" TYPE="Paragraph" ORDER="1">
 									<div ID="L.1.1.5.6.2.1.1.1" TYPE="Text">
 										<fptr>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
 										</fptr>
 									</div>
 								</div>
@@ -3574,14 +3367,10 @@
 									<div ID="L.1.1.5.6.2.1.2.1" TYPE="Text">
 										<fptr>
 											<seq>
-												<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-												<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00002"/>
-												<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
-												<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00002"/>
+												<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+												<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
+												<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
+												<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
 											</seq>
 										</fptr>
 									</div>
@@ -3589,8 +3378,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="4" DMDID="c011"
-						LABEL="Untitled Image by J. M. Auchentaller OM">
+					<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="4" DMDID="c011" LABEL="Untitled Image by J. M. Auchentaller OM">
 						<div ID="L.1.1.5.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00004"/>
@@ -3607,8 +3395,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="5" DMDID="c012"
-						LABEL="Untitled Image by Wilh. List OM">
+					<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="5" DMDID="c012" LABEL="Untitled Image by Wilh. List OM">
 						<div ID="L.1.1.5.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00003"/>
@@ -3625,8 +3412,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.9" TYPE="Illustration" ORDER="6" DMDID="c013"
-						LABEL="Untitled Image by Wilh. List OM">
+					<div ID="L.1.1.5.9" TYPE="Illustration" ORDER="6" DMDID="c013" LABEL="Untitled Image by Wilh. List OM">
 						<div ID="L.1.1.5.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
@@ -3643,8 +3429,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.10" TYPE="Illustration" ORDER="7" DMDID="c014"
-						LABEL="Untitled Image by Kolo Moser OM">
+					<div ID="L.1.1.5.10" TYPE="Illustration" ORDER="7" DMDID="c014" LABEL="Untitled Image by Kolo Moser OM">
 						<div ID="L.1.1.5.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
@@ -3661,8 +3446,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.11" TYPE="Illustration" ORDER="8" DMDID="c015"
-						LABEL="Untitled Image by Kolo Moser OM">
+					<div ID="L.1.1.5.11" TYPE="Illustration" ORDER="8" DMDID="c015" LABEL="Untitled Image by Kolo Moser OM">
 						<div ID="L.1.1.5.11.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00001"/>
@@ -3681,8 +3465,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.12" TYPE="Illustration" ORDER="9" DMDID="c017"
-						LABEL="Untitled Image by Kolo Moser OM">
+					<div ID="L.1.1.5.12" TYPE="Illustration" ORDER="9" DMDID="c017" LABEL="Untitled Image by Kolo Moser OM">
 						<div ID="L.1.1.5.12.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
@@ -3710,8 +3493,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.5.13" TYPE="Illustration" ORDER="10" DMDID="c020"
-						LABEL="Untitled Image by A. Roller OM">
+					<div ID="L.1.1.5.13" TYPE="Illustration" ORDER="10" DMDID="c020" LABEL="Untitled Image by A. Roller OM">
 						<div ID="L.1.1.5.13.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
@@ -3728,8 +3510,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.14" TYPE="Illustration" ORDER="11" DMDID="c021"
-						LABEL="Untitled Image by A. Roller OM">
+					<div ID="L.1.1.5.14" TYPE="Illustration" ORDER="11" DMDID="c021" LABEL="Untitled Image by A. Roller OM">
 						<div ID="L.1.1.5.14.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
@@ -3755,8 +3536,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.5.15" TYPE="Illustration" ORDER="12" DMDID="c023"
-						LABEL="Untitled Image by A. Roller OM">
+					<div ID="L.1.1.5.15" TYPE="Illustration" ORDER="12" DMDID="c023" LABEL="Untitled Image by A. Roller OM">
 						<div ID="L.1.1.5.15.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
@@ -3782,8 +3562,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.5.16" TYPE="Illustration" ORDER="13" DMDID="c025"
-						LABEL="Untitled Image by A. Roller OM">
+					<div ID="L.1.1.5.16" TYPE="Illustration" ORDER="13" DMDID="c025" LABEL="Untitled Image by A. Roller OM">
 						<div ID="L.1.1.5.16.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
@@ -3809,8 +3588,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.5.17" TYPE="Illustration" ORDER="14" DMDID="c027"
-						LABEL="Untitled Image by A. Roller OM">
+					<div ID="L.1.1.5.17" TYPE="Illustration" ORDER="14" DMDID="c027" LABEL="Untitled Image by A. Roller OM">
 						<div ID="L.1.1.5.17.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
@@ -3827,8 +3605,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.18" TYPE="Illustration" ORDER="15" DMDID="c028"
-						LABEL="Untitled Image by E. Stöhr OM">
+					<div ID="L.1.1.5.18" TYPE="Illustration" ORDER="15" DMDID="c028" LABEL="Untitled Image by E. Stöhr OM">
 						<div ID="L.1.1.5.18.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
@@ -3845,8 +3622,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.19" TYPE="Illustration" ORDER="16" DMDID="c029"
-						LABEL="Untitled Image by E. Stöhr OM">
+					<div ID="L.1.1.5.19" TYPE="Illustration" ORDER="16" DMDID="c029" LABEL="Untitled Image by E. Stöhr OM">
 						<div ID="L.1.1.5.19.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
@@ -3927,8 +3703,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.5.20" TYPE="Illustration" ORDER="17" DMDID="c039"
-						LABEL="Untitled Image by E. Stöhr OM">
+					<div ID="L.1.1.5.20" TYPE="Illustration" ORDER="17" DMDID="c039" LABEL="Untitled Image by E. Stöhr OM">
 						<div ID="L.1.1.5.20.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00003"/>
@@ -4010,8 +3785,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.5.21" TYPE="Illustration" ORDER="18" DMDID="c049"
-						LABEL="Untitled Image by E. Stöhr OM">
+					<div ID="L.1.1.5.21" TYPE="Illustration" ORDER="18" DMDID="c049" LABEL="Untitled Image by E. Stöhr OM">
 						<div ID="L.1.1.5.21.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00003"/>
@@ -4051,8 +3825,7 @@
 						</div>
 
 					</div>
-					<div ID="L.1.1.5.22" TYPE="Illustration" ORDER="19" DMDID="c053"
-						LABEL="Untitled Image by E. Stöhr OM">
+					<div ID="L.1.1.5.22" TYPE="Illustration" ORDER="19" DMDID="c053" LABEL="Untitled Image by E. Stöhr OM">
 						<div ID="L.1.1.5.22.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00003"/>
@@ -4114,8 +3887,7 @@
 
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c060"
-					LABEL="Untitled Image by Kolo Moser OM">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c060" LABEL="Untitled Image by Kolo Moser OM">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00001"/>
@@ -4132,8 +3904,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c061"
-					LABEL="Untitled Image by A. Roller OM">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c061" LABEL="Untitled Image by A. Roller OM">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00001"/>
@@ -4150,8 +3921,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c062"
-					LABEL="Untitled Image by E. Stöhr OM">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c062" LABEL="Untitled Image by E. Stöhr OM">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00001"/>
@@ -4168,8 +3938,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c063"
-					LABEL="Untitled Image by J. M. Auchentaller OM">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c063" LABEL="Untitled Image by J. M. Auchentaller OM">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/11/15_01/bmtnabf_1901-11-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/11/15_01/bmtnabf_1901-11-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-11-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-11-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-11-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-11-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-11-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2769,395 +2763,192 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:29:42"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="7afd82aa52edd7ba61123c23fd95652daae11595"
-				CHECKSUMTYPE="SHA-1" SIZE="6135422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:29:42" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="7afd82aa52edd7ba61123c23fd95652daae11595" CHECKSUMTYPE="SHA-1" SIZE="6135422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:30:15"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="467457982e4cde60de2ab577b20909e2e6b8dd07"
-				CHECKSUMTYPE="SHA-1" SIZE="6358629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:30:15" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="467457982e4cde60de2ab577b20909e2e6b8dd07" CHECKSUMTYPE="SHA-1" SIZE="6358629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:30:49"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="43bdf4621e3c592182028a600bbec94e0934586d"
-				CHECKSUMTYPE="SHA-1" SIZE="6135425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:30:49" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="43bdf4621e3c592182028a600bbec94e0934586d" CHECKSUMTYPE="SHA-1" SIZE="6135425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:31:24"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="30676c1a86f2017c97649874c440003a96e8e70f"
-				CHECKSUMTYPE="SHA-1" SIZE="6422528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:31:24" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="30676c1a86f2017c97649874c440003a96e8e70f" CHECKSUMTYPE="SHA-1" SIZE="6422528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:31:59"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="ef6fa558e28b02c4de3255943bd9e02bca9852f1"
-				CHECKSUMTYPE="SHA-1" SIZE="6158823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:31:59" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="ef6fa558e28b02c4de3255943bd9e02bca9852f1" CHECKSUMTYPE="SHA-1" SIZE="6158823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:32:31"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="9cc701deebcd5c330bd33a1c5c966b8d07c4546a"
-				CHECKSUMTYPE="SHA-1" SIZE="6301928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:32:31" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="9cc701deebcd5c330bd33a1c5c966b8d07c4546a" CHECKSUMTYPE="SHA-1" SIZE="6301928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:33:03"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="3d742b350e9c56f6ef86dd4468ddcfee223c836c"
-				CHECKSUMTYPE="SHA-1" SIZE="6219116">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:33:03" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="3d742b350e9c56f6ef86dd4468ddcfee223c836c" CHECKSUMTYPE="SHA-1" SIZE="6219116">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:33:35"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="1faa5e5a6e8eb29b7de5c6470142bb2d838fd763"
-				CHECKSUMTYPE="SHA-1" SIZE="6301923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:33:35" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="1faa5e5a6e8eb29b7de5c6470142bb2d838fd763" CHECKSUMTYPE="SHA-1" SIZE="6301923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:34:08"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="69523644d60e132be6f3e0bc517787d21bcbb434"
-				CHECKSUMTYPE="SHA-1" SIZE="6049928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:34:08" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="69523644d60e132be6f3e0bc517787d21bcbb434" CHECKSUMTYPE="SHA-1" SIZE="6049928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:34:42"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="70fb711098a26ff2d35d97a1ebb19955885932dc"
-				CHECKSUMTYPE="SHA-1" SIZE="6301925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:34:42" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="70fb711098a26ff2d35d97a1ebb19955885932dc" CHECKSUMTYPE="SHA-1" SIZE="6301925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:35:13"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="ca4c34b07d5577c89911f75125683712743a6360"
-				CHECKSUMTYPE="SHA-1" SIZE="6049868">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:35:13" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="ca4c34b07d5577c89911f75125683712743a6360" CHECKSUMTYPE="SHA-1" SIZE="6049868">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:35:45"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="ff12395f6d59c0b8b37c957d2905bab837842813"
-				CHECKSUMTYPE="SHA-1" SIZE="6301929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:35:45" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="ff12395f6d59c0b8b37c957d2905bab837842813" CHECKSUMTYPE="SHA-1" SIZE="6301929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:36:17"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="4e931ad4c9f9e55309047dc7035d398cbd5fb5cc"
-				CHECKSUMTYPE="SHA-1" SIZE="6049928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:36:17" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="4e931ad4c9f9e55309047dc7035d398cbd5fb5cc" CHECKSUMTYPE="SHA-1" SIZE="6049928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:36:48"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="00f02a21e47b0b9274b1965047c49b4bea1d7d7b"
-				CHECKSUMTYPE="SHA-1" SIZE="6301026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:36:48" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="00f02a21e47b0b9274b1965047c49b4bea1d7d7b" CHECKSUMTYPE="SHA-1" SIZE="6301026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:37:18"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="eae38e85cf667b1f409f69e5bbac3644bb9805c8"
-				CHECKSUMTYPE="SHA-1" SIZE="6049908">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:37:18" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="eae38e85cf667b1f409f69e5bbac3644bb9805c8" CHECKSUMTYPE="SHA-1" SIZE="6049908">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:37:47"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="9ca369bbb73086793a7c4f4c32fc6c5394209801"
-				CHECKSUMTYPE="SHA-1" SIZE="6301019">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:37:47" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="9ca369bbb73086793a7c4f4c32fc6c5394209801" CHECKSUMTYPE="SHA-1" SIZE="6301019">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:38:18"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="0a8616d16cf832c269e3b486373a8541deff9462"
-				CHECKSUMTYPE="SHA-1" SIZE="6049928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:38:18" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="0a8616d16cf832c269e3b486373a8541deff9462" CHECKSUMTYPE="SHA-1" SIZE="6049928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:38:49"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="3ad7a501e8bfd62cb4ff8e4300ca39f8c8464fce"
-				CHECKSUMTYPE="SHA-1" SIZE="6301928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:38:49" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="3ad7a501e8bfd62cb4ff8e4300ca39f8c8464fce" CHECKSUMTYPE="SHA-1" SIZE="6301928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:39:23"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="16c0e841946c2032d4f8a962971615830277d05e"
-				CHECKSUMTYPE="SHA-1" SIZE="6049918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:39:23" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="16c0e841946c2032d4f8a962971615830277d05e" CHECKSUMTYPE="SHA-1" SIZE="6049918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:39:55"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="692a4d5faf948fa7d10c3c07c2b8b7be94279069"
-				CHECKSUMTYPE="SHA-1" SIZE="6300822">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:39:55" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="692a4d5faf948fa7d10c3c07c2b8b7be94279069" CHECKSUMTYPE="SHA-1" SIZE="6300822">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:40:26"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="01a694fbadb79ab2684838a31fce0c92c52277bb"
-				CHECKSUMTYPE="SHA-1" SIZE="6011219">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:40:26" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="01a694fbadb79ab2684838a31fce0c92c52277bb" CHECKSUMTYPE="SHA-1" SIZE="6011219">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:41:00"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="d7c2e68904a135c0e137aa8aaf99e8cd3166c0ab"
-				CHECKSUMTYPE="SHA-1" SIZE="6301026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:41:00" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="d7c2e68904a135c0e137aa8aaf99e8cd3166c0ab" CHECKSUMTYPE="SHA-1" SIZE="6301026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:41:32"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="b1668a5db6281c96c6ac70b9e3ad53f8c8b96282"
-				CHECKSUMTYPE="SHA-1" SIZE="6011214">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:41:32" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="b1668a5db6281c96c6ac70b9e3ad53f8c8b96282" CHECKSUMTYPE="SHA-1" SIZE="6011214">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:42:01"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="b26b2303bdbbc2a1f66f2e556b2a4fc506769453"
-				CHECKSUMTYPE="SHA-1" SIZE="6286629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:42:01" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="b26b2303bdbbc2a1f66f2e556b2a4fc506769453" CHECKSUMTYPE="SHA-1" SIZE="6286629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:42:33"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="65a0796d3ae47a3a75c8df3f56986ddd7fa74185"
-				CHECKSUMTYPE="SHA-1" SIZE="6011156">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:42:33" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="65a0796d3ae47a3a75c8df3f56986ddd7fa74185" CHECKSUMTYPE="SHA-1" SIZE="6011156">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:43:05"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="b3c54a4e4f72eaa128df9d73683e5f3f0a9154b9"
-				CHECKSUMTYPE="SHA-1" SIZE="6214622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:43:05" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="b3c54a4e4f72eaa128df9d73683e5f3f0a9154b9" CHECKSUMTYPE="SHA-1" SIZE="6214622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:43:35"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="4ca8baa4f62d96464d86e07d962f15a122bec8ca"
-				CHECKSUMTYPE="SHA-1" SIZE="6047204">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:43:35" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="4ca8baa4f62d96464d86e07d962f15a122bec8ca" CHECKSUMTYPE="SHA-1" SIZE="6047204">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:44:07"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="9e313457e7ca3cfc5f1dada33d762ce416053803"
-				CHECKSUMTYPE="SHA-1" SIZE="6297428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:44:07" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="9e313457e7ca3cfc5f1dada33d762ce416053803" CHECKSUMTYPE="SHA-1" SIZE="6297428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:44:37"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="5ddd6fc12fbbb89bc4474990a3c9db2d65539c3d"
-				CHECKSUMTYPE="SHA-1" SIZE="5920326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:44:37" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="5ddd6fc12fbbb89bc4474990a3c9db2d65539c3d" CHECKSUMTYPE="SHA-1" SIZE="5920326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:45:11"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="ea8a6420314f023898fa28a95b82407424c5262c"
-				CHECKSUMTYPE="SHA-1" SIZE="6157017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:45:11" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="ea8a6420314f023898fa28a95b82407424c5262c" CHECKSUMTYPE="SHA-1" SIZE="6157017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/delivery/bmtnabf_1901-11-15_01_0030.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:45:31" MIMETYPE="text/xml"
-				CHECKSUM="7e8d32ebf49dab066889b11571cff49956179289" CHECKSUMTYPE="SHA-1" SIZE="4704">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:45:31" MIMETYPE="text/xml" CHECKSUM="7e8d32ebf49dab066889b11571cff49956179289" CHECKSUMTYPE="SHA-1" SIZE="4704">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:45:31" MIMETYPE="text/xml"
-				CHECKSUM="bd79712e54bec1c0670781878a6e6bd88f759927" CHECKSUMTYPE="SHA-1"
-				SIZE="45701">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:45:31" MIMETYPE="text/xml" CHECKSUM="bd79712e54bec1c0670781878a6e6bd88f759927" CHECKSUMTYPE="SHA-1" SIZE="45701">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:45:32" MIMETYPE="text/xml"
-				CHECKSUM="3aac97d7f38d9fa8cd91cf63b68b2fd7ed88bdb4" CHECKSUMTYPE="SHA-1" SIZE="9409">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:45:32" MIMETYPE="text/xml" CHECKSUM="3aac97d7f38d9fa8cd91cf63b68b2fd7ed88bdb4" CHECKSUMTYPE="SHA-1" SIZE="9409">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:45:33" MIMETYPE="text/xml"
-				CHECKSUM="b654c661eb6de03d0fcb36c71c6416a53beaa9e4" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:45:33" MIMETYPE="text/xml" CHECKSUM="b654c661eb6de03d0fcb36c71c6416a53beaa9e4" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:45:33" MIMETYPE="text/xml"
-				CHECKSUM="0b5c12530b24864d4f5356f324cdc7b755ccc294" CHECKSUMTYPE="SHA-1" SIZE="3936">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:45:33" MIMETYPE="text/xml" CHECKSUM="0b5c12530b24864d4f5356f324cdc7b755ccc294" CHECKSUMTYPE="SHA-1" SIZE="3936">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:45:34" MIMETYPE="text/xml"
-				CHECKSUM="6fb1c435068d87dbfab561ecdc520c9e9dc3b001" CHECKSUMTYPE="SHA-1" SIZE="2894">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:45:34" MIMETYPE="text/xml" CHECKSUM="6fb1c435068d87dbfab561ecdc520c9e9dc3b001" CHECKSUMTYPE="SHA-1" SIZE="2894">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:45:34" MIMETYPE="text/xml"
-				CHECKSUM="13cbbeb5b6cac186e6b50885fa3e0db11edaee90" CHECKSUMTYPE="SHA-1" SIZE="2010">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:45:34" MIMETYPE="text/xml" CHECKSUM="13cbbeb5b6cac186e6b50885fa3e0db11edaee90" CHECKSUMTYPE="SHA-1" SIZE="2010">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:45:34" MIMETYPE="text/xml"
-				CHECKSUM="5eafc3d32219c78235299cc64a2fef91d2594a62" CHECKSUMTYPE="SHA-1" SIZE="3637">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:45:34" MIMETYPE="text/xml" CHECKSUM="5eafc3d32219c78235299cc64a2fef91d2594a62" CHECKSUMTYPE="SHA-1" SIZE="3637">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:45:34" MIMETYPE="text/xml"
-				CHECKSUM="587a217a63fd65ccd417a7d5f5c0c10135a34b66" CHECKSUMTYPE="SHA-1"
-				SIZE="48610">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:45:34" MIMETYPE="text/xml" CHECKSUM="587a217a63fd65ccd417a7d5f5c0c10135a34b66" CHECKSUMTYPE="SHA-1" SIZE="48610">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:45:35" MIMETYPE="text/xml"
-				CHECKSUM="bae674df1f9cdf62a9d1d265b222742d25e018a1" CHECKSUMTYPE="SHA-1"
-				SIZE="48058">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:45:35" MIMETYPE="text/xml" CHECKSUM="bae674df1f9cdf62a9d1d265b222742d25e018a1" CHECKSUMTYPE="SHA-1" SIZE="48058">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:45:35" MIMETYPE="text/xml"
-				CHECKSUM="88b80f2209dfb64aa51697a8c4454089704c7be5" CHECKSUMTYPE="SHA-1"
-				SIZE="23994">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:45:35" MIMETYPE="text/xml" CHECKSUM="88b80f2209dfb64aa51697a8c4454089704c7be5" CHECKSUMTYPE="SHA-1" SIZE="23994">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml"
-				CHECKSUM="32fb9353e31011774d71c66fdfc15e26f14ef693" CHECKSUMTYPE="SHA-1"
-				SIZE="47412">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml" CHECKSUM="32fb9353e31011774d71c66fdfc15e26f14ef693" CHECKSUMTYPE="SHA-1" SIZE="47412">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml"
-				CHECKSUM="d05e265a6c2cb3e81b3da6d7dc60f8be44921907" CHECKSUMTYPE="SHA-1" SIZE="5008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:45:37" MIMETYPE="text/xml" CHECKSUM="d05e265a6c2cb3e81b3da6d7dc60f8be44921907" CHECKSUMTYPE="SHA-1" SIZE="5008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml"
-				CHECKSUM="75b54bff1d1d538b952ff2ed03aa6e8145b20b5d" CHECKSUMTYPE="SHA-1"
-				SIZE="48068">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml" CHECKSUM="75b54bff1d1d538b952ff2ed03aa6e8145b20b5d" CHECKSUMTYPE="SHA-1" SIZE="48068">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml"
-				CHECKSUM="7a51d86867e3e12d6335a60da7b402657036716c" CHECKSUMTYPE="SHA-1"
-				SIZE="51289">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml" CHECKSUM="7a51d86867e3e12d6335a60da7b402657036716c" CHECKSUMTYPE="SHA-1" SIZE="51289">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml"
-				CHECKSUM="59e68e0448f939929592c8f008a06779b1a7a531" CHECKSUMTYPE="SHA-1"
-				SIZE="47752">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml" CHECKSUM="59e68e0448f939929592c8f008a06779b1a7a531" CHECKSUMTYPE="SHA-1" SIZE="47752">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml"
-				CHECKSUM="9e6f024878ca1acc5658ed8160d6e2078d42f407" CHECKSUMTYPE="SHA-1"
-				SIZE="34245">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:45:38" MIMETYPE="text/xml" CHECKSUM="9e6f024878ca1acc5658ed8160d6e2078d42f407" CHECKSUMTYPE="SHA-1" SIZE="34245">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml"
-				CHECKSUM="62a5ed60c8cd3519ddfa154c0a082cc6c45bbc68" CHECKSUMTYPE="SHA-1"
-				SIZE="47461">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml" CHECKSUM="62a5ed60c8cd3519ddfa154c0a082cc6c45bbc68" CHECKSUMTYPE="SHA-1" SIZE="47461">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml"
-				CHECKSUM="10f0ba5de9f956538ec372bab394df5f8d1046f4" CHECKSUMTYPE="SHA-1"
-				SIZE="22470">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml" CHECKSUM="10f0ba5de9f956538ec372bab394df5f8d1046f4" CHECKSUMTYPE="SHA-1" SIZE="22470">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml"
-				CHECKSUM="fc88fad4a6a58abedcfb2ece661f773dba5c2d77" CHECKSUMTYPE="SHA-1"
-				SIZE="19972">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:45:39" MIMETYPE="text/xml" CHECKSUM="fc88fad4a6a58abedcfb2ece661f773dba5c2d77" CHECKSUMTYPE="SHA-1" SIZE="19972">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml"
-				CHECKSUM="3fd7a1f9d9114358e45d396e6a0a178a4119908e" CHECKSUMTYPE="SHA-1"
-				SIZE="46930">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml" CHECKSUM="3fd7a1f9d9114358e45d396e6a0a178a4119908e" CHECKSUMTYPE="SHA-1" SIZE="46930">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml"
-				CHECKSUM="132d6fb3d3ec68c7a155a8983f503f2641e08a1b" CHECKSUMTYPE="SHA-1"
-				SIZE="51402">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml" CHECKSUM="132d6fb3d3ec68c7a155a8983f503f2641e08a1b" CHECKSUMTYPE="SHA-1" SIZE="51402">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml"
-				CHECKSUM="3616f8684f9e5f0052b5754286518e55ef3b1e99" CHECKSUMTYPE="SHA-1"
-				SIZE="50449">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:45:40" MIMETYPE="text/xml" CHECKSUM="3616f8684f9e5f0052b5754286518e55ef3b1e99" CHECKSUMTYPE="SHA-1" SIZE="50449">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml"
-				CHECKSUM="b9023a35906ce99e4d1862c918087976c8e0a85a" CHECKSUMTYPE="SHA-1"
-				SIZE="51495">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml" CHECKSUM="b9023a35906ce99e4d1862c918087976c8e0a85a" CHECKSUMTYPE="SHA-1" SIZE="51495">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml"
-				CHECKSUM="7648e88076e06d853f7abce56a7301c09608c406" CHECKSUMTYPE="SHA-1" SIZE="4744">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml" CHECKSUM="7648e88076e06d853f7abce56a7301c09608c406" CHECKSUMTYPE="SHA-1" SIZE="4744">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml"
-				CHECKSUM="788a8130bcd506de49e39cc89422402a534127d8" CHECKSUMTYPE="SHA-1" SIZE="5882">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml" CHECKSUM="788a8130bcd506de49e39cc89422402a534127d8" CHECKSUMTYPE="SHA-1" SIZE="5882">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml"
-				CHECKSUM="99175837d6d1bf1a1bb06fdf875c68b131475d92" CHECKSUMTYPE="SHA-1"
-				SIZE="24935">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:45:41" MIMETYPE="text/xml" CHECKSUM="99175837d6d1bf1a1bb06fdf875c68b131475d92" CHECKSUMTYPE="SHA-1" SIZE="24935">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml"
-				CHECKSUM="ae673baca7305b3b4ee2aa5dec394b2ef55665f3" CHECKSUMTYPE="SHA-1"
-				SIZE="35279">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml" CHECKSUM="ae673baca7305b3b4ee2aa5dec394b2ef55665f3" CHECKSUMTYPE="SHA-1" SIZE="35279">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml"
-				CHECKSUM="34c88c0d12ff82e1748fbcb6bfacd20c7ea5eac2" CHECKSUMTYPE="SHA-1"
-				SIZE="38060">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml" CHECKSUM="34c88c0d12ff82e1748fbcb6bfacd20c7ea5eac2" CHECKSUMTYPE="SHA-1" SIZE="38060">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml"
-				CHECKSUM="82067edfb9abf24c56a1e71573de96a1957ad0ab" CHECKSUMTYPE="SHA-1" SIZE="8106">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:45:42" MIMETYPE="text/xml" CHECKSUM="82067edfb9abf24c56a1e71573de96a1957ad0ab" CHECKSUMTYPE="SHA-1" SIZE="8106">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-11-15_01_0030.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:46:19" MIMETYPE="application/pdf"
-				CHECKSUM="2e0924cdaf9f68ff8c37d7226878bd843ed807b9" CHECKSUMTYPE="SHA-1"
-				SIZE="9935194">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/bmtnabf_1901-11-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:46:19" MIMETYPE="application/pdf" CHECKSUM="2e0924cdaf9f68ff8c37d7226878bd843ed807b9" CHECKSUMTYPE="SHA-1" SIZE="9935194">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/11/15_01/bmtnabf_1901-11-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3476,8 +3267,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c008"
-					LABEL="JOUKAHAINEN IM HINTERHALT">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c008" LABEL="JOUKAHAINEN IM HINTERHALT">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00001"/>
@@ -3494,8 +3284,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="TextContent" ORDER="5" DMDID="c009"
-					LABEL="Untitled text by JOHANNES ÖHQUIST">
+				<div ID="L.1.1.7" TYPE="TextContent" ORDER="5" DMDID="c009" LABEL="Untitled text by JOHANNES ÖHQUIST">
 					<div ID="L.1.1.7.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00003"/>
@@ -3515,16 +3304,14 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="3" DMDID="c012"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="3" DMDID="c012" LABEL="Untitled Image">
 						<div ID="L.1.1.7.4.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00001"/>
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.5" TYPE="Illustration" ORDER="4" DMDID="c013"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.7.5" TYPE="Illustration" ORDER="4" DMDID="c013" LABEL="Untitled Image">
 						<div ID="L.1.1.7.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_CB00001"/>
@@ -3537,46 +3324,26 @@
 								<div ID="L.1.1.7.6.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3617,8 +3384,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.9" TYPE="Illustration" ORDER="3" DMDID="c016"
-						LABEL="Holzschnitt">
+					<div ID="L.1.1.7.9" TYPE="Illustration" ORDER="3" DMDID="c016" LABEL="Holzschnitt">
 						<div ID="L.1.1.7.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
@@ -3635,8 +3401,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.10" TYPE="Illustration" ORDER="4" DMDID="c017"
-						LABEL="Holzschnitt">
+					<div ID="L.1.1.7.10" TYPE="Illustration" ORDER="4" DMDID="c017" LABEL="Holzschnitt">
 						<div ID="L.1.1.7.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>
@@ -3654,8 +3419,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c018"
-					LABEL="Kampf um den Sampo">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c018" LABEL="Kampf um den Sampo">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -3706,8 +3470,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c021"
-					LABEL="EPISODE AUS DER JUGEND KULLERWOS. RADIERUNG">
+				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c021" LABEL="EPISODE AUS DER JUGEND KULLERWOS. RADIERUNG">
 					<div ID="L.1.1.11.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1901/12/15_01/bmtnabf_1901-12-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1901/12/15_01/bmtnabf_1901-12-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-12-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1901-12-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-12-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1901-12-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1901-12-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 
@@ -3730,432 +3724,216 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:36:39"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="d698ae89a6d61e1d71aab0be80f6c5ee4ee8b482"
-				CHECKSUMTYPE="SHA-1" SIZE="6124627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:36:39" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="d698ae89a6d61e1d71aab0be80f6c5ee4ee8b482" CHECKSUMTYPE="SHA-1" SIZE="6124627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:37:15"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="591599cf6e6536e31294a280849c1334f3e6f89d"
-				CHECKSUMTYPE="SHA-1" SIZE="6122829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:37:15" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="591599cf6e6536e31294a280849c1334f3e6f89d" CHECKSUMTYPE="SHA-1" SIZE="6122829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:37:51"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c13873778250bbd41998cc43632fe1a728cb582c"
-				CHECKSUMTYPE="SHA-1" SIZE="6125524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:37:51" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c13873778250bbd41998cc43632fe1a728cb582c" CHECKSUMTYPE="SHA-1" SIZE="6125524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:38:27"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="14959db19514428d5aab28019286d35c10ee5f40"
-				CHECKSUMTYPE="SHA-1" SIZE="6123555">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:38:27" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="14959db19514428d5aab28019286d35c10ee5f40" CHECKSUMTYPE="SHA-1" SIZE="6123555">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:39:02"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="8d1de51801e8f027957a2e742d696c6359a4c240"
-				CHECKSUMTYPE="SHA-1" SIZE="6125521">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:39:02" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="8d1de51801e8f027957a2e742d696c6359a4c240" CHECKSUMTYPE="SHA-1" SIZE="6125521">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:39:40"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="066a3924a1081af013d58f5691e4b477c59219cf"
-				CHECKSUMTYPE="SHA-1" SIZE="6123693">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:39:40" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="066a3924a1081af013d58f5691e4b477c59219cf" CHECKSUMTYPE="SHA-1" SIZE="6123693">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:40:22"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="6f26168b96c6d52567346f449e1930afee65e5c2"
-				CHECKSUMTYPE="SHA-1" SIZE="5987827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:40:22" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="6f26168b96c6d52567346f449e1930afee65e5c2" CHECKSUMTYPE="SHA-1" SIZE="5987827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:40:57"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="61e8dcbe67cdacb3e0bf14853c322b57f324323d"
-				CHECKSUMTYPE="SHA-1" SIZE="6131827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:40:57" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="61e8dcbe67cdacb3e0bf14853c322b57f324323d" CHECKSUMTYPE="SHA-1" SIZE="6131827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:41:35"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f7e9e820d66fb71a9fdda0e315bf67127f219d15"
-				CHECKSUMTYPE="SHA-1" SIZE="5951818">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:41:35" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f7e9e820d66fb71a9fdda0e315bf67127f219d15" CHECKSUMTYPE="SHA-1" SIZE="5951818">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:42:10"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="c34a2f978ae503b52a4f26f3091f87821978cb33"
-				CHECKSUMTYPE="SHA-1" SIZE="6186729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:42:10" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="c34a2f978ae503b52a4f26f3091f87821978cb33" CHECKSUMTYPE="SHA-1" SIZE="6186729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:42:45"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="b33a3a5e1b80bcb240e212a0eb3f7ec042849e68"
-				CHECKSUMTYPE="SHA-1" SIZE="5887018">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:42:45" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="b33a3a5e1b80bcb240e212a0eb3f7ec042849e68" CHECKSUMTYPE="SHA-1" SIZE="5887018">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:43:20"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="d17df0f5d2187dbe936d9ab9a51e2164163d0367"
-				CHECKSUMTYPE="SHA-1" SIZE="6186724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:43:20" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="d17df0f5d2187dbe936d9ab9a51e2164163d0367" CHECKSUMTYPE="SHA-1" SIZE="6186724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:43:52"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="db910fe1b80e12a14e6b3f39a7f07b2978ec9d4b"
-				CHECKSUMTYPE="SHA-1" SIZE="5887029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:43:52" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="db910fe1b80e12a14e6b3f39a7f07b2978ec9d4b" CHECKSUMTYPE="SHA-1" SIZE="5887029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:44:28"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="6496c4030e5d6ad7cd54cc1a9d5a2776405a6e0d"
-				CHECKSUMTYPE="SHA-1" SIZE="6228122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:44:28" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="6496c4030e5d6ad7cd54cc1a9d5a2776405a6e0d" CHECKSUMTYPE="SHA-1" SIZE="6228122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:45:02"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="9c956f9b88af8cf34ab83c92f4189309d5ab046c"
-				CHECKSUMTYPE="SHA-1" SIZE="5887023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:45:02" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="9c956f9b88af8cf34ab83c92f4189309d5ab046c" CHECKSUMTYPE="SHA-1" SIZE="5887023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:45:39"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="8ee4c8870ac3f636d1954fc15e207c5bd091f48c"
-				CHECKSUMTYPE="SHA-1" SIZE="6187477">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:45:39" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="8ee4c8870ac3f636d1954fc15e207c5bd091f48c" CHECKSUMTYPE="SHA-1" SIZE="6187477">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:46:15"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="0ddf5c7ffa870261a1e8c0839b02287d10c7b975"
-				CHECKSUMTYPE="SHA-1" SIZE="5970728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:46:15" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="0ddf5c7ffa870261a1e8c0839b02287d10c7b975" CHECKSUMTYPE="SHA-1" SIZE="5970728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:46:50"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="8e3f92c81f1275ad591ee63a5693ba4b883af41f"
-				CHECKSUMTYPE="SHA-1" SIZE="6165123">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:46:50" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="8e3f92c81f1275ad591ee63a5693ba4b883af41f" CHECKSUMTYPE="SHA-1" SIZE="6165123">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:47:27"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="44c092f10522370b3d6ce1fc48e9bd8b07a5a8d4"
-				CHECKSUMTYPE="SHA-1" SIZE="5970727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:47:27" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="44c092f10522370b3d6ce1fc48e9bd8b07a5a8d4" CHECKSUMTYPE="SHA-1" SIZE="5970727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:48:01"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="e110e4b1f17dd7ad9971c948ee58dd57fbb8f721"
-				CHECKSUMTYPE="SHA-1" SIZE="6052620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:48:01" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="e110e4b1f17dd7ad9971c948ee58dd57fbb8f721" CHECKSUMTYPE="SHA-1" SIZE="6052620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:48:35"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="b0a057180d6881499135ad004f9cb76bc8c3d0d0"
-				CHECKSUMTYPE="SHA-1" SIZE="6010328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:48:35" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="b0a057180d6881499135ad004f9cb76bc8c3d0d0" CHECKSUMTYPE="SHA-1" SIZE="6010328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:49:09"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="b5d50b55bf90eddea6d8e4524973c4b086658f04"
-				CHECKSUMTYPE="SHA-1" SIZE="6052627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:49:09" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="b5d50b55bf90eddea6d8e4524973c4b086658f04" CHECKSUMTYPE="SHA-1" SIZE="6052627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:49:42"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="0cb1c9767e4daa7746ef53e36301b637deb94ba4"
-				CHECKSUMTYPE="SHA-1" SIZE="6053528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:49:42" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="0cb1c9767e4daa7746ef53e36301b637deb94ba4" CHECKSUMTYPE="SHA-1" SIZE="6053528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:50:15"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="c813495e5e4b1176fc7c877baf081468774c6613"
-				CHECKSUMTYPE="SHA-1" SIZE="6052625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:50:15" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="c813495e5e4b1176fc7c877baf081468774c6613" CHECKSUMTYPE="SHA-1" SIZE="6052625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:50:49"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="8e0c293b2b999f3cec10cdd74508ee9131a664cf"
-				CHECKSUMTYPE="SHA-1" SIZE="6052625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:50:49" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="8e0c293b2b999f3cec10cdd74508ee9131a664cf" CHECKSUMTYPE="SHA-1" SIZE="6052625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:51:21"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="d43341546a072606db921331e3dcb6686a85be5a"
-				CHECKSUMTYPE="SHA-1" SIZE="6052628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:51:21" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="d43341546a072606db921331e3dcb6686a85be5a" CHECKSUMTYPE="SHA-1" SIZE="6052628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:51:56"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="494160c02029ad6cc7638fdc35b5ce794820f0d3"
-				CHECKSUMTYPE="SHA-1" SIZE="6052622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:51:56" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="494160c02029ad6cc7638fdc35b5ce794820f0d3" CHECKSUMTYPE="SHA-1" SIZE="6052622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:52:31"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="2a76c05d42e70ae00dea6223ba41daa2ca6335c2"
-				CHECKSUMTYPE="SHA-1" SIZE="6052612">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:52:31" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="2a76c05d42e70ae00dea6223ba41daa2ca6335c2" CHECKSUMTYPE="SHA-1" SIZE="6052612">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:53:04"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="58ef020acce810cf2b04038ebd40ff5487e2d9a6"
-				CHECKSUMTYPE="SHA-1" SIZE="6052627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:53:04" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="58ef020acce810cf2b04038ebd40ff5487e2d9a6" CHECKSUMTYPE="SHA-1" SIZE="6052627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:53:36"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="61e3fc287225882bf798bbcbed06468626773ce5"
-				CHECKSUMTYPE="SHA-1" SIZE="6051719">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:53:36" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="61e3fc287225882bf798bbcbed06468626773ce5" CHECKSUMTYPE="SHA-1" SIZE="6051719">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T18:54:10"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="42a5955aa253dd0cb218fd7e461b6616f99efd97"
-				CHECKSUMTYPE="SHA-1" SIZE="6052591">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T18:54:10" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="42a5955aa253dd0cb218fd7e461b6616f99efd97" CHECKSUMTYPE="SHA-1" SIZE="6052591">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T18:54:44"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="9e05107b0dd4ce9a155b89455cd9e4c9727bab4b"
-				CHECKSUMTYPE="SHA-1" SIZE="6052623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T18:54:44" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="9e05107b0dd4ce9a155b89455cd9e4c9727bab4b" CHECKSUMTYPE="SHA-1" SIZE="6052623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T18:55:22"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="381b3950bf87f256517a017559a0689424c12660"
-				CHECKSUMTYPE="SHA-1" SIZE="6052626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T18:55:22" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="381b3950bf87f256517a017559a0689424c12660" CHECKSUMTYPE="SHA-1" SIZE="6052626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T18:55:58"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="b62cee1833be512db45c9f35877f861c703343ae"
-				CHECKSUMTYPE="SHA-1" SIZE="6052626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T18:55:58" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="b62cee1833be512db45c9f35877f861c703343ae" CHECKSUMTYPE="SHA-1" SIZE="6052626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/delivery/bmtnabf_1901-12-15_01_0034.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:56:18" MIMETYPE="text/xml"
-				CHECKSUM="2b9065c4e8edfb07da7be95973407c7dfef305e7" CHECKSUMTYPE="SHA-1" SIZE="4554">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:56:18" MIMETYPE="text/xml" CHECKSUM="2b9065c4e8edfb07da7be95973407c7dfef305e7" CHECKSUMTYPE="SHA-1" SIZE="4554">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:56:18" MIMETYPE="text/xml"
-				CHECKSUM="46b0720fe797eaae0c24328dc68b17a293440b41" CHECKSUMTYPE="SHA-1"
-				SIZE="31875">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:56:18" MIMETYPE="text/xml" CHECKSUM="46b0720fe797eaae0c24328dc68b17a293440b41" CHECKSUMTYPE="SHA-1" SIZE="31875">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:56:19" MIMETYPE="text/xml"
-				CHECKSUM="f060285be496a1e8b35240a089e3cb9c2918c1d9" CHECKSUMTYPE="SHA-1"
-				SIZE="15310">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:56:19" MIMETYPE="text/xml" CHECKSUM="f060285be496a1e8b35240a089e3cb9c2918c1d9" CHECKSUMTYPE="SHA-1" SIZE="15310">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:56:19" MIMETYPE="text/xml"
-				CHECKSUM="1a8aeb419718fcc70ff69980806df367e55d40ce" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:56:19" MIMETYPE="text/xml" CHECKSUM="1a8aeb419718fcc70ff69980806df367e55d40ce" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:56:19" MIMETYPE="text/xml"
-				CHECKSUM="7c10f8d4b2e1d0534667046e251b104acfe67aff" CHECKSUMTYPE="SHA-1" SIZE="9887">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:56:19" MIMETYPE="text/xml" CHECKSUM="7c10f8d4b2e1d0534667046e251b104acfe67aff" CHECKSUMTYPE="SHA-1" SIZE="9887">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:56:19" MIMETYPE="text/xml"
-				CHECKSUM="1b59e128ad53197e65bec80ab361ccaa8d9f6a40" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:56:19" MIMETYPE="text/xml" CHECKSUM="1b59e128ad53197e65bec80ab361ccaa8d9f6a40" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:56:20" MIMETYPE="text/xml"
-				CHECKSUM="a9492c8f592be1f8b0321bd7e9236a13c04a1b83" CHECKSUMTYPE="SHA-1"
-				SIZE="25841">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:56:20" MIMETYPE="text/xml" CHECKSUM="a9492c8f592be1f8b0321bd7e9236a13c04a1b83" CHECKSUMTYPE="SHA-1" SIZE="25841">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:56:20" MIMETYPE="text/xml"
-				CHECKSUM="7d06899f67fe61585af290ff56a67ca210d6628e" CHECKSUMTYPE="SHA-1"
-				SIZE="19681">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:56:20" MIMETYPE="text/xml" CHECKSUM="7d06899f67fe61585af290ff56a67ca210d6628e" CHECKSUMTYPE="SHA-1" SIZE="19681">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:56:20" MIMETYPE="text/xml"
-				CHECKSUM="fae3588fc5319c7281af38151b76bca72523ced7" CHECKSUMTYPE="SHA-1" SIZE="5548">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:56:20" MIMETYPE="text/xml" CHECKSUM="fae3588fc5319c7281af38151b76bca72523ced7" CHECKSUMTYPE="SHA-1" SIZE="5548">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:56:20" MIMETYPE="text/xml"
-				CHECKSUM="928314a0c6d52a07cd08b8ae53e9459c24386f5e" CHECKSUMTYPE="SHA-1" SIZE="5091">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:56:20" MIMETYPE="text/xml" CHECKSUM="928314a0c6d52a07cd08b8ae53e9459c24386f5e" CHECKSUMTYPE="SHA-1" SIZE="5091">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:56:21" MIMETYPE="text/xml"
-				CHECKSUM="448a6a13b3c7f4e0b13cebbcaf8f8680dfbd18d0" CHECKSUMTYPE="SHA-1" SIZE="4520">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:56:21" MIMETYPE="text/xml" CHECKSUM="448a6a13b3c7f4e0b13cebbcaf8f8680dfbd18d0" CHECKSUMTYPE="SHA-1" SIZE="4520">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:56:21" MIMETYPE="text/xml"
-				CHECKSUM="da3e0cce8eb1a1123ab00cea64e6aa8ff86c0ebb" CHECKSUMTYPE="SHA-1" SIZE="5667">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:56:21" MIMETYPE="text/xml" CHECKSUM="da3e0cce8eb1a1123ab00cea64e6aa8ff86c0ebb" CHECKSUMTYPE="SHA-1" SIZE="5667">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:56:21" MIMETYPE="text/xml"
-				CHECKSUM="dfbcb9c251a57a6be3e9e72a5fe84aab8e43bef2" CHECKSUMTYPE="SHA-1" SIZE="5368">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:56:21" MIMETYPE="text/xml" CHECKSUM="dfbcb9c251a57a6be3e9e72a5fe84aab8e43bef2" CHECKSUMTYPE="SHA-1" SIZE="5368">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:56:21" MIMETYPE="text/xml"
-				CHECKSUM="70c6fa9cebf2764ab9bb004f3222e48d9f5ca3ba" CHECKSUMTYPE="SHA-1" SIZE="5035">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:56:21" MIMETYPE="text/xml" CHECKSUM="70c6fa9cebf2764ab9bb004f3222e48d9f5ca3ba" CHECKSUMTYPE="SHA-1" SIZE="5035">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:56:22" MIMETYPE="text/xml"
-				CHECKSUM="8092d4ee1d4fd73e6eab3cf5ea0f0de417837529" CHECKSUMTYPE="SHA-1" SIZE="4622">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:56:22" MIMETYPE="text/xml" CHECKSUM="8092d4ee1d4fd73e6eab3cf5ea0f0de417837529" CHECKSUMTYPE="SHA-1" SIZE="4622">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:56:22" MIMETYPE="text/xml"
-				CHECKSUM="d15eea46a5814fb267ad490384ae16431a1ee17f" CHECKSUMTYPE="SHA-1" SIZE="4548">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:56:22" MIMETYPE="text/xml" CHECKSUM="d15eea46a5814fb267ad490384ae16431a1ee17f" CHECKSUMTYPE="SHA-1" SIZE="4548">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:56:22" MIMETYPE="text/xml"
-				CHECKSUM="3feb45f588ef57b661941be00870581513209eb3" CHECKSUMTYPE="SHA-1" SIZE="4617">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:56:22" MIMETYPE="text/xml" CHECKSUM="3feb45f588ef57b661941be00870581513209eb3" CHECKSUMTYPE="SHA-1" SIZE="4617">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:56:22" MIMETYPE="text/xml"
-				CHECKSUM="8819affc801aa430de360d5eaf8ac68d93706199" CHECKSUMTYPE="SHA-1" SIZE="4553">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:56:22" MIMETYPE="text/xml" CHECKSUM="8819affc801aa430de360d5eaf8ac68d93706199" CHECKSUMTYPE="SHA-1" SIZE="4553">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:56:23" MIMETYPE="text/xml"
-				CHECKSUM="fa5adbba2a2d9acd6e030cc176e1b95aa0567fb0" CHECKSUMTYPE="SHA-1" SIZE="4623">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:56:23" MIMETYPE="text/xml" CHECKSUM="fa5adbba2a2d9acd6e030cc176e1b95aa0567fb0" CHECKSUMTYPE="SHA-1" SIZE="4623">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:56:23" MIMETYPE="text/xml"
-				CHECKSUM="b617e458978ebe0031ebdd432f8084b523eae254" CHECKSUMTYPE="SHA-1" SIZE="5022">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:56:23" MIMETYPE="text/xml" CHECKSUM="b617e458978ebe0031ebdd432f8084b523eae254" CHECKSUMTYPE="SHA-1" SIZE="5022">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:56:23" MIMETYPE="text/xml"
-				CHECKSUM="db9ec488a8465954236c1491cf3054d01ecfa5b7" CHECKSUMTYPE="SHA-1" SIZE="5325">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:56:23" MIMETYPE="text/xml" CHECKSUM="db9ec488a8465954236c1491cf3054d01ecfa5b7" CHECKSUMTYPE="SHA-1" SIZE="5325">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:56:23" MIMETYPE="text/xml"
-				CHECKSUM="e215765a85b955909463d451386533058c0be029" CHECKSUMTYPE="SHA-1" SIZE="5057">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:56:23" MIMETYPE="text/xml" CHECKSUM="e215765a85b955909463d451386533058c0be029" CHECKSUMTYPE="SHA-1" SIZE="5057">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:56:24" MIMETYPE="text/xml"
-				CHECKSUM="a5216238f2305634351a116d157a912ca742ec50" CHECKSUMTYPE="SHA-1" SIZE="4626">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:56:24" MIMETYPE="text/xml" CHECKSUM="a5216238f2305634351a116d157a912ca742ec50" CHECKSUMTYPE="SHA-1" SIZE="4626">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:56:24" MIMETYPE="text/xml"
-				CHECKSUM="adb08b15e83424b20c79d8a4f57fde72e2992a60" CHECKSUMTYPE="SHA-1" SIZE="5147">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:56:24" MIMETYPE="text/xml" CHECKSUM="adb08b15e83424b20c79d8a4f57fde72e2992a60" CHECKSUMTYPE="SHA-1" SIZE="5147">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:56:24" MIMETYPE="text/xml"
-				CHECKSUM="7359bf03be486fe79cda7327cc3c042f6af86b56" CHECKSUMTYPE="SHA-1" SIZE="5089">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:56:24" MIMETYPE="text/xml" CHECKSUM="7359bf03be486fe79cda7327cc3c042f6af86b56" CHECKSUMTYPE="SHA-1" SIZE="5089">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:56:24" MIMETYPE="text/xml"
-				CHECKSUM="b3c9d95a1f00ffb124cd47cb4cf3141ccc444fb9" CHECKSUMTYPE="SHA-1" SIZE="5081">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:56:24" MIMETYPE="text/xml" CHECKSUM="b3c9d95a1f00ffb124cd47cb4cf3141ccc444fb9" CHECKSUMTYPE="SHA-1" SIZE="5081">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:56:24" MIMETYPE="text/xml"
-				CHECKSUM="d98c68e293e75e8efa4ea8391fac95f55702045d" CHECKSUMTYPE="SHA-1" SIZE="4621">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:56:24" MIMETYPE="text/xml" CHECKSUM="d98c68e293e75e8efa4ea8391fac95f55702045d" CHECKSUMTYPE="SHA-1" SIZE="4621">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:56:25" MIMETYPE="text/xml"
-				CHECKSUM="44819a6d138bc7764da40a93056376ac8282c641" CHECKSUMTYPE="SHA-1" SIZE="4550">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:56:25" MIMETYPE="text/xml" CHECKSUM="44819a6d138bc7764da40a93056376ac8282c641" CHECKSUMTYPE="SHA-1" SIZE="4550">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:56:25" MIMETYPE="text/xml"
-				CHECKSUM="6b7791333a6e1fcea7bfb37d1a28ca832319e16a" CHECKSUMTYPE="SHA-1"
-				SIZE="57796">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:56:25" MIMETYPE="text/xml" CHECKSUM="6b7791333a6e1fcea7bfb37d1a28ca832319e16a" CHECKSUMTYPE="SHA-1" SIZE="57796">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:56:25" MIMETYPE="text/xml"
-				CHECKSUM="856a62029f67552b43c8c4562962a69cc661dbdd" CHECKSUMTYPE="SHA-1"
-				SIZE="57643">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:56:25" MIMETYPE="text/xml" CHECKSUM="856a62029f67552b43c8c4562962a69cc661dbdd" CHECKSUMTYPE="SHA-1" SIZE="57643">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T18:56:25" MIMETYPE="text/xml"
-				CHECKSUM="a86cd3e34ca8fec2cecbd8ba7ce0d468bd7d22d5" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T18:56:25" MIMETYPE="text/xml" CHECKSUM="a86cd3e34ca8fec2cecbd8ba7ce0d468bd7d22d5" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T18:56:26" MIMETYPE="text/xml"
-				CHECKSUM="e6fc0bfedb380172fe7b4e82df23c7ae491ae579" CHECKSUMTYPE="SHA-1"
-				SIZE="32997">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T18:56:26" MIMETYPE="text/xml" CHECKSUM="e6fc0bfedb380172fe7b4e82df23c7ae491ae579" CHECKSUMTYPE="SHA-1" SIZE="32997">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T18:56:26" MIMETYPE="text/xml"
-				CHECKSUM="66a82e3c8eac82e105073ca5e188dfd60686c094" CHECKSUMTYPE="SHA-1"
-				SIZE="38316">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0033.alto.xml"
-				/>
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T18:56:26" MIMETYPE="text/xml" CHECKSUM="66a82e3c8eac82e105073ca5e188dfd60686c094" CHECKSUMTYPE="SHA-1" SIZE="38316">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T18:56:26" MIMETYPE="text/xml"
-				CHECKSUM="d97c8aa0c5fc45a14a735c24f7edc81cba9d0271" CHECKSUMTYPE="SHA-1" SIZE="8283">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0034.alto.xml"
-				/>
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T18:56:26" MIMETYPE="text/xml" CHECKSUM="d97c8aa0c5fc45a14a735c24f7edc81cba9d0271" CHECKSUMTYPE="SHA-1" SIZE="8283">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1901-12-15_01_0034.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:57:04" MIMETYPE="application/pdf"
-				CHECKSUM="78e7556bef46d3bc763ca885e252476d195ef410" CHECKSUMTYPE="SHA-1"
-				SIZE="11814905">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/bmtnabf_1901-12-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:57:04" MIMETYPE="application/pdf" CHECKSUM="78e7556bef46d3bc763ca885e252476d195ef410" CHECKSUMTYPE="SHA-1" SIZE="11814905">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1901/12/15_01/bmtnabf_1901-12-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -4620,8 +4398,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="TextContent" ORDER="6" DMDID="c012"
-					LABEL="STIMME DES ABENDS">
+				<div ID="L.1.1.7" TYPE="TextContent" ORDER="6" DMDID="c012" LABEL="STIMME DES ABENDS">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00001"/>
@@ -4676,8 +4453,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="TextContent" ORDER="7" DMDID="c017"
-					LABEL="SIEHST DU DEN STERN?">
+				<div ID="L.1.1.8" TYPE="TextContent" ORDER="7" DMDID="c017" LABEL="SIEHST DU DEN STERN?">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00001"/>
@@ -4708,8 +4484,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="TextContent" ORDER="8" DMDID="c020"
-					LABEL="KURDISCHES LIEBESLIED">
+				<div ID="L.1.1.9" TYPE="TextContent" ORDER="8" DMDID="c020" LABEL="KURDISCHES LIEBESLIED">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00001"/>
@@ -4740,8 +4515,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="TextContent" ORDER="9" DMDID="c023"
-					LABEL="DAS MITLEIDIGE MÄDEL">
+				<div ID="L.1.1.10" TYPE="TextContent" ORDER="9" DMDID="c023" LABEL="DAS MITLEIDIGE MÄDEL">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00001"/>
@@ -4970,8 +4744,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="TextContent" ORDER="11" DMDID="c041"
-					LABEL="NACH EINEM NIEDERLÄNDER">
+				<div ID="L.1.1.12" TYPE="TextContent" ORDER="11" DMDID="c041" LABEL="NACH EINEM NIEDERLÄNDER">
 					<div ID="L.1.1.12.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00001"/>
@@ -5026,8 +4799,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="TextContent" ORDER="12" DMDID="c046"
-					LABEL="DES NARREN REGENLIED">
+				<div ID="L.1.1.13" TYPE="TextContent" ORDER="12" DMDID="c046" LABEL="DES NARREN REGENLIED">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00001"/>
@@ -5173,8 +4945,7 @@
 							<div ID="L.1.1.16.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.16.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00003"/>
 									</fptr>
 								</div>
 							</div>
@@ -5182,10 +4953,8 @@
 								<div ID="L.1.1.16.2.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00029"
-												BEGIN="P29_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00029"
-												BEGIN="P29_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00005"/>
 										</seq>
 									</fptr>
 								</div>
@@ -5194,12 +4963,9 @@
 								<div ID="L.1.1.16.2.1.3.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
@@ -5208,12 +4974,9 @@
 								<div ID="L.1.1.16.2.1.4.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00030"
-												BEGIN="P30_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_TB00007"/>
 										</seq>
 									</fptr>
 								</div>

--- a/metadata/periodicals/bmtnabf/issues/1902/01/01_01/bmtnabf_1902-01-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/01/01_01/bmtnabf_1902-01-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-01-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-01-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-01-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-01-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-01-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3125,450 +3119,216 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:37:53"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="d69b4d5489ba13d433a3d6faabd8706f8d92e7f1"
-				CHECKSUMTYPE="SHA-1" SIZE="6109281">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:37:53" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="d69b4d5489ba13d433a3d6faabd8706f8d92e7f1" CHECKSUMTYPE="SHA-1" SIZE="6109281">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:38:26"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="896208fdec4e72172aab4f15d8ca91d1ec08f4b0"
-				CHECKSUMTYPE="SHA-1" SIZE="6094909">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:38:26" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="896208fdec4e72172aab4f15d8ca91d1ec08f4b0" CHECKSUMTYPE="SHA-1" SIZE="6094909">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:39:00"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="e01028375fcb8794d419370ffab846c7d7d7948a"
-				CHECKSUMTYPE="SHA-1" SIZE="6147129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:39:00" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="e01028375fcb8794d419370ffab846c7d7d7948a" CHECKSUMTYPE="SHA-1" SIZE="6147129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:39:32"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a5199ec80d2cb9497485d8ae81ff3b54624196ef"
-				CHECKSUMTYPE="SHA-1" SIZE="6094929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:39:32" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a5199ec80d2cb9497485d8ae81ff3b54624196ef" CHECKSUMTYPE="SHA-1" SIZE="6094929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:40:03"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="509c7a00c2ce635d41c9f19a0e8675996c9b78b6"
-				CHECKSUMTYPE="SHA-1" SIZE="6051714">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:40:03" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="509c7a00c2ce635d41c9f19a0e8675996c9b78b6" CHECKSUMTYPE="SHA-1" SIZE="6051714">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:40:37"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="a55aee9732adabd5d2f17c60081776cd053d7e51"
-				CHECKSUMTYPE="SHA-1" SIZE="6082325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:40:37" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="a55aee9732adabd5d2f17c60081776cd053d7e51" CHECKSUMTYPE="SHA-1" SIZE="6082325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:41:14"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="a8df60d9b66d2316e4bafe495c224e6f7ce02661"
-				CHECKSUMTYPE="SHA-1" SIZE="6053529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:41:14" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="a8df60d9b66d2316e4bafe495c224e6f7ce02661" CHECKSUMTYPE="SHA-1" SIZE="6053529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:41:47"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="31940fea46d1af57d8392b17987673143f991856"
-				CHECKSUMTYPE="SHA-1" SIZE="6082322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:41:47" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="31940fea46d1af57d8392b17987673143f991856" CHECKSUMTYPE="SHA-1" SIZE="6082322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:42:20"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="45245b57729de21a7f45638c80c5a28b08fbf5a8"
-				CHECKSUMTYPE="SHA-1" SIZE="6053528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:42:20" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="45245b57729de21a7f45638c80c5a28b08fbf5a8" CHECKSUMTYPE="SHA-1" SIZE="6053528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:42:56"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="745c4e3b49dc4d4554a63aff957240fe7629e282"
-				CHECKSUMTYPE="SHA-1" SIZE="6082327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:42:56" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="745c4e3b49dc4d4554a63aff957240fe7629e282" CHECKSUMTYPE="SHA-1" SIZE="6082327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:43:30"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="379ca5c7d807dab8e9f73bf164e68ca12f77d32d"
-				CHECKSUMTYPE="SHA-1" SIZE="6052628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:43:30" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="379ca5c7d807dab8e9f73bf164e68ca12f77d32d" CHECKSUMTYPE="SHA-1" SIZE="6052628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:44:05"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="04fbe323960f65111d03d815873f0022c988f525"
-				CHECKSUMTYPE="SHA-1" SIZE="6082316">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:44:05" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="04fbe323960f65111d03d815873f0022c988f525" CHECKSUMTYPE="SHA-1" SIZE="6082316">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:44:41"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="7bf7aa8f1e9f158e275dc803f57492a7fcadbc23"
-				CHECKSUMTYPE="SHA-1" SIZE="6051715">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T18:44:41" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="7bf7aa8f1e9f158e275dc803f57492a7fcadbc23" CHECKSUMTYPE="SHA-1" SIZE="6051715">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:45:16"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="7044bdbe31ca18231c1beb7f19969f0c5da4eac7"
-				CHECKSUMTYPE="SHA-1" SIZE="6082322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T18:45:16" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="7044bdbe31ca18231c1beb7f19969f0c5da4eac7" CHECKSUMTYPE="SHA-1" SIZE="6082322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:45:49"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="eecf913b8ddeea765b9b80ed56727c4805255924"
-				CHECKSUMTYPE="SHA-1" SIZE="6051729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T18:45:49" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="eecf913b8ddeea765b9b80ed56727c4805255924" CHECKSUMTYPE="SHA-1" SIZE="6051729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:46:20"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="f4c558dc220d509227422c9a0e025d53d6577d46"
-				CHECKSUMTYPE="SHA-1" SIZE="6114729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T18:46:20" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="f4c558dc220d509227422c9a0e025d53d6577d46" CHECKSUMTYPE="SHA-1" SIZE="6114729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:46:55"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7c22bdf3be7fbf0a39fa87b12d160561a3d975cf"
-				CHECKSUMTYPE="SHA-1" SIZE="6051691">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T18:46:55" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="7c22bdf3be7fbf0a39fa87b12d160561a3d975cf" CHECKSUMTYPE="SHA-1" SIZE="6051691">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:47:34"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="ba6841ca1fe99b05be1960b16b1e1ce08fc37cc8"
-				CHECKSUMTYPE="SHA-1" SIZE="6084078">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T18:47:34" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="ba6841ca1fe99b05be1960b16b1e1ce08fc37cc8" CHECKSUMTYPE="SHA-1" SIZE="6084078">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:48:10"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="59a5b6dcc4a18f8a6acfdb30ecfbf03a00057c1f"
-				CHECKSUMTYPE="SHA-1" SIZE="6051729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T18:48:10" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="59a5b6dcc4a18f8a6acfdb30ecfbf03a00057c1f" CHECKSUMTYPE="SHA-1" SIZE="6051729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:48:45"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="0bd286b95fb8f7b0405b81556b0ff322fa028593"
-				CHECKSUMTYPE="SHA-1" SIZE="6084103">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T18:48:45" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="0bd286b95fb8f7b0405b81556b0ff322fa028593" CHECKSUMTYPE="SHA-1" SIZE="6084103">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:49:18"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="1a91724bcf9d7e3dc2840334e7abb5e0f42f16e4"
-				CHECKSUMTYPE="SHA-1" SIZE="6051729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T18:49:18" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="1a91724bcf9d7e3dc2840334e7abb5e0f42f16e4" CHECKSUMTYPE="SHA-1" SIZE="6051729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:49:52"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="6921dd2f9ccc9af03906e2ced3d57ce183929715"
-				CHECKSUMTYPE="SHA-1" SIZE="6084129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T18:49:52" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="6921dd2f9ccc9af03906e2ced3d57ce183929715" CHECKSUMTYPE="SHA-1" SIZE="6084129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:50:25"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="4fe5ef7a72792b0e881c1f1ac90a1a41f3109524"
-				CHECKSUMTYPE="SHA-1" SIZE="6052615">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T18:50:25" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="4fe5ef7a72792b0e881c1f1ac90a1a41f3109524" CHECKSUMTYPE="SHA-1" SIZE="6052615">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:50:58"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="a3e83d816d00b06572690ce9aa47f8fd79fca3c0"
-				CHECKSUMTYPE="SHA-1" SIZE="6084121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T18:50:58" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="a3e83d816d00b06572690ce9aa47f8fd79fca3c0" CHECKSUMTYPE="SHA-1" SIZE="6084121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:51:33"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="4986e21ad4703996e5f1585d8c6d98288d5048f2"
-				CHECKSUMTYPE="SHA-1" SIZE="6051692">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T18:51:33" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="4986e21ad4703996e5f1585d8c6d98288d5048f2" CHECKSUMTYPE="SHA-1" SIZE="6051692">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:52:08"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="32258301a0d22b493932e9885f9d125fafaaa531"
-				CHECKSUMTYPE="SHA-1" SIZE="6084121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T18:52:08" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="32258301a0d22b493932e9885f9d125fafaaa531" CHECKSUMTYPE="SHA-1" SIZE="6084121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:52:44"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="24aa58f6949467cffb0b2a04e16ddc5c1fb84097"
-				CHECKSUMTYPE="SHA-1" SIZE="6051714">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T18:52:44" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="24aa58f6949467cffb0b2a04e16ddc5c1fb84097" CHECKSUMTYPE="SHA-1" SIZE="6051714">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:53:17"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="48677f44d1264c51a336d590d6463c31b0ffa4d9"
-				CHECKSUMTYPE="SHA-1" SIZE="6109316">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T18:53:17" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="48677f44d1264c51a336d590d6463c31b0ffa4d9" CHECKSUMTYPE="SHA-1" SIZE="6109316">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:53:49"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="0be73918a14fb35b33ec18bb0a66716b46188fbf"
-				CHECKSUMTYPE="SHA-1" SIZE="6051710">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T18:53:49" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="0be73918a14fb35b33ec18bb0a66716b46188fbf" CHECKSUMTYPE="SHA-1" SIZE="6051710">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:54:24"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="57ae7dfebf9a2fa812bcbb56f308d7900c451ecd"
-				CHECKSUMTYPE="SHA-1" SIZE="6109325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T18:54:24" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="57ae7dfebf9a2fa812bcbb56f308d7900c451ecd" CHECKSUMTYPE="SHA-1" SIZE="6109325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T18:54:59"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="ff18e8a0c4e8c26da4cf7450ecd29368897e0807"
-				CHECKSUMTYPE="SHA-1" SIZE="6088625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T18:54:59" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="ff18e8a0c4e8c26da4cf7450ecd29368897e0807" CHECKSUMTYPE="SHA-1" SIZE="6088625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T18:55:32"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="cde561b9e83ccab874b1d084474e40f371c789cf"
-				CHECKSUMTYPE="SHA-1" SIZE="6094928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T18:55:32" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="cde561b9e83ccab874b1d084474e40f371c789cf" CHECKSUMTYPE="SHA-1" SIZE="6094928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T18:56:03"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="3407acbc289f9552e39fcd1e52bfeab13771d5a7"
-				CHECKSUMTYPE="SHA-1" SIZE="6088624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T18:56:03" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="3407acbc289f9552e39fcd1e52bfeab13771d5a7" CHECKSUMTYPE="SHA-1" SIZE="6088624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T18:56:36"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="39906c138d40103006aad3c3ccea272d7323fc12"
-				CHECKSUMTYPE="SHA-1" SIZE="6095823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T18:56:36" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="39906c138d40103006aad3c3ccea272d7323fc12" CHECKSUMTYPE="SHA-1" SIZE="6095823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/delivery/bmtnabf_1902-01-01_01_0034.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:56:55" MIMETYPE="text/xml"
-				CHECKSUM="11489405f53de1b2a5d010673dd40a922e64767e" CHECKSUMTYPE="SHA-1" SIZE="5146">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T18:56:55" MIMETYPE="text/xml" CHECKSUM="11489405f53de1b2a5d010673dd40a922e64767e" CHECKSUMTYPE="SHA-1" SIZE="5146">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:56:55" MIMETYPE="text/xml"
-				CHECKSUM="10b57ee951b433cfeef030ed742b189e115391d8" CHECKSUMTYPE="SHA-1" SIZE="8490">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T18:56:55" MIMETYPE="text/xml" CHECKSUM="10b57ee951b433cfeef030ed742b189e115391d8" CHECKSUMTYPE="SHA-1" SIZE="8490">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:56:55" MIMETYPE="text/xml"
-				CHECKSUM="cc6e5c6450b2a763c1b3ea8fd1dab16c32df8b71" CHECKSUMTYPE="SHA-1" SIZE="4681">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T18:56:55" MIMETYPE="text/xml" CHECKSUM="cc6e5c6450b2a763c1b3ea8fd1dab16c32df8b71" CHECKSUMTYPE="SHA-1" SIZE="4681">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:56:55" MIMETYPE="text/xml"
-				CHECKSUM="51dff84cc1a716a39c18994891052b60acf0cc47" CHECKSUMTYPE="SHA-1" SIZE="1716">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T18:56:55" MIMETYPE="text/xml" CHECKSUM="51dff84cc1a716a39c18994891052b60acf0cc47" CHECKSUMTYPE="SHA-1" SIZE="1716">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:56:55" MIMETYPE="text/xml"
-				CHECKSUM="1a9154c1d0fdf1348cdbf793d16ac21c5b1e8b6a" CHECKSUMTYPE="SHA-1" SIZE="3561">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T18:56:55" MIMETYPE="text/xml" CHECKSUM="1a9154c1d0fdf1348cdbf793d16ac21c5b1e8b6a" CHECKSUMTYPE="SHA-1" SIZE="3561">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:56:56" MIMETYPE="text/xml"
-				CHECKSUM="713271c0908919502f4ad51ca998d9ddf2041b20" CHECKSUMTYPE="SHA-1"
-				SIZE="30772">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T18:56:56" MIMETYPE="text/xml" CHECKSUM="713271c0908919502f4ad51ca998d9ddf2041b20" CHECKSUMTYPE="SHA-1" SIZE="30772">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:56:56" MIMETYPE="text/xml"
-				CHECKSUM="81ed31dd1998535fec4be758f7b385b95f9b91bf" CHECKSUMTYPE="SHA-1"
-				SIZE="31947">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T18:56:56" MIMETYPE="text/xml" CHECKSUM="81ed31dd1998535fec4be758f7b385b95f9b91bf" CHECKSUMTYPE="SHA-1" SIZE="31947">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:56:57" MIMETYPE="text/xml"
-				CHECKSUM="47db6a700aa4f9d7fb874299ffab7fc503c904b1" CHECKSUMTYPE="SHA-1"
-				SIZE="28209">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T18:56:57" MIMETYPE="text/xml" CHECKSUM="47db6a700aa4f9d7fb874299ffab7fc503c904b1" CHECKSUMTYPE="SHA-1" SIZE="28209">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:56:57" MIMETYPE="text/xml"
-				CHECKSUM="53e57e277e5f1432e28faac510a880f5cf13e1dd" CHECKSUMTYPE="SHA-1"
-				SIZE="27298">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T18:56:57" MIMETYPE="text/xml" CHECKSUM="53e57e277e5f1432e28faac510a880f5cf13e1dd" CHECKSUMTYPE="SHA-1" SIZE="27298">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:56:58" MIMETYPE="text/xml"
-				CHECKSUM="c620d54350742b81cc8feadc17a0d45869b80e87" CHECKSUMTYPE="SHA-1"
-				SIZE="31030">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T18:56:58" MIMETYPE="text/xml" CHECKSUM="c620d54350742b81cc8feadc17a0d45869b80e87" CHECKSUMTYPE="SHA-1" SIZE="31030">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:56:59" MIMETYPE="text/xml"
-				CHECKSUM="779e28a170c7699dcbb7bb157e5f074a41380060" CHECKSUMTYPE="SHA-1"
-				SIZE="32012">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T18:56:59" MIMETYPE="text/xml" CHECKSUM="779e28a170c7699dcbb7bb157e5f074a41380060" CHECKSUMTYPE="SHA-1" SIZE="32012">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:56:59" MIMETYPE="text/xml"
-				CHECKSUM="05c8a9180e9c1612c4728d13545062b3abfa1aca" CHECKSUMTYPE="SHA-1"
-				SIZE="30169">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T18:56:59" MIMETYPE="text/xml" CHECKSUM="05c8a9180e9c1612c4728d13545062b3abfa1aca" CHECKSUMTYPE="SHA-1" SIZE="30169">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:57:00" MIMETYPE="text/xml"
-				CHECKSUM="8f0eb2bf9147afc912f5470bc639d1005ddc539b" CHECKSUMTYPE="SHA-1"
-				SIZE="32176">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T18:57:00" MIMETYPE="text/xml" CHECKSUM="8f0eb2bf9147afc912f5470bc639d1005ddc539b" CHECKSUMTYPE="SHA-1" SIZE="32176">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:57:00" MIMETYPE="text/xml"
-				CHECKSUM="873eba0f898d9dac5462efb30974b20f3a3627bf" CHECKSUMTYPE="SHA-1"
-				SIZE="32655">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T18:57:00" MIMETYPE="text/xml" CHECKSUM="873eba0f898d9dac5462efb30974b20f3a3627bf" CHECKSUMTYPE="SHA-1" SIZE="32655">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:57:01" MIMETYPE="text/xml"
-				CHECKSUM="cb9ae0496aaca89a994e63fe2563fb01d4c2ddc4" CHECKSUMTYPE="SHA-1"
-				SIZE="30806">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T18:57:01" MIMETYPE="text/xml" CHECKSUM="cb9ae0496aaca89a994e63fe2563fb01d4c2ddc4" CHECKSUMTYPE="SHA-1" SIZE="30806">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:57:01" MIMETYPE="text/xml"
-				CHECKSUM="01b73514e7ab8271cd5429e11cd2c6ec9d6f344c" CHECKSUMTYPE="SHA-1"
-				SIZE="31052">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T18:57:01" MIMETYPE="text/xml" CHECKSUM="01b73514e7ab8271cd5429e11cd2c6ec9d6f344c" CHECKSUMTYPE="SHA-1" SIZE="31052">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:57:02" MIMETYPE="text/xml"
-				CHECKSUM="08c7507a731e2255698360376c6a2046590e6be8" CHECKSUMTYPE="SHA-1"
-				SIZE="31412">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T18:57:02" MIMETYPE="text/xml" CHECKSUM="08c7507a731e2255698360376c6a2046590e6be8" CHECKSUMTYPE="SHA-1" SIZE="31412">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:57:02" MIMETYPE="text/xml"
-				CHECKSUM="62cfcab935d5f52944728574c346565af5363f59" CHECKSUMTYPE="SHA-1"
-				SIZE="32417">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T18:57:02" MIMETYPE="text/xml" CHECKSUM="62cfcab935d5f52944728574c346565af5363f59" CHECKSUMTYPE="SHA-1" SIZE="32417">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:57:02" MIMETYPE="text/xml"
-				CHECKSUM="22d0a9f5450f9deb289a420fc7bb36cab63fb24d" CHECKSUMTYPE="SHA-1"
-				SIZE="29728">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T18:57:02" MIMETYPE="text/xml" CHECKSUM="22d0a9f5450f9deb289a420fc7bb36cab63fb24d" CHECKSUMTYPE="SHA-1" SIZE="29728">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:57:03" MIMETYPE="text/xml"
-				CHECKSUM="f2cc439e247faf417d10a76ce8e4ef6cdca73221" CHECKSUMTYPE="SHA-1"
-				SIZE="31875">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T18:57:03" MIMETYPE="text/xml" CHECKSUM="f2cc439e247faf417d10a76ce8e4ef6cdca73221" CHECKSUMTYPE="SHA-1" SIZE="31875">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:57:03" MIMETYPE="text/xml"
-				CHECKSUM="edc3ac108ddd7052556fa034f2d16e6558693541" CHECKSUMTYPE="SHA-1"
-				SIZE="30268">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T18:57:03" MIMETYPE="text/xml" CHECKSUM="edc3ac108ddd7052556fa034f2d16e6558693541" CHECKSUMTYPE="SHA-1" SIZE="30268">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:57:04" MIMETYPE="text/xml"
-				CHECKSUM="dfeed681a979ce0a21e35006fe0b406b4b17c1e6" CHECKSUMTYPE="SHA-1"
-				SIZE="28959">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T18:57:04" MIMETYPE="text/xml" CHECKSUM="dfeed681a979ce0a21e35006fe0b406b4b17c1e6" CHECKSUMTYPE="SHA-1" SIZE="28959">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:57:04" MIMETYPE="text/xml"
-				CHECKSUM="d67c3474190c4c758f4231dc4de3317f55955ee4" CHECKSUMTYPE="SHA-1"
-				SIZE="29311">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T18:57:04" MIMETYPE="text/xml" CHECKSUM="d67c3474190c4c758f4231dc4de3317f55955ee4" CHECKSUMTYPE="SHA-1" SIZE="29311">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:57:05" MIMETYPE="text/xml"
-				CHECKSUM="110e62cdea5951891abe466d497e24bf39d4a4d7" CHECKSUMTYPE="SHA-1"
-				SIZE="32097">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T18:57:05" MIMETYPE="text/xml" CHECKSUM="110e62cdea5951891abe466d497e24bf39d4a4d7" CHECKSUMTYPE="SHA-1" SIZE="32097">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:57:05" MIMETYPE="text/xml"
-				CHECKSUM="29602591179b45fa29b5c9eca0c6701a27aeddcf" CHECKSUMTYPE="SHA-1"
-				SIZE="30887">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T18:57:05" MIMETYPE="text/xml" CHECKSUM="29602591179b45fa29b5c9eca0c6701a27aeddcf" CHECKSUMTYPE="SHA-1" SIZE="30887">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:57:06" MIMETYPE="text/xml"
-				CHECKSUM="34358515e9e2cb11da7e2b92a51f153e298f7769" CHECKSUMTYPE="SHA-1"
-				SIZE="30376">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T18:57:06" MIMETYPE="text/xml" CHECKSUM="34358515e9e2cb11da7e2b92a51f153e298f7769" CHECKSUMTYPE="SHA-1" SIZE="30376">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:57:06" MIMETYPE="text/xml"
-				CHECKSUM="bc0e6f7587a1cc980d216aab57c36716db59c91e" CHECKSUMTYPE="SHA-1"
-				SIZE="30539">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T18:57:06" MIMETYPE="text/xml" CHECKSUM="bc0e6f7587a1cc980d216aab57c36716db59c91e" CHECKSUMTYPE="SHA-1" SIZE="30539">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:57:07" MIMETYPE="text/xml"
-				CHECKSUM="b20a7b4d2a2cdc81e9d74690dddd481bfe8fc2ae" CHECKSUMTYPE="SHA-1"
-				SIZE="31598">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T18:57:07" MIMETYPE="text/xml" CHECKSUM="b20a7b4d2a2cdc81e9d74690dddd481bfe8fc2ae" CHECKSUMTYPE="SHA-1" SIZE="31598">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:57:07" MIMETYPE="text/xml"
-				CHECKSUM="dfba263ad39c8c218ff459fd21e98abfdf946571" CHECKSUMTYPE="SHA-1"
-				SIZE="31102">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T18:57:07" MIMETYPE="text/xml" CHECKSUM="dfba263ad39c8c218ff459fd21e98abfdf946571" CHECKSUMTYPE="SHA-1" SIZE="31102">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:57:08" MIMETYPE="text/xml"
-				CHECKSUM="f1f895b42a252a86a07c0ba6bdbd80604f824318" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T18:57:08" MIMETYPE="text/xml" CHECKSUM="f1f895b42a252a86a07c0ba6bdbd80604f824318" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T18:57:08" MIMETYPE="text/xml"
-				CHECKSUM="8a0d10fb6c73c00af0560a8c484b8e87dedcbdf3" CHECKSUMTYPE="SHA-1" SIZE="8343">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T18:57:08" MIMETYPE="text/xml" CHECKSUM="8a0d10fb6c73c00af0560a8c484b8e87dedcbdf3" CHECKSUMTYPE="SHA-1" SIZE="8343">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T18:57:08" MIMETYPE="text/xml"
-				CHECKSUM="b2e0573a576ecc017c8d3f2f473b371718e2df88" CHECKSUMTYPE="SHA-1"
-				SIZE="52704">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T18:57:08" MIMETYPE="text/xml" CHECKSUM="b2e0573a576ecc017c8d3f2f473b371718e2df88" CHECKSUMTYPE="SHA-1" SIZE="52704">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T18:57:08" MIMETYPE="text/xml"
-				CHECKSUM="934428c017c96cacb341dc9664dff9ab0dbb5135" CHECKSUMTYPE="SHA-1"
-				SIZE="26163">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0033.alto.xml"
-				/>
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T18:57:08" MIMETYPE="text/xml" CHECKSUM="934428c017c96cacb341dc9664dff9ab0dbb5135" CHECKSUMTYPE="SHA-1" SIZE="26163">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T18:57:09" MIMETYPE="text/xml"
-				CHECKSUM="dc85f7b7a8151297b6d17faf65d6e641044c7b84" CHECKSUMTYPE="SHA-1" SIZE="8463">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0034.alto.xml"
-				/>
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T18:57:09" MIMETYPE="text/xml" CHECKSUM="dc85f7b7a8151297b6d17faf65d6e641044c7b84" CHECKSUMTYPE="SHA-1" SIZE="8463">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-01-01_01_0034.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:57:47" MIMETYPE="application/pdf"
-				CHECKSUM="f2ead1539d2f26f1b4f2aad264b1b08d4020cb13" CHECKSUMTYPE="SHA-1"
-				SIZE="10954230">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/bmtnabf_1902-01-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T18:57:47" MIMETYPE="application/pdf" CHECKSUM="f2ead1539d2f26f1b4f2aad264b1b08d4020cb13" CHECKSUMTYPE="SHA-1" SIZE="10954230">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/01/01_01/bmtnabf_1902-01-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3851,8 +3611,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 1 01.01.1902">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by Rud. Jettmar">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by Rud. Jettmar">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_CB00001"/>
@@ -3960,15 +3719,13 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c004"
-					LABEL="VER SACRUM KALENDER 1902">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c004" LABEL="VER SACRUM KALENDER 1902">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00001"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.5.2" TYPE="Illustration" ORDER="1" DMDID="c005"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.5.2" TYPE="Illustration" ORDER="1" DMDID="c005" LABEL="Untitled Image">
 						<div ID="L.1.1.5.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00001"/>
@@ -3976,8 +3733,7 @@
 						</div>
 					</div>
 					<div ID="L.1.1.5.3" TYPE="Copy">
-						<div ID="L.1.1.5.3.1" TYPE="Illustration" ORDER="1" DMDID="c006"
-							LABEL="Januar">
+						<div ID="L.1.1.5.3.1" TYPE="Illustration" ORDER="1" DMDID="c006" LABEL="Januar">
 							<div ID="L.1.1.5.4.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
@@ -3999,8 +3755,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.2" TYPE="Illustration" ORDER="2" DMDID="c007"
-							LABEL="Januar">
+						<div ID="L.1.1.5.3.2" TYPE="Illustration" ORDER="2" DMDID="c007" LABEL="Januar">
 							<div ID="L.1.1.5.5.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -4022,8 +3777,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.3" TYPE="Illustration" ORDER="3" DMDID="c008"
-							LABEL="Februar">
+						<div ID="L.1.1.5.3.3" TYPE="Illustration" ORDER="3" DMDID="c008" LABEL="Februar">
 							<div ID="L.1.1.5.6.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
@@ -4045,8 +3799,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.4" TYPE="Illustration" ORDER="4" DMDID="c009"
-							LABEL="Februar">
+						<div ID="L.1.1.5.3.4" TYPE="Illustration" ORDER="4" DMDID="c009" LABEL="Februar">
 							<div ID="L.1.1.5.7.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -4068,8 +3821,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.5" TYPE="Illustration" ORDER="5" DMDID="c010"
-							LABEL="Marz">
+						<div ID="L.1.1.5.3.5" TYPE="Illustration" ORDER="5" DMDID="c010" LABEL="Marz">
 							<div ID="L.1.1.5.8.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -4091,8 +3843,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.6" TYPE="Illustration" ORDER="6" DMDID="c011"
-							LABEL="Marz">
+						<div ID="L.1.1.5.3.6" TYPE="Illustration" ORDER="6" DMDID="c011" LABEL="Marz">
 							<div ID="L.1.1.5.9.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -4114,8 +3865,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.7" TYPE="Illustration" ORDER="7" DMDID="c012"
-							LABEL="April">
+						<div ID="L.1.1.5.3.7" TYPE="Illustration" ORDER="7" DMDID="c012" LABEL="April">
 							<div ID="L.1.1.5.10.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -4137,8 +3887,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.8" TYPE="Illustration" ORDER="8" DMDID="c013"
-							LABEL="April">
+						<div ID="L.1.1.5.3.8" TYPE="Illustration" ORDER="8" DMDID="c013" LABEL="April">
 							<div ID="L.1.1.5.11.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -4182,8 +3931,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.10" TYPE="Illustration" ORDER="10" DMDID="c015"
-							LABEL="Mai">
+						<div ID="L.1.1.5.3.10" TYPE="Illustration" ORDER="10" DMDID="c015" LABEL="Mai">
 							<div ID="L.1.1.5.13.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -4205,8 +3953,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.11" TYPE="Illustration" ORDER="11" DMDID="c016"
-							LABEL="Juni">
+						<div ID="L.1.1.5.3.11" TYPE="Illustration" ORDER="11" DMDID="c016" LABEL="Juni">
 							<div ID="L.1.1.5.14.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -4228,8 +3975,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.12" TYPE="Illustration" ORDER="12" DMDID="c017"
-							LABEL="Juni">
+						<div ID="L.1.1.5.3.12" TYPE="Illustration" ORDER="12" DMDID="c017" LABEL="Juni">
 							<div ID="L.1.1.5.15.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -4251,8 +3997,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.13" TYPE="Illustration" ORDER="13" DMDID="c018"
-							LABEL="Juli">
+						<div ID="L.1.1.5.3.13" TYPE="Illustration" ORDER="13" DMDID="c018" LABEL="Juli">
 							<div ID="L.1.1.5.16.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
@@ -4274,8 +4019,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.14" TYPE="Illustration" ORDER="14" DMDID="c019"
-							LABEL="Juli">
+						<div ID="L.1.1.5.3.14" TYPE="Illustration" ORDER="14" DMDID="c019" LABEL="Juli">
 							<div ID="L.1.1.5.17.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
@@ -4297,8 +4041,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.15" TYPE="Illustration" ORDER="15" DMDID="c020"
-							LABEL="August">
+						<div ID="L.1.1.5.3.15" TYPE="Illustration" ORDER="15" DMDID="c020" LABEL="August">
 							<div ID="L.1.1.5.18.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
@@ -4320,8 +4063,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.16" TYPE="Illustration" ORDER="16" DMDID="c021"
-							LABEL="August">
+						<div ID="L.1.1.5.3.16" TYPE="Illustration" ORDER="16" DMDID="c021" LABEL="August">
 							<div ID="L.1.1.5.19.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
@@ -4343,8 +4085,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.17" TYPE="Illustration" ORDER="17" DMDID="c022"
-							LABEL="September">
+						<div ID="L.1.1.5.3.17" TYPE="Illustration" ORDER="17" DMDID="c022" LABEL="September">
 							<div ID="L.1.1.5.20.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
@@ -4366,8 +4107,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.18" TYPE="Illustration" ORDER="18" DMDID="c023"
-							LABEL="September">
+						<div ID="L.1.1.5.3.18" TYPE="Illustration" ORDER="18" DMDID="c023" LABEL="September">
 							<div ID="L.1.1.5.21.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
@@ -4389,8 +4129,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.19" TYPE="Illustration" ORDER="19" DMDID="c024"
-							LABEL="October">
+						<div ID="L.1.1.5.3.19" TYPE="Illustration" ORDER="19" DMDID="c024" LABEL="October">
 							<div ID="L.1.1.5.22.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
@@ -4412,8 +4151,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.20" TYPE="Illustration" ORDER="20" DMDID="c025"
-							LABEL="October">
+						<div ID="L.1.1.5.3.20" TYPE="Illustration" ORDER="20" DMDID="c025" LABEL="October">
 							<div ID="L.1.1.5.23.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
@@ -4435,8 +4173,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.21" TYPE="Illustration" ORDER="21" DMDID="c026"
-							LABEL="November">
+						<div ID="L.1.1.5.3.21" TYPE="Illustration" ORDER="21" DMDID="c026" LABEL="November">
 							<div ID="L.1.1.5.24.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
@@ -4458,8 +4195,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.22" TYPE="Illustration" ORDER="22" DMDID="c027"
-							LABEL="November">
+						<div ID="L.1.1.5.3.22" TYPE="Illustration" ORDER="22" DMDID="c027" LABEL="November">
 							<div ID="L.1.1.5.25.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00002"/>
@@ -4481,8 +4217,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.23" TYPE="Illustration" ORDER="23" DMDID="c028"
-							LABEL="December">
+						<div ID="L.1.1.5.3.23" TYPE="Illustration" ORDER="23" DMDID="c028" LABEL="December">
 							<div ID="L.1.1.5.26.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00002"/>
@@ -4504,8 +4239,7 @@
 								</fptr>
 							</div>
 						</div>
-						<div ID="L.1.1.5.3.24" TYPE="Illustration" ORDER="24" DMDID="c029"
-							LABEL="December">
+						<div ID="L.1.1.5.3.24" TYPE="Illustration" ORDER="24" DMDID="c029" LABEL="December">
 							<div ID="L.1.1.5.27.1" TYPE="Head">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1902/01/15_01/bmtnabf_1902-01-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/01/15_01/bmtnabf_1902-01-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-01-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-01-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-01-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/02/01_01/bmtnabf_1902-02-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/02/01_01/bmtnabf_1902-02-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-02-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-02-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-02-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/02/15_01/bmtnabf_1902-02-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/02/15_01/bmtnabf_1902-02-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-02-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-02-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-02-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/03/01_01/bmtnabf_1902-03-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/03/01_01/bmtnabf_1902-03-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-03-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-03-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-03-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/04/01_01/bmtnabf_1902-04-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/04/01_01/bmtnabf_1902-04-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-04-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-04-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-04-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/04/15_01/bmtnabf_1902-04-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/04/15_01/bmtnabf_1902-04-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-04-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-04-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-04-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/05/01_01/bmtnabf_1902-05-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/05/01_01/bmtnabf_1902-05-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-05-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-05-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-05-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/05/15_01/bmtnabf_1902-05-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/05/15_01/bmtnabf_1902-05-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-05-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-05-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-05-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-05-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-05-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2146,306 +2140,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:54:12"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="8e74c941f85abf5cc4d85372eeb36f0ab13527b9"
-				CHECKSUMTYPE="SHA-1" SIZE="6176827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T18:54:12" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="8e74c941f85abf5cc4d85372eeb36f0ab13527b9" CHECKSUMTYPE="SHA-1" SIZE="6176827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:54:43"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="8dca32cc631dda9c20038be091f496a2745a2d51"
-				CHECKSUMTYPE="SHA-1" SIZE="6133628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T18:54:43" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="8dca32cc631dda9c20038be091f496a2745a2d51" CHECKSUMTYPE="SHA-1" SIZE="6133628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:55:15"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="78906f70d297c33b64420c5f476bd76df393eac6"
-				CHECKSUMTYPE="SHA-1" SIZE="6175921">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T18:55:15" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="78906f70d297c33b64420c5f476bd76df393eac6" CHECKSUMTYPE="SHA-1" SIZE="6175921">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:55:48"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="79ca71cbe4beb3c8dc2fe4e4995a9002f8617c9a"
-				CHECKSUMTYPE="SHA-1" SIZE="6133620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T18:55:48" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="79ca71cbe4beb3c8dc2fe4e4995a9002f8617c9a" CHECKSUMTYPE="SHA-1" SIZE="6133620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:56:19"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2ae6054897a2121cb75c41678bb5abfd7d2956d5"
-				CHECKSUMTYPE="SHA-1" SIZE="6118308">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T18:56:19" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2ae6054897a2121cb75c41678bb5abfd7d2956d5" CHECKSUMTYPE="SHA-1" SIZE="6118308">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:56:51"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="af3da7ee980fb1170202205d5ddfb9c3dc9b50b1"
-				CHECKSUMTYPE="SHA-1" SIZE="6131821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T18:56:51" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="af3da7ee980fb1170202205d5ddfb9c3dc9b50b1" CHECKSUMTYPE="SHA-1" SIZE="6131821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:57:21"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="dd2ac292e20c8a037fd4e31cc85e6c77f2aeb5d6"
-				CHECKSUMTYPE="SHA-1" SIZE="6118321">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T18:57:21" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="dd2ac292e20c8a037fd4e31cc85e6c77f2aeb5d6" CHECKSUMTYPE="SHA-1" SIZE="6118321">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:57:51"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="ee06daa68616efce658a116e2374fc06c98e0762"
-				CHECKSUMTYPE="SHA-1" SIZE="6131823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T18:57:51" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="ee06daa68616efce658a116e2374fc06c98e0762" CHECKSUMTYPE="SHA-1" SIZE="6131823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:58:22"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="1b04723d07cf41c1bb577a04877abdd908bb7335"
-				CHECKSUMTYPE="SHA-1" SIZE="6119208">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T18:58:22" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="1b04723d07cf41c1bb577a04877abdd908bb7335" CHECKSUMTYPE="SHA-1" SIZE="6119208">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:58:56"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="4f85002136714f2968b3a38334a3daee8df98134"
-				CHECKSUMTYPE="SHA-1" SIZE="6131809">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T18:58:56" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="4f85002136714f2968b3a38334a3daee8df98134" CHECKSUMTYPE="SHA-1" SIZE="6131809">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:59:27"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f269620434d9d27327300dda9841f3ea1e77057b"
-				CHECKSUMTYPE="SHA-1" SIZE="6119225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T18:59:27" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f269620434d9d27327300dda9841f3ea1e77057b" CHECKSUMTYPE="SHA-1" SIZE="6119225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:59:56"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="848f82bed2db2aa4e8c7e21539346784f9541808"
-				CHECKSUMTYPE="SHA-1" SIZE="6131826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T18:59:56" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="848f82bed2db2aa4e8c7e21539346784f9541808" CHECKSUMTYPE="SHA-1" SIZE="6131826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:00:25"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="7a428808ade46ba7af48b2747aeb965f520a9b72"
-				CHECKSUMTYPE="SHA-1" SIZE="6119229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:00:25" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="7a428808ade46ba7af48b2747aeb965f520a9b72" CHECKSUMTYPE="SHA-1" SIZE="6119229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:00:52"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="2e967aea5416142f57e99bd35a0df1fa5d64bdaa"
-				CHECKSUMTYPE="SHA-1" SIZE="6131827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:00:52" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="2e967aea5416142f57e99bd35a0df1fa5d64bdaa" CHECKSUMTYPE="SHA-1" SIZE="6131827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:01:20"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="1ae2f673ea66d7d78d3d8e618f481595385585cf"
-				CHECKSUMTYPE="SHA-1" SIZE="6118325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:01:20" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="1ae2f673ea66d7d78d3d8e618f481595385585cf" CHECKSUMTYPE="SHA-1" SIZE="6118325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:01:50"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="6b9f6abd7f26dd0b2eef3139f650274837c20508"
-				CHECKSUMTYPE="SHA-1" SIZE="6131829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:01:50" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="6b9f6abd7f26dd0b2eef3139f650274837c20508" CHECKSUMTYPE="SHA-1" SIZE="6131829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:02:21"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="20ffe630bb9c4d5a482c28b04cd307e20df34d1d"
-				CHECKSUMTYPE="SHA-1" SIZE="6118329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:02:21" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="20ffe630bb9c4d5a482c28b04cd307e20df34d1d" CHECKSUMTYPE="SHA-1" SIZE="6118329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:02:48"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="179c24e5899640a863fd12543407f8d3fc420154"
-				CHECKSUMTYPE="SHA-1" SIZE="6131829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:02:48" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="179c24e5899640a863fd12543407f8d3fc420154" CHECKSUMTYPE="SHA-1" SIZE="6131829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:03:17"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="1382bc9adc060ef462ded66d24597af51a12efd5"
-				CHECKSUMTYPE="SHA-1" SIZE="6119228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:03:17" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="1382bc9adc060ef462ded66d24597af51a12efd5" CHECKSUMTYPE="SHA-1" SIZE="6119228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:03:46"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="9fd7e80bcc298f4cabeca8d395354a4ab1e67a02"
-				CHECKSUMTYPE="SHA-1" SIZE="6131825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:03:46" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="9fd7e80bcc298f4cabeca8d395354a4ab1e67a02" CHECKSUMTYPE="SHA-1" SIZE="6131825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:04:18"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="eebe4d725c3dfaad90d31465d951dd69d8df8148"
-				CHECKSUMTYPE="SHA-1" SIZE="6119213">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:04:18" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="eebe4d725c3dfaad90d31465d951dd69d8df8148" CHECKSUMTYPE="SHA-1" SIZE="6119213">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:04:48"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="73a3c23e704890f0e8fe1559147d9b57ac857d7e"
-				CHECKSUMTYPE="SHA-1" SIZE="6188528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:04:48" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="73a3c23e704890f0e8fe1559147d9b57ac857d7e" CHECKSUMTYPE="SHA-1" SIZE="6188528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:05:18"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="45e829cc0bd3a137267b7846c3a625d5626ed225"
-				CHECKSUMTYPE="SHA-1" SIZE="6090335">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:05:18" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="45e829cc0bd3a137267b7846c3a625d5626ed225" CHECKSUMTYPE="SHA-1" SIZE="6090335">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:05:51"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="0a123a637eb830c4eeca17a669238119080172e9"
-				CHECKSUMTYPE="SHA-1" SIZE="6188507">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:05:51" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="0a123a637eb830c4eeca17a669238119080172e9" CHECKSUMTYPE="SHA-1" SIZE="6188507">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/delivery/bmtnabf_1902-05-15_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:06:08" MIMETYPE="text/xml"
-				CHECKSUM="53f2f97e8b953e5420d48eb5a16d0c86a1d1451b" CHECKSUMTYPE="SHA-1" SIZE="4647">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:06:08" MIMETYPE="text/xml" CHECKSUM="53f2f97e8b953e5420d48eb5a16d0c86a1d1451b" CHECKSUMTYPE="SHA-1" SIZE="4647">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:06:08" MIMETYPE="text/xml"
-				CHECKSUM="23d3160fd1ff1d6624a2389aac84b35894037194" CHECKSUMTYPE="SHA-1"
-				SIZE="45091">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:06:08" MIMETYPE="text/xml" CHECKSUM="23d3160fd1ff1d6624a2389aac84b35894037194" CHECKSUMTYPE="SHA-1" SIZE="45091">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:06:09" MIMETYPE="text/xml"
-				CHECKSUM="16dd42db18e6ef877d3bd8c2d71e0fa421be7a42" CHECKSUMTYPE="SHA-1" SIZE="8441">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:06:09" MIMETYPE="text/xml" CHECKSUM="16dd42db18e6ef877d3bd8c2d71e0fa421be7a42" CHECKSUMTYPE="SHA-1" SIZE="8441">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:06:09" MIMETYPE="text/xml"
-				CHECKSUM="89e3ab505bc8e094b334441b3adc69cd3d8b1543" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:06:09" MIMETYPE="text/xml" CHECKSUM="89e3ab505bc8e094b334441b3adc69cd3d8b1543" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:06:09" MIMETYPE="text/xml"
-				CHECKSUM="0698fbe0aad163b141f44de4406384f6a5ac3794" CHECKSUMTYPE="SHA-1" SIZE="1715">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:06:09" MIMETYPE="text/xml" CHECKSUM="0698fbe0aad163b141f44de4406384f6a5ac3794" CHECKSUMTYPE="SHA-1" SIZE="1715">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:06:09" MIMETYPE="text/xml"
-				CHECKSUM="fc3cd0110fb4ae0af7e471e9cf904392e6727254" CHECKSUMTYPE="SHA-1" SIZE="2103">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:06:09" MIMETYPE="text/xml" CHECKSUM="fc3cd0110fb4ae0af7e471e9cf904392e6727254" CHECKSUMTYPE="SHA-1" SIZE="2103">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:06:10" MIMETYPE="text/xml"
-				CHECKSUM="ec1a38c4552ee62a30b7d8d6a7669dfc053f1361" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:06:10" MIMETYPE="text/xml" CHECKSUM="ec1a38c4552ee62a30b7d8d6a7669dfc053f1361" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:06:10" MIMETYPE="text/xml"
-				CHECKSUM="f39cc1456435e5d22ae82a9a44f339306af10fc1" CHECKSUMTYPE="SHA-1" SIZE="3554">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:06:10" MIMETYPE="text/xml" CHECKSUM="f39cc1456435e5d22ae82a9a44f339306af10fc1" CHECKSUMTYPE="SHA-1" SIZE="3554">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:06:10" MIMETYPE="text/xml"
-				CHECKSUM="65eccc24e52ac035ff2acd9d3723782d238c287f" CHECKSUMTYPE="SHA-1" SIZE="4647">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:06:10" MIMETYPE="text/xml" CHECKSUM="65eccc24e52ac035ff2acd9d3723782d238c287f" CHECKSUMTYPE="SHA-1" SIZE="4647">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:06:10" MIMETYPE="text/xml"
-				CHECKSUM="ea0fa19897d4a422d67268bf9d8da238c8b1fe19" CHECKSUMTYPE="SHA-1" SIZE="4890">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:06:10" MIMETYPE="text/xml" CHECKSUM="ea0fa19897d4a422d67268bf9d8da238c8b1fe19" CHECKSUMTYPE="SHA-1" SIZE="4890">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:06:10" MIMETYPE="text/xml"
-				CHECKSUM="474cd614ba5584ad7cddf865a527813afc11a61f" CHECKSUMTYPE="SHA-1" SIZE="4901">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:06:10" MIMETYPE="text/xml" CHECKSUM="474cd614ba5584ad7cddf865a527813afc11a61f" CHECKSUMTYPE="SHA-1" SIZE="4901">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:06:11" MIMETYPE="text/xml"
-				CHECKSUM="88a195c057896f5e46024075bd8394d6653ee332" CHECKSUMTYPE="SHA-1" SIZE="4890">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:06:11" MIMETYPE="text/xml" CHECKSUM="88a195c057896f5e46024075bd8394d6653ee332" CHECKSUMTYPE="SHA-1" SIZE="4890">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:06:11" MIMETYPE="text/xml"
-				CHECKSUM="c153d5eee2fc7ca2e8396b19acebaba4512280df" CHECKSUMTYPE="SHA-1" SIZE="4901">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:06:11" MIMETYPE="text/xml" CHECKSUM="c153d5eee2fc7ca2e8396b19acebaba4512280df" CHECKSUMTYPE="SHA-1" SIZE="4901">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:06:13" MIMETYPE="text/xml"
-				CHECKSUM="faf6796c74a3f298037b4443c85a3589edc917b7" CHECKSUMTYPE="SHA-1" SIZE="4129">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:06:13" MIMETYPE="text/xml" CHECKSUM="faf6796c74a3f298037b4443c85a3589edc917b7" CHECKSUMTYPE="SHA-1" SIZE="4129">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:06:13" MIMETYPE="text/xml"
-				CHECKSUM="ac91751e77aa6e25eba012825723942e39e6f20e" CHECKSUMTYPE="SHA-1" SIZE="4133">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:06:13" MIMETYPE="text/xml" CHECKSUM="ac91751e77aa6e25eba012825723942e39e6f20e" CHECKSUMTYPE="SHA-1" SIZE="4133">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:06:14" MIMETYPE="text/xml"
-				CHECKSUM="aab128ececa8abd1b7810b86789261a135b2e435" CHECKSUMTYPE="SHA-1" SIZE="4129">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:06:14" MIMETYPE="text/xml" CHECKSUM="aab128ececa8abd1b7810b86789261a135b2e435" CHECKSUMTYPE="SHA-1" SIZE="4129">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:06:14" MIMETYPE="text/xml"
-				CHECKSUM="b1015d04f56e4796f93e7419c92478a641c4fef9" CHECKSUMTYPE="SHA-1" SIZE="4131">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:06:14" MIMETYPE="text/xml" CHECKSUM="b1015d04f56e4796f93e7419c92478a641c4fef9" CHECKSUMTYPE="SHA-1" SIZE="4131">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:06:14" MIMETYPE="text/xml"
-				CHECKSUM="f81595ec944d5ae99cf063748d464489b9bd0fe5" CHECKSUMTYPE="SHA-1" SIZE="4129">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:06:14" MIMETYPE="text/xml" CHECKSUM="f81595ec944d5ae99cf063748d464489b9bd0fe5" CHECKSUMTYPE="SHA-1" SIZE="4129">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:06:14" MIMETYPE="text/xml"
-				CHECKSUM="99e29a38362e677d02221d3453bb82329324b99e" CHECKSUMTYPE="SHA-1" SIZE="4383">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:06:14" MIMETYPE="text/xml" CHECKSUM="99e29a38362e677d02221d3453bb82329324b99e" CHECKSUMTYPE="SHA-1" SIZE="4383">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:06:15" MIMETYPE="text/xml"
-				CHECKSUM="c0f36c034c75880e50ecce10807796436f7f9598" CHECKSUMTYPE="SHA-1" SIZE="4122">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:06:15" MIMETYPE="text/xml" CHECKSUM="c0f36c034c75880e50ecce10807796436f7f9598" CHECKSUMTYPE="SHA-1" SIZE="4122">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:06:15" MIMETYPE="text/xml"
-				CHECKSUM="716978ff4bcf237cde67439b8a8dea0aed038287" CHECKSUMTYPE="SHA-1" SIZE="8434">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:06:15" MIMETYPE="text/xml" CHECKSUM="716978ff4bcf237cde67439b8a8dea0aed038287" CHECKSUMTYPE="SHA-1" SIZE="8434">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:06:15" MIMETYPE="text/xml"
-				CHECKSUM="9b30d98d5bd9b0042d219546163911bc41927008" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:06:15" MIMETYPE="text/xml" CHECKSUM="9b30d98d5bd9b0042d219546163911bc41927008" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:06:15" MIMETYPE="text/xml"
-				CHECKSUM="1346963918af6d0fe9b307af2d81e9b57f4ab220" CHECKSUMTYPE="SHA-1"
-				SIZE="20118">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:06:15" MIMETYPE="text/xml" CHECKSUM="1346963918af6d0fe9b307af2d81e9b57f4ab220" CHECKSUMTYPE="SHA-1" SIZE="20118">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:06:16" MIMETYPE="text/xml"
-				CHECKSUM="7630864445141bf4166e04c06897e16d1195b0ee" CHECKSUMTYPE="SHA-1" SIZE="7938">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:06:16" MIMETYPE="text/xml" CHECKSUM="7630864445141bf4166e04c06897e16d1195b0ee" CHECKSUMTYPE="SHA-1" SIZE="7938">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-05-15_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:06:37" MIMETYPE="application/pdf"
-				CHECKSUM="2a04e0d65fb8b63e09fe8b45988dc740cf998591" CHECKSUMTYPE="SHA-1"
-				SIZE="4712399">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/bmtnabf_1902-05-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:06:37" MIMETYPE="application/pdf" CHECKSUM="2a04e0d65fb8b63e09fe8b45988dc740cf998591" CHECKSUMTYPE="SHA-1" SIZE="4712399">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/05/15_01/bmtnabf_1902-05-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2748,8 +2592,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005"
-					LABEL="Studie zu einer Furie">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005" LABEL="Studie zu einer Furie">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
@@ -2766,8 +2609,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c006"
-					LABEL="Studie zum Bilde &#34;Die Furien&#34;">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c006" LABEL="Studie zum Bilde &#34;Die Furien&#34;">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
@@ -2784,8 +2626,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c007"
-					LABEL="Studie zum Bilde &#34;Die Furien&#34;">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c007" LABEL="Studie zum Bilde &#34;Die Furien&#34;">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
@@ -2802,8 +2643,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="8" DMDID="c008"
-					LABEL="Studie zum Bilde &#34;Die Furien&#34;">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="8" DMDID="c008" LABEL="Studie zum Bilde &#34;Die Furien&#34;">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
@@ -2820,8 +2660,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="9" DMDID="c009"
-					LABEL="Studie zum Bilde &#34;Die Furien&#34;">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="9" DMDID="c009" LABEL="Studie zum Bilde &#34;Die Furien&#34;">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>

--- a/metadata/periodicals/bmtnabf/issues/1902/06/01_01/bmtnabf_1902-06-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/06/01_01/bmtnabf_1902-06-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-06-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-06-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-06-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/06/15_01/bmtnabf_1902-06-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/06/15_01/bmtnabf_1902-06-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-06-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-06-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-06-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/07/01_01/bmtnabf_1902-07-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/07/01_01/bmtnabf_1902-07-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-07-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-07-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-07-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/07/15_01/bmtnabf_1902-07-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/07/15_01/bmtnabf_1902-07-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-07-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-07-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-07-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-07-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-07-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2149,313 +2143,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:01:28"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="9b7f3fdf8d5d030a85ad5ef8817fa0ae88ab3075"
-				CHECKSUMTYPE="SHA-1" SIZE="6134526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:01:28" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="9b7f3fdf8d5d030a85ad5ef8817fa0ae88ab3075" CHECKSUMTYPE="SHA-1" SIZE="6134526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:01:59"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="e60cac692e0871a6a5e82e5818a5b4a9645217c6"
-				CHECKSUMTYPE="SHA-1" SIZE="6120129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:01:59" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="e60cac692e0871a6a5e82e5818a5b4a9645217c6" CHECKSUMTYPE="SHA-1" SIZE="6120129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:02:31"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="ddfe7abe173c3b191cb28b21cbb5f599d51a40d4"
-				CHECKSUMTYPE="SHA-1" SIZE="6211025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:02:31" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="ddfe7abe173c3b191cb28b21cbb5f599d51a40d4" CHECKSUMTYPE="SHA-1" SIZE="6211025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:03:06"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="64ef2bf112a1c00b3b3e2c254048a0a23bc1e62c"
-				CHECKSUMTYPE="SHA-1" SIZE="6120129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:03:06" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="64ef2bf112a1c00b3b3e2c254048a0a23bc1e62c" CHECKSUMTYPE="SHA-1" SIZE="6120129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:03:39"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="7517b1faec7a5d270694fa2c148831abf2851830"
-				CHECKSUMTYPE="SHA-1" SIZE="6193923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:03:39" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="7517b1faec7a5d270694fa2c148831abf2851830" CHECKSUMTYPE="SHA-1" SIZE="6193923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:04:07"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="42bdf1b2f790dd04cb275c8b26496850a9aca5ce"
-				CHECKSUMTYPE="SHA-1" SIZE="6119203">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:04:07" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="42bdf1b2f790dd04cb275c8b26496850a9aca5ce" CHECKSUMTYPE="SHA-1" SIZE="6119203">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:04:43"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="c3f671e20c032a3ec69f8b4071e861b475be7e19"
-				CHECKSUMTYPE="SHA-1" SIZE="6193928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:04:43" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="c3f671e20c032a3ec69f8b4071e861b475be7e19" CHECKSUMTYPE="SHA-1" SIZE="6193928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:05:15"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="96701cc4c8d0695e1a617768eb8fc9ff4897ada2"
-				CHECKSUMTYPE="SHA-1" SIZE="6119190">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:05:15" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="96701cc4c8d0695e1a617768eb8fc9ff4897ada2" CHECKSUMTYPE="SHA-1" SIZE="6119190">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:05:45"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f7143ec0cf0dafa870e9c87c4ac47bd05f03f810"
-				CHECKSUMTYPE="SHA-1" SIZE="6131799">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:05:45" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f7143ec0cf0dafa870e9c87c4ac47bd05f03f810" CHECKSUMTYPE="SHA-1" SIZE="6131799">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:06:15"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="cbde0a6dbb51e3651d78460e088f047622cff562"
-				CHECKSUMTYPE="SHA-1" SIZE="6119211">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:06:15" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="cbde0a6dbb51e3651d78460e088f047622cff562" CHECKSUMTYPE="SHA-1" SIZE="6119211">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:06:46"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="5a47c9fea4e3869735b6749169781425eaf9b736"
-				CHECKSUMTYPE="SHA-1" SIZE="6108428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:06:46" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="5a47c9fea4e3869735b6749169781425eaf9b736" CHECKSUMTYPE="SHA-1" SIZE="6108428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:07:16"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="a6a7026c6abaf986be8b6c13e9b4bdb70b34cff5"
-				CHECKSUMTYPE="SHA-1" SIZE="6119215">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:07:16" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="a6a7026c6abaf986be8b6c13e9b4bdb70b34cff5" CHECKSUMTYPE="SHA-1" SIZE="6119215">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:07:45"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="c32679d9eeb8e35f305048040941efd305130439"
-				CHECKSUMTYPE="SHA-1" SIZE="6108429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:07:45" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="c32679d9eeb8e35f305048040941efd305130439" CHECKSUMTYPE="SHA-1" SIZE="6108429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:08:19"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="6b2a1e2bcaa9e9cb0b7c1dbe6a3c31dd34e8aafc"
-				CHECKSUMTYPE="SHA-1" SIZE="6164229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:08:19" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="6b2a1e2bcaa9e9cb0b7c1dbe6a3c31dd34e8aafc" CHECKSUMTYPE="SHA-1" SIZE="6164229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:08:47"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="9d89ea061ca840af0b4fe25df1f3572594692170"
-				CHECKSUMTYPE="SHA-1" SIZE="6107529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:08:47" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="9d89ea061ca840af0b4fe25df1f3572594692170" CHECKSUMTYPE="SHA-1" SIZE="6107529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:09:17"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="4fcd2b7b7fc83e629026d1b447407ee9f919ebd8"
-				CHECKSUMTYPE="SHA-1" SIZE="6164213">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:09:17" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="4fcd2b7b7fc83e629026d1b447407ee9f919ebd8" CHECKSUMTYPE="SHA-1" SIZE="6164213">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:09:48"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="309d03fbdbcdccd6af1f7109eb4b351b1854cbcd"
-				CHECKSUMTYPE="SHA-1" SIZE="6108429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:09:48" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="309d03fbdbcdccd6af1f7109eb4b351b1854cbcd" CHECKSUMTYPE="SHA-1" SIZE="6108429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:10:19"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="4aa667da7436c2405f7afa1e7d5805edb82e1f47"
-				CHECKSUMTYPE="SHA-1" SIZE="6199326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:10:19" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="4aa667da7436c2405f7afa1e7d5805edb82e1f47" CHECKSUMTYPE="SHA-1" SIZE="6199326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:10:50"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="a4ccffbfbe811ac0866d755c0a742f1e7ead14c4"
-				CHECKSUMTYPE="SHA-1" SIZE="6108428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:10:50" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="a4ccffbfbe811ac0866d755c0a742f1e7ead14c4" CHECKSUMTYPE="SHA-1" SIZE="6108428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:11:21"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="d5f0524341ac0de69a4cb8430c3f7acc9ffc7ce5"
-				CHECKSUMTYPE="SHA-1" SIZE="6199329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:11:21" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="d5f0524341ac0de69a4cb8430c3f7acc9ffc7ce5" CHECKSUMTYPE="SHA-1" SIZE="6199329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:11:53"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="51602f1dbab86a836914f45b1ec24b1355b92293"
-				CHECKSUMTYPE="SHA-1" SIZE="6108425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:11:53" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="51602f1dbab86a836914f45b1ec24b1355b92293" CHECKSUMTYPE="SHA-1" SIZE="6108425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:12:22"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="c3d9f84265bfd937c287c8718cea2b5976efb8c6"
-				CHECKSUMTYPE="SHA-1" SIZE="6255126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:12:22" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="c3d9f84265bfd937c287c8718cea2b5976efb8c6" CHECKSUMTYPE="SHA-1" SIZE="6255126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:12:52"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="21e3767b822097593209b11b9c2ccd31ebbe1928"
-				CHECKSUMTYPE="SHA-1" SIZE="5968028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:12:52" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="21e3767b822097593209b11b9c2ccd31ebbe1928" CHECKSUMTYPE="SHA-1" SIZE="5968028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:13:22"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="fae37fff3ed0385f99b4b7d3ddbf21a04288a063"
-				CHECKSUMTYPE="SHA-1" SIZE="6194824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:13:22" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="fae37fff3ed0385f99b4b7d3ddbf21a04288a063" CHECKSUMTYPE="SHA-1" SIZE="6194824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/delivery/bmtnabf_1902-07-15_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:13:41" MIMETYPE="text/xml"
-				CHECKSUM="ee5ca1b9c573fd8f3fe485081e67ff7d3bc7e70d" CHECKSUMTYPE="SHA-1" SIZE="4907">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:13:41" MIMETYPE="text/xml" CHECKSUM="ee5ca1b9c573fd8f3fe485081e67ff7d3bc7e70d" CHECKSUMTYPE="SHA-1" SIZE="4907">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:13:41" MIMETYPE="text/xml"
-				CHECKSUM="371846f1486ac539bb6891859737f0f6b3c65b2f" CHECKSUMTYPE="SHA-1"
-				SIZE="45553">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:13:41" MIMETYPE="text/xml" CHECKSUM="371846f1486ac539bb6891859737f0f6b3c65b2f" CHECKSUMTYPE="SHA-1" SIZE="45553">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:13:41" MIMETYPE="text/xml"
-				CHECKSUM="f1eb950d8affdb17d0e7fd21eb0c3b147ce6db74" CHECKSUMTYPE="SHA-1" SIZE="8361">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:13:41" MIMETYPE="text/xml" CHECKSUM="f1eb950d8affdb17d0e7fd21eb0c3b147ce6db74" CHECKSUMTYPE="SHA-1" SIZE="8361">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:13:41" MIMETYPE="text/xml"
-				CHECKSUM="40b3aae826146a06f15f526cca400cbcfd690a86" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:13:41" MIMETYPE="text/xml" CHECKSUM="40b3aae826146a06f15f526cca400cbcfd690a86" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:13:42" MIMETYPE="text/xml"
-				CHECKSUM="b535e4716325306195671b724ab183ab8f36310f" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:13:42" MIMETYPE="text/xml" CHECKSUM="b535e4716325306195671b724ab183ab8f36310f" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:13:42" MIMETYPE="text/xml"
-				CHECKSUM="faacb2ec8ad0e444c55f56cbe9448c906bace81a" CHECKSUMTYPE="SHA-1" SIZE="2117">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:13:42" MIMETYPE="text/xml" CHECKSUM="faacb2ec8ad0e444c55f56cbe9448c906bace81a" CHECKSUMTYPE="SHA-1" SIZE="2117">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:13:42" MIMETYPE="text/xml"
-				CHECKSUM="ebb33d213c999d2e4106757dbd311d5d6ed3a3b2" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:13:42" MIMETYPE="text/xml" CHECKSUM="ebb33d213c999d2e4106757dbd311d5d6ed3a3b2" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:13:42" MIMETYPE="text/xml"
-				CHECKSUM="0c99d76c76496a3b8be9a5c6e26913c9454825cc" CHECKSUMTYPE="SHA-1" SIZE="2937">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:13:42" MIMETYPE="text/xml" CHECKSUM="0c99d76c76496a3b8be9a5c6e26913c9454825cc" CHECKSUMTYPE="SHA-1" SIZE="2937">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:13:43" MIMETYPE="text/xml"
-				CHECKSUM="6e68f3f5e6f159d1a4e9c9da8c3d230cf286a736" CHECKSUMTYPE="SHA-1" SIZE="4305">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:13:43" MIMETYPE="text/xml" CHECKSUM="6e68f3f5e6f159d1a4e9c9da8c3d230cf286a736" CHECKSUMTYPE="SHA-1" SIZE="4305">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:13:43" MIMETYPE="text/xml"
-				CHECKSUM="bb36d0b658f2652e99fd9ce6382de22c3fab1ce8" CHECKSUMTYPE="SHA-1" SIZE="4703">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:13:43" MIMETYPE="text/xml" CHECKSUM="bb36d0b658f2652e99fd9ce6382de22c3fab1ce8" CHECKSUMTYPE="SHA-1" SIZE="4703">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:13:43" MIMETYPE="text/xml"
-				CHECKSUM="e790403b89b5d1f90f5c839b7ba36293b703a30e" CHECKSUMTYPE="SHA-1"
-				SIZE="44057">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:13:43" MIMETYPE="text/xml" CHECKSUM="e790403b89b5d1f90f5c839b7ba36293b703a30e" CHECKSUMTYPE="SHA-1" SIZE="44057">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:13:43" MIMETYPE="text/xml"
-				CHECKSUM="aaba6863d02de1d0f9f9d153de53795d189a35e8" CHECKSUMTYPE="SHA-1"
-				SIZE="46828">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:13:43" MIMETYPE="text/xml" CHECKSUM="aaba6863d02de1d0f9f9d153de53795d189a35e8" CHECKSUMTYPE="SHA-1" SIZE="46828">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:13:44" MIMETYPE="text/xml"
-				CHECKSUM="d1d1726aef617740ad6cb724f8df0ad9c51806f1" CHECKSUMTYPE="SHA-1"
-				SIZE="52664">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:13:44" MIMETYPE="text/xml" CHECKSUM="d1d1726aef617740ad6cb724f8df0ad9c51806f1" CHECKSUMTYPE="SHA-1" SIZE="52664">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:13:44" MIMETYPE="text/xml"
-				CHECKSUM="78cf38031797090ac16640113d176017579ff323" CHECKSUMTYPE="SHA-1"
-				SIZE="53408">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:13:44" MIMETYPE="text/xml" CHECKSUM="78cf38031797090ac16640113d176017579ff323" CHECKSUMTYPE="SHA-1" SIZE="53408">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:13:44" MIMETYPE="text/xml"
-				CHECKSUM="171c6f60092541810b8730aca4397ee32450df51" CHECKSUMTYPE="SHA-1" SIZE="4163">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:13:44" MIMETYPE="text/xml" CHECKSUM="171c6f60092541810b8730aca4397ee32450df51" CHECKSUMTYPE="SHA-1" SIZE="4163">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:13:46" MIMETYPE="text/xml"
-				CHECKSUM="700977a690f3eebce8ee3d72728be9984acea932" CHECKSUMTYPE="SHA-1"
-				SIZE="20482">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:13:46" MIMETYPE="text/xml" CHECKSUM="700977a690f3eebce8ee3d72728be9984acea932" CHECKSUMTYPE="SHA-1" SIZE="20482">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:13:46" MIMETYPE="text/xml"
-				CHECKSUM="74e704f4335e1c6bd53ea3bf4a85025b8760b7e8" CHECKSUMTYPE="SHA-1"
-				SIZE="19489">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:13:46" MIMETYPE="text/xml" CHECKSUM="74e704f4335e1c6bd53ea3bf4a85025b8760b7e8" CHECKSUMTYPE="SHA-1" SIZE="19489">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:13:47" MIMETYPE="text/xml"
-				CHECKSUM="1c4132b95b608533a138cb783a3615d77ce87cd3" CHECKSUMTYPE="SHA-1"
-				SIZE="22865">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:13:47" MIMETYPE="text/xml" CHECKSUM="1c4132b95b608533a138cb783a3615d77ce87cd3" CHECKSUMTYPE="SHA-1" SIZE="22865">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:13:47" MIMETYPE="text/xml"
-				CHECKSUM="2d16bc07650281d1baa00706c50583d7f4ed543f" CHECKSUMTYPE="SHA-1" SIZE="3966">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:13:47" MIMETYPE="text/xml" CHECKSUM="2d16bc07650281d1baa00706c50583d7f4ed543f" CHECKSUMTYPE="SHA-1" SIZE="3966">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:13:47" MIMETYPE="text/xml"
-				CHECKSUM="395053f46d07c6d53e13ad4cd65e47b123c2765e" CHECKSUMTYPE="SHA-1" SIZE="4337">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:13:47" MIMETYPE="text/xml" CHECKSUM="395053f46d07c6d53e13ad4cd65e47b123c2765e" CHECKSUMTYPE="SHA-1" SIZE="4337">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:13:47" MIMETYPE="text/xml"
-				CHECKSUM="59fc8bc5ab788e2e391e2e326c16f7eb38ce3783" CHECKSUMTYPE="SHA-1" SIZE="2014">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:13:47" MIMETYPE="text/xml" CHECKSUM="59fc8bc5ab788e2e391e2e326c16f7eb38ce3783" CHECKSUMTYPE="SHA-1" SIZE="2014">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:13:48" MIMETYPE="text/xml"
-				CHECKSUM="19a8609bf23f09b61f82ff6980d6da37b4a55ca1" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:13:48" MIMETYPE="text/xml" CHECKSUM="19a8609bf23f09b61f82ff6980d6da37b4a55ca1" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:13:48" MIMETYPE="text/xml"
-				CHECKSUM="138af26f5b7f6607addec6e476e39d4777aee4d1" CHECKSUMTYPE="SHA-1"
-				SIZE="20002">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:13:48" MIMETYPE="text/xml" CHECKSUM="138af26f5b7f6607addec6e476e39d4777aee4d1" CHECKSUMTYPE="SHA-1" SIZE="20002">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:13:48" MIMETYPE="text/xml"
-				CHECKSUM="58289f9ae2d01230aec27dea5302cc260c510568" CHECKSUMTYPE="SHA-1" SIZE="8283">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:13:48" MIMETYPE="text/xml" CHECKSUM="58289f9ae2d01230aec27dea5302cc260c510568" CHECKSUMTYPE="SHA-1" SIZE="8283">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-07-15_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:14:11" MIMETYPE="application/pdf"
-				CHECKSUM="a8704c0f10985074a1db7884acfca8c569c73ad4" CHECKSUMTYPE="SHA-1"
-				SIZE="6071978">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/bmtnabf_1902-07-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:14:11" MIMETYPE="application/pdf" CHECKSUM="a8704c0f10985074a1db7884acfca8c569c73ad4" CHECKSUMTYPE="SHA-1" SIZE="6071978">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/07/15_01/bmtnabf_1902-07-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2746,8 +2583,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004"
-					LABEL="ORIGINAL-HOLZSCHNITT">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004" LABEL="ORIGINAL-HOLZSCHNITT">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00001"/>
@@ -2764,8 +2600,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c005"
-					LABEL="Badendes Mädchen">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c005" LABEL="Badendes Mädchen">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
@@ -2782,8 +2617,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c006"
-					LABEL="Studie zu einer Furie">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c006" LABEL="Studie zu einer Furie">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
@@ -2800,8 +2634,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="TextContent" ORDER="6" DMDID="c007"
-					LABEL="ZUR PSYCHOLOGIE DER ORGEL">
+				<div ID="L.1.1.8" TYPE="TextContent" ORDER="6" DMDID="c007" LABEL="ZUR PSYCHOLOGIE DER ORGEL">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -2824,40 +2657,35 @@
 							<div ID="L.1.1.8.4.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.8.4.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.8.4.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.8.4.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.8.4.1.3" TYPE="Paragraph" ORDER="3">
 								<div ID="L.1.1.8.4.1.3.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.8.4.1.4" TYPE="Paragraph" ORDER="4">
 								<div ID="L.1.1.8.4.1.4.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c009"
-					LABEL="Original-Zeichnung">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c009" LABEL="Original-Zeichnung">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -2890,15 +2718,13 @@
 							<div ID="L.1.1.10.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.10.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="1" DMDID="c011"
-						LABEL="Umrahmung">
+					<div ID="L.1.1.10.4" TYPE="Illustration" ORDER="1" DMDID="c011" LABEL="Umrahmung">
 						<div ID="L.1.1.10.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00005"/>
@@ -2932,15 +2758,13 @@
 							<div ID="L.1.1.11.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.11.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.11.4" TYPE="Illustration" ORDER="1" DMDID="c013"
-						LABEL="Umrahmung">
+					<div ID="L.1.1.11.4" TYPE="Illustration" ORDER="1" DMDID="c013" LABEL="Umrahmung">
 						<div ID="L.1.1.11.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00005"/>
@@ -2964,8 +2788,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.12.2" TYPE="Illustration" ORDER="1" DMDID="c015"
-						LABEL="[Initial]">
+					<div ID="L.1.1.12.2" TYPE="Illustration" ORDER="1" DMDID="c015" LABEL="[Initial]">
 						<div ID="L.1.1.12.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00002"/>
@@ -2977,8 +2800,7 @@
 							<div ID="L.1.1.12.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.12.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
 									</fptr>
 								</div>
 							</div>
@@ -3019,8 +2841,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c018"
-					LABEL="ORIGINAL-ZEICHNUNG">
+				<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c018" LABEL="ORIGINAL-ZEICHNUNG">
 					<div ID="L.1.1.14.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00003"/>

--- a/metadata/periodicals/bmtnabf/issues/1902/08/01_01/bmtnabf_1902-08-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/08/01_01/bmtnabf_1902-08-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-08-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-08-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-08-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-08-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-08-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2137,309 +2131,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:04:44"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="b030495a16c82230f894a1493430f5d165f94326"
-				CHECKSUMTYPE="SHA-1" SIZE="6215525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:04:44" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="b030495a16c82230f894a1493430f5d165f94326" CHECKSUMTYPE="SHA-1" SIZE="6215525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:05:19"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="ddcb3f2088f4b3e3bdb11f96c70e431c1b394d78"
-				CHECKSUMTYPE="SHA-1" SIZE="6157926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:05:19" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="ddcb3f2088f4b3e3bdb11f96c70e431c1b394d78" CHECKSUMTYPE="SHA-1" SIZE="6157926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:05:55"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c9ae1a1be1fdb52214096e098fbee174db90a5df"
-				CHECKSUMTYPE="SHA-1" SIZE="6215496">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:05:55" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c9ae1a1be1fdb52214096e098fbee174db90a5df" CHECKSUMTYPE="SHA-1" SIZE="6215496">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:06:35"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="74a35958e3af0753c5d5efe63f23aa3a217ad843"
-				CHECKSUMTYPE="SHA-1" SIZE="6157897">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:06:35" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="74a35958e3af0753c5d5efe63f23aa3a217ad843" CHECKSUMTYPE="SHA-1" SIZE="6157897">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:07:14"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="82d87d7b7916d32c933b19e1d4a0c876f8a72ad6"
-				CHECKSUMTYPE="SHA-1" SIZE="6215526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:07:14" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="82d87d7b7916d32c933b19e1d4a0c876f8a72ad6" CHECKSUMTYPE="SHA-1" SIZE="6215526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:07:48"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="7a715933713858f5b86c2569505daaa21374a7a1"
-				CHECKSUMTYPE="SHA-1" SIZE="6157922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:07:48" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="7a715933713858f5b86c2569505daaa21374a7a1" CHECKSUMTYPE="SHA-1" SIZE="6157922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:08:25"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="f9e59669825d8327de0844f0c4d87daddd247f36"
-				CHECKSUMTYPE="SHA-1" SIZE="6215509">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:08:25" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="f9e59669825d8327de0844f0c4d87daddd247f36" CHECKSUMTYPE="SHA-1" SIZE="6215509">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:09:01"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="c4aafecc3c05c2e5c2b85b007141f1a998dad697"
-				CHECKSUMTYPE="SHA-1" SIZE="6157923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:09:01" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="c4aafecc3c05c2e5c2b85b007141f1a998dad697" CHECKSUMTYPE="SHA-1" SIZE="6157923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:09:34"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="e570f9ee3e2dacb29f59e879dcc94c90d185b564"
-				CHECKSUMTYPE="SHA-1" SIZE="6215517">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:09:34" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="e570f9ee3e2dacb29f59e879dcc94c90d185b564" CHECKSUMTYPE="SHA-1" SIZE="6215517">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:10:11"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="2d2ac42fae5d11b1d07c2589e810bb4d87a92ea4"
-				CHECKSUMTYPE="SHA-1" SIZE="6158805">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:10:11" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="2d2ac42fae5d11b1d07c2589e810bb4d87a92ea4" CHECKSUMTYPE="SHA-1" SIZE="6158805">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:10:47"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="8fabc24ea8e6f335fb32931b498fe744a7668e53"
-				CHECKSUMTYPE="SHA-1" SIZE="6215524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:10:47" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="8fabc24ea8e6f335fb32931b498fe744a7668e53" CHECKSUMTYPE="SHA-1" SIZE="6215524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:11:20"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="6666bf317d5b66a825760ac64e13c69c2cacb954"
-				CHECKSUMTYPE="SHA-1" SIZE="6158816">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:11:20" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="6666bf317d5b66a825760ac64e13c69c2cacb954" CHECKSUMTYPE="SHA-1" SIZE="6158816">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:11:53"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="3f79c265817c97c91d82d7cc01b9f57ca9f89697"
-				CHECKSUMTYPE="SHA-1" SIZE="6179514">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:11:53" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="3f79c265817c97c91d82d7cc01b9f57ca9f89697" CHECKSUMTYPE="SHA-1" SIZE="6179514">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:12:25"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="4c196d67c6eb43e3d4e7e0bbd8e922c36c4b54aa"
-				CHECKSUMTYPE="SHA-1" SIZE="6158821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:12:25" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="4c196d67c6eb43e3d4e7e0bbd8e922c36c4b54aa" CHECKSUMTYPE="SHA-1" SIZE="6158821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:12:58"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="ffe1fd05675b65b554b615d7113b6ea4c00163eb"
-				CHECKSUMTYPE="SHA-1" SIZE="6179525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:12:58" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="ffe1fd05675b65b554b615d7113b6ea4c00163eb" CHECKSUMTYPE="SHA-1" SIZE="6179525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:13:33"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ad2ae6ea7fb910960b1f3240775d6674fd17b018"
-				CHECKSUMTYPE="SHA-1" SIZE="6158819">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:13:33" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ad2ae6ea7fb910960b1f3240775d6674fd17b018" CHECKSUMTYPE="SHA-1" SIZE="6158819">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:14:05"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="54f388d341420df47b4d0b3743fd2c558931fe7a"
-				CHECKSUMTYPE="SHA-1" SIZE="6179522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:14:05" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="54f388d341420df47b4d0b3743fd2c558931fe7a" CHECKSUMTYPE="SHA-1" SIZE="6179522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:14:39"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="cc779917d0d671aacebea809c257abe278e2c0c5"
-				CHECKSUMTYPE="SHA-1" SIZE="6158779">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:14:39" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="cc779917d0d671aacebea809c257abe278e2c0c5" CHECKSUMTYPE="SHA-1" SIZE="6158779">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:15:09"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="1003215663a1801d127086384f30224f1fd4557d"
-				CHECKSUMTYPE="SHA-1" SIZE="6179521">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:15:09" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="1003215663a1801d127086384f30224f1fd4557d" CHECKSUMTYPE="SHA-1" SIZE="6179521">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:15:43"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="4960d14adf4076f6c9a2bfa7a0b2670ac7862a35"
-				CHECKSUMTYPE="SHA-1" SIZE="6158829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:15:43" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="4960d14adf4076f6c9a2bfa7a0b2670ac7862a35" CHECKSUMTYPE="SHA-1" SIZE="6158829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:16:16"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="0c558ee217d8ad3a8c69f90ac4d7ebf09a69e2ec"
-				CHECKSUMTYPE="SHA-1" SIZE="6179521">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:16:16" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="0c558ee217d8ad3a8c69f90ac4d7ebf09a69e2ec" CHECKSUMTYPE="SHA-1" SIZE="6179521">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:16:49"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="aa78f0e02c4f19b722bc70dc0ff3a3ca3beb4dc6"
-				CHECKSUMTYPE="SHA-1" SIZE="6230813">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:16:49" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="aa78f0e02c4f19b722bc70dc0ff3a3ca3beb4dc6" CHECKSUMTYPE="SHA-1" SIZE="6230813">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:17:22"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="90944266671d49aaca55e54a874c5bc770ffc943"
-				CHECKSUMTYPE="SHA-1" SIZE="6072428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:17:22" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="90944266671d49aaca55e54a874c5bc770ffc943" CHECKSUMTYPE="SHA-1" SIZE="6072428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:17:58"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f836b052f45c7d51a2f9611630a4706cb729d8a7"
-				CHECKSUMTYPE="SHA-1" SIZE="6207426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:17:58" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f836b052f45c7d51a2f9611630a4706cb729d8a7" CHECKSUMTYPE="SHA-1" SIZE="6207426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/delivery/bmtnabf_1902-08-01_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:18:18" MIMETYPE="text/xml"
-				CHECKSUM="412575ba74e9c51004b97c64df31a7f921ad9ebf" CHECKSUMTYPE="SHA-1" SIZE="4760">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:18:18" MIMETYPE="text/xml" CHECKSUM="412575ba74e9c51004b97c64df31a7f921ad9ebf" CHECKSUMTYPE="SHA-1" SIZE="4760">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:18:19" MIMETYPE="text/xml"
-				CHECKSUM="274e78969b415f937ae8b60c7e8ea660a52ea2a9" CHECKSUMTYPE="SHA-1"
-				SIZE="34886">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:18:19" MIMETYPE="text/xml" CHECKSUM="274e78969b415f937ae8b60c7e8ea660a52ea2a9" CHECKSUMTYPE="SHA-1" SIZE="34886">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:18:19" MIMETYPE="text/xml"
-				CHECKSUM="c2bb7e3e7fce061f5a7d5bdb6f5542fb0507f243" CHECKSUMTYPE="SHA-1" SIZE="9069">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:18:19" MIMETYPE="text/xml" CHECKSUM="c2bb7e3e7fce061f5a7d5bdb6f5542fb0507f243" CHECKSUMTYPE="SHA-1" SIZE="9069">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:18:19" MIMETYPE="text/xml"
-				CHECKSUM="a63c76c043167c369960a9021517b16f33d43f74" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:18:19" MIMETYPE="text/xml" CHECKSUM="a63c76c043167c369960a9021517b16f33d43f74" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:18:19" MIMETYPE="text/xml"
-				CHECKSUM="40641e928606acb2bee8c262be8938124a3f2c18" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:18:19" MIMETYPE="text/xml" CHECKSUM="40641e928606acb2bee8c262be8938124a3f2c18" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:18:20" MIMETYPE="text/xml"
-				CHECKSUM="605afc02b89dd3ceeeae928da5a4825308a787da" CHECKSUMTYPE="SHA-1" SIZE="2105">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:18:20" MIMETYPE="text/xml" CHECKSUM="605afc02b89dd3ceeeae928da5a4825308a787da" CHECKSUMTYPE="SHA-1" SIZE="2105">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:18:20" MIMETYPE="text/xml"
-				CHECKSUM="4821a6158796911e78bffcaca75a5d6610826edd" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:18:20" MIMETYPE="text/xml" CHECKSUM="4821a6158796911e78bffcaca75a5d6610826edd" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:18:20" MIMETYPE="text/xml"
-				CHECKSUM="36789de435a0935bb97359e91f07d13734833fec" CHECKSUMTYPE="SHA-1" SIZE="3336">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:18:20" MIMETYPE="text/xml" CHECKSUM="36789de435a0935bb97359e91f07d13734833fec" CHECKSUMTYPE="SHA-1" SIZE="3336">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:18:20" MIMETYPE="text/xml"
-				CHECKSUM="dedb76146a9f6fef3e87c1be1254eaafd1dee5b8" CHECKSUMTYPE="SHA-1" SIZE="4134">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:18:20" MIMETYPE="text/xml" CHECKSUM="dedb76146a9f6fef3e87c1be1254eaafd1dee5b8" CHECKSUMTYPE="SHA-1" SIZE="4134">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:18:21" MIMETYPE="text/xml"
-				CHECKSUM="3dcd1f0e9fc8b46e58b4f3aac9be7a3c97c98856" CHECKSUMTYPE="SHA-1" SIZE="3952">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:18:21" MIMETYPE="text/xml" CHECKSUM="3dcd1f0e9fc8b46e58b4f3aac9be7a3c97c98856" CHECKSUMTYPE="SHA-1" SIZE="3952">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:18:21" MIMETYPE="text/xml"
-				CHECKSUM="3e13683c1e948ffaa9d5f51dfa97709fdadef1f3" CHECKSUMTYPE="SHA-1" SIZE="3599">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:18:21" MIMETYPE="text/xml" CHECKSUM="3e13683c1e948ffaa9d5f51dfa97709fdadef1f3" CHECKSUMTYPE="SHA-1" SIZE="3599">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:18:21" MIMETYPE="text/xml"
-				CHECKSUM="0b1add505186ecd8c6fbe58b4b306492738348b5" CHECKSUMTYPE="SHA-1" SIZE="4221">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:18:21" MIMETYPE="text/xml" CHECKSUM="0b1add505186ecd8c6fbe58b4b306492738348b5" CHECKSUMTYPE="SHA-1" SIZE="4221">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:18:21" MIMETYPE="text/xml"
-				CHECKSUM="0b1ca654b6d3da0176708cd84018d861165db2a7" CHECKSUMTYPE="SHA-1" SIZE="6318">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:18:21" MIMETYPE="text/xml" CHECKSUM="0b1ca654b6d3da0176708cd84018d861165db2a7" CHECKSUMTYPE="SHA-1" SIZE="6318">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:18:21" MIMETYPE="text/xml"
-				CHECKSUM="462d01e4cb5710e181f48ea3b52f23f05b70d2b7" CHECKSUMTYPE="SHA-1"
-				SIZE="46071">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:18:21" MIMETYPE="text/xml" CHECKSUM="462d01e4cb5710e181f48ea3b52f23f05b70d2b7" CHECKSUMTYPE="SHA-1" SIZE="46071">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:18:22" MIMETYPE="text/xml"
-				CHECKSUM="de701220503fe2abd4aa0afdbb512c882eacf1bd" CHECKSUMTYPE="SHA-1"
-				SIZE="49295">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:18:22" MIMETYPE="text/xml" CHECKSUM="de701220503fe2abd4aa0afdbb512c882eacf1bd" CHECKSUMTYPE="SHA-1" SIZE="49295">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:18:22" MIMETYPE="text/xml"
-				CHECKSUM="d365d9a6d1160b22f0ee25d413de26342a8eae7e" CHECKSUMTYPE="SHA-1" SIZE="3977">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:18:22" MIMETYPE="text/xml" CHECKSUM="d365d9a6d1160b22f0ee25d413de26342a8eae7e" CHECKSUMTYPE="SHA-1" SIZE="3977">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:18:22" MIMETYPE="text/xml"
-				CHECKSUM="10c47c81288c2267872b1ed2143f8e9768a79144" CHECKSUMTYPE="SHA-1" SIZE="3785">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:18:22" MIMETYPE="text/xml" CHECKSUM="10c47c81288c2267872b1ed2143f8e9768a79144" CHECKSUMTYPE="SHA-1" SIZE="3785">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:18:22" MIMETYPE="text/xml"
-				CHECKSUM="91bb590a69d4e8d4f4e51f8827c5f4de85bd1804" CHECKSUMTYPE="SHA-1" SIZE="4212">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:18:22" MIMETYPE="text/xml" CHECKSUM="91bb590a69d4e8d4f4e51f8827c5f4de85bd1804" CHECKSUMTYPE="SHA-1" SIZE="4212">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:18:23" MIMETYPE="text/xml"
-				CHECKSUM="c46dec24d37538f64cb2236e5f83d44edae34045" CHECKSUMTYPE="SHA-1" SIZE="3612">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:18:23" MIMETYPE="text/xml" CHECKSUM="c46dec24d37538f64cb2236e5f83d44edae34045" CHECKSUMTYPE="SHA-1" SIZE="3612">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:18:23" MIMETYPE="text/xml"
-				CHECKSUM="e3d311d2cecaf8be9c36e3b49ab36f26417d2d23" CHECKSUMTYPE="SHA-1" SIZE="3601">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:18:23" MIMETYPE="text/xml" CHECKSUM="e3d311d2cecaf8be9c36e3b49ab36f26417d2d23" CHECKSUMTYPE="SHA-1" SIZE="3601">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:18:23" MIMETYPE="text/xml"
-				CHECKSUM="32f86c171ec4384925c02a5c59eb2245a41210e1" CHECKSUMTYPE="SHA-1"
-				SIZE="21305">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:18:23" MIMETYPE="text/xml" CHECKSUM="32f86c171ec4384925c02a5c59eb2245a41210e1" CHECKSUMTYPE="SHA-1" SIZE="21305">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:18:23" MIMETYPE="text/xml"
-				CHECKSUM="a6aa15e0d22695cfb7f2f5ba190a78653d099470" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:18:23" MIMETYPE="text/xml" CHECKSUM="a6aa15e0d22695cfb7f2f5ba190a78653d099470" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:18:24" MIMETYPE="text/xml"
-				CHECKSUM="f37c6670e02705d4fcc51178fbf67266a3bda52c" CHECKSUMTYPE="SHA-1"
-				SIZE="20707">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:18:24" MIMETYPE="text/xml" CHECKSUM="f37c6670e02705d4fcc51178fbf67266a3bda52c" CHECKSUMTYPE="SHA-1" SIZE="20707">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:18:24" MIMETYPE="text/xml"
-				CHECKSUM="dac911eca563e5f017180fc55925a33dae10b396" CHECKSUMTYPE="SHA-1" SIZE="8457">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:18:24" MIMETYPE="text/xml" CHECKSUM="dac911eca563e5f017180fc55925a33dae10b396" CHECKSUMTYPE="SHA-1" SIZE="8457">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-01_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:18:49" MIMETYPE="application/pdf"
-				CHECKSUM="5da85f684dc011bc4e133dac5ee01d837297ec40" CHECKSUMTYPE="SHA-1"
-				SIZE="5458561">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/bmtnabf_1902-08-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:18:49" MIMETYPE="application/pdf" CHECKSUM="5da85f684dc011bc4e133dac5ee01d837297ec40" CHECKSUMTYPE="SHA-1" SIZE="5458561">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/01_01/bmtnabf_1902-08-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2642,8 +2483,7 @@
 	<structMap LABEL="Logical Structure" TYPE="LOGICAL">
 		<div ID="L.1" TYPE="Magazine" LABEL="VER SACRUM">
 			<div ID="L.1.1" TYPE="Issue" LABEL="VER SACRUM no. 15 01.08.1902">
-				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001"
-					LABEL="Untitled Image by FERDINAND SCHMUTZER">
+				<div ID="L.1.1.1" TYPE="Illustration" ORDER="1" DMDID="c001" LABEL="Untitled Image by FERDINAND SCHMUTZER">
 					<div ID="L.1.1.1.1" TYPE="Image">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00001" BEGIN="P1_CB00001"/>
@@ -2756,8 +2596,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004"
-					LABEL="ORIGINAL-RADIERUNG">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004" LABEL="ORIGINAL-RADIERUNG">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00001"/>
@@ -2774,8 +2613,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c005"
-					LABEL="Aus dem Schifferhaus in Lübeck">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c005" LABEL="Aus dem Schifferhaus in Lübeck">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -2787,8 +2625,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c006"
-					LABEL="Enge Gasse in Rouen">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c006" LABEL="Enge Gasse in Rouen">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -2812,8 +2649,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c008"
-					LABEL="Aus dem Hafenviertel in Hamburg">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c008" LABEL="Aus dem Hafenviertel in Hamburg">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -2825,8 +2661,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c009"
-					LABEL="Originalzeichnungen, Radierung und Holzschnitt in diesem Hefte sind von dem ordentl">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c009" LABEL="Originalzeichnungen, Radierung und Holzschnitt in diesem Hefte sind von dem ordentl">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -2854,8 +2689,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.11.3" TYPE="Illustration" ORDER="1" DMDID="c011"
-						LABEL="[Initial]">
+					<div ID="L.1.1.11.3" TYPE="Illustration" ORDER="1" DMDID="c011" LABEL="[Initial]">
 						<div ID="L.1.1.11.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00001"/>
@@ -2868,10 +2702,8 @@
 								<div ID="L.1.1.11.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -2879,8 +2711,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c012"
-					LABEL="Donaubrücke bei Regensburg">
+				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c012" LABEL="Donaubrücke bei Regensburg">
 					<div ID="L.1.1.12.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -2892,8 +2723,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c013"
-					LABEL="Flet in Hamburg">
+				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c013" LABEL="Flet in Hamburg">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -2905,8 +2735,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.14" TYPE="TextContent" ORDER="12" DMDID="c014"
-					LABEL="Oranienbrücke in Berlin">
+				<div ID="L.1.1.14" TYPE="TextContent" ORDER="12" DMDID="c014" LABEL="Oranienbrücke in Berlin">
 					<div ID="L.1.1.14.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
@@ -2925,8 +2754,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c016"
-					LABEL="Hamburger Flet">
+				<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c016" LABEL="Hamburger Flet">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1902/08/15_01/bmtnabf_1902-08-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/08/15_01/bmtnabf_1902-08-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-08-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-08-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-08-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-08-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-08-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2142,314 +2136,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:05:20"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a5683b911cade600c16507009ebe66612624402c"
-				CHECKSUMTYPE="SHA-1" SIZE="6126429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:05:20" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a5683b911cade600c16507009ebe66612624402c" CHECKSUMTYPE="SHA-1" SIZE="6126429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:05:54"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="3a718aac9470391fb0dc018331dedbfca63a67c1"
-				CHECKSUMTYPE="SHA-1" SIZE="6093129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:05:54" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="3a718aac9470391fb0dc018331dedbfca63a67c1" CHECKSUMTYPE="SHA-1" SIZE="6093129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:06:28"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="85ed0ff98fbcbaf11a1c03d10d58f6de3eff57f9"
-				CHECKSUMTYPE="SHA-1" SIZE="6226310">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:06:28" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="85ed0ff98fbcbaf11a1c03d10d58f6de3eff57f9" CHECKSUMTYPE="SHA-1" SIZE="6226310">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:07:09"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="32480f46495d843d683a9a1c269957fcafc6c74b"
-				CHECKSUMTYPE="SHA-1" SIZE="6092215">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:07:09" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="32480f46495d843d683a9a1c269957fcafc6c74b" CHECKSUMTYPE="SHA-1" SIZE="6092215">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:07:48"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="9b19742f5ccc950edd4d9232dde2f6b8e3e3c7da"
-				CHECKSUMTYPE="SHA-1" SIZE="6200217">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:07:48" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="9b19742f5ccc950edd4d9232dde2f6b8e3e3c7da" CHECKSUMTYPE="SHA-1" SIZE="6200217">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:08:19"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="b2de7719a963940dfdb4b00052be4c0b473f3d2c"
-				CHECKSUMTYPE="SHA-1" SIZE="6092216">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:08:19" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="b2de7719a963940dfdb4b00052be4c0b473f3d2c" CHECKSUMTYPE="SHA-1" SIZE="6092216">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:08:52"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="24dd24788c3834a2bbabf5bb754de3d0be9f8ca7"
-				CHECKSUMTYPE="SHA-1" SIZE="6152523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:08:52" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="24dd24788c3834a2bbabf5bb754de3d0be9f8ca7" CHECKSUMTYPE="SHA-1" SIZE="6152523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:09:26"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="f3b82405b226d64a5bc77c65542c26117f065aae"
-				CHECKSUMTYPE="SHA-1" SIZE="6117425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:09:26" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="f3b82405b226d64a5bc77c65542c26117f065aae" CHECKSUMTYPE="SHA-1" SIZE="6117425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:10:01"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="bfe69d04f1c40f453aaea422016d505c272d534a"
-				CHECKSUMTYPE="SHA-1" SIZE="6150707">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:10:01" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="bfe69d04f1c40f453aaea422016d505c272d534a" CHECKSUMTYPE="SHA-1" SIZE="6150707">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:10:36"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="2e4cf099fb6800e8bc2414dd5e813b172fcce7b3"
-				CHECKSUMTYPE="SHA-1" SIZE="6117425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:10:36" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="2e4cf099fb6800e8bc2414dd5e813b172fcce7b3" CHECKSUMTYPE="SHA-1" SIZE="6117425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:11:13"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="831f08d82441e4442a4e2094e1f3bf94f5ed89bb"
-				CHECKSUMTYPE="SHA-1" SIZE="6150728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:11:13" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="831f08d82441e4442a4e2094e1f3bf94f5ed89bb" CHECKSUMTYPE="SHA-1" SIZE="6150728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:11:46"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="725541f0fa0af39e4d5a5233f89a263fc8cbf2ac"
-				CHECKSUMTYPE="SHA-1" SIZE="6117412">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:11:46" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="725541f0fa0af39e4d5a5233f89a263fc8cbf2ac" CHECKSUMTYPE="SHA-1" SIZE="6117412">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:12:19"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="cad7b9c4c8dccb4c777074739a370760151de76d"
-				CHECKSUMTYPE="SHA-1" SIZE="6091324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:12:19" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="cad7b9c4c8dccb4c777074739a370760151de76d" CHECKSUMTYPE="SHA-1" SIZE="6091324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:12:52"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="525baf03c6f12d97079493a1ae04ba2ae52ed946"
-				CHECKSUMTYPE="SHA-1" SIZE="6126399">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:12:52" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="525baf03c6f12d97079493a1ae04ba2ae52ed946" CHECKSUMTYPE="SHA-1" SIZE="6126399">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:13:26"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="85b70a61d8d20f087169e82e31fad6cd63abe09e"
-				CHECKSUMTYPE="SHA-1" SIZE="6091323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:13:26" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="85b70a61d8d20f087169e82e31fad6cd63abe09e" CHECKSUMTYPE="SHA-1" SIZE="6091323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:14:00"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="c97d2587fa155dbdf3f07ffc0d30b9a07c51e81d"
-				CHECKSUMTYPE="SHA-1" SIZE="6126429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:14:00" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="c97d2587fa155dbdf3f07ffc0d30b9a07c51e81d" CHECKSUMTYPE="SHA-1" SIZE="6126429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:14:32"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="ba3fae86144b76fb9cd39350c1753e4575c15e18"
-				CHECKSUMTYPE="SHA-1" SIZE="6091316">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:14:32" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="ba3fae86144b76fb9cd39350c1753e4575c15e18" CHECKSUMTYPE="SHA-1" SIZE="6091316">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:15:02"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="d9f610a0d1a1ed1354a15b4bbb8eb1ad05445243"
-				CHECKSUMTYPE="SHA-1" SIZE="6126421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:15:02" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="d9f610a0d1a1ed1354a15b4bbb8eb1ad05445243" CHECKSUMTYPE="SHA-1" SIZE="6126421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:15:39"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="633677d4121f8f3232cdd8af7df00d89a4b49296"
-				CHECKSUMTYPE="SHA-1" SIZE="6091328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:15:39" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="633677d4121f8f3232cdd8af7df00d89a4b49296" CHECKSUMTYPE="SHA-1" SIZE="6091328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:16:14"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="5ddae10807d81e5a3150111399ed2a971c59113c"
-				CHECKSUMTYPE="SHA-1" SIZE="6126420">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:16:14" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="5ddae10807d81e5a3150111399ed2a971c59113c" CHECKSUMTYPE="SHA-1" SIZE="6126420">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:16:48"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="0db9f6bb417e843d97d0a233d69be7d16ccee8e5"
-				CHECKSUMTYPE="SHA-1" SIZE="6092213">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:16:48" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="0db9f6bb417e843d97d0a233d69be7d16ccee8e5" CHECKSUMTYPE="SHA-1" SIZE="6092213">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:17:19"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="afa3bc939762b583971405989f3649829a6a15a3"
-				CHECKSUMTYPE="SHA-1" SIZE="6050826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:17:19" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="afa3bc939762b583971405989f3649829a6a15a3" CHECKSUMTYPE="SHA-1" SIZE="6050826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:17:51"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="16c6669e73be729c20e431c5868d7a3607444169"
-				CHECKSUMTYPE="SHA-1" SIZE="6092224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:17:51" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="16c6669e73be729c20e431c5868d7a3607444169" CHECKSUMTYPE="SHA-1" SIZE="6092224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:18:27"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="ee2d2f874f44ccd4c10e8d3f4aa9df8ac7cd995b"
-				CHECKSUMTYPE="SHA-1" SIZE="6050813">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:18:27" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="ee2d2f874f44ccd4c10e8d3f4aa9df8ac7cd995b" CHECKSUMTYPE="SHA-1" SIZE="6050813">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/delivery/bmtnabf_1902-08-15_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:18:48" MIMETYPE="text/xml"
-				CHECKSUM="a3b07673f9a8900b4e7f9b5a70b5a8e6f53df97a" CHECKSUMTYPE="SHA-1" SIZE="4934">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:18:48" MIMETYPE="text/xml" CHECKSUM="a3b07673f9a8900b4e7f9b5a70b5a8e6f53df97a" CHECKSUMTYPE="SHA-1" SIZE="4934">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:18:48" MIMETYPE="text/xml"
-				CHECKSUM="2f135e12f41576831b13b257d331e24d25ade08c" CHECKSUMTYPE="SHA-1"
-				SIZE="32845">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:18:48" MIMETYPE="text/xml" CHECKSUM="2f135e12f41576831b13b257d331e24d25ade08c" CHECKSUMTYPE="SHA-1" SIZE="32845">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:18:49" MIMETYPE="text/xml"
-				CHECKSUM="81cf80d75a9281a18530610fad920e0b575921be" CHECKSUMTYPE="SHA-1" SIZE="8534">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:18:49" MIMETYPE="text/xml" CHECKSUM="81cf80d75a9281a18530610fad920e0b575921be" CHECKSUMTYPE="SHA-1" SIZE="8534">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:18:49" MIMETYPE="text/xml"
-				CHECKSUM="78e737134b29013ddb13b041fbd366990a763438" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:18:49" MIMETYPE="text/xml" CHECKSUM="78e737134b29013ddb13b041fbd366990a763438" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:18:49" MIMETYPE="text/xml"
-				CHECKSUM="c22f19cedfcffbcb2216985ae4b08d3f6234f44d" CHECKSUMTYPE="SHA-1" SIZE="1715">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:18:49" MIMETYPE="text/xml" CHECKSUM="c22f19cedfcffbcb2216985ae4b08d3f6234f44d" CHECKSUMTYPE="SHA-1" SIZE="1715">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:18:49" MIMETYPE="text/xml"
-				CHECKSUM="6b13cf0e188dcc6f18572715b92ca4b9831393a5" CHECKSUMTYPE="SHA-1"
-				SIZE="31632">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:18:49" MIMETYPE="text/xml" CHECKSUM="6b13cf0e188dcc6f18572715b92ca4b9831393a5" CHECKSUMTYPE="SHA-1" SIZE="31632">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:18:50" MIMETYPE="text/xml"
-				CHECKSUM="a0b7e28f842fd781743d1a79a448b64221c4d38c" CHECKSUMTYPE="SHA-1" SIZE="2011">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:18:50" MIMETYPE="text/xml" CHECKSUM="a0b7e28f842fd781743d1a79a448b64221c4d38c" CHECKSUMTYPE="SHA-1" SIZE="2011">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:18:50" MIMETYPE="text/xml"
-				CHECKSUM="60f195835948ea1ef4349a7d9851991712b3b6b6" CHECKSUMTYPE="SHA-1" SIZE="3882">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:18:50" MIMETYPE="text/xml" CHECKSUM="60f195835948ea1ef4349a7d9851991712b3b6b6" CHECKSUMTYPE="SHA-1" SIZE="3882">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:18:50" MIMETYPE="text/xml"
-				CHECKSUM="4baaf6b7b25ef5198e33e9e0726178eff66093dc" CHECKSUMTYPE="SHA-1" SIZE="5052">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:18:50" MIMETYPE="text/xml" CHECKSUM="4baaf6b7b25ef5198e33e9e0726178eff66093dc" CHECKSUMTYPE="SHA-1" SIZE="5052">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:18:50" MIMETYPE="text/xml"
-				CHECKSUM="537adcb13003f74c23fed1768f733929f28da402" CHECKSUMTYPE="SHA-1" SIZE="4492">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:18:50" MIMETYPE="text/xml" CHECKSUM="537adcb13003f74c23fed1768f733929f28da402" CHECKSUMTYPE="SHA-1" SIZE="4492">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:18:50" MIMETYPE="text/xml"
-				CHECKSUM="625bd02b5c543f27061afeb18ce1bb913f716c73" CHECKSUMTYPE="SHA-1"
-				SIZE="43982">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:18:50" MIMETYPE="text/xml" CHECKSUM="625bd02b5c543f27061afeb18ce1bb913f716c73" CHECKSUMTYPE="SHA-1" SIZE="43982">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:18:51" MIMETYPE="text/xml"
-				CHECKSUM="48978866dc1e5465cd5af85a7293fe5db7e3295a" CHECKSUMTYPE="SHA-1" SIZE="3783">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:18:51" MIMETYPE="text/xml" CHECKSUM="48978866dc1e5465cd5af85a7293fe5db7e3295a" CHECKSUMTYPE="SHA-1" SIZE="3783">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:18:51" MIMETYPE="text/xml"
-				CHECKSUM="306272752bdc8348c02b8ca47ed575ec55b92b1a" CHECKSUMTYPE="SHA-1"
-				SIZE="47693">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:18:51" MIMETYPE="text/xml" CHECKSUM="306272752bdc8348c02b8ca47ed575ec55b92b1a" CHECKSUMTYPE="SHA-1" SIZE="47693">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:18:51" MIMETYPE="text/xml"
-				CHECKSUM="3220e252cf840e40f4e27c152897510a38140ab9" CHECKSUMTYPE="SHA-1"
-				SIZE="28150">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:18:51" MIMETYPE="text/xml" CHECKSUM="3220e252cf840e40f4e27c152897510a38140ab9" CHECKSUMTYPE="SHA-1" SIZE="28150">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:18:51" MIMETYPE="text/xml"
-				CHECKSUM="7d9e9332304452ed1a8897ae97b7b472f11a72af" CHECKSUMTYPE="SHA-1"
-				SIZE="24283">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:18:51" MIMETYPE="text/xml" CHECKSUM="7d9e9332304452ed1a8897ae97b7b472f11a72af" CHECKSUMTYPE="SHA-1" SIZE="24283">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:18:52" MIMETYPE="text/xml"
-				CHECKSUM="22c291491331ff2c149add4653ac6c55efcd35f2" CHECKSUMTYPE="SHA-1"
-				SIZE="33845">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:18:52" MIMETYPE="text/xml" CHECKSUM="22c291491331ff2c149add4653ac6c55efcd35f2" CHECKSUMTYPE="SHA-1" SIZE="33845">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:18:52" MIMETYPE="text/xml"
-				CHECKSUM="6aca14919db5bee2f894dfdb9c21aafd7f17863e" CHECKSUMTYPE="SHA-1" SIZE="3790">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:18:52" MIMETYPE="text/xml" CHECKSUM="6aca14919db5bee2f894dfdb9c21aafd7f17863e" CHECKSUMTYPE="SHA-1" SIZE="3790">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:18:52" MIMETYPE="text/xml"
-				CHECKSUM="4b25df35835ecb87f8ae99f93c3d80c2d991ef8f" CHECKSUMTYPE="SHA-1"
-				SIZE="35922">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:18:52" MIMETYPE="text/xml" CHECKSUM="4b25df35835ecb87f8ae99f93c3d80c2d991ef8f" CHECKSUMTYPE="SHA-1" SIZE="35922">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:18:52" MIMETYPE="text/xml"
-				CHECKSUM="8c75de0d3a495a599e1444fac4d73b7d53b8139e" CHECKSUMTYPE="SHA-1"
-				SIZE="28756">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:18:52" MIMETYPE="text/xml" CHECKSUM="8c75de0d3a495a599e1444fac4d73b7d53b8139e" CHECKSUMTYPE="SHA-1" SIZE="28756">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:18:53" MIMETYPE="text/xml"
-				CHECKSUM="2be750bcfbeedf944b50650dcb7b259879aa33c6" CHECKSUMTYPE="SHA-1" SIZE="3790">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:18:53" MIMETYPE="text/xml" CHECKSUM="2be750bcfbeedf944b50650dcb7b259879aa33c6" CHECKSUMTYPE="SHA-1" SIZE="3790">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:18:53" MIMETYPE="text/xml"
-				CHECKSUM="60001d63d7445731838ff104089e2531e07b9cf4" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:18:53" MIMETYPE="text/xml" CHECKSUM="60001d63d7445731838ff104089e2531e07b9cf4" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:18:53" MIMETYPE="text/xml"
-				CHECKSUM="8ed1e983b7f3c841ef1442dfb08fbd221397856f" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:18:53" MIMETYPE="text/xml" CHECKSUM="8ed1e983b7f3c841ef1442dfb08fbd221397856f" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:18:53" MIMETYPE="text/xml"
-				CHECKSUM="3730cca3b820bab2aa932656643d2b5bb88d5907" CHECKSUMTYPE="SHA-1"
-				SIZE="20214">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:18:53" MIMETYPE="text/xml" CHECKSUM="3730cca3b820bab2aa932656643d2b5bb88d5907" CHECKSUMTYPE="SHA-1" SIZE="20214">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:18:54" MIMETYPE="text/xml"
-				CHECKSUM="2d478e4d1b78ec7999d7f68bf773dedc1c009cd5" CHECKSUMTYPE="SHA-1" SIZE="8110">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:18:54" MIMETYPE="text/xml" CHECKSUM="2d478e4d1b78ec7999d7f68bf773dedc1c009cd5" CHECKSUMTYPE="SHA-1" SIZE="8110">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-08-15_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:19:18" MIMETYPE="application/pdf"
-				CHECKSUM="b42082a64c1c0a870bd54717287e684e7fa7f48f" CHECKSUMTYPE="SHA-1"
-				SIZE="5762097">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/bmtnabf_1902-08-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:19:18" MIMETYPE="application/pdf" CHECKSUM="b42082a64c1c0a870bd54717287e684e7fa7f48f" CHECKSUMTYPE="SHA-1" SIZE="5762097">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/08/15_01/bmtnabf_1902-08-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2765,8 +2601,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c004"
-					LABEL="Untitled text by Rudolf von Larisch">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="3" DMDID="c004" LABEL="Untitled text by Rudolf von Larisch">
 					<div ID="L.1.1.5.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00001"/>
@@ -2816,8 +2651,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00005"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="1" DMDID="c007"
-						LABEL="Untitled Image by Rudolf Bacher OM">
+					<div ID="L.1.1.7.3" TYPE="Illustration" ORDER="1" DMDID="c007" LABEL="Untitled Image by Rudolf Bacher OM">
 						<div ID="L.1.1.7.1" TYPE="Head">
 							<fptr>
 								<seq>
@@ -2842,8 +2676,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="1" DMDID="c008"
-						LABEL="Orig. – Holzschnitt">
+					<div ID="L.1.1.7.4" TYPE="Illustration" ORDER="1" DMDID="c008" LABEL="Orig. – Holzschnitt">
 						<div ID="L.1.1.7.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -2877,16 +2710,14 @@
 							<div ID="L.1.1.8.4.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.8.4.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00005"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00005"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.8.4.1.3" TYPE="Paragraph" ORDER="3">
 								<div ID="L.1.1.8.4.1.3.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
 									</fptr>
 								</div>
 							</div>
@@ -2898,16 +2729,14 @@
 							<div ID="L.1.1.8.4.1.5" TYPE="Paragraph" ORDER="5">
 								<div ID="L.1.1.8.4.1.5.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.8.4.1.6" TYPE="Paragraph" ORDER="6">
 								<div ID="L.1.1.8.4.1.6.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
 									</fptr>
 								</div>
 							</div>
@@ -2920,10 +2749,8 @@
 								<div ID="L.1.1.8.4.1.8.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -2936,16 +2763,14 @@
 							<div ID="L.1.1.8.4.1.10" TYPE="Paragraph" ORDER="10">
 								<div ID="L.1.1.8.4.1.10.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.8.4.1.11" TYPE="Paragraph" ORDER="11">
 								<div ID="L.1.1.8.4.1.11.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
 									</fptr>
 								</div>
 							</div>
@@ -2958,12 +2783,9 @@
 								<div ID="L.1.1.8.4.1.13.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -2976,15 +2798,13 @@
 							<div ID="L.1.1.8.4.1.15" TYPE="Paragraph" ORDER="15">
 								<div ID="L.1.1.8.4.1.15.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00004"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="1" DMDID="c011"
-						LABEL="Untitled Image by Rudolf Bacher OM">
+					<div ID="L.1.1.8.5" TYPE="Illustration" ORDER="1" DMDID="c011" LABEL="Untitled Image by Rudolf Bacher OM">
 						<div ID="L.1.1.8.5.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00005"/>
@@ -2996,8 +2816,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="2" DMDID="c012"
-						LABEL="Untitled Image by Rudolf Bacher OM">
+					<div ID="L.1.1.8.6" TYPE="Illustration" ORDER="2" DMDID="c012" LABEL="Untitled Image by Rudolf Bacher OM">
 						<div ID="L.1.1.8.6.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00005"/>
@@ -3009,8 +2828,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.7" TYPE="Illustration" ORDER="3" DMDID="c013"
-						LABEL="Untitled Image by Rudolf Bacher OM">
+					<div ID="L.1.1.8.7" TYPE="Illustration" ORDER="3" DMDID="c013" LABEL="Untitled Image by Rudolf Bacher OM">
 						<div ID="L.1.1.8.7.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00005"/>
@@ -3022,8 +2840,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.8" TYPE="Illustration" ORDER="4" DMDID="c014"
-						LABEL="Untitled Image by Rudolf Bacher OM">
+					<div ID="L.1.1.8.8" TYPE="Illustration" ORDER="4" DMDID="c014" LABEL="Untitled Image by Rudolf Bacher OM">
 						<div ID="L.1.1.8.8.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00003"/>
@@ -3035,8 +2852,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8.9" TYPE="Illustration" ORDER="5" DMDID="c015"
-						LABEL="Untitled Image by Rudolf Bacher OM">
+					<div ID="L.1.1.8.9" TYPE="Illustration" ORDER="5" DMDID="c015" LABEL="Untitled Image by Rudolf Bacher OM">
 						<div ID="L.1.1.8.9.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00006"/>
@@ -3049,8 +2865,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c016"
-					LABEL="Untitled Image by Rudolf Bacher OM">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c016" LABEL="Untitled Image by Rudolf Bacher OM">
 					<div ID="L.1.1.9.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -3062,8 +2877,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c017"
-					LABEL="Untitled Image by Rudolf Bacher OM">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c017" LABEL="Untitled Image by Rudolf Bacher OM">
 					<div ID="L.1.1.10.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -3075,8 +2889,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c018"
-					LABEL="Untitled Image by Rudolf Bacher OM">
+				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c018" LABEL="Untitled Image by Rudolf Bacher OM">
 					<div ID="L.1.1.11.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1902/09/01_01/bmtnabf_1902-09-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/09/01_01/bmtnabf_1902-09-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-09-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-09-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-09-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/09/15_01/bmtnabf_1902-09-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/09/15_01/bmtnabf_1902-09-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-09-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-09-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-09-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1902/10/01_01/bmtnabf_1902-10-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/10/01_01/bmtnabf_1902-10-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-10-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-10-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-10-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-10-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-10-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2137,308 +2131,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:13:14"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="2a14f5d1e0f2739efb1e1975ed2f8ecf3d5fc781"
-				CHECKSUMTYPE="SHA-1" SIZE="6251525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:13:14" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="2a14f5d1e0f2739efb1e1975ed2f8ecf3d5fc781" CHECKSUMTYPE="SHA-1" SIZE="6251525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:13:50"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="12707fedbcdc40b898c485c32f399ef8c0bb51cb"
-				CHECKSUMTYPE="SHA-1" SIZE="6202927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:13:50" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="12707fedbcdc40b898c485c32f399ef8c0bb51cb" CHECKSUMTYPE="SHA-1" SIZE="6202927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:14:29"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="f6fa35c671b453854a8be6d3367286f73cf0ba7b"
-				CHECKSUMTYPE="SHA-1" SIZE="6251529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:14:29" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="f6fa35c671b453854a8be6d3367286f73cf0ba7b" CHECKSUMTYPE="SHA-1" SIZE="6251529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:15:07"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="26226c6236be5639c934a09f9396c9c4cf6972c0"
-				CHECKSUMTYPE="SHA-1" SIZE="6202906">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:15:07" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="26226c6236be5639c934a09f9396c9c4cf6972c0" CHECKSUMTYPE="SHA-1" SIZE="6202906">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:15:48"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="77a4230fc80207003ac7fd6b2c0268b396db0024"
-				CHECKSUMTYPE="SHA-1" SIZE="6251521">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:15:48" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="77a4230fc80207003ac7fd6b2c0268b396db0024" CHECKSUMTYPE="SHA-1" SIZE="6251521">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:16:20"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="80a40e40abc6bce8636fd4a1a2339b1c987d5d80"
-				CHECKSUMTYPE="SHA-1" SIZE="6236196">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:16:20" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="80a40e40abc6bce8636fd4a1a2339b1c987d5d80" CHECKSUMTYPE="SHA-1" SIZE="6236196">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:16:55"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="2c1e7db476c04320413ccde84f6a485a853a31f3"
-				CHECKSUMTYPE="SHA-1" SIZE="6228120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:16:55" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="2c1e7db476c04320413ccde84f6a485a853a31f3" CHECKSUMTYPE="SHA-1" SIZE="6228120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:17:31"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="28769977ce11e2b4ea130f4e56f4cf765de336c9"
-				CHECKSUMTYPE="SHA-1" SIZE="6236225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:17:31" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="28769977ce11e2b4ea130f4e56f4cf765de336c9" CHECKSUMTYPE="SHA-1" SIZE="6236225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:18:03"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="d53b930d808bd05c1f2f2d8cc3ff0b6a24fbb7ac"
-				CHECKSUMTYPE="SHA-1" SIZE="6228128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:18:03" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="d53b930d808bd05c1f2f2d8cc3ff0b6a24fbb7ac" CHECKSUMTYPE="SHA-1" SIZE="6228128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:18:36"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="623bbc9ed3b3f24c30888deccfbc853e51db9d16"
-				CHECKSUMTYPE="SHA-1" SIZE="6201986">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:18:36" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="623bbc9ed3b3f24c30888deccfbc853e51db9d16" CHECKSUMTYPE="SHA-1" SIZE="6201986">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:19:07"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="74996fe9654f571fa22416a52ba5418b51b6dc41"
-				CHECKSUMTYPE="SHA-1" SIZE="6228122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:19:07" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="74996fe9654f571fa22416a52ba5418b51b6dc41" CHECKSUMTYPE="SHA-1" SIZE="6228122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:19:39"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="d31e4e610fc71ef474bba9a5ecc8a2bc87386204"
-				CHECKSUMTYPE="SHA-1" SIZE="6202029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:19:39" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="d31e4e610fc71ef474bba9a5ecc8a2bc87386204" CHECKSUMTYPE="SHA-1" SIZE="6202029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:20:12"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="7700ec71b108194175adfa2b3b831e8813afea9b"
-				CHECKSUMTYPE="SHA-1" SIZE="6228124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:20:12" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="7700ec71b108194175adfa2b3b831e8813afea9b" CHECKSUMTYPE="SHA-1" SIZE="6228124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:20:44"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="1140e0d6eb91077ef3354fc26bd0fea3c1160ef2"
-				CHECKSUMTYPE="SHA-1" SIZE="6202026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:20:44" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="1140e0d6eb91077ef3354fc26bd0fea3c1160ef2" CHECKSUMTYPE="SHA-1" SIZE="6202026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:21:18"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="e235504c7ac7898a37fbb863b26485867a355284"
-				CHECKSUMTYPE="SHA-1" SIZE="6228122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:21:18" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="e235504c7ac7898a37fbb863b26485867a355284" CHECKSUMTYPE="SHA-1" SIZE="6228122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:21:50"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="30f7f124285f72e8b22e2f75267ab6c802464442"
-				CHECKSUMTYPE="SHA-1" SIZE="6202029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:21:50" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="30f7f124285f72e8b22e2f75267ab6c802464442" CHECKSUMTYPE="SHA-1" SIZE="6202029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:22:26"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="ee4424d5adfe1923105a01fa7b906bfd7314722a"
-				CHECKSUMTYPE="SHA-1" SIZE="6228115">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:22:26" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="ee4424d5adfe1923105a01fa7b906bfd7314722a" CHECKSUMTYPE="SHA-1" SIZE="6228115">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:23:00"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="1b3489a1e286292056c7d51a3b6efff0aad526f4"
-				CHECKSUMTYPE="SHA-1" SIZE="6202918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:23:00" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="1b3489a1e286292056c7d51a3b6efff0aad526f4" CHECKSUMTYPE="SHA-1" SIZE="6202918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:23:33"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="457bbc5f8a1101e1d5325e9f5f4bbfd427826653"
-				CHECKSUMTYPE="SHA-1" SIZE="6228075">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:23:33" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="457bbc5f8a1101e1d5325e9f5f4bbfd427826653" CHECKSUMTYPE="SHA-1" SIZE="6228075">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:24:10"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="07c479e835b88f4449f8494380e3a9368c9969d9"
-				CHECKSUMTYPE="SHA-1" SIZE="6232615">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:24:10" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="07c479e835b88f4449f8494380e3a9368c9969d9" CHECKSUMTYPE="SHA-1" SIZE="6232615">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:24:47"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="8ccd6fa218d0713dfa910e9e382a0a3cdd8874bb"
-				CHECKSUMTYPE="SHA-1" SIZE="6228123">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:24:47" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="8ccd6fa218d0713dfa910e9e382a0a3cdd8874bb" CHECKSUMTYPE="SHA-1" SIZE="6228123">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:25:19"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="aaec969021de27474f9bd46facfc7ca2146c7d3e"
-				CHECKSUMTYPE="SHA-1" SIZE="6266829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:25:19" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="aaec969021de27474f9bd46facfc7ca2146c7d3e" CHECKSUMTYPE="SHA-1" SIZE="6266829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:25:54"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="a8355d5134ac8bfcda5c9438e0f3a8f4c3bf15d4"
-				CHECKSUMTYPE="SHA-1" SIZE="6228128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:25:54" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="a8355d5134ac8bfcda5c9438e0f3a8f4c3bf15d4" CHECKSUMTYPE="SHA-1" SIZE="6228128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:26:28"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="454c08f0ba371e5e5cd225945f4c42e51437065f"
-				CHECKSUMTYPE="SHA-1" SIZE="6232454">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:26:28" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="454c08f0ba371e5e5cd225945f4c42e51437065f" CHECKSUMTYPE="SHA-1" SIZE="6232454">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/delivery/bmtnabf_1902-10-01_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:26:49" MIMETYPE="text/xml"
-				CHECKSUM="d0eb6c3cc6a6f94c6c21530dbd29a34683f2a852" CHECKSUMTYPE="SHA-1" SIZE="5068">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:26:49" MIMETYPE="text/xml" CHECKSUM="d0eb6c3cc6a6f94c6c21530dbd29a34683f2a852" CHECKSUMTYPE="SHA-1" SIZE="5068">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:26:49" MIMETYPE="text/xml"
-				CHECKSUM="d4ab20386542bf564591f48f118d166a3465fa26" CHECKSUMTYPE="SHA-1"
-				SIZE="44225">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:26:49" MIMETYPE="text/xml" CHECKSUM="d4ab20386542bf564591f48f118d166a3465fa26" CHECKSUMTYPE="SHA-1" SIZE="44225">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:26:49" MIMETYPE="text/xml"
-				CHECKSUM="4daccb6daf6a584ac783cb2c95e409ff95ad34fe" CHECKSUMTYPE="SHA-1" SIZE="8470">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:26:49" MIMETYPE="text/xml" CHECKSUM="4daccb6daf6a584ac783cb2c95e409ff95ad34fe" CHECKSUMTYPE="SHA-1" SIZE="8470">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:26:50" MIMETYPE="text/xml"
-				CHECKSUM="0c6961a84234d1dfd0f4b143c95bb2e79d810f03" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:26:50" MIMETYPE="text/xml" CHECKSUM="0c6961a84234d1dfd0f4b143c95bb2e79d810f03" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:26:50" MIMETYPE="text/xml"
-				CHECKSUM="1538a185f34aebd4de689e6676c0f7de68983314" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:26:50" MIMETYPE="text/xml" CHECKSUM="1538a185f34aebd4de689e6676c0f7de68983314" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:26:50" MIMETYPE="text/xml"
-				CHECKSUM="feff1a13143ec5034de8f463978ed725f1795ac1" CHECKSUMTYPE="SHA-1" SIZE="2105">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:26:50" MIMETYPE="text/xml" CHECKSUM="feff1a13143ec5034de8f463978ed725f1795ac1" CHECKSUMTYPE="SHA-1" SIZE="2105">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:26:50" MIMETYPE="text/xml"
-				CHECKSUM="e335721b8c27cf80f2391ce068a74fbe21e001ae" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:26:50" MIMETYPE="text/xml" CHECKSUM="e335721b8c27cf80f2391ce068a74fbe21e001ae" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:26:50" MIMETYPE="text/xml"
-				CHECKSUM="903edaacd239cc6f9fb8d6d061830185bb7f843b" CHECKSUMTYPE="SHA-1" SIZE="2906">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:26:50" MIMETYPE="text/xml" CHECKSUM="903edaacd239cc6f9fb8d6d061830185bb7f843b" CHECKSUMTYPE="SHA-1" SIZE="2906">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:26:51" MIMETYPE="text/xml"
-				CHECKSUM="02009fece1cdad195908251de06e30b4678ee683" CHECKSUMTYPE="SHA-1"
-				SIZE="43797">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:26:51" MIMETYPE="text/xml" CHECKSUM="02009fece1cdad195908251de06e30b4678ee683" CHECKSUMTYPE="SHA-1" SIZE="43797">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:26:51" MIMETYPE="text/xml"
-				CHECKSUM="e96c68d4e1ca8a8c02d6c0f36500d0a7cfb9f0d1" CHECKSUMTYPE="SHA-1"
-				SIZE="11376">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:26:51" MIMETYPE="text/xml" CHECKSUM="e96c68d4e1ca8a8c02d6c0f36500d0a7cfb9f0d1" CHECKSUMTYPE="SHA-1" SIZE="11376">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:26:51" MIMETYPE="text/xml"
-				CHECKSUM="a05e9dab8f5c40096ad6516163cf8a738fbac743" CHECKSUMTYPE="SHA-1" SIZE="3778">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:26:51" MIMETYPE="text/xml" CHECKSUM="a05e9dab8f5c40096ad6516163cf8a738fbac743" CHECKSUMTYPE="SHA-1" SIZE="3778">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:26:51" MIMETYPE="text/xml"
-				CHECKSUM="be0b52f0136cb8032c5804d4a76d55a56b1d45fe" CHECKSUMTYPE="SHA-1" SIZE="3771">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:26:51" MIMETYPE="text/xml" CHECKSUM="be0b52f0136cb8032c5804d4a76d55a56b1d45fe" CHECKSUMTYPE="SHA-1" SIZE="3771">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:26:52" MIMETYPE="text/xml"
-				CHECKSUM="1c0dd8f8fb5e42c08e23de35891daa09862dda10" CHECKSUMTYPE="SHA-1" SIZE="3776">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:26:52" MIMETYPE="text/xml" CHECKSUM="1c0dd8f8fb5e42c08e23de35891daa09862dda10" CHECKSUMTYPE="SHA-1" SIZE="3776">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:26:52" MIMETYPE="text/xml"
-				CHECKSUM="663da2541d69c3f50007b8ce8d72858611db0fa6" CHECKSUMTYPE="SHA-1" SIZE="3782">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:26:52" MIMETYPE="text/xml" CHECKSUM="663da2541d69c3f50007b8ce8d72858611db0fa6" CHECKSUMTYPE="SHA-1" SIZE="3782">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:26:52" MIMETYPE="text/xml"
-				CHECKSUM="87d5169f5811892a0cc2c88d51c9bdde825714b2" CHECKSUMTYPE="SHA-1" SIZE="3778">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:26:52" MIMETYPE="text/xml" CHECKSUM="87d5169f5811892a0cc2c88d51c9bdde825714b2" CHECKSUMTYPE="SHA-1" SIZE="3778">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:26:52" MIMETYPE="text/xml"
-				CHECKSUM="3e5b6e6031f761791dba2647ffff6dd017e890c3" CHECKSUMTYPE="SHA-1" SIZE="3778">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:26:52" MIMETYPE="text/xml" CHECKSUM="3e5b6e6031f761791dba2647ffff6dd017e890c3" CHECKSUMTYPE="SHA-1" SIZE="3778">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:26:53" MIMETYPE="text/xml"
-				CHECKSUM="dace5fe3c7ecec689efb385fd7c50bbca8d33674" CHECKSUMTYPE="SHA-1" SIZE="3778">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:26:53" MIMETYPE="text/xml" CHECKSUM="dace5fe3c7ecec689efb385fd7c50bbca8d33674" CHECKSUMTYPE="SHA-1" SIZE="3778">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:26:53" MIMETYPE="text/xml"
-				CHECKSUM="40eb7fa8946fee9bdd02fbb2f77e1a173f9d315a" CHECKSUMTYPE="SHA-1" SIZE="4393">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:26:53" MIMETYPE="text/xml" CHECKSUM="40eb7fa8946fee9bdd02fbb2f77e1a173f9d315a" CHECKSUMTYPE="SHA-1" SIZE="4393">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:26:53" MIMETYPE="text/xml"
-				CHECKSUM="76ac4b1517be6817334063b8f24350b0ba3a3065" CHECKSUMTYPE="SHA-1" SIZE="4376">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:26:53" MIMETYPE="text/xml" CHECKSUM="76ac4b1517be6817334063b8f24350b0ba3a3065" CHECKSUMTYPE="SHA-1" SIZE="4376">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:26:53" MIMETYPE="text/xml"
-				CHECKSUM="0df003efd5709447d716ab2e523a1a87f8580bd4" CHECKSUMTYPE="SHA-1" SIZE="3771">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:26:53" MIMETYPE="text/xml" CHECKSUM="0df003efd5709447d716ab2e523a1a87f8580bd4" CHECKSUMTYPE="SHA-1" SIZE="3771">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:26:53" MIMETYPE="text/xml"
-				CHECKSUM="7cf8c2bf8c2080b7a8df11b061a0de50c4ad0a18" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:26:53" MIMETYPE="text/xml" CHECKSUM="7cf8c2bf8c2080b7a8df11b061a0de50c4ad0a18" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:26:54" MIMETYPE="text/xml"
-				CHECKSUM="2ad1552fca369241cbab3ab4f1240e9b4ad411dd" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:26:54" MIMETYPE="text/xml" CHECKSUM="2ad1552fca369241cbab3ab4f1240e9b4ad411dd" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:26:54" MIMETYPE="text/xml"
-				CHECKSUM="2912080c508a209da0fdffbcfece08d62409b9f0" CHECKSUMTYPE="SHA-1"
-				SIZE="20437">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:26:54" MIMETYPE="text/xml" CHECKSUM="2912080c508a209da0fdffbcfece08d62409b9f0" CHECKSUMTYPE="SHA-1" SIZE="20437">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:26:54" MIMETYPE="text/xml"
-				CHECKSUM="c1fe2abd477d4c7359897fb1df0f006473442b47" CHECKSUMTYPE="SHA-1" SIZE="7422">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:26:54" MIMETYPE="text/xml" CHECKSUM="c1fe2abd477d4c7359897fb1df0f006473442b47" CHECKSUMTYPE="SHA-1" SIZE="7422">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-01_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:27:16" MIMETYPE="application/pdf"
-				CHECKSUM="7395877a32918c5e3794d8692b2ed2196600e5ea" CHECKSUMTYPE="SHA-1"
-				SIZE="5198384">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/bmtnabf_1902-10-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:27:16" MIMETYPE="application/pdf" CHECKSUM="7395877a32918c5e3794d8692b2ed2196600e5ea" CHECKSUMTYPE="SHA-1" SIZE="5198384">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/01_01/bmtnabf_1902-10-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2734,8 +2576,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004"
-					LABEL="STUDIEN-AQUARELL">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004" LABEL="STUDIEN-AQUARELL">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00001"/>
@@ -2766,18 +2607,15 @@
 								<div ID="L.1.1.6.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.3" TYPE="Illustration" ORDER="1" DMDID="c007"
-						LABEL="Untitled Image by Emil Orlik OM">
+					<div ID="L.1.1.6.3" TYPE="Illustration" ORDER="1" DMDID="c007" LABEL="Untitled Image by Emil Orlik OM">
 						<div ID="L.1.1.6.3.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
@@ -2790,8 +2628,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c008"
-					LABEL="Untitled Image by Emil Orlik OM">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c008" LABEL="Untitled Image by Emil Orlik OM">
 					<div ID="L.1.1.7.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -2803,8 +2640,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c009"
-					LABEL="Untitled Image by Emil Orlik OM">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c009" LABEL="Untitled Image by Emil Orlik OM">
 					<div ID="L.1.1.8.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -2816,8 +2652,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c010"
-					LABEL="Untitled Image by Emil Orlik OM">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c010" LABEL="Untitled Image by Emil Orlik OM">
 					<div ID="L.1.1.9.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -2829,8 +2664,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c011"
-					LABEL="Untitled Image by Emil Orlik OM">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c011" LABEL="Untitled Image by Emil Orlik OM">
 					<div ID="L.1.1.10.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
@@ -2842,8 +2676,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c012"
-					LABEL="Untitled Image by Emil Orlik OM">
+				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c012" LABEL="Untitled Image by Emil Orlik OM">
 					<div ID="L.1.1.11.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -2855,8 +2688,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c013"
-					LABEL="Untitled Image by Emil Orlik OM">
+				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c013" LABEL="Untitled Image by Emil Orlik OM">
 					<div ID="L.1.1.12.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -2868,8 +2700,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c014"
-					LABEL="Untitled Image by Emil Orlik OM">
+				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c014" LABEL="Untitled Image by Emil Orlik OM">
 					<div ID="L.1.1.13.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -2915,8 +2746,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c017"
-					LABEL="Untitled Image by Emil Orlik OM">
+				<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c017" LABEL="Untitled Image by Emil Orlik OM">
 					<div ID="L.1.1.16.1" TYPE="Byline">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1902/10/15_01/bmtnabf_1902-10-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/10/15_01/bmtnabf_1902-10-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-10-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-10-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-10-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-10-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-10-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2184,308 +2178,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:14:18"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="ee55ca5b6ba275719585e1b6ee4a98f00ca669d1"
-				CHECKSUMTYPE="SHA-1" SIZE="6154325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:14:18" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="ee55ca5b6ba275719585e1b6ee4a98f00ca669d1" CHECKSUMTYPE="SHA-1" SIZE="6154325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:14:48"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="7d781ecb82c8ab62dca412101f57f74b433b9a2d"
-				CHECKSUMTYPE="SHA-1" SIZE="6125529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:14:48" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="7d781ecb82c8ab62dca412101f57f74b433b9a2d" CHECKSUMTYPE="SHA-1" SIZE="6125529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:15:20"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="2cbc232651bf72a0b80ddb45039f55fc7fdbdf10"
-				CHECKSUMTYPE="SHA-1" SIZE="6169620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:15:20" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="2cbc232651bf72a0b80ddb45039f55fc7fdbdf10" CHECKSUMTYPE="SHA-1" SIZE="6169620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:15:57"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="201f8f044932c68cea9a9c8def367de52b350d63"
-				CHECKSUMTYPE="SHA-1" SIZE="6125503">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:15:57" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="201f8f044932c68cea9a9c8def367de52b350d63" CHECKSUMTYPE="SHA-1" SIZE="6125503">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:16:31"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="b06eac2b7f8a5d0d90e10c48861e2e99181f5ad6"
-				CHECKSUMTYPE="SHA-1" SIZE="6169626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:16:31" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="b06eac2b7f8a5d0d90e10c48861e2e99181f5ad6" CHECKSUMTYPE="SHA-1" SIZE="6169626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:17:03"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="d1d9ed11f4728ec6117f6b8e2f07034778e39aa1"
-				CHECKSUMTYPE="SHA-1" SIZE="6207429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:17:03" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="d1d9ed11f4728ec6117f6b8e2f07034778e39aa1" CHECKSUMTYPE="SHA-1" SIZE="6207429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:17:35"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="7ac84cb42d08683e9bbe73ffffd90e228d109975"
-				CHECKSUMTYPE="SHA-1" SIZE="6170525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:17:35" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="7ac84cb42d08683e9bbe73ffffd90e228d109975" CHECKSUMTYPE="SHA-1" SIZE="6170525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:18:05"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="8f1d2db9f4aff8d447d30bf1fc9033c739b21f39"
-				CHECKSUMTYPE="SHA-1" SIZE="6207417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:18:05" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="8f1d2db9f4aff8d447d30bf1fc9033c739b21f39" CHECKSUMTYPE="SHA-1" SIZE="6207417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:18:37"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="1ba497e84c4ab61bc7478207519e92ec2e92e84a"
-				CHECKSUMTYPE="SHA-1" SIZE="6170514">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:18:37" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="1ba497e84c4ab61bc7478207519e92ec2e92e84a" CHECKSUMTYPE="SHA-1" SIZE="6170514">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:19:08"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="3e2c4906babcfe3d54d21e625369ce8eb04d0ed5"
-				CHECKSUMTYPE="SHA-1" SIZE="6207421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:19:08" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="3e2c4906babcfe3d54d21e625369ce8eb04d0ed5" CHECKSUMTYPE="SHA-1" SIZE="6207421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:19:39"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="2d25448670f79ad4f041ec7a92f71f2630eeb03d"
-				CHECKSUMTYPE="SHA-1" SIZE="6170526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:19:39" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="2d25448670f79ad4f041ec7a92f71f2630eeb03d" CHECKSUMTYPE="SHA-1" SIZE="6170526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:20:11"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="5cf8216be8d2320e2858b6683c1768e6c7051725"
-				CHECKSUMTYPE="SHA-1" SIZE="6207426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:20:11" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="5cf8216be8d2320e2858b6683c1768e6c7051725" CHECKSUMTYPE="SHA-1" SIZE="6207426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:20:41"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="7fda22af3b417dadb0f8895ac46526aed26fb350"
-				CHECKSUMTYPE="SHA-1" SIZE="6110227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:20:41" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="7fda22af3b417dadb0f8895ac46526aed26fb350" CHECKSUMTYPE="SHA-1" SIZE="6110227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:21:11"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="f066c0ef0cbd5c42635a99dcaf8a5c3a656c2439"
-				CHECKSUMTYPE="SHA-1" SIZE="6207421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:21:11" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="f066c0ef0cbd5c42635a99dcaf8a5c3a656c2439" CHECKSUMTYPE="SHA-1" SIZE="6207421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:21:42"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="3377f71fe402555ab65e7c876b47412f95966028"
-				CHECKSUMTYPE="SHA-1" SIZE="6094794">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:21:42" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="3377f71fe402555ab65e7c876b47412f95966028" CHECKSUMTYPE="SHA-1" SIZE="6094794">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:22:12"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="df85d1dabfa586dd62bb679e3a67bf7d71d8aca7"
-				CHECKSUMTYPE="SHA-1" SIZE="6207421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:22:12" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="df85d1dabfa586dd62bb679e3a67bf7d71d8aca7" CHECKSUMTYPE="SHA-1" SIZE="6207421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:22:43"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="6eceec6f4efd62eddd705794ca9f557a73b7f36b"
-				CHECKSUMTYPE="SHA-1" SIZE="6094929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:22:43" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="6eceec6f4efd62eddd705794ca9f557a73b7f36b" CHECKSUMTYPE="SHA-1" SIZE="6094929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:23:13"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="8e21c3f622b58f6d0b508a56fb901e13ee3390ec"
-				CHECKSUMTYPE="SHA-1" SIZE="6208329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:23:13" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="8e21c3f622b58f6d0b508a56fb901e13ee3390ec" CHECKSUMTYPE="SHA-1" SIZE="6208329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:23:44"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="0ba511fc3536d47de8f024cbda8a861120aa11a7"
-				CHECKSUMTYPE="SHA-1" SIZE="6096725">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:23:44" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="0ba511fc3536d47de8f024cbda8a861120aa11a7" CHECKSUMTYPE="SHA-1" SIZE="6096725">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:24:15"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="ee6e972ef9dfc24a33f421fb7ddfee9d424ffb38"
-				CHECKSUMTYPE="SHA-1" SIZE="6207423">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:24:15" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="ee6e972ef9dfc24a33f421fb7ddfee9d424ffb38" CHECKSUMTYPE="SHA-1" SIZE="6207423">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:24:47"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="27ab93a59276d0d84c8c5163e62d0d9396df0ea7"
-				CHECKSUMTYPE="SHA-1" SIZE="6096697">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:24:47" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="27ab93a59276d0d84c8c5163e62d0d9396df0ea7" CHECKSUMTYPE="SHA-1" SIZE="6096697">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:25:20"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="7837db4afb0fb6ba0b2eaf64b1f00eda9c03e2b0"
-				CHECKSUMTYPE="SHA-1" SIZE="6207363">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:25:20" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="7837db4afb0fb6ba0b2eaf64b1f00eda9c03e2b0" CHECKSUMTYPE="SHA-1" SIZE="6207363">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:25:53"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="86f3568efd520775bb206af4bf41bdec514cfad1"
-				CHECKSUMTYPE="SHA-1" SIZE="6096729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:25:53" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="86f3568efd520775bb206af4bf41bdec514cfad1" CHECKSUMTYPE="SHA-1" SIZE="6096729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:26:25"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="7c819e7bb81457b37ed078caafa770d045dc5279"
-				CHECKSUMTYPE="SHA-1" SIZE="6159704">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:26:25" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="7c819e7bb81457b37ed078caafa770d045dc5279" CHECKSUMTYPE="SHA-1" SIZE="6159704">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/delivery/bmtnabf_1902-10-15_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:26:43" MIMETYPE="text/xml"
-				CHECKSUM="ac519191b6a1c607c4c83e7b2d78060a615b545f" CHECKSUMTYPE="SHA-1" SIZE="5345">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:26:43" MIMETYPE="text/xml" CHECKSUM="ac519191b6a1c607c4c83e7b2d78060a615b545f" CHECKSUMTYPE="SHA-1" SIZE="5345">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:26:43" MIMETYPE="text/xml"
-				CHECKSUM="cc12b6392c5006deffdee8db5fecb781cf5c6633" CHECKSUMTYPE="SHA-1"
-				SIZE="31766">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:26:43" MIMETYPE="text/xml" CHECKSUM="cc12b6392c5006deffdee8db5fecb781cf5c6633" CHECKSUMTYPE="SHA-1" SIZE="31766">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:26:44" MIMETYPE="text/xml"
-				CHECKSUM="52c32de6e67c012553f3379d2f93ec3a03274dd3" CHECKSUMTYPE="SHA-1" SIZE="8450">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:26:44" MIMETYPE="text/xml" CHECKSUM="52c32de6e67c012553f3379d2f93ec3a03274dd3" CHECKSUMTYPE="SHA-1" SIZE="8450">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:26:44" MIMETYPE="text/xml"
-				CHECKSUM="b8f5c0dfb0ad6b9c031f0b8c6a49a441e603b01c" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:26:44" MIMETYPE="text/xml" CHECKSUM="b8f5c0dfb0ad6b9c031f0b8c6a49a441e603b01c" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:26:44" MIMETYPE="text/xml"
-				CHECKSUM="da6e75fd76947af19489a1eff4f37dcfc4fdd4f2" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:26:44" MIMETYPE="text/xml" CHECKSUM="da6e75fd76947af19489a1eff4f37dcfc4fdd4f2" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:26:44" MIMETYPE="text/xml"
-				CHECKSUM="fc01bbe4541802fe0c7006483218fae92c6a463d" CHECKSUMTYPE="SHA-1" SIZE="2117">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:26:44" MIMETYPE="text/xml" CHECKSUM="fc01bbe4541802fe0c7006483218fae92c6a463d" CHECKSUMTYPE="SHA-1" SIZE="2117">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:26:44" MIMETYPE="text/xml"
-				CHECKSUM="34ab9a2fad4188847d5e9d3ab2900557ba3bf31c" CHECKSUMTYPE="SHA-1" SIZE="1718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:26:44" MIMETYPE="text/xml" CHECKSUM="34ab9a2fad4188847d5e9d3ab2900557ba3bf31c" CHECKSUMTYPE="SHA-1" SIZE="1718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:26:45" MIMETYPE="text/xml"
-				CHECKSUM="51c49a6d7b5fbcf6387e64d86c3874a2f3a7dbf9" CHECKSUMTYPE="SHA-1" SIZE="3319">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:26:45" MIMETYPE="text/xml" CHECKSUM="51c49a6d7b5fbcf6387e64d86c3874a2f3a7dbf9" CHECKSUMTYPE="SHA-1" SIZE="3319">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:26:45" MIMETYPE="text/xml"
-				CHECKSUM="e7fc347261db97a7288ec49274d520ff5592cbf6" CHECKSUMTYPE="SHA-1" SIZE="4787">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:26:45" MIMETYPE="text/xml" CHECKSUM="e7fc347261db97a7288ec49274d520ff5592cbf6" CHECKSUMTYPE="SHA-1" SIZE="4787">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:26:45" MIMETYPE="text/xml"
-				CHECKSUM="b7e962662ebae27485a7bff52e71ac7118843576" CHECKSUMTYPE="SHA-1" SIZE="5668">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:26:45" MIMETYPE="text/xml" CHECKSUM="b7e962662ebae27485a7bff52e71ac7118843576" CHECKSUMTYPE="SHA-1" SIZE="5668">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:26:45" MIMETYPE="text/xml"
-				CHECKSUM="29a861a4337ec448ef976909dd739e3f512da6ec" CHECKSUMTYPE="SHA-1" SIZE="5887">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:26:45" MIMETYPE="text/xml" CHECKSUM="29a861a4337ec448ef976909dd739e3f512da6ec" CHECKSUMTYPE="SHA-1" SIZE="5887">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:26:46" MIMETYPE="text/xml"
-				CHECKSUM="6c05de7fcc5e9011b1bd542d81957d2fca6d8052" CHECKSUMTYPE="SHA-1"
-				SIZE="24031">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:26:46" MIMETYPE="text/xml" CHECKSUM="6c05de7fcc5e9011b1bd542d81957d2fca6d8052" CHECKSUMTYPE="SHA-1" SIZE="24031">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:26:46" MIMETYPE="text/xml"
-				CHECKSUM="1aab3e63d379e7e01baf75aca9ba443e4f34cb0b" CHECKSUMTYPE="SHA-1" SIZE="4915">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:26:46" MIMETYPE="text/xml" CHECKSUM="1aab3e63d379e7e01baf75aca9ba443e4f34cb0b" CHECKSUMTYPE="SHA-1" SIZE="4915">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:26:46" MIMETYPE="text/xml"
-				CHECKSUM="da5b3dceae3fcb2838734c6cb447d745ca889a11" CHECKSUMTYPE="SHA-1" SIZE="5747">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:26:46" MIMETYPE="text/xml" CHECKSUM="da5b3dceae3fcb2838734c6cb447d745ca889a11" CHECKSUMTYPE="SHA-1" SIZE="5747">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:26:46" MIMETYPE="text/xml"
-				CHECKSUM="b0ebad0bc33989c142773a68e21b2cc5b03f0666" CHECKSUMTYPE="SHA-1" SIZE="5358">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:26:46" MIMETYPE="text/xml" CHECKSUM="b0ebad0bc33989c142773a68e21b2cc5b03f0666" CHECKSUMTYPE="SHA-1" SIZE="5358">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:26:47" MIMETYPE="text/xml"
-				CHECKSUM="df1db77051d95257029d9f0f73e7a00b227acc6b" CHECKSUMTYPE="SHA-1" SIZE="4958">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:26:47" MIMETYPE="text/xml" CHECKSUM="df1db77051d95257029d9f0f73e7a00b227acc6b" CHECKSUMTYPE="SHA-1" SIZE="4958">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:26:47" MIMETYPE="text/xml"
-				CHECKSUM="263b4c2407321bc41d439e4e7568d704b180d880" CHECKSUMTYPE="SHA-1"
-				SIZE="23580">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:26:47" MIMETYPE="text/xml" CHECKSUM="263b4c2407321bc41d439e4e7568d704b180d880" CHECKSUMTYPE="SHA-1" SIZE="23580">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:26:47" MIMETYPE="text/xml"
-				CHECKSUM="aa32801e19f1f6b9d420599d18a2a31dfe279cd3" CHECKSUMTYPE="SHA-1" SIZE="3258">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:26:47" MIMETYPE="text/xml" CHECKSUM="aa32801e19f1f6b9d420599d18a2a31dfe279cd3" CHECKSUMTYPE="SHA-1" SIZE="3258">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:26:47" MIMETYPE="text/xml"
-				CHECKSUM="5174dfe97a2a62350dcc5936dfe2a577f72e80d8" CHECKSUMTYPE="SHA-1" SIZE="8067">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:26:47" MIMETYPE="text/xml" CHECKSUM="5174dfe97a2a62350dcc5936dfe2a577f72e80d8" CHECKSUMTYPE="SHA-1" SIZE="8067">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:26:47" MIMETYPE="text/xml"
-				CHECKSUM="f6ef39cd714cbfc60a566749186b01e23c04cd5f" CHECKSUMTYPE="SHA-1" SIZE="5026">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:26:47" MIMETYPE="text/xml" CHECKSUM="f6ef39cd714cbfc60a566749186b01e23c04cd5f" CHECKSUMTYPE="SHA-1" SIZE="5026">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:26:48" MIMETYPE="text/xml"
-				CHECKSUM="a02bee6ee43566290e1a90e90dbfc6a4b3f96da9" CHECKSUMTYPE="SHA-1" SIZE="8519">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:26:48" MIMETYPE="text/xml" CHECKSUM="a02bee6ee43566290e1a90e90dbfc6a4b3f96da9" CHECKSUMTYPE="SHA-1" SIZE="8519">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:26:48" MIMETYPE="text/xml"
-				CHECKSUM="8585ef49870e9f8d29241892117afd2f8b05f035" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:26:48" MIMETYPE="text/xml" CHECKSUM="8585ef49870e9f8d29241892117afd2f8b05f035" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:26:48" MIMETYPE="text/xml"
-				CHECKSUM="6ecce696edf276a83a01cab481d8a3729f583153" CHECKSUMTYPE="SHA-1"
-				SIZE="13265">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:26:48" MIMETYPE="text/xml" CHECKSUM="6ecce696edf276a83a01cab481d8a3729f583153" CHECKSUMTYPE="SHA-1" SIZE="13265">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:26:48" MIMETYPE="text/xml"
-				CHECKSUM="da03a55985a21957adf769fe0ad0c1f80b58349c" CHECKSUMTYPE="SHA-1" SIZE="7953">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:26:48" MIMETYPE="text/xml" CHECKSUM="da03a55985a21957adf769fe0ad0c1f80b58349c" CHECKSUMTYPE="SHA-1" SIZE="7953">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-10-15_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:27:08" MIMETYPE="application/pdf"
-				CHECKSUM="e770cd624ef3840ec3dd115ec8a6163d63ce8069" CHECKSUMTYPE="SHA-1"
-				SIZE="5833551">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/bmtnabf_1902-10-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:27:08" MIMETYPE="application/pdf" CHECKSUM="e770cd624ef3840ec3dd115ec8a6163d63ce8069" CHECKSUMTYPE="SHA-1" SIZE="5833551">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/10/15_01/bmtnabf_1902-10-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2852,8 +2694,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.9" TYPE="Illustration" ORDER="5" DMDID="c008"
-						LABEL="Zeichnung für eine getriebene Plakette von der XIV. Ausstellung">
+					<div ID="L.1.1.9" TYPE="Illustration" ORDER="5" DMDID="c008" LABEL="Zeichnung für eine getriebene Plakette von der XIV. Ausstellung">
 						<div ID="L.1.1.9.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
@@ -2870,8 +2711,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10" TYPE="Illustration" ORDER="6" DMDID="c009"
-						LABEL="Zeichnung für eine getriebene Plakette von der XIV. Ausstellung">
+					<div ID="L.1.1.10" TYPE="Illustration" ORDER="6" DMDID="c009" LABEL="Zeichnung für eine getriebene Plakette von der XIV. Ausstellung">
 						<div ID="L.1.1.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
@@ -2888,8 +2728,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12" TYPE="Illustration" ORDER="8" DMDID="c013"
-						LABEL="Glasfenster von der XIV. Ausstellung">
+					<div ID="L.1.1.12" TYPE="Illustration" ORDER="8" DMDID="c013" LABEL="Glasfenster von der XIV. Ausstellung">
 						<div ID="L.1.1.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -2906,8 +2745,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13" TYPE="Illustration" ORDER="9" DMDID="c014"
-						LABEL="Brunnenfiguren in farbigem Zementguß von der XIV. Ausstellung">
+					<div ID="L.1.1.13" TYPE="Illustration" ORDER="9" DMDID="c014" LABEL="Brunnenfiguren in farbigem Zementguß von der XIV. Ausstellung">
 						<div ID="L.1.1.13.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
@@ -2929,8 +2767,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.14" TYPE="Illustration" ORDER="10" DMDID="c016"
-						LABEL="Geschnitzte Grotesken von der XIV. Ausstellung">
+					<div ID="L.1.1.14" TYPE="Illustration" ORDER="10" DMDID="c016" LABEL="Geschnitzte Grotesken von der XIV. Ausstellung">
 						<div ID="L.1.1.14.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
@@ -2953,8 +2790,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="TextContent" ORDER="7" DMDID="c010"
-					LABEL="HANDZEICHNUNG LEONARDOS">
+				<div ID="L.1.1.11" TYPE="TextContent" ORDER="7" DMDID="c010" LABEL="HANDZEICHNUNG LEONARDOS">
 					<div ID="L.1.1.11.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -2970,23 +2806,20 @@
 							<div ID="L.1.1.11.3.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.11.3.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.11.3.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.11.3.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.11.4" TYPE="Illustration" ORDER="1" DMDID="c011"
-						LABEL="Umrahmung">
+					<div ID="L.1.1.11.4" TYPE="Illustration" ORDER="1" DMDID="c011" LABEL="Umrahmung">
 						<div ID="L.1.1.11.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00004"/>
@@ -3003,8 +2836,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11.5" TYPE="Illustration" ORDER="2" DMDID="c012"
-						LABEL="Umrahmung">
+					<div ID="L.1.1.11.5" TYPE="Illustration" ORDER="2" DMDID="c012" LABEL="Umrahmung">
 						<div ID="L.1.1.11.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00004"/>
@@ -3022,8 +2854,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="Illustration" ORDER="11" DMDID="c018"
-					LABEL="Mörtelschnitt mit Vergoldung und Glasflüssen">
+				<div ID="L.1.1.15" TYPE="Illustration" ORDER="11" DMDID="c018" LABEL="Mörtelschnitt mit Vergoldung und Glasflüssen">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>
@@ -3040,8 +2871,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.16" TYPE="Illustration" ORDER="12" DMDID="c019"
-					LABEL="DIE BREMER STADTMUSIKANTEN">
+				<div ID="L.1.1.16" TYPE="Illustration" ORDER="12" DMDID="c019" LABEL="DIE BREMER STADTMUSIKANTEN">
 					<div ID="L.1.1.16.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>

--- a/metadata/periodicals/bmtnabf/issues/1902/11/01_01/bmtnabf_1902-11-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/11/01_01/bmtnabf_1902-11-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-11-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-11-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-11-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-11-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-11-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -1861,259 +1855,132 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:15:55"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="b093dee734858a8070fe4bc66e30a2ada61001a6"
-				CHECKSUMTYPE="SHA-1" SIZE="6120129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:15:55" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="b093dee734858a8070fe4bc66e30a2ada61001a6" CHECKSUMTYPE="SHA-1" SIZE="6120129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:16:27"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="96211caedc30b00024305eb446cc49d912daa2e2"
-				CHECKSUMTYPE="SHA-1" SIZE="6103927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:16:27" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="96211caedc30b00024305eb446cc49d912daa2e2" CHECKSUMTYPE="SHA-1" SIZE="6103927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:16:57"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="f2a7883079079f29e97b148f92fae8442da3c14c"
-				CHECKSUMTYPE="SHA-1" SIZE="6120129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:16:57" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="f2a7883079079f29e97b148f92fae8442da3c14c" CHECKSUMTYPE="SHA-1" SIZE="6120129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:17:31"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="1a466d04d8d30a657ca41ff43ed5633426ea7ae9"
-				CHECKSUMTYPE="SHA-1" SIZE="6103908">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:17:31" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="1a466d04d8d30a657ca41ff43ed5633426ea7ae9" CHECKSUMTYPE="SHA-1" SIZE="6103908">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:18:02"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="f1521eb2bb65e1a65fc5ed959dbffa699593c47e"
-				CHECKSUMTYPE="SHA-1" SIZE="6112023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:18:02" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="f1521eb2bb65e1a65fc5ed959dbffa699593c47e" CHECKSUMTYPE="SHA-1" SIZE="6112023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:18:33"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="0e270d49ac25bff151cba125a72b10c8f175cb69"
-				CHECKSUMTYPE="SHA-1" SIZE="6103923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:18:33" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="0e270d49ac25bff151cba125a72b10c8f175cb69" CHECKSUMTYPE="SHA-1" SIZE="6103923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:19:02"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="bd386e4532aceb3e367ff8a51d7ceacf29ef410f"
-				CHECKSUMTYPE="SHA-1" SIZE="6112022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:19:02" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="bd386e4532aceb3e367ff8a51d7ceacf29ef410f" CHECKSUMTYPE="SHA-1" SIZE="6112022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:19:34"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="ee7dcf8b84fbed0b5fa741db0166280a0ce898cf"
-				CHECKSUMTYPE="SHA-1" SIZE="6103919">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:19:34" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="ee7dcf8b84fbed0b5fa741db0166280a0ce898cf" CHECKSUMTYPE="SHA-1" SIZE="6103919">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:20:06"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="728dc19787db675d5d18c68f6fdce06bd1cea23e"
-				CHECKSUMTYPE="SHA-1" SIZE="6065223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:20:06" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="728dc19787db675d5d18c68f6fdce06bd1cea23e" CHECKSUMTYPE="SHA-1" SIZE="6065223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:20:39"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="3f3942708f302060fcf634f9bf8098ea3054c31a"
-				CHECKSUMTYPE="SHA-1" SIZE="6136325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:20:39" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="3f3942708f302060fcf634f9bf8098ea3054c31a" CHECKSUMTYPE="SHA-1" SIZE="6136325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:21:09"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="35a485f7b82f39c7f2fb80d30078d5695c35ff60"
-				CHECKSUMTYPE="SHA-1" SIZE="6066126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:21:09" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="35a485f7b82f39c7f2fb80d30078d5695c35ff60" CHECKSUMTYPE="SHA-1" SIZE="6066126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:21:38"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="94bcf72b92be9d7d6afa0b6f47f610844fcc5d09"
-				CHECKSUMTYPE="SHA-1" SIZE="6136321">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:21:38" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="94bcf72b92be9d7d6afa0b6f47f610844fcc5d09" CHECKSUMTYPE="SHA-1" SIZE="6136321">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:22:09"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="8e27a87e210e541fedc59ca3c1c0921e9e59e236"
-				CHECKSUMTYPE="SHA-1" SIZE="6066128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:22:09" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="8e27a87e210e541fedc59ca3c1c0921e9e59e236" CHECKSUMTYPE="SHA-1" SIZE="6066128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:22:40"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="0715e110bed5dfd8c944f52a908d37f9d5f372bd"
-				CHECKSUMTYPE="SHA-1" SIZE="6136318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:22:40" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="0715e110bed5dfd8c944f52a908d37f9d5f372bd" CHECKSUMTYPE="SHA-1" SIZE="6136318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:23:10"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="7863e010bdb088e6a520c6452aa3d04776340fb8"
-				CHECKSUMTYPE="SHA-1" SIZE="6016612">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:23:10" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="7863e010bdb088e6a520c6452aa3d04776340fb8" CHECKSUMTYPE="SHA-1" SIZE="6016612">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:23:40"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="451d5e94854cc9e1bb2b4752bcd3227a0acd9089"
-				CHECKSUMTYPE="SHA-1" SIZE="6118326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:23:40" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="451d5e94854cc9e1bb2b4752bcd3227a0acd9089" CHECKSUMTYPE="SHA-1" SIZE="6118326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:24:17"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="8a96921a2a821d583e5480d3a961be6aa4ddb309"
-				CHECKSUMTYPE="SHA-1" SIZE="6026526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:24:17" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="8a96921a2a821d583e5480d3a961be6aa4ddb309" CHECKSUMTYPE="SHA-1" SIZE="6026526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:24:47"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="272954aec11442147ce67bd1c279ea12b2d116f0"
-				CHECKSUMTYPE="SHA-1" SIZE="6154328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:24:47" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="272954aec11442147ce67bd1c279ea12b2d116f0" CHECKSUMTYPE="SHA-1" SIZE="6154328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:25:19"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="f196302a5c6ca571e6b289a91b33f7a3a32db30f"
-				CHECKSUMTYPE="SHA-1" SIZE="6013785">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:25:19" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="f196302a5c6ca571e6b289a91b33f7a3a32db30f" CHECKSUMTYPE="SHA-1" SIZE="6013785">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:25:50"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="b6a4dcdc21c446d5e80091fb33cc9683833e9389"
-				CHECKSUMTYPE="SHA-1" SIZE="6186727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:25:50" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="b6a4dcdc21c446d5e80091fb33cc9683833e9389" CHECKSUMTYPE="SHA-1" SIZE="6186727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/delivery/bmtnabf_1902-11-01_01_0020.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:26:10" MIMETYPE="text/xml"
-				CHECKSUM="368bbc22a1f3c95fa0d858095ca832a5ca77d875" CHECKSUMTYPE="SHA-1" SIZE="4704">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:26:10" MIMETYPE="text/xml" CHECKSUM="368bbc22a1f3c95fa0d858095ca832a5ca77d875" CHECKSUMTYPE="SHA-1" SIZE="4704">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:26:10" MIMETYPE="text/xml"
-				CHECKSUM="a551074564ff52e25e2edf7b126d162ea55e5a23" CHECKSUMTYPE="SHA-1"
-				SIZE="45722">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:26:10" MIMETYPE="text/xml" CHECKSUM="a551074564ff52e25e2edf7b126d162ea55e5a23" CHECKSUMTYPE="SHA-1" SIZE="45722">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:26:10" MIMETYPE="text/xml"
-				CHECKSUM="bc389ffbbd8f0c28ad7f42e3a3ac3c520dfbe385" CHECKSUMTYPE="SHA-1" SIZE="8366">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:26:10" MIMETYPE="text/xml" CHECKSUM="bc389ffbbd8f0c28ad7f42e3a3ac3c520dfbe385" CHECKSUMTYPE="SHA-1" SIZE="8366">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:26:11" MIMETYPE="text/xml"
-				CHECKSUM="77d0892a38d5b7742f3effe5914438347e60fc37" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:26:11" MIMETYPE="text/xml" CHECKSUM="77d0892a38d5b7742f3effe5914438347e60fc37" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:26:11" MIMETYPE="text/xml"
-				CHECKSUM="4560c25a7bbbdcc35eaf9e6835c8648b570af755" CHECKSUMTYPE="SHA-1" SIZE="5520">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:26:11" MIMETYPE="text/xml" CHECKSUM="4560c25a7bbbdcc35eaf9e6835c8648b570af755" CHECKSUMTYPE="SHA-1" SIZE="5520">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:26:11" MIMETYPE="text/xml"
-				CHECKSUM="792c2cc4ab025810054a83141850a2bd12eb01d4" CHECKSUMTYPE="SHA-1" SIZE="5379">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:26:11" MIMETYPE="text/xml" CHECKSUM="792c2cc4ab025810054a83141850a2bd12eb01d4" CHECKSUMTYPE="SHA-1" SIZE="5379">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:26:11" MIMETYPE="text/xml"
-				CHECKSUM="4a312eb716c321362af7a0bb36c0fa15cd9cf386" CHECKSUMTYPE="SHA-1" SIZE="5476">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:26:11" MIMETYPE="text/xml" CHECKSUM="4a312eb716c321362af7a0bb36c0fa15cd9cf386" CHECKSUMTYPE="SHA-1" SIZE="5476">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:26:12" MIMETYPE="text/xml"
-				CHECKSUM="e5cebf4dcd15454684724722ec44527b052664be" CHECKSUMTYPE="SHA-1"
-				SIZE="17436">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:26:12" MIMETYPE="text/xml" CHECKSUM="e5cebf4dcd15454684724722ec44527b052664be" CHECKSUMTYPE="SHA-1" SIZE="17436">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:26:12" MIMETYPE="text/xml"
-				CHECKSUM="c4891b09d64a1657acfed936cef7165b994e3c07" CHECKSUMTYPE="SHA-1" SIZE="5800">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:26:12" MIMETYPE="text/xml" CHECKSUM="c4891b09d64a1657acfed936cef7165b994e3c07" CHECKSUMTYPE="SHA-1" SIZE="5800">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:26:12" MIMETYPE="text/xml"
-				CHECKSUM="1a449d8f6f5e22809abca057d41a543c755aa0ef" CHECKSUMTYPE="SHA-1" SIZE="5295">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:26:12" MIMETYPE="text/xml" CHECKSUM="1a449d8f6f5e22809abca057d41a543c755aa0ef" CHECKSUMTYPE="SHA-1" SIZE="5295">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:26:12" MIMETYPE="text/xml"
-				CHECKSUM="0e81aeb44ba5c89ee26f0873a46712172d2915f6" CHECKSUMTYPE="SHA-1" SIZE="5832">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:26:12" MIMETYPE="text/xml" CHECKSUM="0e81aeb44ba5c89ee26f0873a46712172d2915f6" CHECKSUMTYPE="SHA-1" SIZE="5832">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:26:13" MIMETYPE="text/xml"
-				CHECKSUM="285e8cbd9d1529e7d5ec18a51a31f161586e2447" CHECKSUMTYPE="SHA-1" SIZE="5233">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:26:13" MIMETYPE="text/xml" CHECKSUM="285e8cbd9d1529e7d5ec18a51a31f161586e2447" CHECKSUMTYPE="SHA-1" SIZE="5233">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:26:13" MIMETYPE="text/xml"
-				CHECKSUM="efd9de0c326cb49fbd0612433895f53d1742cd1b" CHECKSUMTYPE="SHA-1" SIZE="4148">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:26:13" MIMETYPE="text/xml" CHECKSUM="efd9de0c326cb49fbd0612433895f53d1742cd1b" CHECKSUMTYPE="SHA-1" SIZE="4148">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:26:13" MIMETYPE="text/xml"
-				CHECKSUM="90fef240d0a1b7d7feb1a116e6460dfcbec6bc42" CHECKSUMTYPE="SHA-1" SIZE="4483">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:26:13" MIMETYPE="text/xml" CHECKSUM="90fef240d0a1b7d7feb1a116e6460dfcbec6bc42" CHECKSUMTYPE="SHA-1" SIZE="4483">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:26:13" MIMETYPE="text/xml"
-				CHECKSUM="d96a2100b65ec02cce0a044750a4f791257b603a" CHECKSUMTYPE="SHA-1" SIZE="4697">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:26:13" MIMETYPE="text/xml" CHECKSUM="d96a2100b65ec02cce0a044750a4f791257b603a" CHECKSUMTYPE="SHA-1" SIZE="4697">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:26:13" MIMETYPE="text/xml"
-				CHECKSUM="55c65b20cdafb877b0034cf9f8f9b65ef7c7e1a1" CHECKSUMTYPE="SHA-1" SIZE="4673">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:26:13" MIMETYPE="text/xml" CHECKSUM="55c65b20cdafb877b0034cf9f8f9b65ef7c7e1a1" CHECKSUMTYPE="SHA-1" SIZE="4673">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:26:14" MIMETYPE="text/xml"
-				CHECKSUM="a6f9d93feb882ee06d4cca24dc2956d4d6274ab9" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:26:14" MIMETYPE="text/xml" CHECKSUM="a6f9d93feb882ee06d4cca24dc2956d4d6274ab9" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:26:14" MIMETYPE="text/xml"
-				CHECKSUM="e6df192e0418552e7b9a0971eb2682c74b257102" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:26:14" MIMETYPE="text/xml" CHECKSUM="e6df192e0418552e7b9a0971eb2682c74b257102" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:26:14" MIMETYPE="text/xml"
-				CHECKSUM="8f737c477bab92f01c87af8e76766b17eb2d7cc0" CHECKSUMTYPE="SHA-1"
-				SIZE="16395">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:26:14" MIMETYPE="text/xml" CHECKSUM="8f737c477bab92f01c87af8e76766b17eb2d7cc0" CHECKSUMTYPE="SHA-1" SIZE="16395">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:26:14" MIMETYPE="text/xml"
-				CHECKSUM="e71586f4f6e141fa336b85105bab3a71fa34e189" CHECKSUMTYPE="SHA-1" SIZE="8111">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:26:14" MIMETYPE="text/xml" CHECKSUM="e71586f4f6e141fa336b85105bab3a71fa34e189" CHECKSUMTYPE="SHA-1" SIZE="8111">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-01_01_0020.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:26:37" MIMETYPE="application/pdf"
-				CHECKSUM="8d7d7413a29f5fa30f144314f2bc782ebba8d248" CHECKSUMTYPE="SHA-1"
-				SIZE="4682990">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/bmtnabf_1902-11-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:26:37" MIMETYPE="application/pdf" CHECKSUM="8d7d7413a29f5fa30f144314f2bc782ebba8d248" CHECKSUMTYPE="SHA-1" SIZE="4682990">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/01_01/bmtnabf_1902-11-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2395,8 +2262,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004"
-						LABEL="Konkurrenz -Projekt für das Museum der Stadt Wien">
+					<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004" LABEL="Konkurrenz -Projekt für das Museum der Stadt Wien">
 						<div ID="L.1.1.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -2495,8 +2361,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c011"
-						LABEL="AUSSTELLUNGSRAUM AUF DER DÜSSELDORFER KUNSTAUSSTELLUNG">
+					<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c011" LABEL="AUSSTELLUNGSRAUM AUF DER DÜSSELDORFER KUNSTAUSSTELLUNG">
 						<div ID="L.1.1.10.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -2513,8 +2378,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c012"
-						LABEL="DÜSSELDORFER KUNSTAUSSTELLUNG">
+					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c012" LABEL="DÜSSELDORFER KUNSTAUSSTELLUNG">
 						<div ID="L.1.1.11.1" TYPE="Head">
 							<fptr>
 								<seq>
@@ -2539,8 +2403,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c013"
-						LABEL="LESEZIMMER AUS DER XIV. AUSSTELLUNG">
+					<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c013" LABEL="LESEZIMMER AUS DER XIV. AUSSTELLUNG">
 						<div ID="L.1.1.12.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
@@ -2575,8 +2438,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c015"
-					LABEL="Halle im nebenstehenden Wohnhause">
+				<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c015" LABEL="Halle im nebenstehenden Wohnhause">
 					<div ID="L.1.1.14.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
@@ -2593,8 +2455,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c016"
-					LABEL="Wohnhaus in Brünn">
+				<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c016" LABEL="Wohnhaus in Brünn">
 					<div ID="L.1.1.15.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
@@ -2611,8 +2472,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c017"
-					LABEL="Type von kleinen Wohnhäusern">
+				<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c017" LABEL="Type von kleinen Wohnhäusern">
 					<div ID="L.1.1.16.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00003"/>

--- a/metadata/periodicals/bmtnabf/issues/1902/11/15_01/bmtnabf_1902-11-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/11/15_01/bmtnabf_1902-11-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-11-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-11-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-11-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-11-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -51,10 +46,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-11-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2130,306 +2124,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:16:43"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="c3baa21472ea9d6d9590a725bbd98d7ec7bf8f87"
-				CHECKSUMTYPE="SHA-1" SIZE="6121024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:16:43" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="c3baa21472ea9d6d9590a725bbd98d7ec7bf8f87" CHECKSUMTYPE="SHA-1" SIZE="6121024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:17:20"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="f216aea44b64898773deac6552e4a114ada10c5f"
-				CHECKSUMTYPE="SHA-1" SIZE="6088610">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:17:20" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="f216aea44b64898773deac6552e4a114ada10c5f" CHECKSUMTYPE="SHA-1" SIZE="6088610">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:17:57"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="dd743c9b61c3e92bb90c0cae40db24aabdaf1ada"
-				CHECKSUMTYPE="SHA-1" SIZE="6195706">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:17:57" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="dd743c9b61c3e92bb90c0cae40db24aabdaf1ada" CHECKSUMTYPE="SHA-1" SIZE="6195706">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:18:35"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="5bbd096ebf4b81960ec199508ae7d08a6e7722d0"
-				CHECKSUMTYPE="SHA-1" SIZE="6088628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:18:35" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="5bbd096ebf4b81960ec199508ae7d08a6e7722d0" CHECKSUMTYPE="SHA-1" SIZE="6088628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:19:13"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="fd1d959d0231dd15e1e994844713069dffa4173d"
-				CHECKSUMTYPE="SHA-1" SIZE="6069723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:19:13" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="fd1d959d0231dd15e1e994844713069dffa4173d" CHECKSUMTYPE="SHA-1" SIZE="6069723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:19:46"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="21d20c6743fa4f5cbbdeed2f057c14ab64c3c3fe"
-				CHECKSUMTYPE="SHA-1" SIZE="6088620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:19:46" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="21d20c6743fa4f5cbbdeed2f057c14ab64c3c3fe" CHECKSUMTYPE="SHA-1" SIZE="6088620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:20:19"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="67589c89ed432c03a9e20bbbf63e02fab14f0f8e"
-				CHECKSUMTYPE="SHA-1" SIZE="6128227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:20:19" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="67589c89ed432c03a9e20bbbf63e02fab14f0f8e" CHECKSUMTYPE="SHA-1" SIZE="6128227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:20:55"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a3b797208c127bf75f1575272845c4ac4f83d538"
-				CHECKSUMTYPE="SHA-1" SIZE="6088620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:20:55" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a3b797208c127bf75f1575272845c4ac4f83d538" CHECKSUMTYPE="SHA-1" SIZE="6088620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:21:28"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="c2a2637575a508b11243ae818925f5222f911633"
-				CHECKSUMTYPE="SHA-1" SIZE="6127304">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:21:28" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="c2a2637575a508b11243ae818925f5222f911633" CHECKSUMTYPE="SHA-1" SIZE="6127304">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:22:04"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="04722b4bca24dfb7027fcaf3186cc308dc6bab27"
-				CHECKSUMTYPE="SHA-1" SIZE="6088619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:22:04" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="04722b4bca24dfb7027fcaf3186cc308dc6bab27" CHECKSUMTYPE="SHA-1" SIZE="6088619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:22:39"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="264de43208bc703d5c89754f997c21a3cc677aa4"
-				CHECKSUMTYPE="SHA-1" SIZE="6127325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:22:39" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="264de43208bc703d5c89754f997c21a3cc677aa4" CHECKSUMTYPE="SHA-1" SIZE="6127325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:23:10"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="69ed3a5f87a054fc20bd813d1652ce08e87d59a2"
-				CHECKSUMTYPE="SHA-1" SIZE="6088628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:23:10" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="69ed3a5f87a054fc20bd813d1652ce08e87d59a2" CHECKSUMTYPE="SHA-1" SIZE="6088628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:23:48"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="f9edecfbdfa7b691184fb4a1fae76a7322a8f81b"
-				CHECKSUMTYPE="SHA-1" SIZE="6127312">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:23:48" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="f9edecfbdfa7b691184fb4a1fae76a7322a8f81b" CHECKSUMTYPE="SHA-1" SIZE="6127312">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:24:22"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="5c15b11baed6dac8035c69d90ea75b6c849812e0"
-				CHECKSUMTYPE="SHA-1" SIZE="6165126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:24:22" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="5c15b11baed6dac8035c69d90ea75b6c849812e0" CHECKSUMTYPE="SHA-1" SIZE="6165126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:24:59"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="41724b35f4c45903bdcc41c578a9a7ee0e614d5b"
-				CHECKSUMTYPE="SHA-1" SIZE="6128228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:24:59" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="41724b35f4c45903bdcc41c578a9a7ee0e614d5b" CHECKSUMTYPE="SHA-1" SIZE="6128228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:25:32"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="03680f9cf3c2242f5d4b2252cffe033404c2d630"
-				CHECKSUMTYPE="SHA-1" SIZE="6165127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:25:32" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="03680f9cf3c2242f5d4b2252cffe033404c2d630" CHECKSUMTYPE="SHA-1" SIZE="6165127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:26:05"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="717e3fa4a472313ed59c38e9c42595eff949f50c"
-				CHECKSUMTYPE="SHA-1" SIZE="6070628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:26:05" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="717e3fa4a472313ed59c38e9c42595eff949f50c" CHECKSUMTYPE="SHA-1" SIZE="6070628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:26:38"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="7ecce5790c34a28cb869c4a63769c57e853bc4d8"
-				CHECKSUMTYPE="SHA-1" SIZE="6165072">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:26:38" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="7ecce5790c34a28cb869c4a63769c57e853bc4d8" CHECKSUMTYPE="SHA-1" SIZE="6165072">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:27:12"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="8ef0eb3be95501fd2e0b63ff62ae7d7920a8dd46"
-				CHECKSUMTYPE="SHA-1" SIZE="6070603">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:27:12" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="8ef0eb3be95501fd2e0b63ff62ae7d7920a8dd46" CHECKSUMTYPE="SHA-1" SIZE="6070603">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:27:46"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="74af4133d8f8e8ad468d8233e7286ee0555078ef"
-				CHECKSUMTYPE="SHA-1" SIZE="6165104">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:27:46" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="74af4133d8f8e8ad468d8233e7286ee0555078ef" CHECKSUMTYPE="SHA-1" SIZE="6165104">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:28:23"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="b1dfbba957a687ad304f42e1c6d8faf4b393e4a5"
-				CHECKSUMTYPE="SHA-1" SIZE="6070628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:28:23" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="b1dfbba957a687ad304f42e1c6d8faf4b393e4a5" CHECKSUMTYPE="SHA-1" SIZE="6070628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:28:53"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="5ba5be86c909c8b08576240606e80d9e06e1c667"
-				CHECKSUMTYPE="SHA-1" SIZE="6162427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:28:53" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="5ba5be86c909c8b08576240606e80d9e06e1c667" CHECKSUMTYPE="SHA-1" SIZE="6162427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:29:26"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="3fe27368d2f79248307dc152f51a465c4b7ca36b"
-				CHECKSUMTYPE="SHA-1" SIZE="6022928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:29:26" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="3fe27368d2f79248307dc152f51a465c4b7ca36b" CHECKSUMTYPE="SHA-1" SIZE="6022928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:30:02"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f4259b23a443351ef074008ae47c132e03c65c23"
-				CHECKSUMTYPE="SHA-1" SIZE="6162423">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:30:02" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="f4259b23a443351ef074008ae47c132e03c65c23" CHECKSUMTYPE="SHA-1" SIZE="6162423">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/delivery/bmtnabf_1902-11-15_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:30:27" MIMETYPE="text/xml"
-				CHECKSUM="8533dc42079d5ba638030bc5222ef3c045d6ffb2" CHECKSUMTYPE="SHA-1" SIZE="4773">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:30:27" MIMETYPE="text/xml" CHECKSUM="8533dc42079d5ba638030bc5222ef3c045d6ffb2" CHECKSUMTYPE="SHA-1" SIZE="4773">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:30:27" MIMETYPE="text/xml"
-				CHECKSUM="33cc2e17d33b85c777953de57c0902b37d42feb7" CHECKSUMTYPE="SHA-1"
-				SIZE="32838">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:30:27" MIMETYPE="text/xml" CHECKSUM="33cc2e17d33b85c777953de57c0902b37d42feb7" CHECKSUMTYPE="SHA-1" SIZE="32838">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:30:27" MIMETYPE="text/xml"
-				CHECKSUM="717fcd2c1fdbcb919d1461560e211b1bc8623989" CHECKSUMTYPE="SHA-1" SIZE="8684">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:30:27" MIMETYPE="text/xml" CHECKSUM="717fcd2c1fdbcb919d1461560e211b1bc8623989" CHECKSUMTYPE="SHA-1" SIZE="8684">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:30:27" MIMETYPE="text/xml"
-				CHECKSUM="70ddc0269477e06475c69eec8327f063ed0999fd" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:30:27" MIMETYPE="text/xml" CHECKSUM="70ddc0269477e06475c69eec8327f063ed0999fd" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:30:28" MIMETYPE="text/xml"
-				CHECKSUM="96d8399e449aa8b0d2052f5d65dfc2cf999c5382" CHECKSUMTYPE="SHA-1" SIZE="1719">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:30:28" MIMETYPE="text/xml" CHECKSUM="96d8399e449aa8b0d2052f5d65dfc2cf999c5382" CHECKSUMTYPE="SHA-1" SIZE="1719">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:30:28" MIMETYPE="text/xml"
-				CHECKSUM="c3a1a52d4812ec630355749c2730b81bde8611ec" CHECKSUMTYPE="SHA-1" SIZE="2105">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:30:28" MIMETYPE="text/xml" CHECKSUM="c3a1a52d4812ec630355749c2730b81bde8611ec" CHECKSUMTYPE="SHA-1" SIZE="2105">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:30:28" MIMETYPE="text/xml"
-				CHECKSUM="60671f2327672aeb5aa381ccf6c9b8f05728c67e" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:30:28" MIMETYPE="text/xml" CHECKSUM="60671f2327672aeb5aa381ccf6c9b8f05728c67e" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:30:28" MIMETYPE="text/xml"
-				CHECKSUM="2ba5383e969c5c6bdbbdd4ba2499a708d3c26732" CHECKSUMTYPE="SHA-1" SIZE="3306">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:30:28" MIMETYPE="text/xml" CHECKSUM="2ba5383e969c5c6bdbbdd4ba2499a708d3c26732" CHECKSUMTYPE="SHA-1" SIZE="3306">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:30:28" MIMETYPE="text/xml"
-				CHECKSUM="dda6fb688ccf105741a21e0afc6484952223b7ed" CHECKSUMTYPE="SHA-1" SIZE="4877">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:30:28" MIMETYPE="text/xml" CHECKSUM="dda6fb688ccf105741a21e0afc6484952223b7ed" CHECKSUMTYPE="SHA-1" SIZE="4877">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:30:29" MIMETYPE="text/xml"
-				CHECKSUM="3992f3c687c3615fdd7d56caf6f9e5e44f6af95e" CHECKSUMTYPE="SHA-1" SIZE="4769">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:30:29" MIMETYPE="text/xml" CHECKSUM="3992f3c687c3615fdd7d56caf6f9e5e44f6af95e" CHECKSUMTYPE="SHA-1" SIZE="4769">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:30:29" MIMETYPE="text/xml"
-				CHECKSUM="78ac3785e8a92ac55dd0be2f59af0666e693dbc9" CHECKSUMTYPE="SHA-1" SIZE="4753">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:30:29" MIMETYPE="text/xml" CHECKSUM="78ac3785e8a92ac55dd0be2f59af0666e693dbc9" CHECKSUMTYPE="SHA-1" SIZE="4753">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:30:29" MIMETYPE="text/xml"
-				CHECKSUM="a67c1048da33e255b53bee47d5c6e7a35738fc35" CHECKSUMTYPE="SHA-1" SIZE="4121">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:30:29" MIMETYPE="text/xml" CHECKSUM="a67c1048da33e255b53bee47d5c6e7a35738fc35" CHECKSUMTYPE="SHA-1" SIZE="4121">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:30:29" MIMETYPE="text/xml"
-				CHECKSUM="1633bdfa6b8d4aaf6943fe27ccc4e212c7191047" CHECKSUMTYPE="SHA-1" SIZE="4559">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:30:29" MIMETYPE="text/xml" CHECKSUM="1633bdfa6b8d4aaf6943fe27ccc4e212c7191047" CHECKSUMTYPE="SHA-1" SIZE="4559">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:30:30" MIMETYPE="text/xml"
-				CHECKSUM="e77b3af431713638710ddc8c25ea2f8e9c4d51c5" CHECKSUMTYPE="SHA-1" SIZE="6433">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:30:30" MIMETYPE="text/xml" CHECKSUM="e77b3af431713638710ddc8c25ea2f8e9c4d51c5" CHECKSUMTYPE="SHA-1" SIZE="6433">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:30:30" MIMETYPE="text/xml"
-				CHECKSUM="153e91583b0f2fc23e9755a73080802cee17f720" CHECKSUMTYPE="SHA-1" SIZE="6306">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:30:30" MIMETYPE="text/xml" CHECKSUM="153e91583b0f2fc23e9755a73080802cee17f720" CHECKSUMTYPE="SHA-1" SIZE="6306">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:30:30" MIMETYPE="text/xml"
-				CHECKSUM="ff6795a6710d977ffae10a180011a1587600b322" CHECKSUMTYPE="SHA-1" SIZE="5835">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:30:30" MIMETYPE="text/xml" CHECKSUM="ff6795a6710d977ffae10a180011a1587600b322" CHECKSUMTYPE="SHA-1" SIZE="5835">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:30:30" MIMETYPE="text/xml"
-				CHECKSUM="ce568970672832965561d784b5cdbc6fadc1b868" CHECKSUMTYPE="SHA-1" SIZE="5385">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:30:30" MIMETYPE="text/xml" CHECKSUM="ce568970672832965561d784b5cdbc6fadc1b868" CHECKSUMTYPE="SHA-1" SIZE="5385">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:30:31" MIMETYPE="text/xml"
-				CHECKSUM="3baa2c9ab8fcece300c9053db58eef9633689714" CHECKSUMTYPE="SHA-1" SIZE="5135">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:30:31" MIMETYPE="text/xml" CHECKSUM="3baa2c9ab8fcece300c9053db58eef9633689714" CHECKSUMTYPE="SHA-1" SIZE="5135">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:30:31" MIMETYPE="text/xml"
-				CHECKSUM="4de5dc4beec0e60ea8f6b96fd1f078f728887f4b" CHECKSUMTYPE="SHA-1" SIZE="4729">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:30:31" MIMETYPE="text/xml" CHECKSUM="4de5dc4beec0e60ea8f6b96fd1f078f728887f4b" CHECKSUMTYPE="SHA-1" SIZE="4729">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:30:31" MIMETYPE="text/xml"
-				CHECKSUM="19aa404083412af04c7eea5fcd07bfdab2180325" CHECKSUMTYPE="SHA-1" SIZE="3969">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:30:31" MIMETYPE="text/xml" CHECKSUM="19aa404083412af04c7eea5fcd07bfdab2180325" CHECKSUMTYPE="SHA-1" SIZE="3969">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:30:31" MIMETYPE="text/xml"
-				CHECKSUM="69aedde008013c80088260760720fa61be290175" CHECKSUMTYPE="SHA-1" SIZE="2014">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:30:31" MIMETYPE="text/xml" CHECKSUM="69aedde008013c80088260760720fa61be290175" CHECKSUMTYPE="SHA-1" SIZE="2014">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:30:31" MIMETYPE="text/xml"
-				CHECKSUM="041f33206c3085b2a125537441191bbcc035998a" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:30:31" MIMETYPE="text/xml" CHECKSUM="041f33206c3085b2a125537441191bbcc035998a" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:30:32" MIMETYPE="text/xml"
-				CHECKSUM="f78e648daa2886100b2b94aa4bfdcf080b16d702" CHECKSUMTYPE="SHA-1"
-				SIZE="21192">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:30:32" MIMETYPE="text/xml" CHECKSUM="f78e648daa2886100b2b94aa4bfdcf080b16d702" CHECKSUMTYPE="SHA-1" SIZE="21192">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:30:32" MIMETYPE="text/xml"
-				CHECKSUM="b3b05c8917b7e3adec5433989146ce8c633a0377" CHECKSUMTYPE="SHA-1" SIZE="7937">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:30:32" MIMETYPE="text/xml" CHECKSUM="b3b05c8917b7e3adec5433989146ce8c633a0377" CHECKSUMTYPE="SHA-1" SIZE="7937">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-11-15_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:30:59" MIMETYPE="application/pdf"
-				CHECKSUM="22c2133f74f244a6bf6bf4c97b37aa9e1f887638" CHECKSUMTYPE="SHA-1"
-				SIZE="5025017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/bmtnabf_1902-11-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:30:59" MIMETYPE="application/pdf" CHECKSUM="22c2133f74f244a6bf6bf4c97b37aa9e1f887638" CHECKSUMTYPE="SHA-1" SIZE="5025017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/11/15_01/bmtnabf_1902-11-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2745,8 +2589,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004"
-					LABEL="15 AUSSTELLUNG DER VEREINIGUNG BILDUUNSTEER OSTERREICHS">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004" LABEL="15 AUSSTELLUNG DER VEREINIGUNG BILDUUNSTEER OSTERREICHS">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00001"/>
@@ -2762,8 +2605,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_CB00001"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c006"
-						LABEL="RAUMGESTALTUNG DER XV. AUSSTELLUNG">
+					<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c006" LABEL="RAUMGESTALTUNG DER XV. AUSSTELLUNG">
 						<div ID="L.1.1.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
@@ -2780,8 +2622,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c007"
-						LABEL="RAUMGESTALTUNG DER XV. AUSSTELLUNG">
+					<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c007" LABEL="RAUMGESTALTUNG DER XV. AUSSTELLUNG">
 						<div ID="L.1.1.8.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -2798,8 +2639,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c010"
-						LABEL="Raumgestaltung der XV. Ausstellung">
+					<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c010" LABEL="Raumgestaltung der XV. Ausstellung">
 						<div ID="L.1.1.11.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -2816,8 +2656,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c012"
-						LABEL="XV. AUSSTELLUNG. RAUMGESTALTUNG">
+					<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c012" LABEL="XV. AUSSTELLUNG. RAUMGESTALTUNG">
 						<div ID="L.1.1.13.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -2839,8 +2678,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c013"
-						LABEL="ALT-ZIMMER DER XV. AUSSTELLUNG">
+					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c013" LABEL="ALT-ZIMMER DER XV. AUSSTELLUNG">
 						<div ID="L.1.1.14.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -2862,8 +2700,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c014"
-						LABEL="Raumgestaltung des polnischen Saales der XV">
+					<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c014" LABEL="Raumgestaltung des polnischen Saales der XV">
 						<div ID="L.1.1.15.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
@@ -2880,8 +2717,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c015"
-						LABEL="Interieur der XV. Ausstellung">
+					<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c015" LABEL="Interieur der XV. Ausstellung">
 						<div ID="L.1.1.16.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00003"/>
@@ -2899,8 +2735,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c005"
-					LABEL="Denkmal für den Dichter Rodenbach">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c005" LABEL="Denkmal für den Dichter Rodenbach">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
@@ -2934,8 +2769,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c009"
-					LABEL="FRAGMENT DES RELIEFS &#34;DIE MENSCHLICHEN LEIDENSCHAFTEN&#34; IM BESITZE VON H. ROSSNER IN ZEITZ">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c009" LABEL="FRAGMENT DES RELIEFS &#34;DIE MENSCHLICHEN LEIDENSCHAFTEN&#34; IM BESITZE VON H. ROSSNER IN ZEITZ">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00003"/>
@@ -2952,8 +2786,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c011"
-					LABEL="FRAGMENT DES RELIEFS &#34;DIE MENSCHLICHEN LEIDENSCHAFTEN&#34; IM BESITZE VON H. ROSSNER IN ZEITZ">
+				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c011" LABEL="FRAGMENT DES RELIEFS &#34;DIE MENSCHLICHEN LEIDENSCHAFTEN&#34; IM BESITZE VON H. ROSSNER IN ZEITZ">
 					<div ID="L.1.1.12.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1902/12/01_01/bmtnabf_1902-12-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/12/01_01/bmtnabf_1902-12-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-12-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-12-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-12-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-12-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -51,10 +46,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-12-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -1864,259 +1858,132 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:19:09"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="4f172b39e8af84354e8a555fcc9d41adbc7282c0"
-				CHECKSUMTYPE="SHA-1" SIZE="6191228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:19:09" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="4f172b39e8af84354e8a555fcc9d41adbc7282c0" CHECKSUMTYPE="SHA-1" SIZE="6191228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:19:40"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="328d185acb1ca1738350b8f751fcf9dd5d987b44"
-				CHECKSUMTYPE="SHA-1" SIZE="6183126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:19:40" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="328d185acb1ca1738350b8f751fcf9dd5d987b44" CHECKSUMTYPE="SHA-1" SIZE="6183126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:20:12"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="4f87b35da62812e2a359948272fab90443c68c4d"
-				CHECKSUMTYPE="SHA-1" SIZE="6191225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:20:12" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="4f87b35da62812e2a359948272fab90443c68c4d" CHECKSUMTYPE="SHA-1" SIZE="6191225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:20:44"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="2c7a79dbe4aa574671c3783b554ad8b6fd3d3920"
-				CHECKSUMTYPE="SHA-1" SIZE="6183128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:20:44" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="2c7a79dbe4aa574671c3783b554ad8b6fd3d3920" CHECKSUMTYPE="SHA-1" SIZE="6183128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:21:16"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="1ca484c19d7be8c7f362e0df50129b28f677c060"
-				CHECKSUMTYPE="SHA-1" SIZE="6154329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:21:16" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="1ca484c19d7be8c7f362e0df50129b28f677c060" CHECKSUMTYPE="SHA-1" SIZE="6154329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:21:48"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="5261a4b2f12a0ce569eb4df8ed9acda5ebd678bb"
-				CHECKSUMTYPE="SHA-1" SIZE="6243428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:21:48" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="5261a4b2f12a0ce569eb4df8ed9acda5ebd678bb" CHECKSUMTYPE="SHA-1" SIZE="6243428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:22:20"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="6dfa5c233aa7c58cb7026e28c12f7eeca37d14d0"
-				CHECKSUMTYPE="SHA-1" SIZE="6153424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:22:20" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="6dfa5c233aa7c58cb7026e28c12f7eeca37d14d0" CHECKSUMTYPE="SHA-1" SIZE="6153424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:22:52"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="b9cddfa10897dd2402557cd182c60da5b60d516d"
-				CHECKSUMTYPE="SHA-1" SIZE="6243427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:22:52" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="b9cddfa10897dd2402557cd182c60da5b60d516d" CHECKSUMTYPE="SHA-1" SIZE="6243427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:23:25"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="4bc3fc0dd3ccb09b39083574859e03e9bff21e02"
-				CHECKSUMTYPE="SHA-1" SIZE="6153429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:23:25" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="4bc3fc0dd3ccb09b39083574859e03e9bff21e02" CHECKSUMTYPE="SHA-1" SIZE="6153429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:23:55"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="d724c933588ac4e2d71255ee8f5ed3a7721537dc"
-				CHECKSUMTYPE="SHA-1" SIZE="6243421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:23:55" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="d724c933588ac4e2d71255ee8f5ed3a7721537dc" CHECKSUMTYPE="SHA-1" SIZE="6243421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:24:25"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="fa66a3add5c0aed63f314f37146fbd977c8082aa"
-				CHECKSUMTYPE="SHA-1" SIZE="6153421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:24:25" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="fa66a3add5c0aed63f314f37146fbd977c8082aa" CHECKSUMTYPE="SHA-1" SIZE="6153421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:24:57"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="584cd2097645b1eab15a5b28d0562eeefc44c117"
-				CHECKSUMTYPE="SHA-1" SIZE="6244318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:24:57" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="584cd2097645b1eab15a5b28d0562eeefc44c117" CHECKSUMTYPE="SHA-1" SIZE="6244318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:25:31"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="9ab6833b0ccfe749e5e51c1a2b89190b51ff751d"
-				CHECKSUMTYPE="SHA-1" SIZE="6187629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:25:31" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="9ab6833b0ccfe749e5e51c1a2b89190b51ff751d" CHECKSUMTYPE="SHA-1" SIZE="6187629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:26:03"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="ca2a32b68f059192bb2f252a2d502efbb2a24292"
-				CHECKSUMTYPE="SHA-1" SIZE="6244325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:26:03" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="ca2a32b68f059192bb2f252a2d502efbb2a24292" CHECKSUMTYPE="SHA-1" SIZE="6244325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:26:35"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="c53b49881d10191c176da1587569d2478ba32c28"
-				CHECKSUMTYPE="SHA-1" SIZE="6187621">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:26:35" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="c53b49881d10191c176da1587569d2478ba32c28" CHECKSUMTYPE="SHA-1" SIZE="6187621">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:27:04"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d1c1b3399b728486540eec0cbeea58dcb8431570"
-				CHECKSUMTYPE="SHA-1" SIZE="6268626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:27:04" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d1c1b3399b728486540eec0cbeea58dcb8431570" CHECKSUMTYPE="SHA-1" SIZE="6268626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:27:36"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="338b50abe5e2190713f6c879dad701ae2db6f4d3"
-				CHECKSUMTYPE="SHA-1" SIZE="6203828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:27:36" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="338b50abe5e2190713f6c879dad701ae2db6f4d3" CHECKSUMTYPE="SHA-1" SIZE="6203828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:28:08"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="2f8b17208afdd150dafb46a698108828ab85f601"
-				CHECKSUMTYPE="SHA-1" SIZE="6268618">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:28:08" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="2f8b17208afdd150dafb46a698108828ab85f601" CHECKSUMTYPE="SHA-1" SIZE="6268618">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:28:37"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="f26263a69a419919cb8cabebdd637b0cb07604bd"
-				CHECKSUMTYPE="SHA-1" SIZE="6203826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:28:37" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="f26263a69a419919cb8cabebdd637b0cb07604bd" CHECKSUMTYPE="SHA-1" SIZE="6203826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:29:10"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="e6fa9b6ef9cb60e69123d63123bea348b9b238bf"
-				CHECKSUMTYPE="SHA-1" SIZE="6220019">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:29:10" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="e6fa9b6ef9cb60e69123d63123bea348b9b238bf" CHECKSUMTYPE="SHA-1" SIZE="6220019">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/delivery/bmtnabf_1902-12-01_01_0020.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:29:29" MIMETYPE="text/xml"
-				CHECKSUM="45990689aad92bf40c3f899cc0191d5bb18db42d" CHECKSUMTYPE="SHA-1" SIZE="4735">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:29:29" MIMETYPE="text/xml" CHECKSUM="45990689aad92bf40c3f899cc0191d5bb18db42d" CHECKSUMTYPE="SHA-1" SIZE="4735">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:29:29" MIMETYPE="text/xml"
-				CHECKSUM="f8ad80d34c95b614d48f14239426dbe3f4ac0253" CHECKSUMTYPE="SHA-1"
-				SIZE="45247">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:29:29" MIMETYPE="text/xml" CHECKSUM="f8ad80d34c95b614d48f14239426dbe3f4ac0253" CHECKSUMTYPE="SHA-1" SIZE="45247">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:29:29" MIMETYPE="text/xml"
-				CHECKSUM="699fe4bd6d974af75d4123a0317457681d1385fe" CHECKSUMTYPE="SHA-1" SIZE="8201">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:29:29" MIMETYPE="text/xml" CHECKSUM="699fe4bd6d974af75d4123a0317457681d1385fe" CHECKSUMTYPE="SHA-1" SIZE="8201">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:29:29" MIMETYPE="text/xml"
-				CHECKSUM="0d849a955d3f578093fe9bcb43ed4da8cbb4521e" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:29:29" MIMETYPE="text/xml" CHECKSUM="0d849a955d3f578093fe9bcb43ed4da8cbb4521e" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:29:30" MIMETYPE="text/xml"
-				CHECKSUM="cc1b8ab30c637ac69e4e1fc78951b763043f3289" CHECKSUMTYPE="SHA-1" SIZE="5037">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:29:30" MIMETYPE="text/xml" CHECKSUM="cc1b8ab30c637ac69e4e1fc78951b763043f3289" CHECKSUMTYPE="SHA-1" SIZE="5037">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:29:30" MIMETYPE="text/xml"
-				CHECKSUM="40d6da3dd1658bbeeb46ff3d706e70fc0e49ae88" CHECKSUMTYPE="SHA-1" SIZE="4419">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:29:30" MIMETYPE="text/xml" CHECKSUM="40d6da3dd1658bbeeb46ff3d706e70fc0e49ae88" CHECKSUMTYPE="SHA-1" SIZE="4419">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:29:30" MIMETYPE="text/xml"
-				CHECKSUM="327a5012103ccb2eb634642d776e69033412089f" CHECKSUMTYPE="SHA-1" SIZE="4354">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:29:30" MIMETYPE="text/xml" CHECKSUM="327a5012103ccb2eb634642d776e69033412089f" CHECKSUMTYPE="SHA-1" SIZE="4354">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:29:30" MIMETYPE="text/xml"
-				CHECKSUM="b5926e82830f4b2ce67a9457dbf1d623b4d1824d" CHECKSUMTYPE="SHA-1" SIZE="4691">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:29:30" MIMETYPE="text/xml" CHECKSUM="b5926e82830f4b2ce67a9457dbf1d623b4d1824d" CHECKSUMTYPE="SHA-1" SIZE="4691">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:29:30" MIMETYPE="text/xml"
-				CHECKSUM="c080c33374b10c53abf3767c0677776e567a4bf4" CHECKSUMTYPE="SHA-1" SIZE="4769">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:29:30" MIMETYPE="text/xml" CHECKSUM="c080c33374b10c53abf3767c0677776e567a4bf4" CHECKSUMTYPE="SHA-1" SIZE="4769">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:29:31" MIMETYPE="text/xml"
-				CHECKSUM="29828c09f5e5b3fa1c2f8e90b997a7bdf5162c60" CHECKSUMTYPE="SHA-1" SIZE="5383">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:29:31" MIMETYPE="text/xml" CHECKSUM="29828c09f5e5b3fa1c2f8e90b997a7bdf5162c60" CHECKSUMTYPE="SHA-1" SIZE="5383">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:29:31" MIMETYPE="text/xml"
-				CHECKSUM="8aca702e9553ba6a709a68541b7c94ee4e6bda17" CHECKSUMTYPE="SHA-1" SIZE="5415">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:29:31" MIMETYPE="text/xml" CHECKSUM="8aca702e9553ba6a709a68541b7c94ee4e6bda17" CHECKSUMTYPE="SHA-1" SIZE="5415">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:29:31" MIMETYPE="text/xml"
-				CHECKSUM="51ee17d9be51ec42a4640ab2065b06dc3dd5179d" CHECKSUMTYPE="SHA-1" SIZE="4327">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:29:31" MIMETYPE="text/xml" CHECKSUM="51ee17d9be51ec42a4640ab2065b06dc3dd5179d" CHECKSUMTYPE="SHA-1" SIZE="4327">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:29:31" MIMETYPE="text/xml"
-				CHECKSUM="bc17d7408b699468e47848b0289606919ce5974f" CHECKSUMTYPE="SHA-1" SIZE="4170">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:29:31" MIMETYPE="text/xml" CHECKSUM="bc17d7408b699468e47848b0289606919ce5974f" CHECKSUMTYPE="SHA-1" SIZE="4170">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:29:32" MIMETYPE="text/xml"
-				CHECKSUM="348fc261b02f4f86d9ef34594a0c82bf759db3eb" CHECKSUMTYPE="SHA-1" SIZE="5081">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:29:32" MIMETYPE="text/xml" CHECKSUM="348fc261b02f4f86d9ef34594a0c82bf759db3eb" CHECKSUMTYPE="SHA-1" SIZE="5081">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:29:32" MIMETYPE="text/xml"
-				CHECKSUM="7670438ed3e95559e6d64a2f7ba74e56c12efc05" CHECKSUMTYPE="SHA-1" SIZE="4896">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:29:32" MIMETYPE="text/xml" CHECKSUM="7670438ed3e95559e6d64a2f7ba74e56c12efc05" CHECKSUMTYPE="SHA-1" SIZE="4896">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:29:32" MIMETYPE="text/xml"
-				CHECKSUM="fc889db058e7308c9c7c088a4a0611a8b34ded8d" CHECKSUMTYPE="SHA-1" SIZE="4782">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:29:32" MIMETYPE="text/xml" CHECKSUM="fc889db058e7308c9c7c088a4a0611a8b34ded8d" CHECKSUMTYPE="SHA-1" SIZE="4782">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:29:32" MIMETYPE="text/xml"
-				CHECKSUM="c8d4c9cd1acb72a4f8e3298d1387e82f6dab7d91" CHECKSUMTYPE="SHA-1"
-				SIZE="29553">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:29:32" MIMETYPE="text/xml" CHECKSUM="c8d4c9cd1acb72a4f8e3298d1387e82f6dab7d91" CHECKSUMTYPE="SHA-1" SIZE="29553">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:29:32" MIMETYPE="text/xml"
-				CHECKSUM="a8727084fe2869bc49d53b3e4b0d77771d61dc99" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:29:32" MIMETYPE="text/xml" CHECKSUM="a8727084fe2869bc49d53b3e4b0d77771d61dc99" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:29:33" MIMETYPE="text/xml"
-				CHECKSUM="e64bd0baf48259afa2567180a2f1142d6640c01b" CHECKSUMTYPE="SHA-1"
-				SIZE="18858">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:29:33" MIMETYPE="text/xml" CHECKSUM="e64bd0baf48259afa2567180a2f1142d6640c01b" CHECKSUMTYPE="SHA-1" SIZE="18858">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:29:33" MIMETYPE="text/xml"
-				CHECKSUM="b40c64022922f5b04c259d4ce296550791bae27a" CHECKSUMTYPE="SHA-1" SIZE="7751">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:29:33" MIMETYPE="text/xml" CHECKSUM="b40c64022922f5b04c259d4ce296550791bae27a" CHECKSUMTYPE="SHA-1" SIZE="7751">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-01_01_0020.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:29:51" MIMETYPE="application/pdf"
-				CHECKSUM="f9bfcd4c4c0696f9334fb4dbbca71647b56bceb9" CHECKSUMTYPE="SHA-1"
-				SIZE="4473925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/bmtnabf_1902-12-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:29:51" MIMETYPE="application/pdf" CHECKSUM="f9bfcd4c4c0696f9334fb4dbbca71647b56bceb9" CHECKSUMTYPE="SHA-1" SIZE="4473925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/01_01/bmtnabf_1902-12-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2370,8 +2237,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004"
-					LABEL="Die lachende Welle">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004" LABEL="Die lachende Welle">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -2539,15 +2405,13 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="GH-252-1" TYPE="TextContent" ORDER="1" DMDID="c013a"
-					LABEL="XV. Ausstellung">
+				<div ID="GH-252-1" TYPE="TextContent" ORDER="1" DMDID="c013a" LABEL="XV. Ausstellung">
 					<div ID="L.1.1.14.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c013"
-						LABEL="Raumgestaltung aus der XV. Ausstellung">
+					<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c013" LABEL="Raumgestaltung aus der XV. Ausstellung">
 						<div ID="L.1.1.14.2" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
@@ -2559,8 +2423,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c014"
-						LABEL="Kasten aus der XV. Ausstellung">
+					<div ID="L.1.1.15" TYPE="Illustration" ORDER="13" DMDID="c014" LABEL="Kasten aus der XV. Ausstellung">
 						<div ID="L.1.1.15.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -2578,8 +2441,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c015"
-					LABEL="Papst Leo XIII">
+				<div ID="L.1.1.16" TYPE="Illustration" ORDER="14" DMDID="c015" LABEL="Papst Leo XIII">
 					<div ID="L.1.1.16.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
@@ -2607,23 +2469,20 @@
 							<div ID="L.1.1.17.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.17.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
 									</fptr>
 								</div>
 							</div>
 							<div ID="L.1.1.17.2.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.17.2.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.17.3" TYPE="Illustration" ORDER="1" DMDID="c017"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.17.3" TYPE="Illustration" ORDER="1" DMDID="c017" LABEL="Untitled Image">
 						<div ID="L.1.1.17.3.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_CB00001"/>

--- a/metadata/periodicals/bmtnabf/issues/1902/12/15_01/bmtnabf_1902-12-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902/12/15_01/bmtnabf_1902-12-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-12-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1902-12-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-12-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902-12-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902-12-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2354,333 +2348,168 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:20:48"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="4853e42a7dd3f323799f5819ecc16a992fdbb1f5"
-				CHECKSUMTYPE="SHA-1" SIZE="6247026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:20:48" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="4853e42a7dd3f323799f5819ecc16a992fdbb1f5" CHECKSUMTYPE="SHA-1" SIZE="6247026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:21:22"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="297166988d51c1ca224302fba18cbe48d488ee2c"
-				CHECKSUMTYPE="SHA-1" SIZE="6104822">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:21:22" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="297166988d51c1ca224302fba18cbe48d488ee2c" CHECKSUMTYPE="SHA-1" SIZE="6104822">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:21:58"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="8a8caa9fc60c711ba68f54c31c8da79294d57952"
-				CHECKSUMTYPE="SHA-1" SIZE="6247017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:21:58" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="8a8caa9fc60c711ba68f54c31c8da79294d57952" CHECKSUMTYPE="SHA-1" SIZE="6247017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:22:39"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="1e669d271f087390bdf2f046e7076a364011a09b"
-				CHECKSUMTYPE="SHA-1" SIZE="6103901">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:22:39" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="1e669d271f087390bdf2f046e7076a364011a09b" CHECKSUMTYPE="SHA-1" SIZE="6103901">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:23:18"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="72044070ec8933b22c493c2adf768d8385f62484"
-				CHECKSUMTYPE="SHA-1" SIZE="6165126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:23:18" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="72044070ec8933b22c493c2adf768d8385f62484" CHECKSUMTYPE="SHA-1" SIZE="6165126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:23:51"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="08e41d49b9a8437fc399451c058627f21076f58d"
-				CHECKSUMTYPE="SHA-1" SIZE="6103914">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:23:51" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="08e41d49b9a8437fc399451c058627f21076f58d" CHECKSUMTYPE="SHA-1" SIZE="6103914">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:24:24"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="bb0c429e1e9e620c6ccd5ff71f92b257d4832973"
-				CHECKSUMTYPE="SHA-1" SIZE="6165122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:24:24" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="bb0c429e1e9e620c6ccd5ff71f92b257d4832973" CHECKSUMTYPE="SHA-1" SIZE="6165122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:24:57"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="543c00c029e253c61f423fa8f680b3bb42fb1fe9"
-				CHECKSUMTYPE="SHA-1" SIZE="6162384">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:24:57" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="543c00c029e253c61f423fa8f680b3bb42fb1fe9" CHECKSUMTYPE="SHA-1" SIZE="6162384">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:25:31"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f016c20f8414ca602caa678647e9bfcdf0b7c3e6"
-				CHECKSUMTYPE="SHA-1" SIZE="6107521">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:25:31" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f016c20f8414ca602caa678647e9bfcdf0b7c3e6" CHECKSUMTYPE="SHA-1" SIZE="6107521">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:26:04"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="47f1a9d27829eade8b3ecffd605af1481ae184be"
-				CHECKSUMTYPE="SHA-1" SIZE="6162426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:26:04" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="47f1a9d27829eade8b3ecffd605af1481ae184be" CHECKSUMTYPE="SHA-1" SIZE="6162426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:26:39"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="81fcef6b6de458514f72a51cff7ab6af18a8269a"
-				CHECKSUMTYPE="SHA-1" SIZE="6157017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:26:39" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="81fcef6b6de458514f72a51cff7ab6af18a8269a" CHECKSUMTYPE="SHA-1" SIZE="6157017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:27:13"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="7c7a4ab86b140dbd2f32d24eb9ca30c40adf6349"
-				CHECKSUMTYPE="SHA-1" SIZE="6162421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:27:13" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="7c7a4ab86b140dbd2f32d24eb9ca30c40adf6349" CHECKSUMTYPE="SHA-1" SIZE="6162421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:27:46"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="2089a8d38ed4760bf86a774f15df3379d661555b"
-				CHECKSUMTYPE="SHA-1" SIZE="6157029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:27:46" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="2089a8d38ed4760bf86a774f15df3379d661555b" CHECKSUMTYPE="SHA-1" SIZE="6157029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:28:23"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="895266d633f8207abbde53f5953fcad43a080f4e"
-				CHECKSUMTYPE="SHA-1" SIZE="6162409">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:28:23" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="895266d633f8207abbde53f5953fcad43a080f4e" CHECKSUMTYPE="SHA-1" SIZE="6162409">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:28:58"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="1fc2fd1fb751c6fab7bc6bd524eaf1138973d9e7"
-				CHECKSUMTYPE="SHA-1" SIZE="6157017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:28:58" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="1fc2fd1fb751c6fab7bc6bd524eaf1138973d9e7" CHECKSUMTYPE="SHA-1" SIZE="6157017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:29:31"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="3e73eda05d61b894a2e317e9443a66e9289a63f1"
-				CHECKSUMTYPE="SHA-1" SIZE="6162417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:29:31" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="3e73eda05d61b894a2e317e9443a66e9289a63f1" CHECKSUMTYPE="SHA-1" SIZE="6162417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:30:06"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e30340e8417e064a8d556eabc668ed5eed0eb4cd"
-				CHECKSUMTYPE="SHA-1" SIZE="6157023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:30:06" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e30340e8417e064a8d556eabc668ed5eed0eb4cd" CHECKSUMTYPE="SHA-1" SIZE="6157023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:30:41"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="9cdb68e1364de0e557c680eb5f2253794ed4f73f"
-				CHECKSUMTYPE="SHA-1" SIZE="6162428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:30:41" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="9cdb68e1364de0e557c680eb5f2253794ed4f73f" CHECKSUMTYPE="SHA-1" SIZE="6162428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:31:12"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="afa08a3f56b269ddb8e7c45a0b8da23c70ede86e"
-				CHECKSUMTYPE="SHA-1" SIZE="6157911">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:31:12" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="afa08a3f56b269ddb8e7c45a0b8da23c70ede86e" CHECKSUMTYPE="SHA-1" SIZE="6157911">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:31:44"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="53b180a908adb93264c3f0848b9d16340d714231"
-				CHECKSUMTYPE="SHA-1" SIZE="6164212">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:31:44" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="53b180a908adb93264c3f0848b9d16340d714231" CHECKSUMTYPE="SHA-1" SIZE="6164212">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:32:18"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="0de48513affcdd5c13055c856390552c5a6bc2eb"
-				CHECKSUMTYPE="SHA-1" SIZE="6158827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:32:18" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="0de48513affcdd5c13055c856390552c5a6bc2eb" CHECKSUMTYPE="SHA-1" SIZE="6158827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:32:54"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="dd00c2ffe4d5aef3c59409ea61ffba2abf54b6af"
-				CHECKSUMTYPE="SHA-1" SIZE="6292028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:32:54" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="dd00c2ffe4d5aef3c59409ea61ffba2abf54b6af" CHECKSUMTYPE="SHA-1" SIZE="6292028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:33:30"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="bcde2860a8652d2715d111a1cf549d4bf3ec538a"
-				CHECKSUMTYPE="SHA-1" SIZE="6012127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:33:30" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="bcde2860a8652d2715d111a1cf549d4bf3ec538a" CHECKSUMTYPE="SHA-1" SIZE="6012127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:34:07"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="279a6bc8b22049109084dd8b754fadc64ff97720"
-				CHECKSUMTYPE="SHA-1" SIZE="6260523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:34:07" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="279a6bc8b22049109084dd8b754fadc64ff97720" CHECKSUMTYPE="SHA-1" SIZE="6260523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:34:41"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="5f13a781c1c26ecbb44f454101b6d9678cb1fe30"
-				CHECKSUMTYPE="SHA-1" SIZE="6012129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:34:41" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="5f13a781c1c26ecbb44f454101b6d9678cb1fe30" CHECKSUMTYPE="SHA-1" SIZE="6012129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:35:16"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="b32d102e7ad6d5f39a52fcec9b0a4ff127820c03"
-				CHECKSUMTYPE="SHA-1" SIZE="6227224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:35:16" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="b32d102e7ad6d5f39a52fcec9b0a4ff127820c03" CHECKSUMTYPE="SHA-1" SIZE="6227224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/delivery/bmtnabf_1902-12-15_01_0026.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:35:38" MIMETYPE="text/xml"
-				CHECKSUM="185d77b7e4bf5d85c65dca39c45da43418469cdb" CHECKSUMTYPE="SHA-1" SIZE="4719">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:35:38" MIMETYPE="text/xml" CHECKSUM="185d77b7e4bf5d85c65dca39c45da43418469cdb" CHECKSUMTYPE="SHA-1" SIZE="4719">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:35:39" MIMETYPE="text/xml"
-				CHECKSUM="6dfd7c4c04bdb72151ed0f91ad3f4b4d8cdfb5b8" CHECKSUMTYPE="SHA-1"
-				SIZE="47508">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:35:39" MIMETYPE="text/xml" CHECKSUM="6dfd7c4c04bdb72151ed0f91ad3f4b4d8cdfb5b8" CHECKSUMTYPE="SHA-1" SIZE="47508">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:35:39" MIMETYPE="text/xml"
-				CHECKSUM="7dce1179409d9c4eb133bdda279329fe61c3cccb" CHECKSUMTYPE="SHA-1" SIZE="8369">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:35:39" MIMETYPE="text/xml" CHECKSUM="7dce1179409d9c4eb133bdda279329fe61c3cccb" CHECKSUMTYPE="SHA-1" SIZE="8369">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:35:39" MIMETYPE="text/xml"
-				CHECKSUM="deddff548d4f2dd1d795d2bb674d0963684aea9f" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:35:39" MIMETYPE="text/xml" CHECKSUM="deddff548d4f2dd1d795d2bb674d0963684aea9f" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:35:40" MIMETYPE="text/xml"
-				CHECKSUM="e494d073edee0e99d715d0cf23f3da7fc3c2e646" CHECKSUMTYPE="SHA-1" SIZE="5950">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:35:40" MIMETYPE="text/xml" CHECKSUM="e494d073edee0e99d715d0cf23f3da7fc3c2e646" CHECKSUMTYPE="SHA-1" SIZE="5950">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:35:40" MIMETYPE="text/xml"
-				CHECKSUM="4dcdda482e382fecb1fc6f4afd77d45825b7a698" CHECKSUMTYPE="SHA-1" SIZE="4850">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:35:40" MIMETYPE="text/xml" CHECKSUM="4dcdda482e382fecb1fc6f4afd77d45825b7a698" CHECKSUMTYPE="SHA-1" SIZE="4850">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:35:40" MIMETYPE="text/xml"
-				CHECKSUM="642184a8ad9efdd358a6e72a00bb0ffd7ae6daf2" CHECKSUMTYPE="SHA-1" SIZE="5156">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:35:40" MIMETYPE="text/xml" CHECKSUM="642184a8ad9efdd358a6e72a00bb0ffd7ae6daf2" CHECKSUMTYPE="SHA-1" SIZE="5156">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:35:40" MIMETYPE="text/xml"
-				CHECKSUM="1fee9d8f10206cfeaee174e2d30136b362130f3d" CHECKSUMTYPE="SHA-1" SIZE="4348">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:35:40" MIMETYPE="text/xml" CHECKSUM="1fee9d8f10206cfeaee174e2d30136b362130f3d" CHECKSUMTYPE="SHA-1" SIZE="4348">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:35:41" MIMETYPE="text/xml"
-				CHECKSUM="383071a71d0afff1aef39f1abbfe41369eea7874" CHECKSUMTYPE="SHA-1" SIZE="4361">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:35:41" MIMETYPE="text/xml" CHECKSUM="383071a71d0afff1aef39f1abbfe41369eea7874" CHECKSUMTYPE="SHA-1" SIZE="4361">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:35:41" MIMETYPE="text/xml"
-				CHECKSUM="4a81f9b9158a486a39b8869208e043f40375d06d" CHECKSUMTYPE="SHA-1" SIZE="4372">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:35:41" MIMETYPE="text/xml" CHECKSUM="4a81f9b9158a486a39b8869208e043f40375d06d" CHECKSUMTYPE="SHA-1" SIZE="4372">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:35:41" MIMETYPE="text/xml"
-				CHECKSUM="41e3e0303718707a39d3a45021de2fc963408756" CHECKSUMTYPE="SHA-1" SIZE="4385">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:35:41" MIMETYPE="text/xml" CHECKSUM="41e3e0303718707a39d3a45021de2fc963408756" CHECKSUMTYPE="SHA-1" SIZE="4385">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:35:41" MIMETYPE="text/xml"
-				CHECKSUM="3fae0c7b60e4d0a52c71ede2d80b366f14731805" CHECKSUMTYPE="SHA-1" SIZE="5180">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:35:41" MIMETYPE="text/xml" CHECKSUM="3fae0c7b60e4d0a52c71ede2d80b366f14731805" CHECKSUMTYPE="SHA-1" SIZE="5180">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:35:42" MIMETYPE="text/xml"
-				CHECKSUM="d73259f665b00181de0b75984bf3e52b5f857751" CHECKSUMTYPE="SHA-1" SIZE="5197">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:35:42" MIMETYPE="text/xml" CHECKSUM="d73259f665b00181de0b75984bf3e52b5f857751" CHECKSUMTYPE="SHA-1" SIZE="5197">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:35:42" MIMETYPE="text/xml"
-				CHECKSUM="eac54cdbe900a23c9afa792022333c005d6c854b" CHECKSUMTYPE="SHA-1" SIZE="4379">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:35:42" MIMETYPE="text/xml" CHECKSUM="eac54cdbe900a23c9afa792022333c005d6c854b" CHECKSUMTYPE="SHA-1" SIZE="4379">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:35:42" MIMETYPE="text/xml"
-				CHECKSUM="6f948a06b9cc1116447c8f788bc08973f3e2e03f" CHECKSUMTYPE="SHA-1" SIZE="4398">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:35:42" MIMETYPE="text/xml" CHECKSUM="6f948a06b9cc1116447c8f788bc08973f3e2e03f" CHECKSUMTYPE="SHA-1" SIZE="4398">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:35:42" MIMETYPE="text/xml"
-				CHECKSUM="46da2eb525729ebc2f53182f9b130d850710b7ec" CHECKSUMTYPE="SHA-1" SIZE="4372">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:35:42" MIMETYPE="text/xml" CHECKSUM="46da2eb525729ebc2f53182f9b130d850710b7ec" CHECKSUMTYPE="SHA-1" SIZE="4372">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:35:42" MIMETYPE="text/xml"
-				CHECKSUM="de740d49b38754d3423f49bcac476807d9845a42" CHECKSUMTYPE="SHA-1" SIZE="4383">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:35:42" MIMETYPE="text/xml" CHECKSUM="de740d49b38754d3423f49bcac476807d9845a42" CHECKSUMTYPE="SHA-1" SIZE="4383">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:35:43" MIMETYPE="text/xml"
-				CHECKSUM="cf1f33793775f43400236f64b37c28d6eab19e8d" CHECKSUMTYPE="SHA-1" SIZE="4376">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:35:43" MIMETYPE="text/xml" CHECKSUM="cf1f33793775f43400236f64b37c28d6eab19e8d" CHECKSUMTYPE="SHA-1" SIZE="4376">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:35:43" MIMETYPE="text/xml"
-				CHECKSUM="1b5fab8a5a254042afb6ed1355d16d9894253841" CHECKSUMTYPE="SHA-1" SIZE="4392">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:35:43" MIMETYPE="text/xml" CHECKSUM="1b5fab8a5a254042afb6ed1355d16d9894253841" CHECKSUMTYPE="SHA-1" SIZE="4392">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:35:43" MIMETYPE="text/xml"
-				CHECKSUM="5fd158ada6b3eaba815f717b77c81f4c0c4b8dbd" CHECKSUMTYPE="SHA-1" SIZE="4379">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:35:43" MIMETYPE="text/xml" CHECKSUM="5fd158ada6b3eaba815f717b77c81f4c0c4b8dbd" CHECKSUMTYPE="SHA-1" SIZE="4379">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:35:44" MIMETYPE="text/xml"
-				CHECKSUM="cd103af7a77bc7beed684e683cedbe4c680e0f1a" CHECKSUMTYPE="SHA-1"
-				SIZE="53139">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:35:44" MIMETYPE="text/xml" CHECKSUM="cd103af7a77bc7beed684e683cedbe4c680e0f1a" CHECKSUMTYPE="SHA-1" SIZE="53139">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:35:44" MIMETYPE="text/xml"
-				CHECKSUM="1df681a33e7c500f19e5552bc3c0147199eae4e2" CHECKSUMTYPE="SHA-1"
-				SIZE="51933">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:35:44" MIMETYPE="text/xml" CHECKSUM="1df681a33e7c500f19e5552bc3c0147199eae4e2" CHECKSUMTYPE="SHA-1" SIZE="51933">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:35:44" MIMETYPE="text/xml"
-				CHECKSUM="ac0b2be21db629757d810fbba07acbf7c0664980" CHECKSUMTYPE="SHA-1"
-				SIZE="23728">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:35:44" MIMETYPE="text/xml" CHECKSUM="ac0b2be21db629757d810fbba07acbf7c0664980" CHECKSUMTYPE="SHA-1" SIZE="23728">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:35:44" MIMETYPE="text/xml"
-				CHECKSUM="ed870b32271d6165608d3ba8cb96dcc8e5747d4a" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:35:44" MIMETYPE="text/xml" CHECKSUM="ed870b32271d6165608d3ba8cb96dcc8e5747d4a" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:35:45" MIMETYPE="text/xml"
-				CHECKSUM="aee13936b0b545745f48043f294b084150532833" CHECKSUMTYPE="SHA-1"
-				SIZE="21968">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:35:45" MIMETYPE="text/xml" CHECKSUM="aee13936b0b545745f48043f294b084150532833" CHECKSUMTYPE="SHA-1" SIZE="21968">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:35:45" MIMETYPE="text/xml"
-				CHECKSUM="760c8c76e666b0634115c7bd5fd15b6e485c97e7" CHECKSUMTYPE="SHA-1" SIZE="8288">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:35:45" MIMETYPE="text/xml" CHECKSUM="760c8c76e666b0634115c7bd5fd15b6e485c97e7" CHECKSUMTYPE="SHA-1" SIZE="8288">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1902-12-15_01_0026.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:36:10" MIMETYPE="application/pdf"
-				CHECKSUM="5df8bbdb6c5cf5ac0e01027f043d8e1fa8db42db" CHECKSUMTYPE="SHA-1"
-				SIZE="6124214">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/bmtnabf_1902-12-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:36:10" MIMETYPE="application/pdf" CHECKSUM="5df8bbdb6c5cf5ac0e01027f043d8e1fa8db42db" CHECKSUMTYPE="SHA-1" SIZE="6124214">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1902/12/15_01/bmtnabf_1902-12-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2992,8 +2821,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004"
-					LABEL="16 STUDIEN U. ZEICHNUNGEN">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="3" DMDID="c004" LABEL="16 STUDIEN U. ZEICHNUNGEN">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -3015,8 +2843,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c005"
-					LABEL="Studie zu einem Porträt">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="4" DMDID="c005" LABEL="Studie zu einem Porträt">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
@@ -3033,8 +2860,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c006"
-					LABEL="Studie zum Porträt meiner Frau">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c006" LABEL="Studie zum Porträt meiner Frau">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
@@ -3119,8 +2945,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c011"
-					LABEL="Karton für die Krakauer Kathedrale">
+				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c011" LABEL="Karton für die Krakauer Kathedrale">
 					<div ID="L.1.1.12.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00003"/>
@@ -3137,8 +2962,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c012"
-					LABEL="Karton für die Krakauer Kathedrale">
+				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c012" LABEL="Karton für die Krakauer Kathedrale">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>

--- a/metadata/periodicals/bmtnabf/issues/1902_01/bmtnabf_1902_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1902_01/bmtnabf_1902_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1902_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1902_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1903/01/01_01/bmtnabf_1903-01-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/01/01_01/bmtnabf_1903-01-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-01-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-01-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-01-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-01-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-01-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3017,461 +3011,228 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:27:50"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a1c0f8d4d1fe737d0b717fbaeb78e6fbb6f0c7a7"
-				CHECKSUMTYPE="SHA-1" SIZE="6132703">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:27:50" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a1c0f8d4d1fe737d0b717fbaeb78e6fbb6f0c7a7" CHECKSUMTYPE="SHA-1" SIZE="6132703">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:28:22"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="91592f489ef21c87061a1dfb63387ac2a8a35ea8"
-				CHECKSUMTYPE="SHA-1" SIZE="5857328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:28:22" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="91592f489ef21c87061a1dfb63387ac2a8a35ea8" CHECKSUMTYPE="SHA-1" SIZE="5857328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:28:52"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="3b1815416c4ebae3a58e79b8975969d4636ca88a"
-				CHECKSUMTYPE="SHA-1" SIZE="6211893">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:28:52" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="3b1815416c4ebae3a58e79b8975969d4636ca88a" CHECKSUMTYPE="SHA-1" SIZE="6211893">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:29:27"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="b1e6dd4767c3293a1b2fabf818b63f6d24e869b1"
-				CHECKSUMTYPE="SHA-1" SIZE="5857328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:29:27" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="b1e6dd4767c3293a1b2fabf818b63f6d24e869b1" CHECKSUMTYPE="SHA-1" SIZE="5857328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:29:59"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="10123167947de021250e97156365b53756e9a8a9"
-				CHECKSUMTYPE="SHA-1" SIZE="5989624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:29:59" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="10123167947de021250e97156365b53756e9a8a9" CHECKSUMTYPE="SHA-1" SIZE="5989624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:30:28"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="728d198317ddba918ee9b42194f8072d5e6b58d8"
-				CHECKSUMTYPE="SHA-1" SIZE="5885215">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:30:28" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="728d198317ddba918ee9b42194f8072d5e6b58d8" CHECKSUMTYPE="SHA-1" SIZE="5885215">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:30:59"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="359bb95b58d81664f8bdb291d5147477f38f6ccf"
-				CHECKSUMTYPE="SHA-1" SIZE="6004928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:30:59" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="359bb95b58d81664f8bdb291d5147477f38f6ccf" CHECKSUMTYPE="SHA-1" SIZE="6004928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:31:28"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="06e01d0b1ecf5424bbdbb7ecd579f4b00949147f"
-				CHECKSUMTYPE="SHA-1" SIZE="5885227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:31:28" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="06e01d0b1ecf5424bbdbb7ecd579f4b00949147f" CHECKSUMTYPE="SHA-1" SIZE="5885227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:32:00"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="b7e35219fb5a29ffb45ac1d38a8e15e08172b8b6"
-				CHECKSUMTYPE="SHA-1" SIZE="6004921">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:32:00" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="b7e35219fb5a29ffb45ac1d38a8e15e08172b8b6" CHECKSUMTYPE="SHA-1" SIZE="6004921">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:32:31"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="61d9664cfb0ca692dddb6fadd414b88738a0a42a"
-				CHECKSUMTYPE="SHA-1" SIZE="5938324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:32:31" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="61d9664cfb0ca692dddb6fadd414b88738a0a42a" CHECKSUMTYPE="SHA-1" SIZE="5938324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:33:04"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="47421df891a8f54ecc4e6411fd1ab6742860ad5f"
-				CHECKSUMTYPE="SHA-1" SIZE="6004892">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:33:04" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="47421df891a8f54ecc4e6411fd1ab6742860ad5f" CHECKSUMTYPE="SHA-1" SIZE="6004892">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:33:35"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="526dcaae787b5c879630ee50efa05751d1ba9df6"
-				CHECKSUMTYPE="SHA-1" SIZE="6010313">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:33:35" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="526dcaae787b5c879630ee50efa05751d1ba9df6" CHECKSUMTYPE="SHA-1" SIZE="6010313">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:34:10"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="7b74be052a15e5a4e0e6b15a07880ed99bfa6a96"
-				CHECKSUMTYPE="SHA-1" SIZE="6145321">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:34:10" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="7b74be052a15e5a4e0e6b15a07880ed99bfa6a96" CHECKSUMTYPE="SHA-1" SIZE="6145321">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:34:38"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="9359e12f7317faa961abf1521c7dde297cdd4e16"
-				CHECKSUMTYPE="SHA-1" SIZE="5938325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:34:38" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="9359e12f7317faa961abf1521c7dde297cdd4e16" CHECKSUMTYPE="SHA-1" SIZE="5938325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:35:09"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="050b88f4f84b2fb0016257d5053f8786aaace24d"
-				CHECKSUMTYPE="SHA-1" SIZE="6040024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:35:09" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="050b88f4f84b2fb0016257d5053f8786aaace24d" CHECKSUMTYPE="SHA-1" SIZE="6040024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:35:41"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="12569f6eb7aa0f886cb849faf47844b39417f0f9"
-				CHECKSUMTYPE="SHA-1" SIZE="6015721">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:35:41" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="12569f6eb7aa0f886cb849faf47844b39417f0f9" CHECKSUMTYPE="SHA-1" SIZE="6015721">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:36:15"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="4f3cb7a663737ce0fadd7c20aad44b6dcc56bddf"
-				CHECKSUMTYPE="SHA-1" SIZE="6074207">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:36:15" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="4f3cb7a663737ce0fadd7c20aad44b6dcc56bddf" CHECKSUMTYPE="SHA-1" SIZE="6074207">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:36:44"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="c4c493ac2389041a1dd26f5f56d9baafdb77ddf6"
-				CHECKSUMTYPE="SHA-1" SIZE="6015729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:36:44" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="c4c493ac2389041a1dd26f5f56d9baafdb77ddf6" CHECKSUMTYPE="SHA-1" SIZE="6015729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:37:17"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="dd545c66c6a61ab62864e50f6545c69c00d44372"
-				CHECKSUMTYPE="SHA-1" SIZE="6074207">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:37:17" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="dd545c66c6a61ab62864e50f6545c69c00d44372" CHECKSUMTYPE="SHA-1" SIZE="6074207">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:37:49"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="dfe8d041eab5bee726dacd7b05814238b36411cb"
-				CHECKSUMTYPE="SHA-1" SIZE="6059700">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:37:49" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="dfe8d041eab5bee726dacd7b05814238b36411cb" CHECKSUMTYPE="SHA-1" SIZE="6059700">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:38:19"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="f8ff44b3bf0e020b060e2ed7a18d0cf576a19275"
-				CHECKSUMTYPE="SHA-1" SIZE="6074198">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:38:19" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="f8ff44b3bf0e020b060e2ed7a18d0cf576a19275" CHECKSUMTYPE="SHA-1" SIZE="6074198">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:38:51"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="f37e84cb910dced6da76df9f12d088b42bf3fc04"
-				CHECKSUMTYPE="SHA-1" SIZE="6059822">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:38:51" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="f37e84cb910dced6da76df9f12d088b42bf3fc04" CHECKSUMTYPE="SHA-1" SIZE="6059822">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:39:23"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="0edb849fb44f4ddead0645660a91430f38d2c526"
-				CHECKSUMTYPE="SHA-1" SIZE="6074216">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:39:23" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="0edb849fb44f4ddead0645660a91430f38d2c526" CHECKSUMTYPE="SHA-1" SIZE="6074216">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:39:52"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="08940410885eedff00e61b794ee6964112dab20d"
-				CHECKSUMTYPE="SHA-1" SIZE="6060715">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:39:52" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="08940410885eedff00e61b794ee6964112dab20d" CHECKSUMTYPE="SHA-1" SIZE="6060715">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:40:24"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="461c66518227844ee467713d2b7898e1f6585a88"
-				CHECKSUMTYPE="SHA-1" SIZE="6073325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:40:24" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="461c66518227844ee467713d2b7898e1f6585a88" CHECKSUMTYPE="SHA-1" SIZE="6073325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:40:53"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="602c343a51e213d871b215e07d034a8cc0df1a4f"
-				CHECKSUMTYPE="SHA-1" SIZE="6059818">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:40:53" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="602c343a51e213d871b215e07d034a8cc0df1a4f" CHECKSUMTYPE="SHA-1" SIZE="6059818">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:41:23"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="748385dfbf04992edb9258413e6c5ee88a3c4e60"
-				CHECKSUMTYPE="SHA-1" SIZE="6073328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:41:23" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="748385dfbf04992edb9258413e6c5ee88a3c4e60" CHECKSUMTYPE="SHA-1" SIZE="6073328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:41:53"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="bb8326d131ac9137e7f1037bcad68510adbb97ed"
-				CHECKSUMTYPE="SHA-1" SIZE="6059824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:41:53" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="bb8326d131ac9137e7f1037bcad68510adbb97ed" CHECKSUMTYPE="SHA-1" SIZE="6059824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T19:42:23"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="c2d59a61f056b6f0e381b6b23913f269fbd3a25b"
-				CHECKSUMTYPE="SHA-1" SIZE="6073288">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T19:42:23" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="c2d59a61f056b6f0e381b6b23913f269fbd3a25b" CHECKSUMTYPE="SHA-1" SIZE="6073288">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T19:42:53"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="cb0ec9d88ddc97c2492f986d24323ef1b4059bb7"
-				CHECKSUMTYPE="SHA-1" SIZE="6060716">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T19:42:53" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="cb0ec9d88ddc97c2492f986d24323ef1b4059bb7" CHECKSUMTYPE="SHA-1" SIZE="6060716">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T19:43:21"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="bb2fc29a8683a22539227f0bbba267f650cc7022"
-				CHECKSUMTYPE="SHA-1" SIZE="6073311">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T19:43:21" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="bb2fc29a8683a22539227f0bbba267f650cc7022" CHECKSUMTYPE="SHA-1" SIZE="6073311">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T19:43:52"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="3adc998664c1eb6e9e656c77015a526254b20892"
-				CHECKSUMTYPE="SHA-1" SIZE="6192985">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T19:43:52" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="3adc998664c1eb6e9e656c77015a526254b20892" CHECKSUMTYPE="SHA-1" SIZE="6192985">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T19:44:23"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="8ce42a11a73d1d33ef70159df810812031b4ddc4"
-				CHECKSUMTYPE="SHA-1" SIZE="5949127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T19:44:23" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="8ce42a11a73d1d33ef70159df810812031b4ddc4" CHECKSUMTYPE="SHA-1" SIZE="5949127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T19:44:52"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="fa6d4fe8facdad5d11ec8b0b8781efd1a40bb5c8"
-				CHECKSUMTYPE="SHA-1" SIZE="6233529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T19:44:52" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="fa6d4fe8facdad5d11ec8b0b8781efd1a40bb5c8" CHECKSUMTYPE="SHA-1" SIZE="6233529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0034.jp2"/>
 			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T19:45:22"
-				MIMETYPE="image/jp2" SEQ="35" CHECKSUM="f0333a8f368d50b6ccec64acc946846d96d530fe"
-				CHECKSUMTYPE="SHA-1" SIZE="5949125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0035.jp2"
-				/>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T19:45:22" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="f0333a8f368d50b6ccec64acc946846d96d530fe" CHECKSUMTYPE="SHA-1" SIZE="5949125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0035.jp2"/>
 			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T19:45:54"
-				MIMETYPE="image/jp2" SEQ="36" CHECKSUM="a88deb21b9a6c06ebe55cd1847c18f8be0fb9777"
-				CHECKSUMTYPE="SHA-1" SIZE="6137228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0036.jp2"
-				/>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T19:45:54" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="a88deb21b9a6c06ebe55cd1847c18f8be0fb9777" CHECKSUMTYPE="SHA-1" SIZE="6137228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/delivery/bmtnabf_1903-01-01_01_0036.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:46:10" MIMETYPE="text/xml"
-				CHECKSUM="3fb059c81e94ca434d3387f8b6b5503f7c1deb4d" CHECKSUMTYPE="SHA-1" SIZE="5391">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:46:10" MIMETYPE="text/xml" CHECKSUM="3fb059c81e94ca434d3387f8b6b5503f7c1deb4d" CHECKSUMTYPE="SHA-1" SIZE="5391">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:46:11" MIMETYPE="text/xml"
-				CHECKSUM="d5b20d4cd8fdaea7e1abfe680813256749d21d0b" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:46:11" MIMETYPE="text/xml" CHECKSUM="d5b20d4cd8fdaea7e1abfe680813256749d21d0b" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:46:11" MIMETYPE="text/xml"
-				CHECKSUM="e36376a8b006dc31a786c6e0b1f3d83c6d7e3b42" CHECKSUMTYPE="SHA-1" SIZE="8864">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:46:11" MIMETYPE="text/xml" CHECKSUM="e36376a8b006dc31a786c6e0b1f3d83c6d7e3b42" CHECKSUMTYPE="SHA-1" SIZE="8864">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:46:11" MIMETYPE="text/xml"
-				CHECKSUM="443a0117b3286105adac3a7eed4bd519b9e4e462" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:46:11" MIMETYPE="text/xml" CHECKSUM="443a0117b3286105adac3a7eed4bd519b9e4e462" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:46:11" MIMETYPE="text/xml"
-				CHECKSUM="613d9c9ad7414ceabb014ea4d41f4915f032acc7" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:46:11" MIMETYPE="text/xml" CHECKSUM="613d9c9ad7414ceabb014ea4d41f4915f032acc7" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:46:12" MIMETYPE="text/xml"
-				CHECKSUM="d30d526a828a579cb23458cfe775c8a87b660dea" CHECKSUMTYPE="SHA-1" SIZE="4821">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:46:12" MIMETYPE="text/xml" CHECKSUM="d30d526a828a579cb23458cfe775c8a87b660dea" CHECKSUMTYPE="SHA-1" SIZE="4821">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:46:12" MIMETYPE="text/xml"
-				CHECKSUM="1cc5d26ffc61500ef91d6e181f7ec2f729bcffff" CHECKSUMTYPE="SHA-1"
-				SIZE="49673">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:46:12" MIMETYPE="text/xml" CHECKSUM="1cc5d26ffc61500ef91d6e181f7ec2f729bcffff" CHECKSUMTYPE="SHA-1" SIZE="49673">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:46:12" MIMETYPE="text/xml"
-				CHECKSUM="8f95a03588afa3ae6457865ddf8cb65fc2edee8d" CHECKSUMTYPE="SHA-1"
-				SIZE="73924">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:46:12" MIMETYPE="text/xml" CHECKSUM="8f95a03588afa3ae6457865ddf8cb65fc2edee8d" CHECKSUMTYPE="SHA-1" SIZE="73924">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:46:12" MIMETYPE="text/xml"
-				CHECKSUM="da3640e1bb92e4e64e5d44b3def7f199b0c3b932" CHECKSUMTYPE="SHA-1"
-				SIZE="75734">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:46:12" MIMETYPE="text/xml" CHECKSUM="da3640e1bb92e4e64e5d44b3def7f199b0c3b932" CHECKSUMTYPE="SHA-1" SIZE="75734">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:46:13" MIMETYPE="text/xml"
-				CHECKSUM="3c09bba4753ba8f92542743a0250c84ad0b93250" CHECKSUMTYPE="SHA-1"
-				SIZE="65991">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:46:13" MIMETYPE="text/xml" CHECKSUM="3c09bba4753ba8f92542743a0250c84ad0b93250" CHECKSUMTYPE="SHA-1" SIZE="65991">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:46:13" MIMETYPE="text/xml"
-				CHECKSUM="11ba5878f2f050633004f6ea9bb814c7ff3cb8cf" CHECKSUMTYPE="SHA-1"
-				SIZE="76990">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:46:13" MIMETYPE="text/xml" CHECKSUM="11ba5878f2f050633004f6ea9bb814c7ff3cb8cf" CHECKSUMTYPE="SHA-1" SIZE="76990">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:46:13" MIMETYPE="text/xml"
-				CHECKSUM="1970165a8277345362f19ca57ffaa03738c0cc4b" CHECKSUMTYPE="SHA-1"
-				SIZE="73916">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:46:13" MIMETYPE="text/xml" CHECKSUM="1970165a8277345362f19ca57ffaa03738c0cc4b" CHECKSUMTYPE="SHA-1" SIZE="73916">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:46:14" MIMETYPE="text/xml"
-				CHECKSUM="b538a34207e3cc15dc21bb6d2d86f2f45354091f" CHECKSUMTYPE="SHA-1"
-				SIZE="69886">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:46:14" MIMETYPE="text/xml" CHECKSUM="b538a34207e3cc15dc21bb6d2d86f2f45354091f" CHECKSUMTYPE="SHA-1" SIZE="69886">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:46:14" MIMETYPE="text/xml"
-				CHECKSUM="30cc0168cebffe8148308523fa93b607389b363b" CHECKSUMTYPE="SHA-1"
-				SIZE="45731">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:46:14" MIMETYPE="text/xml" CHECKSUM="30cc0168cebffe8148308523fa93b607389b363b" CHECKSUMTYPE="SHA-1" SIZE="45731">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:46:14" MIMETYPE="text/xml"
-				CHECKSUM="02d48fe1c02567769baab650ccb97d53fec2651d" CHECKSUMTYPE="SHA-1" SIZE="4828">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:46:14" MIMETYPE="text/xml" CHECKSUM="02d48fe1c02567769baab650ccb97d53fec2651d" CHECKSUMTYPE="SHA-1" SIZE="4828">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:46:14" MIMETYPE="text/xml"
-				CHECKSUM="513bed8884e9db4e7e2b99813039d2195f5fa7d0" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:46:14" MIMETYPE="text/xml" CHECKSUM="513bed8884e9db4e7e2b99813039d2195f5fa7d0" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:46:15" MIMETYPE="text/xml"
-				CHECKSUM="bf4d9dd9c722b584ecee83e1c2cef8da2237bf84" CHECKSUMTYPE="SHA-1" SIZE="4861">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:46:15" MIMETYPE="text/xml" CHECKSUM="bf4d9dd9c722b584ecee83e1c2cef8da2237bf84" CHECKSUMTYPE="SHA-1" SIZE="4861">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:46:15" MIMETYPE="text/xml"
-				CHECKSUM="a52049790a4880de2b706d53a15dba2179dcb6fc" CHECKSUMTYPE="SHA-1" SIZE="2019">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:46:15" MIMETYPE="text/xml" CHECKSUM="a52049790a4880de2b706d53a15dba2179dcb6fc" CHECKSUMTYPE="SHA-1" SIZE="2019">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:46:15" MIMETYPE="text/xml"
-				CHECKSUM="d553e4ed687062bac559c8c94de7b889f89790ea" CHECKSUMTYPE="SHA-1" SIZE="4993">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:46:15" MIMETYPE="text/xml" CHECKSUM="d553e4ed687062bac559c8c94de7b889f89790ea" CHECKSUMTYPE="SHA-1" SIZE="4993">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:46:15" MIMETYPE="text/xml"
-				CHECKSUM="144ef7361d9ee9014d101022801ea32fea7c1f3f" CHECKSUMTYPE="SHA-1" SIZE="2022">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:46:15" MIMETYPE="text/xml" CHECKSUM="144ef7361d9ee9014d101022801ea32fea7c1f3f" CHECKSUMTYPE="SHA-1" SIZE="2022">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:46:15" MIMETYPE="text/xml"
-				CHECKSUM="0c2af217aaada7b36c703043917b2889f5e96a37" CHECKSUMTYPE="SHA-1" SIZE="4888">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:46:15" MIMETYPE="text/xml" CHECKSUM="0c2af217aaada7b36c703043917b2889f5e96a37" CHECKSUMTYPE="SHA-1" SIZE="4888">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:46:16" MIMETYPE="text/xml"
-				CHECKSUM="65fad827b5f0588068cf332f7e831fa78d87059a" CHECKSUMTYPE="SHA-1" SIZE="2022">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:46:16" MIMETYPE="text/xml" CHECKSUM="65fad827b5f0588068cf332f7e831fa78d87059a" CHECKSUMTYPE="SHA-1" SIZE="2022">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:46:16" MIMETYPE="text/xml"
-				CHECKSUM="e30664d0a62ba2378099f26ff8727c74b536a1df" CHECKSUMTYPE="SHA-1" SIZE="4812">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:46:16" MIMETYPE="text/xml" CHECKSUM="e30664d0a62ba2378099f26ff8727c74b536a1df" CHECKSUMTYPE="SHA-1" SIZE="4812">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:46:16" MIMETYPE="text/xml"
-				CHECKSUM="346cc2927a28e85f7284e4490c94c571500d1a72" CHECKSUMTYPE="SHA-1" SIZE="2022">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:46:16" MIMETYPE="text/xml" CHECKSUM="346cc2927a28e85f7284e4490c94c571500d1a72" CHECKSUMTYPE="SHA-1" SIZE="2022">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:46:16" MIMETYPE="text/xml"
-				CHECKSUM="ac67103882c6167a18983a2fa93039e58b165c64" CHECKSUMTYPE="SHA-1" SIZE="4812">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:46:16" MIMETYPE="text/xml" CHECKSUM="ac67103882c6167a18983a2fa93039e58b165c64" CHECKSUMTYPE="SHA-1" SIZE="4812">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:46:17" MIMETYPE="text/xml"
-				CHECKSUM="163f6ecff4eb2ff40e6e583e3b89edc46b2e78a6" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:46:17" MIMETYPE="text/xml" CHECKSUM="163f6ecff4eb2ff40e6e583e3b89edc46b2e78a6" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:46:17" MIMETYPE="text/xml"
-				CHECKSUM="d1b1c6daf349f07ad97db041f62deeb838cd7bda" CHECKSUMTYPE="SHA-1" SIZE="5174">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:46:17" MIMETYPE="text/xml" CHECKSUM="d1b1c6daf349f07ad97db041f62deeb838cd7bda" CHECKSUMTYPE="SHA-1" SIZE="5174">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:46:17" MIMETYPE="text/xml"
-				CHECKSUM="1755ba4e245169794d2a40fb81158875374cf2cf" CHECKSUMTYPE="SHA-1" SIZE="2020">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:46:17" MIMETYPE="text/xml" CHECKSUM="1755ba4e245169794d2a40fb81158875374cf2cf" CHECKSUMTYPE="SHA-1" SIZE="2020">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T19:46:17" MIMETYPE="text/xml"
-				CHECKSUM="eb7e96c1fa2bb165f4e222ce2348c974f200ce45" CHECKSUMTYPE="SHA-1" SIZE="8568">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T19:46:17" MIMETYPE="text/xml" CHECKSUM="eb7e96c1fa2bb165f4e222ce2348c974f200ce45" CHECKSUMTYPE="SHA-1" SIZE="8568">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T19:46:17" MIMETYPE="text/xml"
-				CHECKSUM="e7cb78d1e491a592c52cdf6142d61993583a3945" CHECKSUMTYPE="SHA-1"
-				SIZE="22474">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T19:46:17" MIMETYPE="text/xml" CHECKSUM="e7cb78d1e491a592c52cdf6142d61993583a3945" CHECKSUMTYPE="SHA-1" SIZE="22474">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T19:46:18" MIMETYPE="text/xml"
-				CHECKSUM="e060f0ba369b6f4eb6f0f0ac2b67bc5290d7fc8c" CHECKSUMTYPE="SHA-1"
-				SIZE="70502">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T19:46:18" MIMETYPE="text/xml" CHECKSUM="e060f0ba369b6f4eb6f0f0ac2b67bc5290d7fc8c" CHECKSUMTYPE="SHA-1" SIZE="70502">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T19:46:18" MIMETYPE="text/xml"
-				CHECKSUM="fabd48f647567f392e0d5bcfbc36e1b103709059" CHECKSUMTYPE="SHA-1"
-				SIZE="22424">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T19:46:18" MIMETYPE="text/xml" CHECKSUM="fabd48f647567f392e0d5bcfbc36e1b103709059" CHECKSUMTYPE="SHA-1" SIZE="22424">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T19:46:18" MIMETYPE="text/xml"
-				CHECKSUM="cfcfe01c54fcee50cd6f441da284dc7eb49d79af" CHECKSUMTYPE="SHA-1"
-				SIZE="19826">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0033.alto.xml"
-				/>
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T19:46:18" MIMETYPE="text/xml" CHECKSUM="cfcfe01c54fcee50cd6f441da284dc7eb49d79af" CHECKSUMTYPE="SHA-1" SIZE="19826">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T19:46:20" MIMETYPE="text/xml"
-				CHECKSUM="bc9f9ebec5262f8daaee79f1914b4c7c47b4586f" CHECKSUMTYPE="SHA-1" SIZE="7549">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0034.alto.xml"
-				/>
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T19:46:20" MIMETYPE="text/xml" CHECKSUM="bc9f9ebec5262f8daaee79f1914b4c7c47b4586f" CHECKSUMTYPE="SHA-1" SIZE="7549">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T19:46:20" MIMETYPE="text/xml"
-				CHECKSUM="4ba4cec34a1ba86f011a7e70e85544b096fad305" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0035.alto.xml"
-				/>
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T19:46:20" MIMETYPE="text/xml" CHECKSUM="4ba4cec34a1ba86f011a7e70e85544b096fad305" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T19:46:20" MIMETYPE="text/xml"
-				CHECKSUM="057d886252d2c4aab9ad9883275e867f8cb31003" CHECKSUMTYPE="SHA-1"
-				SIZE="19205">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0036.alto.xml"
-				/>
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T19:46:20" MIMETYPE="text/xml" CHECKSUM="057d886252d2c4aab9ad9883275e867f8cb31003" CHECKSUMTYPE="SHA-1" SIZE="19205">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-01-01_01_0036.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:46:56" MIMETYPE="application/pdf"
-				CHECKSUM="1e3df825e5be1190c8e719ab707a79bad5ac908a" CHECKSUMTYPE="SHA-1"
-				SIZE="9035982">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/bmtnabf_1903-01-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:46:56" MIMETYPE="application/pdf" CHECKSUM="1e3df825e5be1190c8e719ab707a79bad5ac908a" CHECKSUMTYPE="SHA-1" SIZE="9035982">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/01/01_01/bmtnabf_1903-01-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3831,8 +3592,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003"
-					LABEL="KREISLAUF DER MONATE">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003" LABEL="KREISLAUF DER MONATE">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00001"/>
@@ -3862,8 +3622,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.2" TYPE="Illustration" ORDER="2" DMDID="c006"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.5.2" TYPE="Illustration" ORDER="2" DMDID="c006" LABEL="Untitled Image">
 						<div ID="L.1.1.5.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00001"/>
@@ -3876,24 +3635,15 @@
 								<div ID="L.1.1.5.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
 										</seq>
 									</fptr>
 								</div>

--- a/metadata/periodicals/bmtnabf/issues/1903/01/15_01/bmtnabf_1903-01-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/01/15_01/bmtnabf_1903-01-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-01-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-01-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-01-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1903/02/01_01/bmtnabf_1903-02-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/02/01_01/bmtnabf_1903-02-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-02-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-02-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-02-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-02-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-02-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3028,501 +3022,240 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:29:07"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="9ffd4870c42ba5c241f6ee5cbd4cbf35a353febb"
-				CHECKSUMTYPE="SHA-1" SIZE="6198405">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:29:07" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="9ffd4870c42ba5c241f6ee5cbd4cbf35a353febb" CHECKSUMTYPE="SHA-1" SIZE="6198405">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:29:42"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="34349579572803219cc038cfbbd42d937d0bc477"
-				CHECKSUMTYPE="SHA-1" SIZE="6254225">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:29:42" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="34349579572803219cc038cfbbd42d937d0bc477" CHECKSUMTYPE="SHA-1" SIZE="6254225">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:30:15"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="f7347f2dcb9fafd031f1aa61cd63be18b9e8b201"
-				CHECKSUMTYPE="SHA-1" SIZE="6198427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:30:15" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="f7347f2dcb9fafd031f1aa61cd63be18b9e8b201" CHECKSUMTYPE="SHA-1" SIZE="6198427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:30:57"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="71c7e3a6a4aef1617dc17118ca22004295d2845d"
-				CHECKSUMTYPE="SHA-1" SIZE="6254222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:30:57" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="71c7e3a6a4aef1617dc17118ca22004295d2845d" CHECKSUMTYPE="SHA-1" SIZE="6254222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:31:36"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="8101cbcef28856eebae3d026b20be85af5435e56"
-				CHECKSUMTYPE="SHA-1" SIZE="6148003">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:31:36" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="8101cbcef28856eebae3d026b20be85af5435e56" CHECKSUMTYPE="SHA-1" SIZE="6148003">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:32:09"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="fa6526fd4b9b9f7cbca05cee16d58e210382be01"
-				CHECKSUMTYPE="SHA-1" SIZE="6242522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:32:09" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="fa6526fd4b9b9f7cbca05cee16d58e210382be01" CHECKSUMTYPE="SHA-1" SIZE="6242522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:32:43"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="6bbeaa705c62ddce9342b6aa3da95727a7d2c113"
-				CHECKSUMTYPE="SHA-1" SIZE="6090426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:32:43" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="6bbeaa705c62ddce9342b6aa3da95727a7d2c113" CHECKSUMTYPE="SHA-1" SIZE="6090426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:33:19"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a1aa6561247e494eb506624744e97129e2cbdfac"
-				CHECKSUMTYPE="SHA-1" SIZE="6242518">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:33:19" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a1aa6561247e494eb506624744e97129e2cbdfac" CHECKSUMTYPE="SHA-1" SIZE="6242518">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:33:55"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="ca6c43a2aa3ba50a9d306605b4c3bb36add1227b"
-				CHECKSUMTYPE="SHA-1" SIZE="6090422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:33:55" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="ca6c43a2aa3ba50a9d306605b4c3bb36add1227b" CHECKSUMTYPE="SHA-1" SIZE="6090422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:34:31"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="f823afb1f59b77cf8d611b60893d3df50238a981"
-				CHECKSUMTYPE="SHA-1" SIZE="6242529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:34:31" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="f823afb1f59b77cf8d611b60893d3df50238a981" CHECKSUMTYPE="SHA-1" SIZE="6242529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:35:05"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="2c4a576bc4f2aa00a341a9f61261944cf68ee319"
-				CHECKSUMTYPE="SHA-1" SIZE="6090429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:35:05" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="2c4a576bc4f2aa00a341a9f61261944cf68ee319" CHECKSUMTYPE="SHA-1" SIZE="6090429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:35:40"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="08d0b0ce6690d3f1419a7ee1f4872143237c2f6f"
-				CHECKSUMTYPE="SHA-1" SIZE="6242526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:35:40" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="08d0b0ce6690d3f1419a7ee1f4872143237c2f6f" CHECKSUMTYPE="SHA-1" SIZE="6242526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:36:16"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="261ff2f9d89cca87c2d34ef9e31894d051c9846a"
-				CHECKSUMTYPE="SHA-1" SIZE="6090419">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:36:16" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="261ff2f9d89cca87c2d34ef9e31894d051c9846a" CHECKSUMTYPE="SHA-1" SIZE="6090419">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:36:53"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="8abb9a3af7e22671b31d7fa30bb69e937ce7319d"
-				CHECKSUMTYPE="SHA-1" SIZE="6209228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:36:53" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="8abb9a3af7e22671b31d7fa30bb69e937ce7319d" CHECKSUMTYPE="SHA-1" SIZE="6209228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:37:30"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="56d897976e0a08a056238efeeed693ba5aef1f32"
-				CHECKSUMTYPE="SHA-1" SIZE="6090419">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:37:30" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="56d897976e0a08a056238efeeed693ba5aef1f32" CHECKSUMTYPE="SHA-1" SIZE="6090419">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:38:04"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="e09fb6951ffdef0a06c72c8092be885cd9f0b80e"
-				CHECKSUMTYPE="SHA-1" SIZE="6210127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:38:04" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="e09fb6951ffdef0a06c72c8092be885cd9f0b80e" CHECKSUMTYPE="SHA-1" SIZE="6210127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:38:42"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="9adec634c3aba79762827dc4c6e2ad6f70181e5e"
-				CHECKSUMTYPE="SHA-1" SIZE="6089479">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:38:42" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="9adec634c3aba79762827dc4c6e2ad6f70181e5e" CHECKSUMTYPE="SHA-1" SIZE="6089479">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:39:16"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="f83cf4212d6810dcd200ec3403f594c3589e47d0"
-				CHECKSUMTYPE="SHA-1" SIZE="6210114">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:39:16" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="f83cf4212d6810dcd200ec3403f594c3589e47d0" CHECKSUMTYPE="SHA-1" SIZE="6210114">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:39:52"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="17df73ec3849554da6604ecb7ddc6f599c9f81dd"
-				CHECKSUMTYPE="SHA-1" SIZE="6089517">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:39:52" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="17df73ec3849554da6604ecb7ddc6f599c9f81dd" CHECKSUMTYPE="SHA-1" SIZE="6089517">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:40:29"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="714d996b930eff1be390c8b709d70287f87d6c98"
-				CHECKSUMTYPE="SHA-1" SIZE="6210122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:40:29" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="714d996b930eff1be390c8b709d70287f87d6c98" CHECKSUMTYPE="SHA-1" SIZE="6210122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:41:07"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="1193dc9b50768b39605ef130a3ee4de0b1c4fa50"
-				CHECKSUMTYPE="SHA-1" SIZE="6089514">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:41:07" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="1193dc9b50768b39605ef130a3ee4de0b1c4fa50" CHECKSUMTYPE="SHA-1" SIZE="6089514">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:41:44"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="2454c2ccee103081df9857d38b4c4d0ebbc473c5"
-				CHECKSUMTYPE="SHA-1" SIZE="6209209">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:41:44" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="2454c2ccee103081df9857d38b4c4d0ebbc473c5" CHECKSUMTYPE="SHA-1" SIZE="6209209">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:42:19"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="679c9dfa6832534390b11e735da15e58daf5db3f"
-				CHECKSUMTYPE="SHA-1" SIZE="6008525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:42:19" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="679c9dfa6832534390b11e735da15e58daf5db3f" CHECKSUMTYPE="SHA-1" SIZE="6008525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:42:52"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="82d1a1be592dd80608327f27644ae81c4b658b57"
-				CHECKSUMTYPE="SHA-1" SIZE="6208312">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:42:52" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="82d1a1be592dd80608327f27644ae81c4b658b57" CHECKSUMTYPE="SHA-1" SIZE="6208312">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:43:26"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="79011a2ee522d033ccc588129500bacc882f787f"
-				CHECKSUMTYPE="SHA-1" SIZE="6009422">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:43:26" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="79011a2ee522d033ccc588129500bacc882f787f" CHECKSUMTYPE="SHA-1" SIZE="6009422">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:44:02"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="6f5afa2f18c3e2d937bbbadc0b6ee2a3e98466bd"
-				CHECKSUMTYPE="SHA-1" SIZE="6232628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:44:02" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="6f5afa2f18c3e2d937bbbadc0b6ee2a3e98466bd" CHECKSUMTYPE="SHA-1" SIZE="6232628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:44:35"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="063104346f720d40fe97aad39fb4d417ea96dc4e"
-				CHECKSUMTYPE="SHA-1" SIZE="6009424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:44:35" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="063104346f720d40fe97aad39fb4d417ea96dc4e" CHECKSUMTYPE="SHA-1" SIZE="6009424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:45:12"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="9dda549bca153987c9d8fcf4bbcf8a0b31e075d3"
-				CHECKSUMTYPE="SHA-1" SIZE="6232609">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:45:12" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="9dda549bca153987c9d8fcf4bbcf8a0b31e075d3" CHECKSUMTYPE="SHA-1" SIZE="6232609">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T19:45:46"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="5afc42d8571589ace9b8efa7fddc310ba3067294"
-				CHECKSUMTYPE="SHA-1" SIZE="6009424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T19:45:46" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="5afc42d8571589ace9b8efa7fddc310ba3067294" CHECKSUMTYPE="SHA-1" SIZE="6009424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T19:46:24"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="e0d4e0da0567888ba91cefb367013e3229f2a9b7"
-				CHECKSUMTYPE="SHA-1" SIZE="6188528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T19:46:24" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="e0d4e0da0567888ba91cefb367013e3229f2a9b7" CHECKSUMTYPE="SHA-1" SIZE="6188528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T19:46:55"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="aeed4101764cc7a3a84ee42fe2fc2724f7c0ad4d"
-				CHECKSUMTYPE="SHA-1" SIZE="6009413">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T19:46:55" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="aeed4101764cc7a3a84ee42fe2fc2724f7c0ad4d" CHECKSUMTYPE="SHA-1" SIZE="6009413">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T19:47:30"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="0f5b0dab2b03d06189aba1b8a7750dee1977f921"
-				CHECKSUMTYPE="SHA-1" SIZE="6189405">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T19:47:30" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="0f5b0dab2b03d06189aba1b8a7750dee1977f921" CHECKSUMTYPE="SHA-1" SIZE="6189405">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T19:48:05"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="6e168d617b0c1ddb2f1fa9d8dbf4f939db6f3f77"
-				CHECKSUMTYPE="SHA-1" SIZE="6008528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T19:48:05" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="6e168d617b0c1ddb2f1fa9d8dbf4f939db6f3f77" CHECKSUMTYPE="SHA-1" SIZE="6008528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T19:48:40"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="b2d9472d5dcdefd91619ae9a10678a2185fb849a"
-				CHECKSUMTYPE="SHA-1" SIZE="6327112">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T19:48:40" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="b2d9472d5dcdefd91619ae9a10678a2185fb849a" CHECKSUMTYPE="SHA-1" SIZE="6327112">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0034.jp2"/>
 			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T19:49:14"
-				MIMETYPE="image/jp2" SEQ="35" CHECKSUM="bb9fc3284566e62de18c891825361e5a3a7ad1dd"
-				CHECKSUMTYPE="SHA-1" SIZE="5927517">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0035.jp2"
-				/>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T19:49:14" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="bb9fc3284566e62de18c891825361e5a3a7ad1dd" CHECKSUMTYPE="SHA-1" SIZE="5927517">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0035.jp2"/>
 			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T19:49:47"
-				MIMETYPE="image/jp2" SEQ="36" CHECKSUM="4c6c4b973085f37f27d375c7d0a988c9e5e12c85"
-				CHECKSUMTYPE="SHA-1" SIZE="6183987">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0036.jp2"
-				/>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T19:49:47" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="4c6c4b973085f37f27d375c7d0a988c9e5e12c85" CHECKSUMTYPE="SHA-1" SIZE="6183987">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0036.jp2"/>
 			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T19:50:21"
-				MIMETYPE="image/jp2" SEQ="37" CHECKSUM="72bd430c79da8951e3e4a7056215bef3af30d6c3"
-				CHECKSUMTYPE="SHA-1" SIZE="5962615">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0037.jp2"
-				/>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T19:50:21" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="72bd430c79da8951e3e4a7056215bef3af30d6c3" CHECKSUMTYPE="SHA-1" SIZE="5962615">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0037.jp2"/>
 			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T19:50:55"
-				MIMETYPE="image/jp2" SEQ="38" CHECKSUM="106101f5cf7cca9d7f7d5f49c0c347f6891cf109"
-				CHECKSUMTYPE="SHA-1" SIZE="6246095">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0038.jp2"
-				/>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T19:50:55" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="106101f5cf7cca9d7f7d5f49c0c347f6891cf109" CHECKSUMTYPE="SHA-1" SIZE="6246095">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/delivery/bmtnabf_1903-02-01_01_0038.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:51:17" MIMETYPE="text/xml"
-				CHECKSUM="dfaf84da049141d3d45feb63744d77d9a05e6df2" CHECKSUMTYPE="SHA-1" SIZE="4783">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:51:17" MIMETYPE="text/xml" CHECKSUM="dfaf84da049141d3d45feb63744d77d9a05e6df2" CHECKSUMTYPE="SHA-1" SIZE="4783">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:51:17" MIMETYPE="text/xml"
-				CHECKSUM="9e5f3072d025d0929f992076ec9faee2018dc985" CHECKSUMTYPE="SHA-1" SIZE="1718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:51:17" MIMETYPE="text/xml" CHECKSUM="9e5f3072d025d0929f992076ec9faee2018dc985" CHECKSUMTYPE="SHA-1" SIZE="1718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:51:18" MIMETYPE="text/xml"
-				CHECKSUM="6217638a8758f02a2fda918e3d6d416fd649086d" CHECKSUMTYPE="SHA-1" SIZE="8871">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:51:18" MIMETYPE="text/xml" CHECKSUM="6217638a8758f02a2fda918e3d6d416fd649086d" CHECKSUMTYPE="SHA-1" SIZE="8871">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:51:18" MIMETYPE="text/xml"
-				CHECKSUM="1febb3feadfcebdbce3eb40b5b16f9c4061729ab" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:51:18" MIMETYPE="text/xml" CHECKSUM="1febb3feadfcebdbce3eb40b5b16f9c4061729ab" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:51:18" MIMETYPE="text/xml"
-				CHECKSUM="87c7f79524310829595753000d992f782572a07e" CHECKSUMTYPE="SHA-1"
-				SIZE="58622">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:51:18" MIMETYPE="text/xml" CHECKSUM="87c7f79524310829595753000d992f782572a07e" CHECKSUMTYPE="SHA-1" SIZE="58622">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:51:18" MIMETYPE="text/xml"
-				CHECKSUM="171c383a71d6f61d48ce849ba6386e4eccff04e8" CHECKSUMTYPE="SHA-1"
-				SIZE="73392">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:51:18" MIMETYPE="text/xml" CHECKSUM="171c383a71d6f61d48ce849ba6386e4eccff04e8" CHECKSUMTYPE="SHA-1" SIZE="73392">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:51:19" MIMETYPE="text/xml"
-				CHECKSUM="d8d056e575694caf282e39871782d25a65c18cd4" CHECKSUMTYPE="SHA-1"
-				SIZE="68506">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:51:19" MIMETYPE="text/xml" CHECKSUM="d8d056e575694caf282e39871782d25a65c18cd4" CHECKSUMTYPE="SHA-1" SIZE="68506">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:51:19" MIMETYPE="text/xml"
-				CHECKSUM="21f13422c1825eaee2e6dc333b2ded8c4869588c" CHECKSUMTYPE="SHA-1"
-				SIZE="70421">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:51:19" MIMETYPE="text/xml" CHECKSUM="21f13422c1825eaee2e6dc333b2ded8c4869588c" CHECKSUMTYPE="SHA-1" SIZE="70421">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:51:19" MIMETYPE="text/xml"
-				CHECKSUM="60e717e0ecea47a113373d3e8e628ccd4f861ce2" CHECKSUMTYPE="SHA-1"
-				SIZE="69257">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:51:19" MIMETYPE="text/xml" CHECKSUM="60e717e0ecea47a113373d3e8e628ccd4f861ce2" CHECKSUMTYPE="SHA-1" SIZE="69257">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:51:20" MIMETYPE="text/xml"
-				CHECKSUM="f5993c560f2bf2541a68b913e8809465a8e0bdb6" CHECKSUMTYPE="SHA-1"
-				SIZE="70373">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:51:20" MIMETYPE="text/xml" CHECKSUM="f5993c560f2bf2541a68b913e8809465a8e0bdb6" CHECKSUMTYPE="SHA-1" SIZE="70373">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:51:20" MIMETYPE="text/xml"
-				CHECKSUM="2e44e5d6f2aee20c3a34d12af56a9ce0ab3da000" CHECKSUMTYPE="SHA-1"
-				SIZE="74261">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:51:20" MIMETYPE="text/xml" CHECKSUM="2e44e5d6f2aee20c3a34d12af56a9ce0ab3da000" CHECKSUMTYPE="SHA-1" SIZE="74261">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:51:20" MIMETYPE="text/xml"
-				CHECKSUM="687d09ec0eec400b3494a19fa9472a9faa8fa8d6" CHECKSUMTYPE="SHA-1"
-				SIZE="68893">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:51:20" MIMETYPE="text/xml" CHECKSUM="687d09ec0eec400b3494a19fa9472a9faa8fa8d6" CHECKSUMTYPE="SHA-1" SIZE="68893">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:51:21" MIMETYPE="text/xml"
-				CHECKSUM="6093c234ed1362167bfccf1c45386e1653e8588c" CHECKSUMTYPE="SHA-1"
-				SIZE="74194">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:51:21" MIMETYPE="text/xml" CHECKSUM="6093c234ed1362167bfccf1c45386e1653e8588c" CHECKSUMTYPE="SHA-1" SIZE="74194">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:51:21" MIMETYPE="text/xml"
-				CHECKSUM="e6b252cfba4d92ba85f0074ab81495f6f9997f50" CHECKSUMTYPE="SHA-1"
-				SIZE="76451">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:51:21" MIMETYPE="text/xml" CHECKSUM="e6b252cfba4d92ba85f0074ab81495f6f9997f50" CHECKSUMTYPE="SHA-1" SIZE="76451">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:51:21" MIMETYPE="text/xml"
-				CHECKSUM="3c2a97f2102fd85ef80297770db8bee1ef826a97" CHECKSUMTYPE="SHA-1"
-				SIZE="71429">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:51:21" MIMETYPE="text/xml" CHECKSUM="3c2a97f2102fd85ef80297770db8bee1ef826a97" CHECKSUMTYPE="SHA-1" SIZE="71429">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:51:22" MIMETYPE="text/xml"
-				CHECKSUM="63cf1b65c86cf7a5f05bf3266c32d1c35ed611fe" CHECKSUMTYPE="SHA-1"
-				SIZE="71807">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:51:22" MIMETYPE="text/xml" CHECKSUM="63cf1b65c86cf7a5f05bf3266c32d1c35ed611fe" CHECKSUMTYPE="SHA-1" SIZE="71807">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:51:22" MIMETYPE="text/xml"
-				CHECKSUM="9043674eeab774a162c6f06f237631812b29bac3" CHECKSUMTYPE="SHA-1"
-				SIZE="72207">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:51:22" MIMETYPE="text/xml" CHECKSUM="9043674eeab774a162c6f06f237631812b29bac3" CHECKSUMTYPE="SHA-1" SIZE="72207">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:51:22" MIMETYPE="text/xml"
-				CHECKSUM="85463cbfb303199b857756bd5feb3e8af2e26a62" CHECKSUMTYPE="SHA-1"
-				SIZE="68657">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:51:22" MIMETYPE="text/xml" CHECKSUM="85463cbfb303199b857756bd5feb3e8af2e26a62" CHECKSUMTYPE="SHA-1" SIZE="68657">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:51:23" MIMETYPE="text/xml"
-				CHECKSUM="4d0d379ddc4696748df15f772cb26eb139d86b4c" CHECKSUMTYPE="SHA-1"
-				SIZE="70318">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:51:23" MIMETYPE="text/xml" CHECKSUM="4d0d379ddc4696748df15f772cb26eb139d86b4c" CHECKSUMTYPE="SHA-1" SIZE="70318">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:51:23" MIMETYPE="text/xml"
-				CHECKSUM="a30dea7986b8d5b22ffb85e5fdb961f0f0669cb3" CHECKSUMTYPE="SHA-1"
-				SIZE="72745">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:51:23" MIMETYPE="text/xml" CHECKSUM="a30dea7986b8d5b22ffb85e5fdb961f0f0669cb3" CHECKSUMTYPE="SHA-1" SIZE="72745">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:51:23" MIMETYPE="text/xml"
-				CHECKSUM="7ea83dc28a6b2020041ae1c00be7558857219056" CHECKSUMTYPE="SHA-1"
-				SIZE="72018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:51:23" MIMETYPE="text/xml" CHECKSUM="7ea83dc28a6b2020041ae1c00be7558857219056" CHECKSUMTYPE="SHA-1" SIZE="72018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:51:24" MIMETYPE="text/xml"
-				CHECKSUM="91827d400da4520716171d49f81ece57115a4fc8" CHECKSUMTYPE="SHA-1"
-				SIZE="73338">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:51:24" MIMETYPE="text/xml" CHECKSUM="91827d400da4520716171d49f81ece57115a4fc8" CHECKSUMTYPE="SHA-1" SIZE="73338">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:51:24" MIMETYPE="text/xml"
-				CHECKSUM="c2e6baa726c3e11a4b7edd9c9140ed7afb67e722" CHECKSUMTYPE="SHA-1"
-				SIZE="73331">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:51:24" MIMETYPE="text/xml" CHECKSUM="c2e6baa726c3e11a4b7edd9c9140ed7afb67e722" CHECKSUMTYPE="SHA-1" SIZE="73331">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:51:24" MIMETYPE="text/xml"
-				CHECKSUM="811e8f369841091d00c276e2f1f1126681ccd529" CHECKSUMTYPE="SHA-1"
-				SIZE="73918">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:51:24" MIMETYPE="text/xml" CHECKSUM="811e8f369841091d00c276e2f1f1126681ccd529" CHECKSUMTYPE="SHA-1" SIZE="73918">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:51:25" MIMETYPE="text/xml"
-				CHECKSUM="7172ca7cfe6ce5ede7ed737f7281ad41be04c6d0" CHECKSUMTYPE="SHA-1"
-				SIZE="68865">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:51:25" MIMETYPE="text/xml" CHECKSUM="7172ca7cfe6ce5ede7ed737f7281ad41be04c6d0" CHECKSUMTYPE="SHA-1" SIZE="68865">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:51:25" MIMETYPE="text/xml"
-				CHECKSUM="665456dfebc1269d97054d369a6333703690715b" CHECKSUMTYPE="SHA-1"
-				SIZE="69777">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:51:25" MIMETYPE="text/xml" CHECKSUM="665456dfebc1269d97054d369a6333703690715b" CHECKSUMTYPE="SHA-1" SIZE="69777">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:51:25" MIMETYPE="text/xml"
-				CHECKSUM="f2292c78fbe2d183db458572fb81da53fa25e0e0" CHECKSUMTYPE="SHA-1"
-				SIZE="50347">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:51:25" MIMETYPE="text/xml" CHECKSUM="f2292c78fbe2d183db458572fb81da53fa25e0e0" CHECKSUMTYPE="SHA-1" SIZE="50347">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:51:26" MIMETYPE="text/xml"
-				CHECKSUM="3ca403c26611d56b1c2c64ae1c7b57cf5457276d" CHECKSUMTYPE="SHA-1"
-				SIZE="16009">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:51:26" MIMETYPE="text/xml" CHECKSUM="3ca403c26611d56b1c2c64ae1c7b57cf5457276d" CHECKSUMTYPE="SHA-1" SIZE="16009">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T19:51:26" MIMETYPE="text/xml"
-				CHECKSUM="3f96dfe164e507f618239194ee48207225d1c0d3" CHECKSUMTYPE="SHA-1" SIZE="4722">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T19:51:26" MIMETYPE="text/xml" CHECKSUM="3f96dfe164e507f618239194ee48207225d1c0d3" CHECKSUMTYPE="SHA-1" SIZE="4722">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T19:51:26" MIMETYPE="text/xml"
-				CHECKSUM="578357ce49049720269a43b913517d14f7691459" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T19:51:26" MIMETYPE="text/xml" CHECKSUM="578357ce49049720269a43b913517d14f7691459" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T19:51:26" MIMETYPE="text/xml"
-				CHECKSUM="2447fe5cb308ebefe8ce12a9657656b69c4f3283" CHECKSUMTYPE="SHA-1" SIZE="8571">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T19:51:26" MIMETYPE="text/xml" CHECKSUM="2447fe5cb308ebefe8ce12a9657656b69c4f3283" CHECKSUMTYPE="SHA-1" SIZE="8571">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T19:51:27" MIMETYPE="text/xml"
-				CHECKSUM="791478b58557d243fb3416306d1e52b94fb1e79b" CHECKSUMTYPE="SHA-1"
-				SIZE="22389">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T19:51:27" MIMETYPE="text/xml" CHECKSUM="791478b58557d243fb3416306d1e52b94fb1e79b" CHECKSUMTYPE="SHA-1" SIZE="22389">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T19:51:27" MIMETYPE="text/xml"
-				CHECKSUM="5978b674c80bf629c73554af3bbf3de0af16e6a5" CHECKSUMTYPE="SHA-1"
-				SIZE="31186">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0033.alto.xml"
-				/>
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T19:51:27" MIMETYPE="text/xml" CHECKSUM="5978b674c80bf629c73554af3bbf3de0af16e6a5" CHECKSUMTYPE="SHA-1" SIZE="31186">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T19:51:28" MIMETYPE="text/xml"
-				CHECKSUM="ae64ca2cbd762832bfdaec80e11e742dea722fb0" CHECKSUMTYPE="SHA-1"
-				SIZE="16508">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0034.alto.xml"
-				/>
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T19:51:28" MIMETYPE="text/xml" CHECKSUM="ae64ca2cbd762832bfdaec80e11e742dea722fb0" CHECKSUMTYPE="SHA-1" SIZE="16508">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T19:51:28" MIMETYPE="text/xml"
-				CHECKSUM="9ea85aabdbdc170b595f0ce24fb0efd3a9052c59" CHECKSUMTYPE="SHA-1"
-				SIZE="37289">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0035.alto.xml"
-				/>
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T19:51:28" MIMETYPE="text/xml" CHECKSUM="9ea85aabdbdc170b595f0ce24fb0efd3a9052c59" CHECKSUMTYPE="SHA-1" SIZE="37289">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T19:51:28" MIMETYPE="text/xml"
-				CHECKSUM="3b643c08ac8023f1a5736c911a63637dff4332bc" CHECKSUMTYPE="SHA-1"
-				SIZE="10750">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0036.alto.xml"
-				/>
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T19:51:28" MIMETYPE="text/xml" CHECKSUM="3b643c08ac8023f1a5736c911a63637dff4332bc" CHECKSUMTYPE="SHA-1" SIZE="10750">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T19:51:29" MIMETYPE="text/xml"
-				CHECKSUM="43f4ce744297aa158822cc987351957584896b2e" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0037.alto.xml"
-				/>
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T19:51:29" MIMETYPE="text/xml" CHECKSUM="43f4ce744297aa158822cc987351957584896b2e" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T19:51:29" MIMETYPE="text/xml"
-				CHECKSUM="c32a87cad62259d33b5fc336997d5a2b8d79ef86" CHECKSUMTYPE="SHA-1" SIZE="7614">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0038.alto.xml"
-				/>
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T19:51:29" MIMETYPE="text/xml" CHECKSUM="c32a87cad62259d33b5fc336997d5a2b8d79ef86" CHECKSUMTYPE="SHA-1" SIZE="7614">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-01_01_0038.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:52:24" MIMETYPE="application/pdf"
-				CHECKSUM="8e965cc420453a4363299ca59841a68c3c1a0293" CHECKSUMTYPE="SHA-1"
-				SIZE="12443085">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/bmtnabf_1903-02-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:52:24" MIMETYPE="application/pdf" CHECKSUM="8e965cc420453a4363299ca59841a68c3c1a0293" CHECKSUMTYPE="SHA-1" SIZE="12443085">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/01_01/bmtnabf_1903-02-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3893,8 +3626,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="TextContent" ORDER="3" DMDID="c003"
-					LABEL="AKADEMIE DER KÜNSTE UND DAS VERHÄLTNIS DER KÜNSTLER ZUM STAATE">
+				<div ID="L.1.1.4" TYPE="TextContent" ORDER="3" DMDID="c003" LABEL="AKADEMIE DER KÜNSTE UND DAS VERHÄLTNIS DER KÜNSTLER ZUM STAATE">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -3928,56 +3660,31 @@
 								<div ID="L.1.1.4.5.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00023"
-												BEGIN="P23_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00027"
-												BEGIN="P27_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3991,8 +3698,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.4.6" TYPE="Illustration" ORDER="1" DMDID="c005"
-						LABEL="Untitled Image by Ludwig von Hofmann CM">
+					<div ID="L.1.1.4.6" TYPE="Illustration" ORDER="1" DMDID="c005" LABEL="Untitled Image by Ludwig von Hofmann CM">
 						<div ID="L.1.1.4.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00004"/>
@@ -4010,8 +3716,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c006"
-					LABEL="Original-Holzschnitt in 4 Platten">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c006" LABEL="Original-Holzschnitt in 4 Platten">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00001"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/02/15_01/bmtnabf_1903-02-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/02/15_01/bmtnabf_1903-02-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-02-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-02-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-02-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-02-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-02-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3451,504 +3445,252 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:29:16"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="c699e25b08d6750ac167f80861897eb102bfe9de"
-				CHECKSUMTYPE="SHA-1" SIZE="6243366">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:29:16" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="c699e25b08d6750ac167f80861897eb102bfe9de" CHECKSUMTYPE="SHA-1" SIZE="6243366">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:29:46"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="14b70abffc00dc5c4d1e827f317d8f3f2c76305b"
-				CHECKSUMTYPE="SHA-1" SIZE="6311820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:29:46" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="14b70abffc00dc5c4d1e827f317d8f3f2c76305b" CHECKSUMTYPE="SHA-1" SIZE="6311820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:30:17"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c646980afd220d2d65eaa387cff2310c65ab1d6c"
-				CHECKSUMTYPE="SHA-1" SIZE="6243414">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:30:17" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c646980afd220d2d65eaa387cff2310c65ab1d6c" CHECKSUMTYPE="SHA-1" SIZE="6243414">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:30:57"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="bc7763cf04d5d47f7369e8baf3a04d16bc851a3f"
-				CHECKSUMTYPE="SHA-1" SIZE="6311665">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:30:57" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="bc7763cf04d5d47f7369e8baf3a04d16bc851a3f" CHECKSUMTYPE="SHA-1" SIZE="6311665">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:31:35"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="26212434c15a4f0b65a9f835cb03e3e01f51d5c7"
-				CHECKSUMTYPE="SHA-1" SIZE="6243429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:31:35" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="26212434c15a4f0b65a9f835cb03e3e01f51d5c7" CHECKSUMTYPE="SHA-1" SIZE="6243429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:32:09"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="88b33012a8c4c9630ad6ab0c17cba780a138d66f"
-				CHECKSUMTYPE="SHA-1" SIZE="6311829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:32:09" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="88b33012a8c4c9630ad6ab0c17cba780a138d66f" CHECKSUMTYPE="SHA-1" SIZE="6311829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:32:45"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="dec8c6d52818c6a8a5717575defcc109ae7e4e94"
-				CHECKSUMTYPE="SHA-1" SIZE="6243427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:32:45" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="dec8c6d52818c6a8a5717575defcc109ae7e4e94" CHECKSUMTYPE="SHA-1" SIZE="6243427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:33:20"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a1090b1e01a52f4387eadf89ced90fb841aa4241"
-				CHECKSUMTYPE="SHA-1" SIZE="6312705">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:33:20" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a1090b1e01a52f4387eadf89ced90fb841aa4241" CHECKSUMTYPE="SHA-1" SIZE="6312705">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:33:50"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="557132c235fc2e749a9d0de356628946f936b80e"
-				CHECKSUMTYPE="SHA-1" SIZE="6174127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:33:50" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="557132c235fc2e749a9d0de356628946f936b80e" CHECKSUMTYPE="SHA-1" SIZE="6174127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:34:21"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="566b9a743b39f9de003d58c736fc92a5c277bc54"
-				CHECKSUMTYPE="SHA-1" SIZE="6311825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:34:21" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="566b9a743b39f9de003d58c736fc92a5c277bc54" CHECKSUMTYPE="SHA-1" SIZE="6311825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:34:53"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="0d52482c5c2e42b3c6fdc195ceaa6e20c6349565"
-				CHECKSUMTYPE="SHA-1" SIZE="6174128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:34:53" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="0d52482c5c2e42b3c6fdc195ceaa6e20c6349565" CHECKSUMTYPE="SHA-1" SIZE="6174128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:35:28"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="811f1a388fb21cadc1d10c3b8009e830340ced69"
-				CHECKSUMTYPE="SHA-1" SIZE="6311824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:35:28" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="811f1a388fb21cadc1d10c3b8009e830340ced69" CHECKSUMTYPE="SHA-1" SIZE="6311824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:35:58"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="79de039268b5c3ce56a06da067067f54df03680d"
-				CHECKSUMTYPE="SHA-1" SIZE="6174945">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:35:58" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="79de039268b5c3ce56a06da067067f54df03680d" CHECKSUMTYPE="SHA-1" SIZE="6174945">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:36:30"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="27a443431e33538d3f67b2d414dae3e41787ce56"
-				CHECKSUMTYPE="SHA-1" SIZE="6311827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:36:30" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="27a443431e33538d3f67b2d414dae3e41787ce56" CHECKSUMTYPE="SHA-1" SIZE="6311827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:37:01"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="8275eb36b43718e99b1a24c37021a9ab391f0659"
-				CHECKSUMTYPE="SHA-1" SIZE="6175029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:37:01" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="8275eb36b43718e99b1a24c37021a9ab391f0659" CHECKSUMTYPE="SHA-1" SIZE="6175029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:37:33"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="2718b61a049088ae7023c991edc34987a6e299b2"
-				CHECKSUMTYPE="SHA-1" SIZE="6312722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:37:33" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="2718b61a049088ae7023c991edc34987a6e299b2" CHECKSUMTYPE="SHA-1" SIZE="6312722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:38:05"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="ce9cbf16553dd51e463582b5f72e8519272b59c8"
-				CHECKSUMTYPE="SHA-1" SIZE="6134527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:38:05" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="ce9cbf16553dd51e463582b5f72e8519272b59c8" CHECKSUMTYPE="SHA-1" SIZE="6134527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:38:36"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="d083babc72a2cf49ab3fb74739b5b01bf24f1784"
-				CHECKSUMTYPE="SHA-1" SIZE="6313615">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:38:36" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="d083babc72a2cf49ab3fb74739b5b01bf24f1784" CHECKSUMTYPE="SHA-1" SIZE="6313615">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:39:07"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="1063800adb2391e2fa1568f9a3f3942d356bc7b7"
-				CHECKSUMTYPE="SHA-1" SIZE="6134529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:39:07" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="1063800adb2391e2fa1568f9a3f3942d356bc7b7" CHECKSUMTYPE="SHA-1" SIZE="6134529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:39:39"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="5b4fd0acd95895b14ca09f0fe1c5adb6b6900b50"
-				CHECKSUMTYPE="SHA-1" SIZE="6313628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:39:39" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="5b4fd0acd95895b14ca09f0fe1c5adb6b6900b50" CHECKSUMTYPE="SHA-1" SIZE="6313628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:40:12"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="96822fb2dfbc1c70e1239afb39cf3dc7c8512b41"
-				CHECKSUMTYPE="SHA-1" SIZE="6122739">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:40:12" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="96822fb2dfbc1c70e1239afb39cf3dc7c8512b41" CHECKSUMTYPE="SHA-1" SIZE="6122739">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:40:42"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="217ac516ba123738817cdb9aa01cb03830fc7eb2"
-				CHECKSUMTYPE="SHA-1" SIZE="6271329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:40:42" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="217ac516ba123738817cdb9aa01cb03830fc7eb2" CHECKSUMTYPE="SHA-1" SIZE="6271329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:41:14"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="cd13295ff959908a5edf11f5865c159e9e5b689c"
-				CHECKSUMTYPE="SHA-1" SIZE="6092990">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:41:14" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="cd13295ff959908a5edf11f5865c159e9e5b689c" CHECKSUMTYPE="SHA-1" SIZE="6092990">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:41:46"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="d2d9f4e1a53b7055dca6308041bb2d99ff6ebc4c"
-				CHECKSUMTYPE="SHA-1" SIZE="6334316">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:41:46" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="d2d9f4e1a53b7055dca6308041bb2d99ff6ebc4c" CHECKSUMTYPE="SHA-1" SIZE="6334316">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:42:19"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="65dd72ee9a1548743a3a0724d9c8194385ca945c"
-				CHECKSUMTYPE="SHA-1" SIZE="6037329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:42:19" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="65dd72ee9a1548743a3a0724d9c8194385ca945c" CHECKSUMTYPE="SHA-1" SIZE="6037329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:42:53"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="fdfe5af0b223b5eda6b7c87b5c04f7f538ac83bc"
-				CHECKSUMTYPE="SHA-1" SIZE="6314508">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:42:53" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="fdfe5af0b223b5eda6b7c87b5c04f7f538ac83bc" CHECKSUMTYPE="SHA-1" SIZE="6314508">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:43:26"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="938e5eba9ec0a08dc73cecc044bd2912e4444d86"
-				CHECKSUMTYPE="SHA-1" SIZE="6037311">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:43:26" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="938e5eba9ec0a08dc73cecc044bd2912e4444d86" CHECKSUMTYPE="SHA-1" SIZE="6037311">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:43:58"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="f9828f5b10f4442903ba69f5a84e30abcde91ff8"
-				CHECKSUMTYPE="SHA-1" SIZE="6315420">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:43:58" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="f9828f5b10f4442903ba69f5a84e30abcde91ff8" CHECKSUMTYPE="SHA-1" SIZE="6315420">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T19:44:30"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="ac5fddbb81715b9eb2a3b8924ad26feca6a204ea"
-				CHECKSUMTYPE="SHA-1" SIZE="6037317">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T19:44:30" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="ac5fddbb81715b9eb2a3b8924ad26feca6a204ea" CHECKSUMTYPE="SHA-1" SIZE="6037317">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T19:45:01"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="1cb6f3fa4423019106c6cb280ed108e9b4ff1919"
-				CHECKSUMTYPE="SHA-1" SIZE="6315409">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T19:45:01" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="1cb6f3fa4423019106c6cb280ed108e9b4ff1919" CHECKSUMTYPE="SHA-1" SIZE="6315409">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T19:45:33"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="e797aaf204221c26cefe07cc2e5b775d46f34f77"
-				CHECKSUMTYPE="SHA-1" SIZE="6037327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T19:45:33" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="e797aaf204221c26cefe07cc2e5b775d46f34f77" CHECKSUMTYPE="SHA-1" SIZE="6037327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T19:46:04"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="f562e0eddd31ae4be61de448f2e97f5b23a1b4b7"
-				CHECKSUMTYPE="SHA-1" SIZE="6373911">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T19:46:04" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="f562e0eddd31ae4be61de448f2e97f5b23a1b4b7" CHECKSUMTYPE="SHA-1" SIZE="6373911">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T19:46:33"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="b10f6dd5ad0d58b9f55454418811e01011d41f78"
-				CHECKSUMTYPE="SHA-1" SIZE="5930227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T19:46:33" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="b10f6dd5ad0d58b9f55454418811e01011d41f78" CHECKSUMTYPE="SHA-1" SIZE="5930227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T19:47:02"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="06be12a4e17dabf06cce78e5213cf32ea0202ec8"
-				CHECKSUMTYPE="SHA-1" SIZE="6284825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T19:47:02" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="06be12a4e17dabf06cce78e5213cf32ea0202ec8" CHECKSUMTYPE="SHA-1" SIZE="6284825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0034.jp2"/>
 			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T19:47:32"
-				MIMETYPE="image/jp2" SEQ="35" CHECKSUM="1c35eb3440916a66c4281be9388479a14aca9af1"
-				CHECKSUMTYPE="SHA-1" SIZE="6053527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0035.jp2"
-				/>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T19:47:32" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="1c35eb3440916a66c4281be9388479a14aca9af1" CHECKSUMTYPE="SHA-1" SIZE="6053527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0035.jp2"/>
 			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T19:48:02"
-				MIMETYPE="image/jp2" SEQ="36" CHECKSUM="127980951873eb1806a016c9577472abf8d901d5"
-				CHECKSUMTYPE="SHA-1" SIZE="6334329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0036.jp2"
-				/>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T19:48:02" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="127980951873eb1806a016c9577472abf8d901d5" CHECKSUMTYPE="SHA-1" SIZE="6334329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0036.jp2"/>
 			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T19:48:34"
-				MIMETYPE="image/jp2" SEQ="37" CHECKSUM="bb56a745ba4e258fcc84e380b0cf418627905823"
-				CHECKSUMTYPE="SHA-1" SIZE="6051695">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0037.jp2"
-				/>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T19:48:34" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="bb56a745ba4e258fcc84e380b0cf418627905823" CHECKSUMTYPE="SHA-1" SIZE="6051695">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0037.jp2"/>
 			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T19:49:04"
-				MIMETYPE="image/jp2" SEQ="38" CHECKSUM="5254a9e13b4509be23937a744c4a32070cc2b2e1"
-				CHECKSUMTYPE="SHA-1" SIZE="6334317">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0038.jp2"
-				/>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T19:49:04" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="5254a9e13b4509be23937a744c4a32070cc2b2e1" CHECKSUMTYPE="SHA-1" SIZE="6334317">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0038.jp2"/>
 			</file>
-			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-10-09T19:49:36"
-				MIMETYPE="image/jp2" SEQ="39" CHECKSUM="60fac3d3717de3f7cda78f360289431808b9bad3"
-				CHECKSUMTYPE="SHA-1" SIZE="6051708">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0039.jp2"
-				/>
+			<file ID="IMG00039" ADMID="techmd39" GROUPID="page39" CREATED="2015-10-09T19:49:36" MIMETYPE="image/jp2" SEQ="39" CHECKSUM="60fac3d3717de3f7cda78f360289431808b9bad3" CHECKSUMTYPE="SHA-1" SIZE="6051708">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0039.jp2"/>
 			</file>
-			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-10-09T19:50:06"
-				MIMETYPE="image/jp2" SEQ="40" CHECKSUM="6432cdc94ccb3a51bb9245322b1f48cdc1bfaf48"
-				CHECKSUMTYPE="SHA-1" SIZE="6219120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0040.jp2"
-				/>
+			<file ID="IMG00040" ADMID="techmd40" GROUPID="page40" CREATED="2015-10-09T19:50:06" MIMETYPE="image/jp2" SEQ="40" CHECKSUM="6432cdc94ccb3a51bb9245322b1f48cdc1bfaf48" CHECKSUMTYPE="SHA-1" SIZE="6219120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/delivery/bmtnabf_1903-02-15_01_0040.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:50:23" MIMETYPE="text/xml"
-				CHECKSUM="242e235767020e842dbaf97907862b3056f98eab" CHECKSUMTYPE="SHA-1" SIZE="4784">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:50:23" MIMETYPE="text/xml" CHECKSUM="242e235767020e842dbaf97907862b3056f98eab" CHECKSUMTYPE="SHA-1" SIZE="4784">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:50:23" MIMETYPE="text/xml"
-				CHECKSUM="131883b15a39c847d6ff0c928fc371e8004027d1" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:50:23" MIMETYPE="text/xml" CHECKSUM="131883b15a39c847d6ff0c928fc371e8004027d1" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:50:23" MIMETYPE="text/xml"
-				CHECKSUM="f75234a2f9b4f0ab3ee94c3dbc8ba06e12a29876" CHECKSUMTYPE="SHA-1" SIZE="8232">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:50:23" MIMETYPE="text/xml" CHECKSUM="f75234a2f9b4f0ab3ee94c3dbc8ba06e12a29876" CHECKSUMTYPE="SHA-1" SIZE="8232">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:50:23" MIMETYPE="text/xml"
-				CHECKSUM="319a8ab4664fbdc17b4895576c5a07cc9b70f5a7" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:50:23" MIMETYPE="text/xml" CHECKSUM="319a8ab4664fbdc17b4895576c5a07cc9b70f5a7" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:50:24" MIMETYPE="text/xml"
-				CHECKSUM="be228b18240f1da19a5a8da55a91ba94b5f74c8e" CHECKSUMTYPE="SHA-1" SIZE="8159">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:50:24" MIMETYPE="text/xml" CHECKSUM="be228b18240f1da19a5a8da55a91ba94b5f74c8e" CHECKSUMTYPE="SHA-1" SIZE="8159">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:50:24" MIMETYPE="text/xml"
-				CHECKSUM="d918f3b635648799c8d8be8a7f570f9cce7e51f5" CHECKSUMTYPE="SHA-1" SIZE="3405">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:50:24" MIMETYPE="text/xml" CHECKSUM="d918f3b635648799c8d8be8a7f570f9cce7e51f5" CHECKSUMTYPE="SHA-1" SIZE="3405">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:50:24" MIMETYPE="text/xml"
-				CHECKSUM="eae17147efd1206b764050aa8f15b7b9fd5e1318" CHECKSUMTYPE="SHA-1" SIZE="4820">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:50:24" MIMETYPE="text/xml" CHECKSUM="eae17147efd1206b764050aa8f15b7b9fd5e1318" CHECKSUMTYPE="SHA-1" SIZE="4820">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:50:24" MIMETYPE="text/xml"
-				CHECKSUM="29174c308e439db31f3c9ea490dac218e8ba85b9" CHECKSUMTYPE="SHA-1" SIZE="3417">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:50:24" MIMETYPE="text/xml" CHECKSUM="29174c308e439db31f3c9ea490dac218e8ba85b9" CHECKSUMTYPE="SHA-1" SIZE="3417">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:50:24" MIMETYPE="text/xml"
-				CHECKSUM="5ac0bcce0d112db818fdf92c89c0b07b9e89ef07" CHECKSUMTYPE="SHA-1" SIZE="4899">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:50:24" MIMETYPE="text/xml" CHECKSUM="5ac0bcce0d112db818fdf92c89c0b07b9e89ef07" CHECKSUMTYPE="SHA-1" SIZE="4899">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:50:25" MIMETYPE="text/xml"
-				CHECKSUM="be792c4b46ad5ce3fa6f12d4bf7f4569fb112648" CHECKSUMTYPE="SHA-1" SIZE="3417">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:50:25" MIMETYPE="text/xml" CHECKSUM="be792c4b46ad5ce3fa6f12d4bf7f4569fb112648" CHECKSUMTYPE="SHA-1" SIZE="3417">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:50:25" MIMETYPE="text/xml"
-				CHECKSUM="218526c404279af05c351d9c5029f532cdb68709" CHECKSUMTYPE="SHA-1" SIZE="4926">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:50:25" MIMETYPE="text/xml" CHECKSUM="218526c404279af05c351d9c5029f532cdb68709" CHECKSUMTYPE="SHA-1" SIZE="4926">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:50:25" MIMETYPE="text/xml"
-				CHECKSUM="86564da1a2e4eee3b330b1edc1819b7fb09a8f7e" CHECKSUMTYPE="SHA-1" SIZE="3418">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:50:25" MIMETYPE="text/xml" CHECKSUM="86564da1a2e4eee3b330b1edc1819b7fb09a8f7e" CHECKSUMTYPE="SHA-1" SIZE="3418">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:50:25" MIMETYPE="text/xml"
-				CHECKSUM="9d139b0963cbd9ef8697f081501b4a4628e24ed7" CHECKSUMTYPE="SHA-1" SIZE="4923">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:50:25" MIMETYPE="text/xml" CHECKSUM="9d139b0963cbd9ef8697f081501b4a4628e24ed7" CHECKSUMTYPE="SHA-1" SIZE="4923">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:50:26" MIMETYPE="text/xml"
-				CHECKSUM="756b47c8cb5085284bba1304be874dbce7b24753" CHECKSUMTYPE="SHA-1" SIZE="3418">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:50:26" MIMETYPE="text/xml" CHECKSUM="756b47c8cb5085284bba1304be874dbce7b24753" CHECKSUMTYPE="SHA-1" SIZE="3418">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:50:26" MIMETYPE="text/xml"
-				CHECKSUM="09b7cb836e8b9aad7c33cdf7bf976f95e826aed3" CHECKSUMTYPE="SHA-1" SIZE="4919">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:50:26" MIMETYPE="text/xml" CHECKSUM="09b7cb836e8b9aad7c33cdf7bf976f95e826aed3" CHECKSUMTYPE="SHA-1" SIZE="4919">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:50:26" MIMETYPE="text/xml"
-				CHECKSUM="16cafeb7eb5dfbb9d19cdcb3793239853b2f79af" CHECKSUMTYPE="SHA-1" SIZE="3418">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:50:26" MIMETYPE="text/xml" CHECKSUM="16cafeb7eb5dfbb9d19cdcb3793239853b2f79af" CHECKSUMTYPE="SHA-1" SIZE="3418">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:50:26" MIMETYPE="text/xml"
-				CHECKSUM="2dcfddd520f03afd6dad41af17976003b8bda952" CHECKSUMTYPE="SHA-1" SIZE="4921">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:50:26" MIMETYPE="text/xml" CHECKSUM="2dcfddd520f03afd6dad41af17976003b8bda952" CHECKSUMTYPE="SHA-1" SIZE="4921">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:50:28" MIMETYPE="text/xml"
-				CHECKSUM="e859220225306da7a56efe53fe0cfcaaa9d9c61f" CHECKSUMTYPE="SHA-1" SIZE="3417">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:50:28" MIMETYPE="text/xml" CHECKSUM="e859220225306da7a56efe53fe0cfcaaa9d9c61f" CHECKSUMTYPE="SHA-1" SIZE="3417">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:50:28" MIMETYPE="text/xml"
-				CHECKSUM="b02c5a55e8440cef13571f0622ab7c3c7b4fb2df" CHECKSUMTYPE="SHA-1" SIZE="4921">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:50:28" MIMETYPE="text/xml" CHECKSUM="b02c5a55e8440cef13571f0622ab7c3c7b4fb2df" CHECKSUMTYPE="SHA-1" SIZE="4921">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:50:29" MIMETYPE="text/xml"
-				CHECKSUM="a432dd86b3914a24e948ee6090b5f3807fe36804" CHECKSUMTYPE="SHA-1" SIZE="3431">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:50:29" MIMETYPE="text/xml" CHECKSUM="a432dd86b3914a24e948ee6090b5f3807fe36804" CHECKSUMTYPE="SHA-1" SIZE="3431">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:50:29" MIMETYPE="text/xml"
-				CHECKSUM="6ff8b270942f43f4cb047b752dbd2bf8fd7c8701" CHECKSUMTYPE="SHA-1" SIZE="5032">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:50:29" MIMETYPE="text/xml" CHECKSUM="6ff8b270942f43f4cb047b752dbd2bf8fd7c8701" CHECKSUMTYPE="SHA-1" SIZE="5032">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:50:29" MIMETYPE="text/xml"
-				CHECKSUM="36d7f00db1fc405467973102d5d79ecef9d5473b" CHECKSUMTYPE="SHA-1" SIZE="3417">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:50:29" MIMETYPE="text/xml" CHECKSUM="36d7f00db1fc405467973102d5d79ecef9d5473b" CHECKSUMTYPE="SHA-1" SIZE="3417">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:50:30" MIMETYPE="text/xml"
-				CHECKSUM="87106e1945af099b6f8ef1ac7e90c36dfa613cfb" CHECKSUMTYPE="SHA-1" SIZE="4919">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:50:30" MIMETYPE="text/xml" CHECKSUM="87106e1945af099b6f8ef1ac7e90c36dfa613cfb" CHECKSUMTYPE="SHA-1" SIZE="4919">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:50:30" MIMETYPE="text/xml"
-				CHECKSUM="4bbafc67cc77e5c9af0a877d496a0870ca5e7e12" CHECKSUMTYPE="SHA-1" SIZE="3417">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:50:30" MIMETYPE="text/xml" CHECKSUM="4bbafc67cc77e5c9af0a877d496a0870ca5e7e12" CHECKSUMTYPE="SHA-1" SIZE="3417">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:50:30" MIMETYPE="text/xml"
-				CHECKSUM="6e4794dece1d99d34905f12feaffb1eaad029999" CHECKSUMTYPE="SHA-1" SIZE="4929">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:50:30" MIMETYPE="text/xml" CHECKSUM="6e4794dece1d99d34905f12feaffb1eaad029999" CHECKSUMTYPE="SHA-1" SIZE="4929">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:50:30" MIMETYPE="text/xml"
-				CHECKSUM="24b0d92b5496dff4f292006a9a881bc014e5a3fe" CHECKSUMTYPE="SHA-1" SIZE="3421">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:50:30" MIMETYPE="text/xml" CHECKSUM="24b0d92b5496dff4f292006a9a881bc014e5a3fe" CHECKSUMTYPE="SHA-1" SIZE="3421">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:50:30" MIMETYPE="text/xml"
-				CHECKSUM="b5ed8a33ca18a050c4509b5c2975d3761000e834" CHECKSUMTYPE="SHA-1" SIZE="4922">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:50:30" MIMETYPE="text/xml" CHECKSUM="b5ed8a33ca18a050c4509b5c2975d3761000e834" CHECKSUMTYPE="SHA-1" SIZE="4922">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:50:31" MIMETYPE="text/xml"
-				CHECKSUM="8eb0a47f0119a4cf2ec9d19f5d0498b6e4ea4932" CHECKSUMTYPE="SHA-1" SIZE="2914">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:50:31" MIMETYPE="text/xml" CHECKSUM="8eb0a47f0119a4cf2ec9d19f5d0498b6e4ea4932" CHECKSUMTYPE="SHA-1" SIZE="2914">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T19:50:31" MIMETYPE="text/xml"
-				CHECKSUM="6ad0a9aa003c15ff716fd7899cc2ea460c76b20c" CHECKSUMTYPE="SHA-1" SIZE="8565">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T19:50:31" MIMETYPE="text/xml" CHECKSUM="6ad0a9aa003c15ff716fd7899cc2ea460c76b20c" CHECKSUMTYPE="SHA-1" SIZE="8565">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T19:50:31" MIMETYPE="text/xml"
-				CHECKSUM="a13a20210e342b2bbb745a39bbdccfc1a081bd85" CHECKSUMTYPE="SHA-1"
-				SIZE="23822">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T19:50:31" MIMETYPE="text/xml" CHECKSUM="a13a20210e342b2bbb745a39bbdccfc1a081bd85" CHECKSUMTYPE="SHA-1" SIZE="23822">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T19:50:31" MIMETYPE="text/xml"
-				CHECKSUM="0251499d2104bbfd5929db625e88c081c013d180" CHECKSUMTYPE="SHA-1"
-				SIZE="25347">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T19:50:31" MIMETYPE="text/xml" CHECKSUM="0251499d2104bbfd5929db625e88c081c013d180" CHECKSUMTYPE="SHA-1" SIZE="25347">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T19:50:32" MIMETYPE="text/xml"
-				CHECKSUM="2fe41b060d6880592ecdec92bfe0153e04245ae6" CHECKSUMTYPE="SHA-1"
-				SIZE="17619">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T19:50:32" MIMETYPE="text/xml" CHECKSUM="2fe41b060d6880592ecdec92bfe0153e04245ae6" CHECKSUMTYPE="SHA-1" SIZE="17619">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T19:50:32" MIMETYPE="text/xml"
-				CHECKSUM="6740d60a5c72671fb02ab09bc899ba85288d03d2" CHECKSUMTYPE="SHA-1" SIZE="8624">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0033.alto.xml"
-				/>
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T19:50:32" MIMETYPE="text/xml" CHECKSUM="6740d60a5c72671fb02ab09bc899ba85288d03d2" CHECKSUMTYPE="SHA-1" SIZE="8624">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T19:50:32" MIMETYPE="text/xml"
-				CHECKSUM="432220af0eab8f8dc25d3ccf3c37f877a8310165" CHECKSUMTYPE="SHA-1"
-				SIZE="20108">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0034.alto.xml"
-				/>
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T19:50:32" MIMETYPE="text/xml" CHECKSUM="432220af0eab8f8dc25d3ccf3c37f877a8310165" CHECKSUMTYPE="SHA-1" SIZE="20108">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T19:50:33" MIMETYPE="text/xml"
-				CHECKSUM="7af27dd5adbf25a3746cdfd266c3a8f8b21daaf3" CHECKSUMTYPE="SHA-1"
-				SIZE="23379">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0035.alto.xml"
-				/>
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T19:50:33" MIMETYPE="text/xml" CHECKSUM="7af27dd5adbf25a3746cdfd266c3a8f8b21daaf3" CHECKSUMTYPE="SHA-1" SIZE="23379">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T19:50:33" MIMETYPE="text/xml"
-				CHECKSUM="5c47aff217692733c62a783b2941cb1186e00bd7" CHECKSUMTYPE="SHA-1"
-				SIZE="14718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0036.alto.xml"
-				/>
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T19:50:33" MIMETYPE="text/xml" CHECKSUM="5c47aff217692733c62a783b2941cb1186e00bd7" CHECKSUMTYPE="SHA-1" SIZE="14718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T19:50:33" MIMETYPE="text/xml"
-				CHECKSUM="5ee766464007d0017b11344bd0e538068ba15a04" CHECKSUMTYPE="SHA-1"
-				SIZE="28397">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0037.alto.xml"
-				/>
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T19:50:33" MIMETYPE="text/xml" CHECKSUM="5ee766464007d0017b11344bd0e538068ba15a04" CHECKSUMTYPE="SHA-1" SIZE="28397">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T19:50:34" MIMETYPE="text/xml"
-				CHECKSUM="9b02ecdf255a5d20736f902ea05a9c86f27880b9" CHECKSUMTYPE="SHA-1"
-				SIZE="14592">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0038.alto.xml"
-				/>
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T19:50:34" MIMETYPE="text/xml" CHECKSUM="9b02ecdf255a5d20736f902ea05a9c86f27880b9" CHECKSUMTYPE="SHA-1" SIZE="14592">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0038.alto.xml"/>
 			</file>
-			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-10-09T19:50:35" MIMETYPE="text/xml"
-				CHECKSUM="f3b8a5cd6fc2ea8e5592826c8684842783c889d7" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0039.alto.xml"
-				/>
+			<file ID="ALTO00039" GROUPID="page39" CREATED="2015-10-09T19:50:35" MIMETYPE="text/xml" CHECKSUM="f3b8a5cd6fc2ea8e5592826c8684842783c889d7" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0039.alto.xml"/>
 			</file>
-			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-10-09T19:50:35" MIMETYPE="text/xml"
-				CHECKSUM="011cbff1e86461325d438611ad02da96c8e01837" CHECKSUMTYPE="SHA-1" SIZE="7788">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0040.alto.xml"
-				/>
+			<file ID="ALTO00040" GROUPID="page40" CREATED="2015-10-09T19:50:35" MIMETYPE="text/xml" CHECKSUM="011cbff1e86461325d438611ad02da96c8e01837" CHECKSUMTYPE="SHA-1" SIZE="7788">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-02-15_01_0040.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:51:11" MIMETYPE="application/pdf"
-				CHECKSUM="d6ca8937df9a6298aa1717e391e03ff57fa21740" CHECKSUMTYPE="SHA-1"
-				SIZE="11354410">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/bmtnabf_1903-02-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:51:11" MIMETYPE="application/pdf" CHECKSUM="d6ca8937df9a6298aa1717e391e03ff57fa21740" CHECKSUMTYPE="SHA-1" SIZE="11354410">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/02/15_01/bmtnabf_1903-02-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -4341,8 +4083,7 @@
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
 						</fptr>
 					</div>
-					<div ID="L.1.1.4.2" TYPE="Illustration" ORDER="1" DMDID="c004"
-						LABEL="Untitled Image">
+					<div ID="L.1.1.4.2" TYPE="Illustration" ORDER="1" DMDID="c004" LABEL="Untitled Image">
 						<div ID="L.1.1.4.2.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_CB00001"/>
@@ -4681,8 +4422,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.14" TYPE="Illustration" ORDER="1" DMDID="c027"
-						LABEL="ABACCABACCABA">
+					<div ID="L.1.1.4.14" TYPE="Illustration" ORDER="1" DMDID="c027" LABEL="ABACCABACCABA">
 						<div ID="L.1.1.4.14.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_CB00001"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/03/01_01/bmtnabf_1903-03-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/03/01_01/bmtnabf_1903-03-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-03-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-03-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-03-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-03-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-03-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2884,432 +2878,216 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:30:53"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="1588585d5ea0a4593f7736444751cfbdfe4f2429"
-				CHECKSUMTYPE="SHA-1" SIZE="6220925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:30:53" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="1588585d5ea0a4593f7736444751cfbdfe4f2429" CHECKSUMTYPE="SHA-1" SIZE="6220925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:31:26"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="21f5139193e2ef5679e03d6ccc0e01e95c302727"
-				CHECKSUMTYPE="SHA-1" SIZE="6137221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:31:26" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="21f5139193e2ef5679e03d6ccc0e01e95c302727" CHECKSUMTYPE="SHA-1" SIZE="6137221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:31:57"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="97ab11795a46f4310fde600b4e4544008e9eb398"
-				CHECKSUMTYPE="SHA-1" SIZE="6220017">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:31:57" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="97ab11795a46f4310fde600b4e4544008e9eb398" CHECKSUMTYPE="SHA-1" SIZE="6220017">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:32:34"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="15cee67f20ea94ef55f3bdcb74b5b73a2e795e5b"
-				CHECKSUMTYPE="SHA-1" SIZE="6137181">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:32:34" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="15cee67f20ea94ef55f3bdcb74b5b73a2e795e5b" CHECKSUMTYPE="SHA-1" SIZE="6137181">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:33:07"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="a0cfe4feb3af8c446a55abbc713b68c30522deb3"
-				CHECKSUMTYPE="SHA-1" SIZE="6162427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:33:07" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="a0cfe4feb3af8c446a55abbc713b68c30522deb3" CHECKSUMTYPE="SHA-1" SIZE="6162427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:33:38"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="aa1b58ab4a0652659b271b422acb11a36588200c"
-				CHECKSUMTYPE="SHA-1" SIZE="6165982">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:33:38" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="aa1b58ab4a0652659b271b422acb11a36588200c" CHECKSUMTYPE="SHA-1" SIZE="6165982">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:34:10"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="a119863ab0ab477be23893b8391124baec9f7eec"
-				CHECKSUMTYPE="SHA-1" SIZE="6164204">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:34:10" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="a119863ab0ab477be23893b8391124baec9f7eec" CHECKSUMTYPE="SHA-1" SIZE="6164204">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:34:42"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="f481b61f1d2a29fc5ddb88956b740c3d9874a01d"
-				CHECKSUMTYPE="SHA-1" SIZE="6166000">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:34:42" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="f481b61f1d2a29fc5ddb88956b740c3d9874a01d" CHECKSUMTYPE="SHA-1" SIZE="6166000">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:35:14"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="91891668910edc65c5a61dff807bad83cfd96155"
-				CHECKSUMTYPE="SHA-1" SIZE="6132718">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:35:14" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="91891668910edc65c5a61dff807bad83cfd96155" CHECKSUMTYPE="SHA-1" SIZE="6132718">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:35:45"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="c68d87867e2acbc4125137620331e316dd24aa65"
-				CHECKSUMTYPE="SHA-1" SIZE="6217312">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:35:45" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="c68d87867e2acbc4125137620331e316dd24aa65" CHECKSUMTYPE="SHA-1" SIZE="6217312">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:36:16"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="d8b4991ea8fe14394bee3c0c99540403d4026245"
-				CHECKSUMTYPE="SHA-1" SIZE="6133588">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:36:16" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="d8b4991ea8fe14394bee3c0c99540403d4026245" CHECKSUMTYPE="SHA-1" SIZE="6133588">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:36:48"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="7409e681cd25204ec16bb095b5ec48d3df21f565"
-				CHECKSUMTYPE="SHA-1" SIZE="6217324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:36:48" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="7409e681cd25204ec16bb095b5ec48d3df21f565" CHECKSUMTYPE="SHA-1" SIZE="6217324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:37:21"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="bb5b6a34c84271ae78e3a5e03cf95d96c8498be1"
-				CHECKSUMTYPE="SHA-1" SIZE="6133613">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:37:21" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="bb5b6a34c84271ae78e3a5e03cf95d96c8498be1" CHECKSUMTYPE="SHA-1" SIZE="6133613">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:37:54"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="757ede223a2801d047b2213b40b0601925cbb077"
-				CHECKSUMTYPE="SHA-1" SIZE="6217327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:37:54" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="757ede223a2801d047b2213b40b0601925cbb077" CHECKSUMTYPE="SHA-1" SIZE="6217327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:38:25"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="22a36bed7546955498d4f93c12efb07459d95e1e"
-				CHECKSUMTYPE="SHA-1" SIZE="6131826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:38:25" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="22a36bed7546955498d4f93c12efb07459d95e1e" CHECKSUMTYPE="SHA-1" SIZE="6131826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:38:55"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="1c54f89823922136b4945e150690bb2399dcb48d"
-				CHECKSUMTYPE="SHA-1" SIZE="6216428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:38:55" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="1c54f89823922136b4945e150690bb2399dcb48d" CHECKSUMTYPE="SHA-1" SIZE="6216428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:39:25"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="0738785cb3712eaf7ee17e4a2560cae15d628dc7"
-				CHECKSUMTYPE="SHA-1" SIZE="6131828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:39:25" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="0738785cb3712eaf7ee17e4a2560cae15d628dc7" CHECKSUMTYPE="SHA-1" SIZE="6131828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:39:57"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="9e903d05ccb8f712e3d35907b8a27972a81ac35d"
-				CHECKSUMTYPE="SHA-1" SIZE="6241622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:39:57" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="9e903d05ccb8f712e3d35907b8a27972a81ac35d" CHECKSUMTYPE="SHA-1" SIZE="6241622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:40:31"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="61b84941d6847db833c7da0f7973a76d68554590"
-				CHECKSUMTYPE="SHA-1" SIZE="6096549">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:40:31" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="61b84941d6847db833c7da0f7973a76d68554590" CHECKSUMTYPE="SHA-1" SIZE="6096549">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:41:04"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="48386142ac7ab338fdbd211e57d66c036d03ea66"
-				CHECKSUMTYPE="SHA-1" SIZE="6240720">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:41:04" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="48386142ac7ab338fdbd211e57d66c036d03ea66" CHECKSUMTYPE="SHA-1" SIZE="6240720">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:41:35"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="6ed66aa01afc5d9d31be6ab7593cfe232156c525"
-				CHECKSUMTYPE="SHA-1" SIZE="6097602">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:41:35" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="6ed66aa01afc5d9d31be6ab7593cfe232156c525" CHECKSUMTYPE="SHA-1" SIZE="6097602">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:42:07"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="f69af8bf8fea3d290b4575f636224dff38c46e55"
-				CHECKSUMTYPE="SHA-1" SIZE="6228963">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:42:07" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="f69af8bf8fea3d290b4575f636224dff38c46e55" CHECKSUMTYPE="SHA-1" SIZE="6228963">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:42:39"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="8f8bedd34ea19285f2eebb2cff01c4b94c2fa490"
-				CHECKSUMTYPE="SHA-1" SIZE="6097473">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:42:39" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="8f8bedd34ea19285f2eebb2cff01c4b94c2fa490" CHECKSUMTYPE="SHA-1" SIZE="6097473">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:43:10"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="3ffff918d650dcef00b131c93afea6cfece4dab2"
-				CHECKSUMTYPE="SHA-1" SIZE="6211025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:43:10" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="3ffff918d650dcef00b131c93afea6cfece4dab2" CHECKSUMTYPE="SHA-1" SIZE="6211025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:43:39"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="509e939c699e7904f030bf5d7d1b83c3599e5b7e"
-				CHECKSUMTYPE="SHA-1" SIZE="6097628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:43:39" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="509e939c699e7904f030bf5d7d1b83c3599e5b7e" CHECKSUMTYPE="SHA-1" SIZE="6097628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:44:11"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="e990adbac7c3254b0afa9d92f77f1dd3661c4939"
-				CHECKSUMTYPE="SHA-1" SIZE="6404527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:44:11" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="e990adbac7c3254b0afa9d92f77f1dd3661c4939" CHECKSUMTYPE="SHA-1" SIZE="6404527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:44:46"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="d524b8980cf63ab75fd096b5605915a3c499e1cc"
-				CHECKSUMTYPE="SHA-1" SIZE="5991405">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:44:46" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="d524b8980cf63ab75fd096b5605915a3c499e1cc" CHECKSUMTYPE="SHA-1" SIZE="5991405">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:45:20"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="f659079ca64cc8ae553f35f8404dea6fa5b8968f"
-				CHECKSUMTYPE="SHA-1" SIZE="6310916">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:45:20" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="f659079ca64cc8ae553f35f8404dea6fa5b8968f" CHECKSUMTYPE="SHA-1" SIZE="6310916">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T19:45:51"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="12d1e51cefa7ab72a30978dd4ee9596f87bd706c"
-				CHECKSUMTYPE="SHA-1" SIZE="6094014">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T19:45:51" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="12d1e51cefa7ab72a30978dd4ee9596f87bd706c" CHECKSUMTYPE="SHA-1" SIZE="6094014">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T19:46:22"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="458485578968892f63fb59686d378d3695d276cf"
-				CHECKSUMTYPE="SHA-1" SIZE="6310929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T19:46:22" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="458485578968892f63fb59686d378d3695d276cf" CHECKSUMTYPE="SHA-1" SIZE="6310929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T19:46:52"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="cc067fc673126b610a097216e00e2ad0160ec8c5"
-				CHECKSUMTYPE="SHA-1" SIZE="6094011">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T19:46:52" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="cc067fc673126b610a097216e00e2ad0160ec8c5" CHECKSUMTYPE="SHA-1" SIZE="6094011">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T19:47:22"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="03f9b76f1df71442db97f8f16f2f63f6dcd97f34"
-				CHECKSUMTYPE="SHA-1" SIZE="6310913">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T19:47:22" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="03f9b76f1df71442db97f8f16f2f63f6dcd97f34" CHECKSUMTYPE="SHA-1" SIZE="6310913">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T19:47:54"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="48644a607f8aa944a0ec8c6770db124e5a0e2bb6"
-				CHECKSUMTYPE="SHA-1" SIZE="6095802">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T19:47:54" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="48644a607f8aa944a0ec8c6770db124e5a0e2bb6" CHECKSUMTYPE="SHA-1" SIZE="6095802">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T19:48:22"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="677048d28be79f4befbf1e8b43912715f2e474e3"
-				CHECKSUMTYPE="SHA-1" SIZE="6192129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T19:48:22" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="677048d28be79f4befbf1e8b43912715f2e474e3" CHECKSUMTYPE="SHA-1" SIZE="6192129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/delivery/bmtnabf_1903-03-01_01_0034.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:48:41" MIMETYPE="text/xml"
-				CHECKSUM="accf4d3daaa811ec06fe288d1ace72da9870e0dd" CHECKSUMTYPE="SHA-1" SIZE="4784">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:48:41" MIMETYPE="text/xml" CHECKSUM="accf4d3daaa811ec06fe288d1ace72da9870e0dd" CHECKSUMTYPE="SHA-1" SIZE="4784">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:48:41" MIMETYPE="text/xml"
-				CHECKSUM="a77b340ab51eed24a2167cba47996c5ff9800f05" CHECKSUMTYPE="SHA-1" SIZE="1718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:48:41" MIMETYPE="text/xml" CHECKSUM="a77b340ab51eed24a2167cba47996c5ff9800f05" CHECKSUMTYPE="SHA-1" SIZE="1718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:48:41" MIMETYPE="text/xml"
-				CHECKSUM="216aefcc623a2aa9bcc3c3a457ed60bd3fa417cb" CHECKSUMTYPE="SHA-1" SIZE="8284">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:48:41" MIMETYPE="text/xml" CHECKSUM="216aefcc623a2aa9bcc3c3a457ed60bd3fa417cb" CHECKSUMTYPE="SHA-1" SIZE="8284">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:48:42" MIMETYPE="text/xml"
-				CHECKSUM="00817f378619566a0e58554032619dac8d72acd7" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:48:42" MIMETYPE="text/xml" CHECKSUM="00817f378619566a0e58554032619dac8d72acd7" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:48:42" MIMETYPE="text/xml"
-				CHECKSUM="9646ae6db577fa65126344e2fcedb361979bdf2c" CHECKSUMTYPE="SHA-1" SIZE="1719">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:48:42" MIMETYPE="text/xml" CHECKSUM="9646ae6db577fa65126344e2fcedb361979bdf2c" CHECKSUMTYPE="SHA-1" SIZE="1719">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:48:42" MIMETYPE="text/xml"
-				CHECKSUM="0cb46ce3a384ef5509eaee4dda82d24998bdf68e" CHECKSUMTYPE="SHA-1" SIZE="4104">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:48:42" MIMETYPE="text/xml" CHECKSUM="0cb46ce3a384ef5509eaee4dda82d24998bdf68e" CHECKSUMTYPE="SHA-1" SIZE="4104">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:48:42" MIMETYPE="text/xml"
-				CHECKSUM="f7201f81d833c69e0bb229fcb9eaba426961bcda" CHECKSUMTYPE="SHA-1"
-				SIZE="53158">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:48:42" MIMETYPE="text/xml" CHECKSUM="f7201f81d833c69e0bb229fcb9eaba426961bcda" CHECKSUMTYPE="SHA-1" SIZE="53158">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:48:42" MIMETYPE="text/xml"
-				CHECKSUM="67849f871b715fc8316e9b19ef7ec95fbd3d0346" CHECKSUMTYPE="SHA-1"
-				SIZE="66882">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:48:42" MIMETYPE="text/xml" CHECKSUM="67849f871b715fc8316e9b19ef7ec95fbd3d0346" CHECKSUMTYPE="SHA-1" SIZE="66882">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:48:43" MIMETYPE="text/xml"
-				CHECKSUM="ac411bf2d296637fee680ffe31689fd17ffebf62" CHECKSUMTYPE="SHA-1"
-				SIZE="74373">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:48:43" MIMETYPE="text/xml" CHECKSUM="ac411bf2d296637fee680ffe31689fd17ffebf62" CHECKSUMTYPE="SHA-1" SIZE="74373">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:48:43" MIMETYPE="text/xml"
-				CHECKSUM="44a2360d46424392bb817a6007873cf594269ea0" CHECKSUMTYPE="SHA-1"
-				SIZE="75269">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:48:43" MIMETYPE="text/xml" CHECKSUM="44a2360d46424392bb817a6007873cf594269ea0" CHECKSUMTYPE="SHA-1" SIZE="75269">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:48:43" MIMETYPE="text/xml"
-				CHECKSUM="4e15d10dba294059bdc1a2aa76e770c95364a269" CHECKSUMTYPE="SHA-1" SIZE="5045">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:48:43" MIMETYPE="text/xml" CHECKSUM="4e15d10dba294059bdc1a2aa76e770c95364a269" CHECKSUMTYPE="SHA-1" SIZE="5045">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:48:44" MIMETYPE="text/xml"
-				CHECKSUM="3915dccbe294d5aa0c4afaa0100ff7662807eb44" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:48:44" MIMETYPE="text/xml" CHECKSUM="3915dccbe294d5aa0c4afaa0100ff7662807eb44" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:48:44" MIMETYPE="text/xml"
-				CHECKSUM="45830660eba6fa1ab220eaca444097e702c5ac7a" CHECKSUMTYPE="SHA-1" SIZE="5029">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:48:44" MIMETYPE="text/xml" CHECKSUM="45830660eba6fa1ab220eaca444097e702c5ac7a" CHECKSUMTYPE="SHA-1" SIZE="5029">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:48:44" MIMETYPE="text/xml"
-				CHECKSUM="5b87324d1f98bb5421e8f34efb51cc119da3ea15" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:48:44" MIMETYPE="text/xml" CHECKSUM="5b87324d1f98bb5421e8f34efb51cc119da3ea15" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:48:44" MIMETYPE="text/xml"
-				CHECKSUM="cf0b4046eb84c7c651ce46bbd1f549f0ccdf3ac3" CHECKSUMTYPE="SHA-1" SIZE="5216">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:48:44" MIMETYPE="text/xml" CHECKSUM="cf0b4046eb84c7c651ce46bbd1f549f0ccdf3ac3" CHECKSUMTYPE="SHA-1" SIZE="5216">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:48:44" MIMETYPE="text/xml"
-				CHECKSUM="87cd829af1e71ba514c23c22e980309cd2da9060" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:48:44" MIMETYPE="text/xml" CHECKSUM="87cd829af1e71ba514c23c22e980309cd2da9060" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:48:45" MIMETYPE="text/xml"
-				CHECKSUM="385975d384872e7533f2db412a20a0e8707834d7" CHECKSUMTYPE="SHA-1" SIZE="5105">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:48:45" MIMETYPE="text/xml" CHECKSUM="385975d384872e7533f2db412a20a0e8707834d7" CHECKSUMTYPE="SHA-1" SIZE="5105">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:48:45" MIMETYPE="text/xml"
-				CHECKSUM="3b33c074ca85d0ec1e41725b9aff276fb946b427" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:48:45" MIMETYPE="text/xml" CHECKSUM="3b33c074ca85d0ec1e41725b9aff276fb946b427" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:48:45" MIMETYPE="text/xml"
-				CHECKSUM="d32c101973ac1b897f17d805f62891d6cf6fd343" CHECKSUMTYPE="SHA-1" SIZE="5103">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:48:45" MIMETYPE="text/xml" CHECKSUM="d32c101973ac1b897f17d805f62891d6cf6fd343" CHECKSUMTYPE="SHA-1" SIZE="5103">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:48:45" MIMETYPE="text/xml"
-				CHECKSUM="114f1abdfaedd4dc82c0c8dcd0dc3b2ab24cc036" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:48:45" MIMETYPE="text/xml" CHECKSUM="114f1abdfaedd4dc82c0c8dcd0dc3b2ab24cc036" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:48:46" MIMETYPE="text/xml"
-				CHECKSUM="f4152db2f6a101ec7d5e369145df808c875d4f3a" CHECKSUMTYPE="SHA-1" SIZE="5096">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:48:46" MIMETYPE="text/xml" CHECKSUM="f4152db2f6a101ec7d5e369145df808c875d4f3a" CHECKSUMTYPE="SHA-1" SIZE="5096">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:48:46" MIMETYPE="text/xml"
-				CHECKSUM="ad320fc406757291e33dcecd2b301a7b08816166" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:48:46" MIMETYPE="text/xml" CHECKSUM="ad320fc406757291e33dcecd2b301a7b08816166" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:48:46" MIMETYPE="text/xml"
-				CHECKSUM="e4743946c58b26060ddebab04c3beb5b52799e1f" CHECKSUMTYPE="SHA-1" SIZE="5098">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:48:46" MIMETYPE="text/xml" CHECKSUM="e4743946c58b26060ddebab04c3beb5b52799e1f" CHECKSUMTYPE="SHA-1" SIZE="5098">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:48:46" MIMETYPE="text/xml"
-				CHECKSUM="9f2c7f5e52d86860042a8dacd68912bb64c0cc6b" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:48:46" MIMETYPE="text/xml" CHECKSUM="9f2c7f5e52d86860042a8dacd68912bb64c0cc6b" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:48:47" MIMETYPE="text/xml"
-				CHECKSUM="befac76b8a03726d39bb24e66a7ef5c020004b63" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:48:47" MIMETYPE="text/xml" CHECKSUM="befac76b8a03726d39bb24e66a7ef5c020004b63" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:48:47" MIMETYPE="text/xml"
-				CHECKSUM="ac80306cc10edb4e7cee07733c94341affc4263e" CHECKSUMTYPE="SHA-1" SIZE="9340">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:48:47" MIMETYPE="text/xml" CHECKSUM="ac80306cc10edb4e7cee07733c94341affc4263e" CHECKSUMTYPE="SHA-1" SIZE="9340">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:48:47" MIMETYPE="text/xml"
-				CHECKSUM="69d395c3fdfd5f90195ec4aa862375c4b1538f27" CHECKSUMTYPE="SHA-1" SIZE="9520">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:48:47" MIMETYPE="text/xml" CHECKSUM="69d395c3fdfd5f90195ec4aa862375c4b1538f27" CHECKSUMTYPE="SHA-1" SIZE="9520">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:48:47" MIMETYPE="text/xml"
-				CHECKSUM="1199de0997e34156fa573dd5df61020667631e67" CHECKSUMTYPE="SHA-1"
-				SIZE="21894">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:48:47" MIMETYPE="text/xml" CHECKSUM="1199de0997e34156fa573dd5df61020667631e67" CHECKSUMTYPE="SHA-1" SIZE="21894">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T19:48:47" MIMETYPE="text/xml"
-				CHECKSUM="d00d2b96b26347ba6341f899cf494c127206be9e" CHECKSUMTYPE="SHA-1"
-				SIZE="22265">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T19:48:47" MIMETYPE="text/xml" CHECKSUM="d00d2b96b26347ba6341f899cf494c127206be9e" CHECKSUMTYPE="SHA-1" SIZE="22265">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T19:48:48" MIMETYPE="text/xml"
-				CHECKSUM="51605b5eabd1b5be3073f8b2f409f669b38c280b" CHECKSUMTYPE="SHA-1"
-				SIZE="13783">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T19:48:48" MIMETYPE="text/xml" CHECKSUM="51605b5eabd1b5be3073f8b2f409f669b38c280b" CHECKSUMTYPE="SHA-1" SIZE="13783">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T19:48:48" MIMETYPE="text/xml"
-				CHECKSUM="f1d8ca24a3df09b0b5e1183a21ca437dff854d59" CHECKSUMTYPE="SHA-1"
-				SIZE="25406">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T19:48:48" MIMETYPE="text/xml" CHECKSUM="f1d8ca24a3df09b0b5e1183a21ca437dff854d59" CHECKSUMTYPE="SHA-1" SIZE="25406">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T19:48:48" MIMETYPE="text/xml"
-				CHECKSUM="9d1a55b62d9d1a4a2c54113037f931c7028b285c" CHECKSUMTYPE="SHA-1" SIZE="7756">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T19:48:48" MIMETYPE="text/xml" CHECKSUM="9d1a55b62d9d1a4a2c54113037f931c7028b285c" CHECKSUMTYPE="SHA-1" SIZE="7756">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T19:48:48" MIMETYPE="text/xml"
-				CHECKSUM="255abea99ccbc19b494302c52961f50c6db69897" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0033.alto.xml"
-				/>
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T19:48:48" MIMETYPE="text/xml" CHECKSUM="255abea99ccbc19b494302c52961f50c6db69897" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T19:48:49" MIMETYPE="text/xml"
-				CHECKSUM="ea39ac9dee9b915bf57f785b50e0ef007d654b89" CHECKSUMTYPE="SHA-1" SIZE="7793">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0034.alto.xml"
-				/>
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T19:48:49" MIMETYPE="text/xml" CHECKSUM="ea39ac9dee9b915bf57f785b50e0ef007d654b89" CHECKSUMTYPE="SHA-1" SIZE="7793">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-01_01_0034.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:49:21" MIMETYPE="application/pdf"
-				CHECKSUM="e39fc07f252c6c3c8c8903c28902ebcc1832e2ae" CHECKSUMTYPE="SHA-1"
-				SIZE="8537077">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/bmtnabf_1903-03-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:49:21" MIMETYPE="application/pdf" CHECKSUM="e39fc07f252c6c3c8c8903c28902ebcc1832e2ae" CHECKSUMTYPE="SHA-1" SIZE="8537077">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/01_01/bmtnabf_1903-03-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3648,8 +3426,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003"
-					LABEL="Brigitta-Kapelle">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003" LABEL="Brigitta-Kapelle">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00001"/>
@@ -3708,14 +3485,10 @@
 								<div ID="L.1.1.5.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
 										</seq>
 									</fptr>
 								</div>

--- a/metadata/periodicals/bmtnabf/issues/1903/03/15_01/bmtnabf_1903-03-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/03/15_01/bmtnabf_1903-03-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-03-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-03-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-03-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-03-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-03-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3193,490 +3187,240 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:30:56"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="d51855963b304d71c3ec1f6510a290aab3764ae1"
-				CHECKSUMTYPE="SHA-1" SIZE="6172270">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:30:56" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="d51855963b304d71c3ec1f6510a290aab3764ae1" CHECKSUMTYPE="SHA-1" SIZE="6172270">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:31:30"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="1b0b74c9a9e37b46847dc186316f2b1e6d8faea5"
-				CHECKSUMTYPE="SHA-1" SIZE="6245195">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:31:30" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="1b0b74c9a9e37b46847dc186316f2b1e6d8faea5" CHECKSUMTYPE="SHA-1" SIZE="6245195">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:32:08"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="811d78303a4861ba981c1e87f961939873a0509f"
-				CHECKSUMTYPE="SHA-1" SIZE="6172207">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:32:08" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="811d78303a4861ba981c1e87f961939873a0509f" CHECKSUMTYPE="SHA-1" SIZE="6172207">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:32:49"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="5d92b09601f57c1dace40da54250fd167c19bded"
-				CHECKSUMTYPE="SHA-1" SIZE="6245203">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:32:49" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="5d92b09601f57c1dace40da54250fd167c19bded" CHECKSUMTYPE="SHA-1" SIZE="6245203">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:33:34"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="71220a387332906229a66d475a2fac2d58a3db59"
-				CHECKSUMTYPE="SHA-1" SIZE="6172309">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:33:34" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="71220a387332906229a66d475a2fac2d58a3db59" CHECKSUMTYPE="SHA-1" SIZE="6172309">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:34:07"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="43a31b598a88af3ad66acb79007b8aae8eb16f6f"
-				CHECKSUMTYPE="SHA-1" SIZE="6167815">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:34:07" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="43a31b598a88af3ad66acb79007b8aae8eb16f6f" CHECKSUMTYPE="SHA-1" SIZE="6167815">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:34:41"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="63b02bec43a3b6f04eb2962c57570233716acdb7"
-				CHECKSUMTYPE="SHA-1" SIZE="6172327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:34:41" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="63b02bec43a3b6f04eb2962c57570233716acdb7" CHECKSUMTYPE="SHA-1" SIZE="6172327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:35:19"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a5afe1054b0c070b80200ddc68e61e00d363a4a8"
-				CHECKSUMTYPE="SHA-1" SIZE="6168720">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:35:19" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="a5afe1054b0c070b80200ddc68e61e00d363a4a8" CHECKSUMTYPE="SHA-1" SIZE="6168720">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:35:55"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="fb146d5edddd0ae0897e0921cb1446e1e9015083"
-				CHECKSUMTYPE="SHA-1" SIZE="6172299">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:35:55" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="fb146d5edddd0ae0897e0921cb1446e1e9015083" CHECKSUMTYPE="SHA-1" SIZE="6172299">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:36:27"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="d52392b3e2764e97defa1186fb31859aaf1689e6"
-				CHECKSUMTYPE="SHA-1" SIZE="6167826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:36:27" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="d52392b3e2764e97defa1186fb31859aaf1689e6" CHECKSUMTYPE="SHA-1" SIZE="6167826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:37:06"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="24c25c4657265e1aec0a9a9501a441bc84da62e6"
-				CHECKSUMTYPE="SHA-1" SIZE="6079611">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:37:06" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="24c25c4657265e1aec0a9a9501a441bc84da62e6" CHECKSUMTYPE="SHA-1" SIZE="6079611">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:37:41"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="82dcb8b89f0e1ba9a7da81d6cc05ffc2f52c51d3"
-				CHECKSUMTYPE="SHA-1" SIZE="6167811">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:37:41" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="82dcb8b89f0e1ba9a7da81d6cc05ffc2f52c51d3" CHECKSUMTYPE="SHA-1" SIZE="6167811">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:38:17"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="2c189a1bb6801acc73991e71891eb3f5a4c741ae"
-				CHECKSUMTYPE="SHA-1" SIZE="6079622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:38:17" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="2c189a1bb6801acc73991e71891eb3f5a4c741ae" CHECKSUMTYPE="SHA-1" SIZE="6079622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:38:53"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="9f20d8cf919691a83b3f47300bf68d6543d5ddc8"
-				CHECKSUMTYPE="SHA-1" SIZE="6167820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:38:53" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="9f20d8cf919691a83b3f47300bf68d6543d5ddc8" CHECKSUMTYPE="SHA-1" SIZE="6167820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:39:25"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="13c5ce1d1f4f19a55efec148e7634620c9cb48aa"
-				CHECKSUMTYPE="SHA-1" SIZE="6079627">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:39:25" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="13c5ce1d1f4f19a55efec148e7634620c9cb48aa" CHECKSUMTYPE="SHA-1" SIZE="6079627">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:40:01"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d610d9462c0a2bf40ce0a74e3af82d9aaf00e6be"
-				CHECKSUMTYPE="SHA-1" SIZE="6167827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:40:01" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d610d9462c0a2bf40ce0a74e3af82d9aaf00e6be" CHECKSUMTYPE="SHA-1" SIZE="6167827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:40:35"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="f7272f3e79548ec551645209a10829a1e6864bf9"
-				CHECKSUMTYPE="SHA-1" SIZE="6079563">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:40:35" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="f7272f3e79548ec551645209a10829a1e6864bf9" CHECKSUMTYPE="SHA-1" SIZE="6079563">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:41:07"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="f6d13144f4209e6e866ab494c1ad17412cd5605e"
-				CHECKSUMTYPE="SHA-1" SIZE="6167824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:41:07" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="f6d13144f4209e6e866ab494c1ad17412cd5605e" CHECKSUMTYPE="SHA-1" SIZE="6167824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:41:43"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="1ae59ea2475fe3a3a043b6b205e6ee2fa0bee057"
-				CHECKSUMTYPE="SHA-1" SIZE="6079618">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:41:43" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="1ae59ea2475fe3a3a043b6b205e6ee2fa0bee057" CHECKSUMTYPE="SHA-1" SIZE="6079618">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:42:19"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="8e06d6bb7e2f0544b2ddc3407fe2f38d992ad717"
-				CHECKSUMTYPE="SHA-1" SIZE="6167820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:42:19" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="8e06d6bb7e2f0544b2ddc3407fe2f38d992ad717" CHECKSUMTYPE="SHA-1" SIZE="6167820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:42:53"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="85fcb0f194866d4c4ec3421b6f4064f5c12181e9"
-				CHECKSUMTYPE="SHA-1" SIZE="6079629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:42:53" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="85fcb0f194866d4c4ec3421b6f4064f5c12181e9" CHECKSUMTYPE="SHA-1" SIZE="6079629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:43:26"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="803f636226efc94ab4beb8fae0b945852f3a5dd9"
-				CHECKSUMTYPE="SHA-1" SIZE="6167809">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:43:26" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="803f636226efc94ab4beb8fae0b945852f3a5dd9" CHECKSUMTYPE="SHA-1" SIZE="6167809">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:44:01"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="a57d5e0256f43609e7ffadd2db18105d08e5afff"
-				CHECKSUMTYPE="SHA-1" SIZE="6079628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:44:01" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="a57d5e0256f43609e7ffadd2db18105d08e5afff" CHECKSUMTYPE="SHA-1" SIZE="6079628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:44:35"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="27972dd4708002b047c2aacc5bbd1cbb42e21636"
-				CHECKSUMTYPE="SHA-1" SIZE="6168727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:44:35" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="27972dd4708002b047c2aacc5bbd1cbb42e21636" CHECKSUMTYPE="SHA-1" SIZE="6168727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:45:11"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="27ab5bbec00d672f0a07567995b6234a5198e1ff"
-				CHECKSUMTYPE="SHA-1" SIZE="6079626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:45:11" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="27ab5bbec00d672f0a07567995b6234a5198e1ff" CHECKSUMTYPE="SHA-1" SIZE="6079626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:45:46"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ff3d633c783b087e90c3ffe18052bba3b283858c"
-				CHECKSUMTYPE="SHA-1" SIZE="6168722">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:45:46" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ff3d633c783b087e90c3ffe18052bba3b283858c" CHECKSUMTYPE="SHA-1" SIZE="6168722">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:46:20"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="897df93cb28197d6ee0a800f06f1f95fd1832da5"
-				CHECKSUMTYPE="SHA-1" SIZE="6017528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:46:20" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="897df93cb28197d6ee0a800f06f1f95fd1832da5" CHECKSUMTYPE="SHA-1" SIZE="6017528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:46:55"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="63fd930ba6e5e8a0219d38d51b32f48f9b8d719f"
-				CHECKSUMTYPE="SHA-1" SIZE="6168727">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:46:55" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="63fd930ba6e5e8a0219d38d51b32f48f9b8d719f" CHECKSUMTYPE="SHA-1" SIZE="6168727">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T19:47:30"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="4939ff25edf414a4a39856e43f58b2925e981def"
-				CHECKSUMTYPE="SHA-1" SIZE="6017524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T19:47:30" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="4939ff25edf414a4a39856e43f58b2925e981def" CHECKSUMTYPE="SHA-1" SIZE="6017524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T19:48:03"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="dffdbb73e4c0f149fd9706700ef126d7f3c47e5f"
-				CHECKSUMTYPE="SHA-1" SIZE="6157023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T19:48:03" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="dffdbb73e4c0f149fd9706700ef126d7f3c47e5f" CHECKSUMTYPE="SHA-1" SIZE="6157023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T19:48:39"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="b60ef6ed528f967096630ffbaed241910071d169"
-				CHECKSUMTYPE="SHA-1" SIZE="6017269">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T19:48:39" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="b60ef6ed528f967096630ffbaed241910071d169" CHECKSUMTYPE="SHA-1" SIZE="6017269">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T19:49:13"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="0f17f342f534bd2212b665e9f8fc7c1bd9687323"
-				CHECKSUMTYPE="SHA-1" SIZE="6157016">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T19:49:13" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="0f17f342f534bd2212b665e9f8fc7c1bd9687323" CHECKSUMTYPE="SHA-1" SIZE="6157016">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T19:49:48"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="ca2bca40e24afc6f9621fedb1e0997db749be85b"
-				CHECKSUMTYPE="SHA-1" SIZE="6017522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T19:49:48" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="ca2bca40e24afc6f9621fedb1e0997db749be85b" CHECKSUMTYPE="SHA-1" SIZE="6017522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T19:50:21"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="ba656b82375beb6bfdec6224a4c9ecf053e47eff"
-				CHECKSUMTYPE="SHA-1" SIZE="6157026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T19:50:21" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="ba656b82375beb6bfdec6224a4c9ecf053e47eff" CHECKSUMTYPE="SHA-1" SIZE="6157026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0034.jp2"/>
 			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T19:50:56"
-				MIMETYPE="image/jp2" SEQ="35" CHECKSUM="2c0aaa29d46947dc2e0de42c5737b7ac7d6d0f27"
-				CHECKSUMTYPE="SHA-1" SIZE="6017475">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0035.jp2"
-				/>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T19:50:56" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="2c0aaa29d46947dc2e0de42c5737b7ac7d6d0f27" CHECKSUMTYPE="SHA-1" SIZE="6017475">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0035.jp2"/>
 			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T19:51:30"
-				MIMETYPE="image/jp2" SEQ="36" CHECKSUM="74d102304f2fae2551e4d11e16f2049e4fd47ab7"
-				CHECKSUMTYPE="SHA-1" SIZE="6155209">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0036.jp2"
-				/>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T19:51:30" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="74d102304f2fae2551e4d11e16f2049e4fd47ab7" CHECKSUMTYPE="SHA-1" SIZE="6155209">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0036.jp2"/>
 			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T19:52:07"
-				MIMETYPE="image/jp2" SEQ="37" CHECKSUM="66836546bd928d72a7d963d33207e7e17b629a2e"
-				CHECKSUMTYPE="SHA-1" SIZE="6017488">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0037.jp2"
-				/>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T19:52:07" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="66836546bd928d72a7d963d33207e7e17b629a2e" CHECKSUMTYPE="SHA-1" SIZE="6017488">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0037.jp2"/>
 			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T19:52:41"
-				MIMETYPE="image/jp2" SEQ="38" CHECKSUM="eaa745775a92d2d394a9d51a2e74f69e64051cbc"
-				CHECKSUMTYPE="SHA-1" SIZE="6155228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0038.jp2"
-				/>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T19:52:41" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="eaa745775a92d2d394a9d51a2e74f69e64051cbc" CHECKSUMTYPE="SHA-1" SIZE="6155228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/delivery/bmtnabf_1903-03-15_01_0038.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:53:04" MIMETYPE="text/xml"
-				CHECKSUM="502e89251a076ccb2fd8a412364df13088436532" CHECKSUMTYPE="SHA-1" SIZE="5038">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:53:04" MIMETYPE="text/xml" CHECKSUM="502e89251a076ccb2fd8a412364df13088436532" CHECKSUMTYPE="SHA-1" SIZE="5038">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:53:04" MIMETYPE="text/xml"
-				CHECKSUM="c69b0507d628755b8472a2d62d4708efb076fda7" CHECKSUMTYPE="SHA-1" SIZE="1720">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:53:04" MIMETYPE="text/xml" CHECKSUM="c69b0507d628755b8472a2d62d4708efb076fda7" CHECKSUMTYPE="SHA-1" SIZE="1720">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:53:05" MIMETYPE="text/xml"
-				CHECKSUM="9e51c786e135619219824cc6f3618e356ca8ea0d" CHECKSUMTYPE="SHA-1" SIZE="8730">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:53:05" MIMETYPE="text/xml" CHECKSUM="9e51c786e135619219824cc6f3618e356ca8ea0d" CHECKSUMTYPE="SHA-1" SIZE="8730">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:53:05" MIMETYPE="text/xml"
-				CHECKSUM="d0fb1fa1dc6f53d96b03a4448156254687891992" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:53:05" MIMETYPE="text/xml" CHECKSUM="d0fb1fa1dc6f53d96b03a4448156254687891992" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:53:05" MIMETYPE="text/xml"
-				CHECKSUM="a84d9af67abb894a0acee31141ce3a9c06c483f6" CHECKSUMTYPE="SHA-1" SIZE="5199">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:53:05" MIMETYPE="text/xml" CHECKSUM="a84d9af67abb894a0acee31141ce3a9c06c483f6" CHECKSUMTYPE="SHA-1" SIZE="5199">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:53:05" MIMETYPE="text/xml"
-				CHECKSUM="6d7589e55ee43a6c202edaa9632868f4c99d6a5b" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:53:05" MIMETYPE="text/xml" CHECKSUM="6d7589e55ee43a6c202edaa9632868f4c99d6a5b" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:53:06" MIMETYPE="text/xml"
-				CHECKSUM="23cc0ea68c60435e365d78121094eda5f9cfbe67" CHECKSUMTYPE="SHA-1"
-				SIZE="68400">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:53:06" MIMETYPE="text/xml" CHECKSUM="23cc0ea68c60435e365d78121094eda5f9cfbe67" CHECKSUMTYPE="SHA-1" SIZE="68400">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:53:06" MIMETYPE="text/xml"
-				CHECKSUM="7a7fb23ea60b5144f54d1ef9216bd811fa9df0a3" CHECKSUMTYPE="SHA-1"
-				SIZE="70922">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:53:06" MIMETYPE="text/xml" CHECKSUM="7a7fb23ea60b5144f54d1ef9216bd811fa9df0a3" CHECKSUMTYPE="SHA-1" SIZE="70922">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:53:06" MIMETYPE="text/xml"
-				CHECKSUM="a436444bea0899048be746b1b78ff320b9d68a43" CHECKSUMTYPE="SHA-1" SIZE="5208">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:53:06" MIMETYPE="text/xml" CHECKSUM="a436444bea0899048be746b1b78ff320b9d68a43" CHECKSUMTYPE="SHA-1" SIZE="5208">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:53:06" MIMETYPE="text/xml"
-				CHECKSUM="5f170aa0114b7fdff1d0e71ac965332e6d308d98" CHECKSUMTYPE="SHA-1"
-				SIZE="74227">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:53:06" MIMETYPE="text/xml" CHECKSUM="5f170aa0114b7fdff1d0e71ac965332e6d308d98" CHECKSUMTYPE="SHA-1" SIZE="74227">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:53:07" MIMETYPE="text/xml"
-				CHECKSUM="d90489ee7a612766af36d6335cef7d517f8d0e3c" CHECKSUMTYPE="SHA-1" SIZE="5133">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:53:07" MIMETYPE="text/xml" CHECKSUM="d90489ee7a612766af36d6335cef7d517f8d0e3c" CHECKSUMTYPE="SHA-1" SIZE="5133">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:53:07" MIMETYPE="text/xml"
-				CHECKSUM="d9acdfb7fcbc4800524734c822dcea805118c459" CHECKSUMTYPE="SHA-1"
-				SIZE="73968">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:53:07" MIMETYPE="text/xml" CHECKSUM="d9acdfb7fcbc4800524734c822dcea805118c459" CHECKSUMTYPE="SHA-1" SIZE="73968">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:53:07" MIMETYPE="text/xml"
-				CHECKSUM="402a7841c13c5205946179fd0e2da12648ce00af" CHECKSUMTYPE="SHA-1"
-				SIZE="67939">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:53:07" MIMETYPE="text/xml" CHECKSUM="402a7841c13c5205946179fd0e2da12648ce00af" CHECKSUMTYPE="SHA-1" SIZE="67939">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:53:08" MIMETYPE="text/xml"
-				CHECKSUM="590f5650612c02e1706f41bd106a928456e7d65b" CHECKSUMTYPE="SHA-1"
-				SIZE="70959">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:53:08" MIMETYPE="text/xml" CHECKSUM="590f5650612c02e1706f41bd106a928456e7d65b" CHECKSUMTYPE="SHA-1" SIZE="70959">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:53:08" MIMETYPE="text/xml"
-				CHECKSUM="a109150156852c8e78a50be92d30a21463bce243" CHECKSUMTYPE="SHA-1" SIZE="5133">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:53:08" MIMETYPE="text/xml" CHECKSUM="a109150156852c8e78a50be92d30a21463bce243" CHECKSUMTYPE="SHA-1" SIZE="5133">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:53:08" MIMETYPE="text/xml"
-				CHECKSUM="2e0c4ddc9cc0af7e2381a2c2a21ad8b0488596e1" CHECKSUMTYPE="SHA-1"
-				SIZE="76207">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:53:08" MIMETYPE="text/xml" CHECKSUM="2e0c4ddc9cc0af7e2381a2c2a21ad8b0488596e1" CHECKSUMTYPE="SHA-1" SIZE="76207">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:53:08" MIMETYPE="text/xml"
-				CHECKSUM="74d3eb65835e5d55c2c6bc79808c86f932cef22c" CHECKSUMTYPE="SHA-1" SIZE="5133">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:53:08" MIMETYPE="text/xml" CHECKSUM="74d3eb65835e5d55c2c6bc79808c86f932cef22c" CHECKSUMTYPE="SHA-1" SIZE="5133">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:53:09" MIMETYPE="text/xml"
-				CHECKSUM="7fc062483d2a9f73f1e6023d2fa7b104c61e7319" CHECKSUMTYPE="SHA-1"
-				SIZE="72904">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:53:09" MIMETYPE="text/xml" CHECKSUM="7fc062483d2a9f73f1e6023d2fa7b104c61e7319" CHECKSUMTYPE="SHA-1" SIZE="72904">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:53:09" MIMETYPE="text/xml"
-				CHECKSUM="377e38c9ac773348780eb9fe30f6feeb5f77be33" CHECKSUMTYPE="SHA-1"
-				SIZE="72573">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:53:09" MIMETYPE="text/xml" CHECKSUM="377e38c9ac773348780eb9fe30f6feeb5f77be33" CHECKSUMTYPE="SHA-1" SIZE="72573">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:53:09" MIMETYPE="text/xml"
-				CHECKSUM="27f8d2c3833de025b9095642eb57ec5b53b99622" CHECKSUMTYPE="SHA-1"
-				SIZE="71148">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:53:09" MIMETYPE="text/xml" CHECKSUM="27f8d2c3833de025b9095642eb57ec5b53b99622" CHECKSUMTYPE="SHA-1" SIZE="71148">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:53:09" MIMETYPE="text/xml"
-				CHECKSUM="9d184c014894f6c98ef82027a54452ca09898e0d" CHECKSUMTYPE="SHA-1" SIZE="5237">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:53:09" MIMETYPE="text/xml" CHECKSUM="9d184c014894f6c98ef82027a54452ca09898e0d" CHECKSUMTYPE="SHA-1" SIZE="5237">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:53:10" MIMETYPE="text/xml"
-				CHECKSUM="cde0c4e4fa5a42c601143a88ff85a87e0b666d7a" CHECKSUMTYPE="SHA-1"
-				SIZE="79213">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:53:10" MIMETYPE="text/xml" CHECKSUM="cde0c4e4fa5a42c601143a88ff85a87e0b666d7a" CHECKSUMTYPE="SHA-1" SIZE="79213">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:53:10" MIMETYPE="text/xml"
-				CHECKSUM="be1774c7a3359fe02d35921914bfe4219579b486" CHECKSUMTYPE="SHA-1" SIZE="5134">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:53:10" MIMETYPE="text/xml" CHECKSUM="be1774c7a3359fe02d35921914bfe4219579b486" CHECKSUMTYPE="SHA-1" SIZE="5134">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:53:10" MIMETYPE="text/xml"
-				CHECKSUM="4dceb1e76f9fba5bb08bec4a0177af421b675175" CHECKSUMTYPE="SHA-1"
-				SIZE="75088">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:53:10" MIMETYPE="text/xml" CHECKSUM="4dceb1e76f9fba5bb08bec4a0177af421b675175" CHECKSUMTYPE="SHA-1" SIZE="75088">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:53:11" MIMETYPE="text/xml"
-				CHECKSUM="efd2a22b8cde772e14a1baf89aaa5a442e638048" CHECKSUMTYPE="SHA-1" SIZE="5133">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:53:11" MIMETYPE="text/xml" CHECKSUM="efd2a22b8cde772e14a1baf89aaa5a442e638048" CHECKSUMTYPE="SHA-1" SIZE="5133">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:53:11" MIMETYPE="text/xml"
-				CHECKSUM="b79aa868c4aaf62be64496883c7b083b7d3b2308" CHECKSUMTYPE="SHA-1"
-				SIZE="69227">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:53:11" MIMETYPE="text/xml" CHECKSUM="b79aa868c4aaf62be64496883c7b083b7d3b2308" CHECKSUMTYPE="SHA-1" SIZE="69227">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:53:11" MIMETYPE="text/xml"
-				CHECKSUM="4cfb0c06c0f2a6a49a1dee9706f745fce327852e" CHECKSUMTYPE="SHA-1" SIZE="5133">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:53:11" MIMETYPE="text/xml" CHECKSUM="4cfb0c06c0f2a6a49a1dee9706f745fce327852e" CHECKSUMTYPE="SHA-1" SIZE="5133">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:53:12" MIMETYPE="text/xml"
-				CHECKSUM="122aa7dda4f4a0fafdcffd644448935c9890efdb" CHECKSUMTYPE="SHA-1"
-				SIZE="71268">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:53:12" MIMETYPE="text/xml" CHECKSUM="122aa7dda4f4a0fafdcffd644448935c9890efdb" CHECKSUMTYPE="SHA-1" SIZE="71268">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T19:53:12" MIMETYPE="text/xml"
-				CHECKSUM="c08340fcadb76e388d4ab6ec1716e54f9a7dccc8" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T19:53:12" MIMETYPE="text/xml" CHECKSUM="c08340fcadb76e388d4ab6ec1716e54f9a7dccc8" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T19:53:12" MIMETYPE="text/xml"
-				CHECKSUM="f132da232f0fb5d16885027bc6031a8545f33e07" CHECKSUMTYPE="SHA-1" SIZE="9343">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T19:53:12" MIMETYPE="text/xml" CHECKSUM="f132da232f0fb5d16885027bc6031a8545f33e07" CHECKSUMTYPE="SHA-1" SIZE="9343">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T19:53:12" MIMETYPE="text/xml"
-				CHECKSUM="ed3c0d6f602b6ca62b8becfcd7fd19a171a1b6f1" CHECKSUMTYPE="SHA-1" SIZE="8832">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T19:53:12" MIMETYPE="text/xml" CHECKSUM="ed3c0d6f602b6ca62b8becfcd7fd19a171a1b6f1" CHECKSUMTYPE="SHA-1" SIZE="8832">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T19:53:13" MIMETYPE="text/xml"
-				CHECKSUM="6e79455be7cb45c9ac41089a19c0a75a423c5f70" CHECKSUMTYPE="SHA-1"
-				SIZE="15979">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T19:53:13" MIMETYPE="text/xml" CHECKSUM="6e79455be7cb45c9ac41089a19c0a75a423c5f70" CHECKSUMTYPE="SHA-1" SIZE="15979">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T19:53:13" MIMETYPE="text/xml"
-				CHECKSUM="f94d92084d781914c8f80dc5a23464ea73f70b22" CHECKSUMTYPE="SHA-1"
-				SIZE="23855">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0033.alto.xml"
-				/>
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T19:53:13" MIMETYPE="text/xml" CHECKSUM="f94d92084d781914c8f80dc5a23464ea73f70b22" CHECKSUMTYPE="SHA-1" SIZE="23855">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T19:53:13" MIMETYPE="text/xml"
-				CHECKSUM="eb6d2d8928fd809742d0d895e40318bcdeed033c" CHECKSUMTYPE="SHA-1"
-				SIZE="16268">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0034.alto.xml"
-				/>
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T19:53:13" MIMETYPE="text/xml" CHECKSUM="eb6d2d8928fd809742d0d895e40318bcdeed033c" CHECKSUMTYPE="SHA-1" SIZE="16268">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T19:53:13" MIMETYPE="text/xml"
-				CHECKSUM="c293917d9409c39b0d2a988be46e8ec79232771b" CHECKSUMTYPE="SHA-1"
-				SIZE="22495">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0035.alto.xml"
-				/>
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T19:53:13" MIMETYPE="text/xml" CHECKSUM="c293917d9409c39b0d2a988be46e8ec79232771b" CHECKSUMTYPE="SHA-1" SIZE="22495">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T19:53:14" MIMETYPE="text/xml"
-				CHECKSUM="0a00aea79b6d11a9070439cc146c149377e33a4c" CHECKSUMTYPE="SHA-1" SIZE="7637">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0036.alto.xml"
-				/>
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T19:53:14" MIMETYPE="text/xml" CHECKSUM="0a00aea79b6d11a9070439cc146c149377e33a4c" CHECKSUMTYPE="SHA-1" SIZE="7637">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T19:53:14" MIMETYPE="text/xml"
-				CHECKSUM="d87ab529c571908a15065009f295cd363e5a22ac" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0037.alto.xml"
-				/>
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T19:53:14" MIMETYPE="text/xml" CHECKSUM="d87ab529c571908a15065009f295cd363e5a22ac" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T19:53:14" MIMETYPE="text/xml"
-				CHECKSUM="a5f0ad6a77596c74921cb4ed702d485bdd246fbb" CHECKSUMTYPE="SHA-1" SIZE="7944">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0038.alto.xml"
-				/>
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T19:53:14" MIMETYPE="text/xml" CHECKSUM="a5f0ad6a77596c74921cb4ed702d485bdd246fbb" CHECKSUMTYPE="SHA-1" SIZE="7944">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-03-15_01_0038.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:54:02" MIMETYPE="application/pdf"
-				CHECKSUM="0313f8bdd0a0f9fbc2065f5a6d8d5dfc3583e1d6" CHECKSUMTYPE="SHA-1"
-				SIZE="9938091">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/bmtnabf_1903-03-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:54:02" MIMETYPE="application/pdf" CHECKSUM="0313f8bdd0a0f9fbc2065f5a6d8d5dfc3583e1d6" CHECKSUMTYPE="SHA-1" SIZE="9938091">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/03/15_01/bmtnabf_1903-03-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -4095,36 +3839,21 @@
 								<div ID="L.1.1.6.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00022"
-												BEGIN="P22_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00024"
-												BEGIN="P24_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00028"
-												BEGIN="P28_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -4132,8 +3861,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c007"
-					LABEL="Untitled Image by Josef Hoffmann OM">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="5" DMDID="c007" LABEL="Untitled Image by Josef Hoffmann OM">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -4150,8 +3878,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c008"
-					LABEL="Untitled Image by Josef Hoffmann OM">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="6" DMDID="c008" LABEL="Untitled Image by Josef Hoffmann OM">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -4168,8 +3895,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c009"
-					LABEL="Untitled Image by Josef Hoffmann OM">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="7" DMDID="c009" LABEL="Untitled Image by Josef Hoffmann OM">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -4186,8 +3912,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c010"
-					LABEL="Untitled Image by Josef Hoffmann OM">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="8" DMDID="c010" LABEL="Untitled Image by Josef Hoffmann OM">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -4204,8 +3929,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c011"
-					LABEL="Untitled Image by Josef Hoffmann OM">
+				<div ID="L.1.1.11" TYPE="Illustration" ORDER="9" DMDID="c011" LABEL="Untitled Image by Josef Hoffmann OM">
 					<div ID="L.1.1.11.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
@@ -4222,8 +3946,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c012"
-					LABEL="Untitled Image by Josef Hoffmann OM">
+				<div ID="L.1.1.12" TYPE="Illustration" ORDER="10" DMDID="c012" LABEL="Untitled Image by Josef Hoffmann OM">
 					<div ID="L.1.1.12.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
@@ -4240,8 +3963,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c013"
-					LABEL="Untitled Image by Josef Hoffmann OM">
+				<div ID="L.1.1.13" TYPE="Illustration" ORDER="11" DMDID="c013" LABEL="Untitled Image by Josef Hoffmann OM">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00002"/>
@@ -4258,8 +3980,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c014"
-					LABEL="Untitled Image by Josef Hoffmann OM">
+				<div ID="L.1.1.14" TYPE="Illustration" ORDER="12" DMDID="c014" LABEL="Untitled Image by Josef Hoffmann OM">
 					<div ID="L.1.1.14.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/04/01_01/bmtnabf_1903-04-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/04/01_01/bmtnabf_1903-04-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-04-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-04-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-04-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-04-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-04-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2761,411 +2755,204 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:04:22"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="1607260e896b280ba1d98bb6f9688d221978885a"
-				CHECKSUMTYPE="SHA-1" SIZE="6175925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:04:22" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="1607260e896b280ba1d98bb6f9688d221978885a" CHECKSUMTYPE="SHA-1" SIZE="6175925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:04:59"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="d8c0f625b90aef576e3a6591f029fcebbb524f98"
-				CHECKSUMTYPE="SHA-1" SIZE="6225090">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:04:59" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="d8c0f625b90aef576e3a6591f029fcebbb524f98" CHECKSUMTYPE="SHA-1" SIZE="6225090">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:05:36"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="3d524aa81438a3d1e63c005a2295fb447f909ab2"
-				CHECKSUMTYPE="SHA-1" SIZE="6175900">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:05:36" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="3d524aa81438a3d1e63c005a2295fb447f909ab2" CHECKSUMTYPE="SHA-1" SIZE="6175900">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:06:18"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="3fd3ad92beb94476c3c90b3893d5b07ef1f25cf6"
-				CHECKSUMTYPE="SHA-1" SIZE="6224490">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:06:18" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="3fd3ad92beb94476c3c90b3893d5b07ef1f25cf6" CHECKSUMTYPE="SHA-1" SIZE="6224490">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:06:59"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="e4de5487237ce6a760b5528df41931a30675f919"
-				CHECKSUMTYPE="SHA-1" SIZE="6087712">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:06:59" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="e4de5487237ce6a760b5528df41931a30675f919" CHECKSUMTYPE="SHA-1" SIZE="6087712">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:07:35"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="944d98e68f887d2e07d96b114a8204e8bc164558"
-				CHECKSUMTYPE="SHA-1" SIZE="6152505">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:07:35" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="944d98e68f887d2e07d96b114a8204e8bc164558" CHECKSUMTYPE="SHA-1" SIZE="6152505">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:08:10"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="a6cd7698b65809a4789b60644288e2b4b6fa888e"
-				CHECKSUMTYPE="SHA-1" SIZE="6087723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:08:10" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="a6cd7698b65809a4789b60644288e2b4b6fa888e" CHECKSUMTYPE="SHA-1" SIZE="6087723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:08:45"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="62442be2f408ed46bd455523e5c08964569dac8a"
-				CHECKSUMTYPE="SHA-1" SIZE="6152526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:08:45" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="62442be2f408ed46bd455523e5c08964569dac8a" CHECKSUMTYPE="SHA-1" SIZE="6152526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:09:17"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="97834db1cb0ec50decbad11ccb203ea3c661f467"
-				CHECKSUMTYPE="SHA-1" SIZE="6017524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:09:17" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="97834db1cb0ec50decbad11ccb203ea3c661f467" CHECKSUMTYPE="SHA-1" SIZE="6017524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:09:54"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="a7037e9bb86c302d63243f3ab7db6ef0c0ec9789"
-				CHECKSUMTYPE="SHA-1" SIZE="6152513">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:09:54" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="a7037e9bb86c302d63243f3ab7db6ef0c0ec9789" CHECKSUMTYPE="SHA-1" SIZE="6152513">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:10:27"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="61518db19eea4ea63160c9e61db05dc167054059"
-				CHECKSUMTYPE="SHA-1" SIZE="6017527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:10:27" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="61518db19eea4ea63160c9e61db05dc167054059" CHECKSUMTYPE="SHA-1" SIZE="6017527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:11:02"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="5b94712f1af9df5e576db3e87b233b0f325ffac7"
-				CHECKSUMTYPE="SHA-1" SIZE="6152522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:11:02" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="5b94712f1af9df5e576db3e87b233b0f325ffac7" CHECKSUMTYPE="SHA-1" SIZE="6152522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:11:38"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="ae659ce4f61e24c8c8148fa38cb9f760950258a7"
-				CHECKSUMTYPE="SHA-1" SIZE="6017519">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:11:38" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="ae659ce4f61e24c8c8148fa38cb9f760950258a7" CHECKSUMTYPE="SHA-1" SIZE="6017519">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:12:15"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="26c1af3c1853e67d16e4594a3d7603783546b6ce"
-				CHECKSUMTYPE="SHA-1" SIZE="6153417">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:12:15" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="26c1af3c1853e67d16e4594a3d7603783546b6ce" CHECKSUMTYPE="SHA-1" SIZE="6153417">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:12:49"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="1652c554bb517b04ee33d4acc16b7e1c97018c29"
-				CHECKSUMTYPE="SHA-1" SIZE="6017524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:12:49" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="1652c554bb517b04ee33d4acc16b7e1c97018c29" CHECKSUMTYPE="SHA-1" SIZE="6017524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:13:24"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="bc14af1fc6a9b9c9566e96db7b6812e6999641b5"
-				CHECKSUMTYPE="SHA-1" SIZE="6153426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:13:24" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="bc14af1fc6a9b9c9566e96db7b6812e6999641b5" CHECKSUMTYPE="SHA-1" SIZE="6153426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:13:55"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="aa511758c641e2ad2d26e7ec26de7d4b27e4289e"
-				CHECKSUMTYPE="SHA-1" SIZE="6017520">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:13:55" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="aa511758c641e2ad2d26e7ec26de7d4b27e4289e" CHECKSUMTYPE="SHA-1" SIZE="6017520">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:14:28"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="98c5dc60b0372f78c6099c24504a47df2d496b59"
-				CHECKSUMTYPE="SHA-1" SIZE="6153392">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:14:28" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="98c5dc60b0372f78c6099c24504a47df2d496b59" CHECKSUMTYPE="SHA-1" SIZE="6153392">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:15:01"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="23cc85bda9bf5db100eb584dfbdb89f81dabd7ae"
-				CHECKSUMTYPE="SHA-1" SIZE="6017527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:15:01" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="23cc85bda9bf5db100eb584dfbdb89f81dabd7ae" CHECKSUMTYPE="SHA-1" SIZE="6017527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:15:35"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="c0f11659a58e60bef513264938d2959aee5b9b7f"
-				CHECKSUMTYPE="SHA-1" SIZE="6211916">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:15:35" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="c0f11659a58e60bef513264938d2959aee5b9b7f" CHECKSUMTYPE="SHA-1" SIZE="6211916">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:16:10"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="f68e0955924877c1d9a7ec0f340a4e7f0b37507e"
-				CHECKSUMTYPE="SHA-1" SIZE="5965328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:16:10" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="f68e0955924877c1d9a7ec0f340a4e7f0b37507e" CHECKSUMTYPE="SHA-1" SIZE="5965328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:16:48"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="48ded3b72eab873cdb8070643469ee8f5d8b9d89"
-				CHECKSUMTYPE="SHA-1" SIZE="6211027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:16:48" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="48ded3b72eab873cdb8070643469ee8f5d8b9d89" CHECKSUMTYPE="SHA-1" SIZE="6211027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:17:21"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="7e97e98508bad20f75fa3ee9bb3dc108f8ee4614"
-				CHECKSUMTYPE="SHA-1" SIZE="5965325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:17:21" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="7e97e98508bad20f75fa3ee9bb3dc108f8ee4614" CHECKSUMTYPE="SHA-1" SIZE="5965325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:17:56"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="3a6a054a90c2304d74232ccb2a6813a337477a39"
-				CHECKSUMTYPE="SHA-1" SIZE="6211019">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:17:56" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="3a6a054a90c2304d74232ccb2a6813a337477a39" CHECKSUMTYPE="SHA-1" SIZE="6211019">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:18:32"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="84412c24f7a91984647add246b0a3e40628d29d3"
-				CHECKSUMTYPE="SHA-1" SIZE="5965310">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T16:18:32" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="84412c24f7a91984647add246b0a3e40628d29d3" CHECKSUMTYPE="SHA-1" SIZE="5965310">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:19:09"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="6d291f13835d182a5bb5eebfff83c5f8c06c8c60"
-				CHECKSUMTYPE="SHA-1" SIZE="6119174">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T16:19:09" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="6d291f13835d182a5bb5eebfff83c5f8c06c8c60" CHECKSUMTYPE="SHA-1" SIZE="6119174">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:19:42"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="2abff3c022fe859072de12eaa69b746b69cae8ce"
-				CHECKSUMTYPE="SHA-1" SIZE="6005801">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T16:19:42" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="2abff3c022fe859072de12eaa69b746b69cae8ce" CHECKSUMTYPE="SHA-1" SIZE="6005801">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:20:18"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="4ace4afc82a35ab2bb2ee1b5b5adb854e75995b2"
-				CHECKSUMTYPE="SHA-1" SIZE="6222697">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T16:20:18" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="4ace4afc82a35ab2bb2ee1b5b5adb854e75995b2" CHECKSUMTYPE="SHA-1" SIZE="6222697">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:20:54"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="3b77fb6d379efe57127a84ecc189259981a4c7c0"
-				CHECKSUMTYPE="SHA-1" SIZE="5937427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T16:20:54" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="3b77fb6d379efe57127a84ecc189259981a4c7c0" CHECKSUMTYPE="SHA-1" SIZE="5937427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:21:27"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="d624648f6ecfc80d9f16df43460e7abd8dddcc03"
-				CHECKSUMTYPE="SHA-1" SIZE="6153388">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T16:21:27" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="d624648f6ecfc80d9f16df43460e7abd8dddcc03" CHECKSUMTYPE="SHA-1" SIZE="6153388">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:22:02"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="cf197a40170f49591741fcd7d99a58f98edfa655"
-				CHECKSUMTYPE="SHA-1" SIZE="6096724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T16:22:02" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="cf197a40170f49591741fcd7d99a58f98edfa655" CHECKSUMTYPE="SHA-1" SIZE="6096724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:22:34"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="773da3ced95107eb1a4418aeade53340b04fcd54"
-				CHECKSUMTYPE="SHA-1" SIZE="6153425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T16:22:34" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="773da3ced95107eb1a4418aeade53340b04fcd54" CHECKSUMTYPE="SHA-1" SIZE="6153425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/delivery/bmtnabf_1903-04-01_01_0032.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:22:55" MIMETYPE="text/xml"
-				CHECKSUM="7b30d0e4dfdece33807dd2b1cae8000737b8461a" CHECKSUMTYPE="SHA-1" SIZE="4789">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:22:55" MIMETYPE="text/xml" CHECKSUM="7b30d0e4dfdece33807dd2b1cae8000737b8461a" CHECKSUMTYPE="SHA-1" SIZE="4789">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:22:55" MIMETYPE="text/xml"
-				CHECKSUM="a3f9482a89f3f2bbe537449a090174f8d5ecd9b4" CHECKSUMTYPE="SHA-1" SIZE="1718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:22:55" MIMETYPE="text/xml" CHECKSUM="a3f9482a89f3f2bbe537449a090174f8d5ecd9b4" CHECKSUMTYPE="SHA-1" SIZE="1718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:22:55" MIMETYPE="text/xml"
-				CHECKSUM="ce1185329ae0dcad8dcde2794ae74c09e544f7d9" CHECKSUMTYPE="SHA-1" SIZE="8359">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:22:55" MIMETYPE="text/xml" CHECKSUM="ce1185329ae0dcad8dcde2794ae74c09e544f7d9" CHECKSUMTYPE="SHA-1" SIZE="8359">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:22:55" MIMETYPE="text/xml"
-				CHECKSUM="f59ac5b04209c431f6a307a42f6c27757d7dc0ff" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:22:55" MIMETYPE="text/xml" CHECKSUM="f59ac5b04209c431f6a307a42f6c27757d7dc0ff" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:22:56" MIMETYPE="text/xml"
-				CHECKSUM="4e517c75e3016f23316664fddc292f010f9398d4" CHECKSUMTYPE="SHA-1"
-				SIZE="27089">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:22:56" MIMETYPE="text/xml" CHECKSUM="4e517c75e3016f23316664fddc292f010f9398d4" CHECKSUMTYPE="SHA-1" SIZE="27089">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:22:56" MIMETYPE="text/xml"
-				CHECKSUM="e57feda39160bef2dbfd6ec158834f33b727fa9a" CHECKSUMTYPE="SHA-1"
-				SIZE="57544">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:22:56" MIMETYPE="text/xml" CHECKSUM="e57feda39160bef2dbfd6ec158834f33b727fa9a" CHECKSUMTYPE="SHA-1" SIZE="57544">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:22:56" MIMETYPE="text/xml"
-				CHECKSUM="9b9a9d1cb1b67e75a4207e431823840931a2c1c7" CHECKSUMTYPE="SHA-1"
-				SIZE="44935">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:22:56" MIMETYPE="text/xml" CHECKSUM="9b9a9d1cb1b67e75a4207e431823840931a2c1c7" CHECKSUMTYPE="SHA-1" SIZE="44935">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:22:57" MIMETYPE="text/xml"
-				CHECKSUM="d1a7a829daa93fc873bf3e782bb61228ac913d32" CHECKSUMTYPE="SHA-1"
-				SIZE="68242">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:22:57" MIMETYPE="text/xml" CHECKSUM="d1a7a829daa93fc873bf3e782bb61228ac913d32" CHECKSUMTYPE="SHA-1" SIZE="68242">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:22:57" MIMETYPE="text/xml"
-				CHECKSUM="cf768fe49bef560817c9747d34eb661e45dd80bf" CHECKSUMTYPE="SHA-1" SIZE="4300">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:22:57" MIMETYPE="text/xml" CHECKSUM="cf768fe49bef560817c9747d34eb661e45dd80bf" CHECKSUMTYPE="SHA-1" SIZE="4300">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:22:57" MIMETYPE="text/xml"
-				CHECKSUM="cf2177e175669b7a03c2b5e0307166818f02152e" CHECKSUMTYPE="SHA-1"
-				SIZE="71926">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:22:57" MIMETYPE="text/xml" CHECKSUM="cf2177e175669b7a03c2b5e0307166818f02152e" CHECKSUMTYPE="SHA-1" SIZE="71926">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:22:57" MIMETYPE="text/xml"
-				CHECKSUM="b71e15dceea7a13c273c9bf9bd14b544c567f6da" CHECKSUMTYPE="SHA-1"
-				SIZE="39043">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:22:57" MIMETYPE="text/xml" CHECKSUM="b71e15dceea7a13c273c9bf9bd14b544c567f6da" CHECKSUMTYPE="SHA-1" SIZE="39043">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:22:58" MIMETYPE="text/xml"
-				CHECKSUM="ac3e67f28030f905b874a77ecad48fa94e573c39" CHECKSUMTYPE="SHA-1"
-				SIZE="66717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:22:58" MIMETYPE="text/xml" CHECKSUM="ac3e67f28030f905b874a77ecad48fa94e573c39" CHECKSUMTYPE="SHA-1" SIZE="66717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:22:58" MIMETYPE="text/xml"
-				CHECKSUM="98fdf931b8d9d7b7313efc466a3965c0109838d2" CHECKSUMTYPE="SHA-1" SIZE="3976">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:22:58" MIMETYPE="text/xml" CHECKSUM="98fdf931b8d9d7b7313efc466a3965c0109838d2" CHECKSUMTYPE="SHA-1" SIZE="3976">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:22:58" MIMETYPE="text/xml"
-				CHECKSUM="de24d52fac44c54cf9e0e34e544a6159fa1701c3" CHECKSUMTYPE="SHA-1" SIZE="2022">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:22:58" MIMETYPE="text/xml" CHECKSUM="de24d52fac44c54cf9e0e34e544a6159fa1701c3" CHECKSUMTYPE="SHA-1" SIZE="2022">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:22:59" MIMETYPE="text/xml"
-				CHECKSUM="a4025319bb3b4d3b55c2cff50039e2f2a1079963" CHECKSUMTYPE="SHA-1" SIZE="3966">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:22:59" MIMETYPE="text/xml" CHECKSUM="a4025319bb3b4d3b55c2cff50039e2f2a1079963" CHECKSUMTYPE="SHA-1" SIZE="3966">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:22:59" MIMETYPE="text/xml"
-				CHECKSUM="286ea6cef2360ed05a459a101cbc323ea6c9ba78" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:22:59" MIMETYPE="text/xml" CHECKSUM="286ea6cef2360ed05a459a101cbc323ea6c9ba78" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:22:59" MIMETYPE="text/xml"
-				CHECKSUM="bfa7623fa4f310b6d9a89a6f83c1bb1146dbf184" CHECKSUMTYPE="SHA-1" SIZE="3983">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:22:59" MIMETYPE="text/xml" CHECKSUM="bfa7623fa4f310b6d9a89a6f83c1bb1146dbf184" CHECKSUMTYPE="SHA-1" SIZE="3983">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:22:59" MIMETYPE="text/xml"
-				CHECKSUM="1ec1bdc46cd1c7be408cc1e8691c08ac2836d0ed" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:22:59" MIMETYPE="text/xml" CHECKSUM="1ec1bdc46cd1c7be408cc1e8691c08ac2836d0ed" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:23:00" MIMETYPE="text/xml"
-				CHECKSUM="699b7a6383cbca2514a3b0708acafd073c5201ab" CHECKSUMTYPE="SHA-1" SIZE="3983">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:23:00" MIMETYPE="text/xml" CHECKSUM="699b7a6383cbca2514a3b0708acafd073c5201ab" CHECKSUMTYPE="SHA-1" SIZE="3983">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:23:00" MIMETYPE="text/xml"
-				CHECKSUM="a5b5e186f9737a47fc2cd9c87a79307b4725c6d3" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:23:00" MIMETYPE="text/xml" CHECKSUM="a5b5e186f9737a47fc2cd9c87a79307b4725c6d3" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:23:00" MIMETYPE="text/xml"
-				CHECKSUM="02cf4580def56639f4b21ba9d1f51c746b4fcbe0" CHECKSUMTYPE="SHA-1" SIZE="3961">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:23:00" MIMETYPE="text/xml" CHECKSUM="02cf4580def56639f4b21ba9d1f51c746b4fcbe0" CHECKSUMTYPE="SHA-1" SIZE="3961">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:23:00" MIMETYPE="text/xml"
-				CHECKSUM="7aa728aabe198f708543a9ad6743343f55370267" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:23:00" MIMETYPE="text/xml" CHECKSUM="7aa728aabe198f708543a9ad6743343f55370267" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:23:01" MIMETYPE="text/xml"
-				CHECKSUM="4caf2c3ffc8f2d352d4941afbb963a5570cfed21" CHECKSUMTYPE="SHA-1" SIZE="4509">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:23:01" MIMETYPE="text/xml" CHECKSUM="4caf2c3ffc8f2d352d4941afbb963a5570cfed21" CHECKSUMTYPE="SHA-1" SIZE="4509">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:23:01" MIMETYPE="text/xml"
-				CHECKSUM="636fca7adccb9afe0bb7ab878740595d568ba2e8" CHECKSUMTYPE="SHA-1" SIZE="2021">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:23:01" MIMETYPE="text/xml" CHECKSUM="636fca7adccb9afe0bb7ab878740595d568ba2e8" CHECKSUMTYPE="SHA-1" SIZE="2021">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:23:01" MIMETYPE="text/xml"
-				CHECKSUM="621d81c9f7bf3bbe7f73c0ceeea0e979a9b1249f" CHECKSUMTYPE="SHA-1" SIZE="8657">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T16:23:01" MIMETYPE="text/xml" CHECKSUM="621d81c9f7bf3bbe7f73c0ceeea0e979a9b1249f" CHECKSUMTYPE="SHA-1" SIZE="8657">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:23:01" MIMETYPE="text/xml"
-				CHECKSUM="1895fcdb4c9977669432ea742574c808cb46eb5e" CHECKSUMTYPE="SHA-1"
-				SIZE="16038">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T16:23:01" MIMETYPE="text/xml" CHECKSUM="1895fcdb4c9977669432ea742574c808cb46eb5e" CHECKSUMTYPE="SHA-1" SIZE="16038">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:23:01" MIMETYPE="text/xml"
-				CHECKSUM="8c21f45af3f4b20bc3dec459a404ba1fb92d9b6a" CHECKSUMTYPE="SHA-1"
-				SIZE="75796">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T16:23:01" MIMETYPE="text/xml" CHECKSUM="8c21f45af3f4b20bc3dec459a404ba1fb92d9b6a" CHECKSUMTYPE="SHA-1" SIZE="75796">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:23:02" MIMETYPE="text/xml"
-				CHECKSUM="a41333bb60219ea106dca131f5e629f8257764d3" CHECKSUMTYPE="SHA-1"
-				SIZE="16307">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T16:23:02" MIMETYPE="text/xml" CHECKSUM="a41333bb60219ea106dca131f5e629f8257764d3" CHECKSUMTYPE="SHA-1" SIZE="16307">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:23:02" MIMETYPE="text/xml"
-				CHECKSUM="981094abf3a1e5a2a6c80ab3bef95a9431f19161" CHECKSUMTYPE="SHA-1"
-				SIZE="32041">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T16:23:02" MIMETYPE="text/xml" CHECKSUM="981094abf3a1e5a2a6c80ab3bef95a9431f19161" CHECKSUMTYPE="SHA-1" SIZE="32041">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:23:02" MIMETYPE="text/xml"
-				CHECKSUM="cd4bbe2858ff80d6452bfcc7f6edbf07052d919c" CHECKSUMTYPE="SHA-1" SIZE="9901">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T16:23:02" MIMETYPE="text/xml" CHECKSUM="cd4bbe2858ff80d6452bfcc7f6edbf07052d919c" CHECKSUMTYPE="SHA-1" SIZE="9901">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:23:02" MIMETYPE="text/xml"
-				CHECKSUM="c5f6dc5eba374693852f9bff7bb464df16809d37" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T16:23:02" MIMETYPE="text/xml" CHECKSUM="c5f6dc5eba374693852f9bff7bb464df16809d37" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:23:03" MIMETYPE="text/xml"
-				CHECKSUM="272fa34305813cd7f77b9fbc645d19d488f498c2" CHECKSUMTYPE="SHA-1" SIZE="8289">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T16:23:03" MIMETYPE="text/xml" CHECKSUM="272fa34305813cd7f77b9fbc645d19d488f498c2" CHECKSUMTYPE="SHA-1" SIZE="8289">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-01_01_0032.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:23:40" MIMETYPE="application/pdf"
-				CHECKSUM="83e3265ce3a7cddeb7d4e90c0d2eb992a05b2de0" CHECKSUMTYPE="SHA-1"
-				SIZE="8564370">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/bmtnabf_1903-04-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:23:40" MIMETYPE="application/pdf" CHECKSUM="83e3265ce3a7cddeb7d4e90c0d2eb992a05b2de0" CHECKSUMTYPE="SHA-1" SIZE="8564370">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/01_01/bmtnabf_1903-04-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3488,8 +3275,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="TextContent" ORDER="3" DMDID="c003"
-					LABEL="RODIN, MEUNIER, BARTHOLOME UND DESBOIS ÜBER DIE ZIELE DER PLASTIK">
+				<div ID="L.1.1.4" TYPE="TextContent" ORDER="3" DMDID="c003" LABEL="RODIN, MEUNIER, BARTHOLOME UND DESBOIS ÜBER DIE ZIELE DER PLASTIK">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -3513,18 +3299,12 @@
 								<div ID="L.1.1.4.3.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3565,8 +3345,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.6" TYPE="Illustration" ORDER="3" DMDID="c006"
-						LABEL="Krinolinen">
+					<div ID="L.1.1.4.6" TYPE="Illustration" ORDER="3" DMDID="c006" LABEL="Krinolinen">
 						<div ID="L.1.1.4.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
@@ -3583,8 +3362,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.7" TYPE="Illustration" ORDER="4" DMDID="c007"
-						LABEL="Kaisermühlen">
+					<div ID="L.1.1.4.7" TYPE="Illustration" ORDER="4" DMDID="c007" LABEL="Kaisermühlen">
 						<div ID="L.1.1.4.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
@@ -3658,8 +3436,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c011"
-					LABEL="Klavierunterricht">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c011" LABEL="Klavierunterricht">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
@@ -3710,8 +3487,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="Illustration" ORDER="10" DMDID="c014"
-					LABEL="Don Quichotte beim Herzog">
+				<div ID="L.1.1.11" TYPE="Illustration" ORDER="10" DMDID="c014" LABEL="Don Quichotte beim Herzog">
 					<div ID="L.1.1.11.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/04/15_01/bmtnabf_1903-04-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/04/15_01/bmtnabf_1903-04-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-04-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-04-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-04-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-04-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-04-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2266,339 +2260,168 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:32:57"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="4efabf1094b056bead34872099a418eaa38efa9e"
-				CHECKSUMTYPE="SHA-1" SIZE="6184029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:32:57" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="4efabf1094b056bead34872099a418eaa38efa9e" CHECKSUMTYPE="SHA-1" SIZE="6184029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:33:30"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="d42349d578efa022cfa6259076d43c892435df6e"
-				CHECKSUMTYPE="SHA-1" SIZE="5875129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:33:30" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="d42349d578efa022cfa6259076d43c892435df6e" CHECKSUMTYPE="SHA-1" SIZE="5875129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:34:04"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="211c35a2437fbb2bb35bd256f41b1632aa8dac2a"
-				CHECKSUMTYPE="SHA-1" SIZE="6183126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:34:04" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="211c35a2437fbb2bb35bd256f41b1632aa8dac2a" CHECKSUMTYPE="SHA-1" SIZE="6183126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:34:47"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="765d64aec3a0b3ec519a1a789b6d4e842e378390"
-				CHECKSUMTYPE="SHA-1" SIZE="6020166">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:34:47" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="765d64aec3a0b3ec519a1a789b6d4e842e378390" CHECKSUMTYPE="SHA-1" SIZE="6020166">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:35:28"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="014a3b09de06273fd95a624bc37375a08d562269"
-				CHECKSUMTYPE="SHA-1" SIZE="5940983">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:35:28" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="014a3b09de06273fd95a624bc37375a08d562269" CHECKSUMTYPE="SHA-1" SIZE="5940983">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:36:02"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="0371b0446e0c15ba8e0471829c7f338597360f68"
-				CHECKSUMTYPE="SHA-1" SIZE="5946414">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:36:02" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="0371b0446e0c15ba8e0471829c7f338597360f68" CHECKSUMTYPE="SHA-1" SIZE="5946414">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:36:39"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="03e574530c9956efb1773c962467717bd151915c"
-				CHECKSUMTYPE="SHA-1" SIZE="5940991">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:36:39" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="03e574530c9956efb1773c962467717bd151915c" CHECKSUMTYPE="SHA-1" SIZE="5940991">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:37:18"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="d3efac062efb113fca1024401b15a09315da6d6e"
-				CHECKSUMTYPE="SHA-1" SIZE="5946424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:37:18" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="d3efac062efb113fca1024401b15a09315da6d6e" CHECKSUMTYPE="SHA-1" SIZE="5946424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:37:52"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="1a47144977dfb07feb70edcbf738f6e146da856d"
-				CHECKSUMTYPE="SHA-1" SIZE="5940977">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:37:52" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="1a47144977dfb07feb70edcbf738f6e146da856d" CHECKSUMTYPE="SHA-1" SIZE="5940977">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:38:28"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="e97e341fac43cec95543121e543ba32816cfcf19"
-				CHECKSUMTYPE="SHA-1" SIZE="5947326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:38:28" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="e97e341fac43cec95543121e543ba32816cfcf19" CHECKSUMTYPE="SHA-1" SIZE="5947326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:39:02"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f37ca9bb8836f0a93103c5b876dc9c53ab83fdc6"
-				CHECKSUMTYPE="SHA-1" SIZE="5940125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:39:02" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f37ca9bb8836f0a93103c5b876dc9c53ab83fdc6" CHECKSUMTYPE="SHA-1" SIZE="5940125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:39:37"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="0921045c24a294e10f6f56f2a242c78b17e46863"
-				CHECKSUMTYPE="SHA-1" SIZE="6017509">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:39:37" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="0921045c24a294e10f6f56f2a242c78b17e46863" CHECKSUMTYPE="SHA-1" SIZE="6017509">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:40:11"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="6e90bd88c07ed841d1cbd46bb12bd579d02d02d5"
-				CHECKSUMTYPE="SHA-1" SIZE="5940126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:40:11" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="6e90bd88c07ed841d1cbd46bb12bd579d02d02d5" CHECKSUMTYPE="SHA-1" SIZE="5940126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:40:45"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="1c9a0576b6357dc020fdfdd3adc0f8c373eab4b2"
-				CHECKSUMTYPE="SHA-1" SIZE="6017521">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:40:45" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="1c9a0576b6357dc020fdfdd3adc0f8c373eab4b2" CHECKSUMTYPE="SHA-1" SIZE="6017521">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:41:19"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="0990805d5a0ff45b157fecbc14f53912b95a5734"
-				CHECKSUMTYPE="SHA-1" SIZE="5940128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:41:19" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="0990805d5a0ff45b157fecbc14f53912b95a5734" CHECKSUMTYPE="SHA-1" SIZE="5940128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:41:55"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="673b324ff1c283eaec00c252b0afa93fad88d434"
-				CHECKSUMTYPE="SHA-1" SIZE="6017523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:41:55" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="673b324ff1c283eaec00c252b0afa93fad88d434" CHECKSUMTYPE="SHA-1" SIZE="6017523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:42:27"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="6e9392351dd473719fcb71631a6104a083f89240"
-				CHECKSUMTYPE="SHA-1" SIZE="5941022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:42:27" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="6e9392351dd473719fcb71631a6104a083f89240" CHECKSUMTYPE="SHA-1" SIZE="5941022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:43:03"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="5ea90e4f17d7c291e76d8fb75fa9b64c33eac94d"
-				CHECKSUMTYPE="SHA-1" SIZE="6109328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:43:03" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="5ea90e4f17d7c291e76d8fb75fa9b64c33eac94d" CHECKSUMTYPE="SHA-1" SIZE="6109328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:43:36"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7887fc02c590c70d225898c9f8e7be7246be7431"
-				CHECKSUMTYPE="SHA-1" SIZE="5892378">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:43:36" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7887fc02c590c70d225898c9f8e7be7246be7431" CHECKSUMTYPE="SHA-1" SIZE="5892378">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:44:11"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="47c1b105a3a30f37d7b47d506d12faab0fbb1432"
-				CHECKSUMTYPE="SHA-1" SIZE="6017486">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:44:11" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="47c1b105a3a30f37d7b47d506d12faab0fbb1432" CHECKSUMTYPE="SHA-1" SIZE="6017486">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:44:47"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="0751f3523aec9014e73e4e46135874709906391e"
-				CHECKSUMTYPE="SHA-1" SIZE="5951828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:44:47" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="0751f3523aec9014e73e4e46135874709906391e" CHECKSUMTYPE="SHA-1" SIZE="5951828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:45:22"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="5aace9bab1fdad6bb0c1527c20f6677fd7074687"
-				CHECKSUMTYPE="SHA-1" SIZE="6064326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:45:22" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="5aace9bab1fdad6bb0c1527c20f6677fd7074687" CHECKSUMTYPE="SHA-1" SIZE="6064326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:45:59"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="8153251c201e9ceaba4d12a9f2fb2a9e19641c5c"
-				CHECKSUMTYPE="SHA-1" SIZE="5923025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:45:59" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="8153251c201e9ceaba4d12a9f2fb2a9e19641c5c" CHECKSUMTYPE="SHA-1" SIZE="5923025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:46:32"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="35fa94319d92a443c7514555a44ec85b95c8d02d"
-				CHECKSUMTYPE="SHA-1" SIZE="6064313">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:46:32" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="35fa94319d92a443c7514555a44ec85b95c8d02d" CHECKSUMTYPE="SHA-1" SIZE="6064313">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:47:07"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="818b5472a527aabefdb39ed908c8af2982a476a1"
-				CHECKSUMTYPE="SHA-1" SIZE="5923022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:47:07" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="818b5472a527aabefdb39ed908c8af2982a476a1" CHECKSUMTYPE="SHA-1" SIZE="5923022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:47:38"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="f6944b4d28fa117042b285e72ccf3a1533544044"
-				CHECKSUMTYPE="SHA-1" SIZE="6063387">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:47:38" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="f6944b4d28fa117042b285e72ccf3a1533544044" CHECKSUMTYPE="SHA-1" SIZE="6063387">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/delivery/bmtnabf_1903-04-15_01_0026.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:47:57" MIMETYPE="text/xml"
-				CHECKSUM="01b17a4d3a59df15121b9f83758658564c97da99" CHECKSUMTYPE="SHA-1" SIZE="4790">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:47:57" MIMETYPE="text/xml" CHECKSUM="01b17a4d3a59df15121b9f83758658564c97da99" CHECKSUMTYPE="SHA-1" SIZE="4790">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:47:57" MIMETYPE="text/xml"
-				CHECKSUM="10207d3e74d6ff88e56a97ea5413a1a741c7eb82" CHECKSUMTYPE="SHA-1" SIZE="1718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:47:57" MIMETYPE="text/xml" CHECKSUM="10207d3e74d6ff88e56a97ea5413a1a741c7eb82" CHECKSUMTYPE="SHA-1" SIZE="1718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:47:58" MIMETYPE="text/xml"
-				CHECKSUM="6397215aa8e40f4d187edc79edca8872b71cf905" CHECKSUMTYPE="SHA-1" SIZE="8527">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:47:58" MIMETYPE="text/xml" CHECKSUM="6397215aa8e40f4d187edc79edca8872b71cf905" CHECKSUMTYPE="SHA-1" SIZE="8527">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:47:58" MIMETYPE="text/xml"
-				CHECKSUM="632d66ddb86d34c11dad94487def27bcedaf2aa4" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:47:58" MIMETYPE="text/xml" CHECKSUM="632d66ddb86d34c11dad94487def27bcedaf2aa4" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:47:58" MIMETYPE="text/xml"
-				CHECKSUM="d429017597fb608770878cbdd01dbbff5e067830" CHECKSUMTYPE="SHA-1"
-				SIZE="19917">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:47:58" MIMETYPE="text/xml" CHECKSUM="d429017597fb608770878cbdd01dbbff5e067830" CHECKSUMTYPE="SHA-1" SIZE="19917">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:47:58" MIMETYPE="text/xml"
-				CHECKSUM="19de357d9dcceae721f23a4335966de8aad80db8" CHECKSUMTYPE="SHA-1"
-				SIZE="44446">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:47:58" MIMETYPE="text/xml" CHECKSUM="19de357d9dcceae721f23a4335966de8aad80db8" CHECKSUMTYPE="SHA-1" SIZE="44446">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:47:59" MIMETYPE="text/xml"
-				CHECKSUM="a1f48a06fe693d5541c6c0111a5075615f63b521" CHECKSUMTYPE="SHA-1" SIZE="4439">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:47:59" MIMETYPE="text/xml" CHECKSUM="a1f48a06fe693d5541c6c0111a5075615f63b521" CHECKSUMTYPE="SHA-1" SIZE="4439">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:47:59" MIMETYPE="text/xml"
-				CHECKSUM="e20f07e09755fe8b736b86eca84b92891186803d" CHECKSUMTYPE="SHA-1" SIZE="2009">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:47:59" MIMETYPE="text/xml" CHECKSUM="e20f07e09755fe8b736b86eca84b92891186803d" CHECKSUMTYPE="SHA-1" SIZE="2009">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:47:59" MIMETYPE="text/xml"
-				CHECKSUM="cb39390810b99b4e5b097a0c40d5d4cb9e84fa3f" CHECKSUMTYPE="SHA-1"
-				SIZE="50591">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:47:59" MIMETYPE="text/xml" CHECKSUM="cb39390810b99b4e5b097a0c40d5d4cb9e84fa3f" CHECKSUMTYPE="SHA-1" SIZE="50591">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:48:00" MIMETYPE="text/xml"
-				CHECKSUM="58cee9d341b0ec8ebdfca795a853cf74847e49f6" CHECKSUMTYPE="SHA-1"
-				SIZE="60857">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:48:00" MIMETYPE="text/xml" CHECKSUM="58cee9d341b0ec8ebdfca795a853cf74847e49f6" CHECKSUMTYPE="SHA-1" SIZE="60857">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:48:00" MIMETYPE="text/xml"
-				CHECKSUM="93f56cf0cfc39499a2d3cf9dcfda2ec98bec7ae0" CHECKSUMTYPE="SHA-1" SIZE="4296">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:48:00" MIMETYPE="text/xml" CHECKSUM="93f56cf0cfc39499a2d3cf9dcfda2ec98bec7ae0" CHECKSUMTYPE="SHA-1" SIZE="4296">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:48:00" MIMETYPE="text/xml"
-				CHECKSUM="ccb3dfac1ea05d15cbca7bf8849d138bf0e59477" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:48:00" MIMETYPE="text/xml" CHECKSUM="ccb3dfac1ea05d15cbca7bf8849d138bf0e59477" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:48:01" MIMETYPE="text/xml"
-				CHECKSUM="cafedfc08fdcea27617ad6f3530f625c4635d1bb" CHECKSUMTYPE="SHA-1"
-				SIZE="46153">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:48:01" MIMETYPE="text/xml" CHECKSUM="cafedfc08fdcea27617ad6f3530f625c4635d1bb" CHECKSUMTYPE="SHA-1" SIZE="46153">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:48:01" MIMETYPE="text/xml"
-				CHECKSUM="8cd2e28da7e3bfb6c7dee41e1c8a5cdba5708530" CHECKSUMTYPE="SHA-1"
-				SIZE="22182">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:48:01" MIMETYPE="text/xml" CHECKSUM="8cd2e28da7e3bfb6c7dee41e1c8a5cdba5708530" CHECKSUMTYPE="SHA-1" SIZE="22182">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:48:01" MIMETYPE="text/xml"
-				CHECKSUM="f1b420cdf4bfa3fd2e37c6c3905f714f50e74a74" CHECKSUMTYPE="SHA-1" SIZE="4822">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:48:01" MIMETYPE="text/xml" CHECKSUM="f1b420cdf4bfa3fd2e37c6c3905f714f50e74a74" CHECKSUMTYPE="SHA-1" SIZE="4822">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:48:02" MIMETYPE="text/xml"
-				CHECKSUM="b31610d1dcae169b617d94b6e6af88543a2c2ca2" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:48:02" MIMETYPE="text/xml" CHECKSUM="b31610d1dcae169b617d94b6e6af88543a2c2ca2" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:48:02" MIMETYPE="text/xml"
-				CHECKSUM="5e97af530a863920edebd04203d0209895b94f82" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:48:02" MIMETYPE="text/xml" CHECKSUM="5e97af530a863920edebd04203d0209895b94f82" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:48:02" MIMETYPE="text/xml"
-				CHECKSUM="66ac0ee9cb1ab14d2ae33b182d6151f6e77949e8" CHECKSUMTYPE="SHA-1" SIZE="9343">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:48:02" MIMETYPE="text/xml" CHECKSUM="66ac0ee9cb1ab14d2ae33b182d6151f6e77949e8" CHECKSUMTYPE="SHA-1" SIZE="9343">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:48:02" MIMETYPE="text/xml"
-				CHECKSUM="30d76f037d8e5e0829afad87b196e5af07ee2733" CHECKSUMTYPE="SHA-1" SIZE="8578">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:48:02" MIMETYPE="text/xml" CHECKSUM="30d76f037d8e5e0829afad87b196e5af07ee2733" CHECKSUMTYPE="SHA-1" SIZE="8578">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:48:03" MIMETYPE="text/xml"
-				CHECKSUM="63efecb5be4ad65adaaf1b3ec8f8cbfc50ad9d3b" CHECKSUMTYPE="SHA-1"
-				SIZE="20017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:48:03" MIMETYPE="text/xml" CHECKSUM="63efecb5be4ad65adaaf1b3ec8f8cbfc50ad9d3b" CHECKSUMTYPE="SHA-1" SIZE="20017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:48:03" MIMETYPE="text/xml"
-				CHECKSUM="62428c45fab3fdfc92f2b5659e33c7bc611aa9d1" CHECKSUMTYPE="SHA-1"
-				SIZE="23459">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:48:03" MIMETYPE="text/xml" CHECKSUM="62428c45fab3fdfc92f2b5659e33c7bc611aa9d1" CHECKSUMTYPE="SHA-1" SIZE="23459">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:48:03" MIMETYPE="text/xml"
-				CHECKSUM="3dd0dddcc529aa0188a36e648d64b1d63848290b" CHECKSUMTYPE="SHA-1"
-				SIZE="16620">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:48:03" MIMETYPE="text/xml" CHECKSUM="3dd0dddcc529aa0188a36e648d64b1d63848290b" CHECKSUMTYPE="SHA-1" SIZE="16620">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:48:04" MIMETYPE="text/xml"
-				CHECKSUM="d0e7484c60d42d40866f845f2945ecc87306efa2" CHECKSUMTYPE="SHA-1"
-				SIZE="20890">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:48:04" MIMETYPE="text/xml" CHECKSUM="d0e7484c60d42d40866f845f2945ecc87306efa2" CHECKSUMTYPE="SHA-1" SIZE="20890">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:48:04" MIMETYPE="text/xml"
-				CHECKSUM="6f8aa65317ea28a396c53d1bd3a962b675a14064" CHECKSUMTYPE="SHA-1"
-				SIZE="13256">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:48:04" MIMETYPE="text/xml" CHECKSUM="6f8aa65317ea28a396c53d1bd3a962b675a14064" CHECKSUMTYPE="SHA-1" SIZE="13256">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:48:04" MIMETYPE="text/xml"
-				CHECKSUM="2d17684bcbe2aa0966f66e45b69084df13991762" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:48:04" MIMETYPE="text/xml" CHECKSUM="2d17684bcbe2aa0966f66e45b69084df13991762" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:48:04" MIMETYPE="text/xml"
-				CHECKSUM="6620185e33947b06109ec73b5fc06874c18cd3f3" CHECKSUMTYPE="SHA-1" SIZE="7782">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:48:04" MIMETYPE="text/xml" CHECKSUM="6620185e33947b06109ec73b5fc06874c18cd3f3" CHECKSUMTYPE="SHA-1" SIZE="7782">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-04-15_01_0026.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:48:34" MIMETYPE="application/pdf"
-				CHECKSUM="e4903f011d0b708d798b263084fcd8f4157f7150" CHECKSUMTYPE="SHA-1"
-				SIZE="7299898">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/bmtnabf_1903-04-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:48:34" MIMETYPE="application/pdf" CHECKSUM="e4903f011d0b708d798b263084fcd8f4157f7150" CHECKSUMTYPE="SHA-1" SIZE="7299898">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/04/15_01/bmtnabf_1903-04-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2873,8 +2696,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="TextContent" ORDER="3" DMDID="c003"
-					LABEL="XVII. AUSSTELLUNG DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
+				<div ID="L.1.1.4" TYPE="TextContent" ORDER="3" DMDID="c003" LABEL="XVII. AUSSTELLUNG DER VEREINIGUNG BILDENDER KÜNSTLER ÖSTERREICHS">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -2893,30 +2715,18 @@
 								<div ID="L.1.1.4.2.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -2940,8 +2750,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.4" TYPE="Illustration" ORDER="2" DMDID="c005"
-						LABEL="Original-Holzschnitt">
+					<div ID="L.1.1.4.4" TYPE="Illustration" ORDER="2" DMDID="c005" LABEL="Original-Holzschnitt">
 						<div ID="L.1.1.4.4.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00006"/>
@@ -2958,8 +2767,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.5" TYPE="Illustration" ORDER="3" DMDID="c006"
-						LABEL="Original-Holzschnitt">
+					<div ID="L.1.1.4.5" TYPE="Illustration" ORDER="3" DMDID="c006" LABEL="Original-Holzschnitt">
 						<div ID="L.1.1.4.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00005"/>
@@ -2976,8 +2784,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.6" TYPE="Illustration" ORDER="4" DMDID="c007"
-						LABEL="Original-Holzschnitt">
+					<div ID="L.1.1.4.6" TYPE="Illustration" ORDER="4" DMDID="c007" LABEL="Original-Holzschnitt">
 						<div ID="L.1.1.4.6.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00005"/>
@@ -2994,8 +2801,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.7" TYPE="Illustration" ORDER="5" DMDID="c008"
-						LABEL="Buchschmuck">
+					<div ID="L.1.1.4.7" TYPE="Illustration" ORDER="5" DMDID="c008" LABEL="Buchschmuck">
 						<div ID="L.1.1.4.7.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
@@ -3020,8 +2826,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c010"
-					LABEL="ORIGINAL-HOLZSCHNITT">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c010" LABEL="ORIGINAL-HOLZSCHNITT">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -3038,8 +2843,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c011"
-					LABEL="ORIGINAL-HOLZSCHNITT">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c011" LABEL="ORIGINAL-HOLZSCHNITT">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -3056,8 +2860,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c012"
-					LABEL="Original-Holzschnitt in 3 Platten">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c012" LABEL="Original-Holzschnitt in 3 Platten">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/05/01_01/bmtnabf_1903-05-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/05/01_01/bmtnabf_1903-05-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-05-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-05-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-05-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-05-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-05-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2293,371 +2287,180 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:38:18"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="96cd94905d3dec2f4e78b2eedc0951a1fadc252b"
-				CHECKSUMTYPE="SHA-1" SIZE="6130912">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:38:18" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="96cd94905d3dec2f4e78b2eedc0951a1fadc252b" CHECKSUMTYPE="SHA-1" SIZE="6130912">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:38:52"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="83f555837175b3d842da1026980257be3227ee1a"
-				CHECKSUMTYPE="SHA-1" SIZE="5890613">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:38:52" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="83f555837175b3d842da1026980257be3227ee1a" CHECKSUMTYPE="SHA-1" SIZE="5890613">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:39:23"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="a2f7bb9bf5145de2873c1dd15d69eaae8c04e82e"
-				CHECKSUMTYPE="SHA-1" SIZE="6130900">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:39:23" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="a2f7bb9bf5145de2873c1dd15d69eaae8c04e82e" CHECKSUMTYPE="SHA-1" SIZE="6130900">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:40:05"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="d03974f1bb381311b1e1ba7aad6ba5ab9991492c"
-				CHECKSUMTYPE="SHA-1" SIZE="5890626">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:40:05" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="d03974f1bb381311b1e1ba7aad6ba5ab9991492c" CHECKSUMTYPE="SHA-1" SIZE="5890626">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:40:45"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="7497b1bafe7530d71752f0309a4966498faef816"
-				CHECKSUMTYPE="SHA-1" SIZE="5923026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:40:45" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="7497b1bafe7530d71752f0309a4966498faef816" CHECKSUMTYPE="SHA-1" SIZE="5923026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:41:20"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="a2258060ec3066a72521fe428eb79b5b3251cbf7"
-				CHECKSUMTYPE="SHA-1" SIZE="5992324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:41:20" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="a2258060ec3066a72521fe428eb79b5b3251cbf7" CHECKSUMTYPE="SHA-1" SIZE="5992324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:41:55"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="b7755f34686d0161891913e2f57124f3a2fb6af6"
-				CHECKSUMTYPE="SHA-1" SIZE="5957220">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:41:55" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="b7755f34686d0161891913e2f57124f3a2fb6af6" CHECKSUMTYPE="SHA-1" SIZE="5957220">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:42:29"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="56935acbb25a33a6516ccc00005d11d7e9f3edab"
-				CHECKSUMTYPE="SHA-1" SIZE="5992315">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:42:29" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="56935acbb25a33a6516ccc00005d11d7e9f3edab" CHECKSUMTYPE="SHA-1" SIZE="5992315">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:43:03"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="43a97c0c2e373167bb4b23f477a6842016b3e838"
-				CHECKSUMTYPE="SHA-1" SIZE="5957223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:43:03" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="43a97c0c2e373167bb4b23f477a6842016b3e838" CHECKSUMTYPE="SHA-1" SIZE="5957223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:43:37"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="a176103b345192c52b2f00de0600dc8cd0b690ff"
-				CHECKSUMTYPE="SHA-1" SIZE="5992325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:43:37" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="a176103b345192c52b2f00de0600dc8cd0b690ff" CHECKSUMTYPE="SHA-1" SIZE="5992325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:44:11"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="db52fbc9da9849f9ca6db301d04f0c4b4ea4adc2"
-				CHECKSUMTYPE="SHA-1" SIZE="5968919">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:44:11" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="db52fbc9da9849f9ca6db301d04f0c4b4ea4adc2" CHECKSUMTYPE="SHA-1" SIZE="5968919">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:44:46"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="ebfba2bf5bb5c1d2ea1712eaea117ccb6f321c69"
-				CHECKSUMTYPE="SHA-1" SIZE="5992318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:44:46" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="ebfba2bf5bb5c1d2ea1712eaea117ccb6f321c69" CHECKSUMTYPE="SHA-1" SIZE="5992318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:45:21"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="c0c478cff13203a06e3b415ee79612012e76945f"
-				CHECKSUMTYPE="SHA-1" SIZE="5923926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:45:21" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="c0c478cff13203a06e3b415ee79612012e76945f" CHECKSUMTYPE="SHA-1" SIZE="5923926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:45:59"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="d3374cb961d889e52acf5021b491f756675a73b0"
-				CHECKSUMTYPE="SHA-1" SIZE="6031929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:45:59" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="d3374cb961d889e52acf5021b491f756675a73b0" CHECKSUMTYPE="SHA-1" SIZE="6031929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:46:33"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="8ce5a244b795cf9aca85d2b85b84084e9fc54235"
-				CHECKSUMTYPE="SHA-1" SIZE="5881624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:46:33" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="8ce5a244b795cf9aca85d2b85b84084e9fc54235" CHECKSUMTYPE="SHA-1" SIZE="5881624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:47:07"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="180fd94ff09101d8f8d8eb508a76b57ea9721636"
-				CHECKSUMTYPE="SHA-1" SIZE="6088625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:47:07" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="180fd94ff09101d8f8d8eb508a76b57ea9721636" CHECKSUMTYPE="SHA-1" SIZE="6088625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:47:41"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="3e957b22c927864acb885e741c77f6266a633104"
-				CHECKSUMTYPE="SHA-1" SIZE="5882519">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:47:41" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="3e957b22c927864acb885e741c77f6266a633104" CHECKSUMTYPE="SHA-1" SIZE="5882519">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:48:15"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="aa660c0e7a790d7727744207e1a2c934ea9a0de7"
-				CHECKSUMTYPE="SHA-1" SIZE="6088622">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:48:15" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="aa660c0e7a790d7727744207e1a2c934ea9a0de7" CHECKSUMTYPE="SHA-1" SIZE="6088622">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:48:50"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="8dde60c886859ff0eeaf07aaf0933894c4a6546f"
-				CHECKSUMTYPE="SHA-1" SIZE="5905004">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:48:50" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="8dde60c886859ff0eeaf07aaf0933894c4a6546f" CHECKSUMTYPE="SHA-1" SIZE="5905004">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:49:22"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="8e3292e9886f20a36fb43096d1ffc3d3f517341b"
-				CHECKSUMTYPE="SHA-1" SIZE="6088628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:49:22" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="8e3292e9886f20a36fb43096d1ffc3d3f517341b" CHECKSUMTYPE="SHA-1" SIZE="6088628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:49:56"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="43a1dec438b3749664f0bb07f9ea81a2d469058c"
-				CHECKSUMTYPE="SHA-1" SIZE="5905027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:49:56" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="43a1dec438b3749664f0bb07f9ea81a2d469058c" CHECKSUMTYPE="SHA-1" SIZE="5905027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:50:33"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="1bfad9ad7b7e42588700fb004b57fba09e2a34b5"
-				CHECKSUMTYPE="SHA-1" SIZE="6088602">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:50:33" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="1bfad9ad7b7e42588700fb004b57fba09e2a34b5" CHECKSUMTYPE="SHA-1" SIZE="6088602">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:51:08"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="b098b03c07610c91543ff28750191456abcf136c"
-				CHECKSUMTYPE="SHA-1" SIZE="5904105">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:51:08" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="b098b03c07610c91543ff28750191456abcf136c" CHECKSUMTYPE="SHA-1" SIZE="5904105">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:51:43"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="9c56a65af0e72717678a6eb3aed9dd0518163443"
-				CHECKSUMTYPE="SHA-1" SIZE="6089507">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:51:43" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="9c56a65af0e72717678a6eb3aed9dd0518163443" CHECKSUMTYPE="SHA-1" SIZE="6089507">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:52:17"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="351ece3cd0698c02d2f3f8ec277717a76bd1b5b7"
-				CHECKSUMTYPE="SHA-1" SIZE="5905025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T19:52:17" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="351ece3cd0698c02d2f3f8ec277717a76bd1b5b7" CHECKSUMTYPE="SHA-1" SIZE="5905025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:52:55"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="4e10e90064d5b363d955604ce1c48a7c6e8360b1"
-				CHECKSUMTYPE="SHA-1" SIZE="6089449">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T19:52:55" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="4e10e90064d5b363d955604ce1c48a7c6e8360b1" CHECKSUMTYPE="SHA-1" SIZE="6089449">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:53:28"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="f5f6182a6f771541341536d94b53c9bd83b3fa78"
-				CHECKSUMTYPE="SHA-1" SIZE="5905906">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T19:53:28" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="f5f6182a6f771541341536d94b53c9bd83b3fa78" CHECKSUMTYPE="SHA-1" SIZE="5905906">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:54:09"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="d802577d98e1f86b48467efad04e1ee8c24671ef"
-				CHECKSUMTYPE="SHA-1" SIZE="6089519">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T19:54:09" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="d802577d98e1f86b48467efad04e1ee8c24671ef" CHECKSUMTYPE="SHA-1" SIZE="6089519">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/delivery/bmtnabf_1903-05-01_01_0028.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:54:28" MIMETYPE="text/xml"
-				CHECKSUM="d45715823d9459fcb72aa87f7756010fda36b63d" CHECKSUMTYPE="SHA-1" SIZE="4719">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T19:54:28" MIMETYPE="text/xml" CHECKSUM="d45715823d9459fcb72aa87f7756010fda36b63d" CHECKSUMTYPE="SHA-1" SIZE="4719">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:54:28" MIMETYPE="text/xml"
-				CHECKSUM="3c1311ab219041c62f1b5d75973144dec0180271" CHECKSUMTYPE="SHA-1" SIZE="1718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T19:54:28" MIMETYPE="text/xml" CHECKSUM="3c1311ab219041c62f1b5d75973144dec0180271" CHECKSUMTYPE="SHA-1" SIZE="1718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:54:29" MIMETYPE="text/xml"
-				CHECKSUM="e84b871bbcd74bc57dd16d1010911644cdf5519b" CHECKSUMTYPE="SHA-1" SIZE="8283">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T19:54:29" MIMETYPE="text/xml" CHECKSUM="e84b871bbcd74bc57dd16d1010911644cdf5519b" CHECKSUMTYPE="SHA-1" SIZE="8283">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:54:29" MIMETYPE="text/xml"
-				CHECKSUM="2d497c538857501d57b6082f3fde64d8d08d6cfa" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T19:54:29" MIMETYPE="text/xml" CHECKSUM="2d497c538857501d57b6082f3fde64d8d08d6cfa" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:54:29" MIMETYPE="text/xml"
-				CHECKSUM="b8198f42bd9a7fdd59f360852b51fec213ecef70" CHECKSUMTYPE="SHA-1"
-				SIZE="54669">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T19:54:29" MIMETYPE="text/xml" CHECKSUM="b8198f42bd9a7fdd59f360852b51fec213ecef70" CHECKSUMTYPE="SHA-1" SIZE="54669">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:54:29" MIMETYPE="text/xml"
-				CHECKSUM="54fd014e46799d17a1d36269897c5b36082ebcd3" CHECKSUMTYPE="SHA-1"
-				SIZE="71980">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T19:54:29" MIMETYPE="text/xml" CHECKSUM="54fd014e46799d17a1d36269897c5b36082ebcd3" CHECKSUMTYPE="SHA-1" SIZE="71980">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:54:30" MIMETYPE="text/xml"
-				CHECKSUM="2765af2ab86ecc25bd4435ab919b1bdfeb9c0567" CHECKSUMTYPE="SHA-1"
-				SIZE="71318">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T19:54:30" MIMETYPE="text/xml" CHECKSUM="2765af2ab86ecc25bd4435ab919b1bdfeb9c0567" CHECKSUMTYPE="SHA-1" SIZE="71318">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:54:30" MIMETYPE="text/xml"
-				CHECKSUM="8c1687bacbc746f03c068d37e06b3c8639fcce9b" CHECKSUMTYPE="SHA-1"
-				SIZE="73479">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T19:54:30" MIMETYPE="text/xml" CHECKSUM="8c1687bacbc746f03c068d37e06b3c8639fcce9b" CHECKSUMTYPE="SHA-1" SIZE="73479">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:54:30" MIMETYPE="text/xml"
-				CHECKSUM="444f4c0b41547425f811f1b19294994b99b1db9e" CHECKSUMTYPE="SHA-1"
-				SIZE="70387">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T19:54:30" MIMETYPE="text/xml" CHECKSUM="444f4c0b41547425f811f1b19294994b99b1db9e" CHECKSUMTYPE="SHA-1" SIZE="70387">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:54:30" MIMETYPE="text/xml"
-				CHECKSUM="8445efac37b5461dbc36c02c72d78540e8ebf449" CHECKSUMTYPE="SHA-1"
-				SIZE="70471">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T19:54:30" MIMETYPE="text/xml" CHECKSUM="8445efac37b5461dbc36c02c72d78540e8ebf449" CHECKSUMTYPE="SHA-1" SIZE="70471">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:54:31" MIMETYPE="text/xml"
-				CHECKSUM="39d35c353d3a0d160ee089080cae06bc238559f3" CHECKSUMTYPE="SHA-1"
-				SIZE="96472">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T19:54:31" MIMETYPE="text/xml" CHECKSUM="39d35c353d3a0d160ee089080cae06bc238559f3" CHECKSUMTYPE="SHA-1" SIZE="96472">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:54:31" MIMETYPE="text/xml"
-				CHECKSUM="0b3ef8a2ecbf6efcde8571030eee21fecd1c33b5" CHECKSUMTYPE="SHA-1"
-				SIZE="84251">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T19:54:31" MIMETYPE="text/xml" CHECKSUM="0b3ef8a2ecbf6efcde8571030eee21fecd1c33b5" CHECKSUMTYPE="SHA-1" SIZE="84251">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:54:31" MIMETYPE="text/xml"
-				CHECKSUM="69675eb5b32e03ffb5c7fea33e812a15b5fb967e" CHECKSUMTYPE="SHA-1"
-				SIZE="78028">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T19:54:31" MIMETYPE="text/xml" CHECKSUM="69675eb5b32e03ffb5c7fea33e812a15b5fb967e" CHECKSUMTYPE="SHA-1" SIZE="78028">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:54:32" MIMETYPE="text/xml"
-				CHECKSUM="e46199eaf02f6d2c414afe9807e007b2d7afc038" CHECKSUMTYPE="SHA-1"
-				SIZE="75211">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T19:54:32" MIMETYPE="text/xml" CHECKSUM="e46199eaf02f6d2c414afe9807e007b2d7afc038" CHECKSUMTYPE="SHA-1" SIZE="75211">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:54:32" MIMETYPE="text/xml"
-				CHECKSUM="793686c19df8f79f2f824effa0da24ce595f7f23" CHECKSUMTYPE="SHA-1"
-				SIZE="78969">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T19:54:32" MIMETYPE="text/xml" CHECKSUM="793686c19df8f79f2f824effa0da24ce595f7f23" CHECKSUMTYPE="SHA-1" SIZE="78969">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:54:32" MIMETYPE="text/xml"
-				CHECKSUM="9ef917a2b80488f3c81b77bfc8dfb6bc4090aa97" CHECKSUMTYPE="SHA-1"
-				SIZE="71622">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T19:54:32" MIMETYPE="text/xml" CHECKSUM="9ef917a2b80488f3c81b77bfc8dfb6bc4090aa97" CHECKSUMTYPE="SHA-1" SIZE="71622">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:54:33" MIMETYPE="text/xml"
-				CHECKSUM="f121b0d058e5ccda383c3c39caefaa8e401fa132" CHECKSUMTYPE="SHA-1"
-				SIZE="66978">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T19:54:33" MIMETYPE="text/xml" CHECKSUM="f121b0d058e5ccda383c3c39caefaa8e401fa132" CHECKSUMTYPE="SHA-1" SIZE="66978">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:54:33" MIMETYPE="text/xml"
-				CHECKSUM="9c8d4c606a254633cca44e8b0a7486f7533fbffa" CHECKSUMTYPE="SHA-1"
-				SIZE="76958">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T19:54:33" MIMETYPE="text/xml" CHECKSUM="9c8d4c606a254633cca44e8b0a7486f7533fbffa" CHECKSUMTYPE="SHA-1" SIZE="76958">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:54:33" MIMETYPE="text/xml"
-				CHECKSUM="80895828f9817dee97cbf1d971598d10dc5882be" CHECKSUMTYPE="SHA-1"
-				SIZE="46510">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T19:54:33" MIMETYPE="text/xml" CHECKSUM="80895828f9817dee97cbf1d971598d10dc5882be" CHECKSUMTYPE="SHA-1" SIZE="46510">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:54:34" MIMETYPE="text/xml"
-				CHECKSUM="515c02dc4d05d32389b75c21576cd64257a9e972" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T19:54:34" MIMETYPE="text/xml" CHECKSUM="515c02dc4d05d32389b75c21576cd64257a9e972" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:54:34" MIMETYPE="text/xml"
-				CHECKSUM="5bd4fe6695aa904cbfc5e82ebaadbedcda0799bc" CHECKSUMTYPE="SHA-1" SIZE="9508">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T19:54:34" MIMETYPE="text/xml" CHECKSUM="5bd4fe6695aa904cbfc5e82ebaadbedcda0799bc" CHECKSUMTYPE="SHA-1" SIZE="9508">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:54:34" MIMETYPE="text/xml"
-				CHECKSUM="0482152491144c30d691760b60a1a34cd1b436f6" CHECKSUMTYPE="SHA-1"
-				SIZE="21785">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T19:54:34" MIMETYPE="text/xml" CHECKSUM="0482152491144c30d691760b60a1a34cd1b436f6" CHECKSUMTYPE="SHA-1" SIZE="21785">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:54:34" MIMETYPE="text/xml"
-				CHECKSUM="973a5b2453abf18b7085743ffc7d62bd3f271a9a" CHECKSUMTYPE="SHA-1"
-				SIZE="21826">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T19:54:34" MIMETYPE="text/xml" CHECKSUM="973a5b2453abf18b7085743ffc7d62bd3f271a9a" CHECKSUMTYPE="SHA-1" SIZE="21826">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:54:35" MIMETYPE="text/xml"
-				CHECKSUM="079743c68a093a36c4e9346eeddceda52e78036e" CHECKSUMTYPE="SHA-1"
-				SIZE="16953">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T19:54:35" MIMETYPE="text/xml" CHECKSUM="079743c68a093a36c4e9346eeddceda52e78036e" CHECKSUMTYPE="SHA-1" SIZE="16953">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:54:35" MIMETYPE="text/xml"
-				CHECKSUM="bdcb9a62ca02ef6e5e5ea9d7242b31f96a483ba5" CHECKSUMTYPE="SHA-1"
-				SIZE="25520">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T19:54:35" MIMETYPE="text/xml" CHECKSUM="bdcb9a62ca02ef6e5e5ea9d7242b31f96a483ba5" CHECKSUMTYPE="SHA-1" SIZE="25520">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:54:35" MIMETYPE="text/xml"
-				CHECKSUM="145d2cb52504637bae0c5d438924dd010a4f45dc" CHECKSUMTYPE="SHA-1" SIZE="8616">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T19:54:35" MIMETYPE="text/xml" CHECKSUM="145d2cb52504637bae0c5d438924dd010a4f45dc" CHECKSUMTYPE="SHA-1" SIZE="8616">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:54:35" MIMETYPE="text/xml"
-				CHECKSUM="6484d38b18a1fc0feaa497690cbd425ecf064ff8" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T19:54:35" MIMETYPE="text/xml" CHECKSUM="6484d38b18a1fc0feaa497690cbd425ecf064ff8" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:54:36" MIMETYPE="text/xml"
-				CHECKSUM="a3670ac9f30737edef935677beb7abfc7fbcb64b" CHECKSUMTYPE="SHA-1" SIZE="8031">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T19:54:36" MIMETYPE="text/xml" CHECKSUM="a3670ac9f30737edef935677beb7abfc7fbcb64b" CHECKSUMTYPE="SHA-1" SIZE="8031">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-01_01_0028.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:55:20" MIMETYPE="application/pdf"
-				CHECKSUM="bda2e89fd61d99dd7758aed7833b60a04a01bc6c" CHECKSUMTYPE="SHA-1"
-				SIZE="8342996">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/bmtnabf_1903-05-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T19:55:20" MIMETYPE="application/pdf" CHECKSUM="bda2e89fd61d99dd7758aed7833b60a04a01bc6c" CHECKSUMTYPE="SHA-1" SIZE="8342996">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/01_01/bmtnabf_1903-05-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2965,38 +2768,22 @@
 								<div ID="L.1.1.4.3.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3216,8 +3003,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.4.5" TYPE="Illustration" ORDER="1" DMDID="c005"
-						LABEL="Schlußstück">
+					<div ID="L.1.1.4.5" TYPE="Illustration" ORDER="1" DMDID="c005" LABEL="Schlußstück">
 						<div ID="L.1.1.4.5.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_CB00001"/>
@@ -3263,8 +3049,7 @@
 							<div ID="L.1.1.6.1.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.6.1.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00001"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_TB00001"/>
 									</fptr>
 								</div>
 							</div>

--- a/metadata/periodicals/bmtnabf/issues/1903/05/15_01/bmtnabf_1903-05-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/05/15_01/bmtnabf_1903-05-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-05-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-05-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-05-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-05-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-05-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2209,332 +2203,168 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:47:55"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="c04309ea7ff839a1c2f07cf848fbc63e6e533f52"
-				CHECKSUMTYPE="SHA-1" SIZE="6115616">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:47:55" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="c04309ea7ff839a1c2f07cf848fbc63e6e533f52" CHECKSUMTYPE="SHA-1" SIZE="6115616">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:48:26"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="9b8fdc83252404d635dee5cc1671cb16b5144c39"
-				CHECKSUMTYPE="SHA-1" SIZE="6090385">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:48:26" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="9b8fdc83252404d635dee5cc1671cb16b5144c39" CHECKSUMTYPE="SHA-1" SIZE="6090385">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:48:58"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="01cd69513fea359a4be4ed704fbf007ff2256caf"
-				CHECKSUMTYPE="SHA-1" SIZE="6228103">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:48:58" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="01cd69513fea359a4be4ed704fbf007ff2256caf" CHECKSUMTYPE="SHA-1" SIZE="6228103">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:49:31"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="d08191ce269e625cc379e7f3ea21293316fb97a3"
-				CHECKSUMTYPE="SHA-1" SIZE="6091318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:49:31" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="d08191ce269e625cc379e7f3ea21293316fb97a3" CHECKSUMTYPE="SHA-1" SIZE="6091318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:50:05"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="d4f7337f785072880802f65de8bfbac420b59eae"
-				CHECKSUMTYPE="SHA-1" SIZE="6228126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:50:05" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="d4f7337f785072880802f65de8bfbac420b59eae" CHECKSUMTYPE="SHA-1" SIZE="6228126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:50:37"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="e4a9f046593491460c202ffb6cb7052eff6b80ca"
-				CHECKSUMTYPE="SHA-1" SIZE="6092226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:50:37" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="e4a9f046593491460c202ffb6cb7052eff6b80ca" CHECKSUMTYPE="SHA-1" SIZE="6092226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:51:06"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="964ffffbb9b6cec3a14a145f19baef6ed2314f32"
-				CHECKSUMTYPE="SHA-1" SIZE="6085005">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:51:06" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="964ffffbb9b6cec3a14a145f19baef6ed2314f32" CHECKSUMTYPE="SHA-1" SIZE="6085005">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:51:36"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="77f7a67556cefbce01b9ba538913ec27720e400a"
-				CHECKSUMTYPE="SHA-1" SIZE="6091318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:51:36" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="77f7a67556cefbce01b9ba538913ec27720e400a" CHECKSUMTYPE="SHA-1" SIZE="6091318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:52:05"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="e0a91f8a8c988f7f98fcff6782e7fdcd4a8a4ce4"
-				CHECKSUMTYPE="SHA-1" SIZE="6085025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:52:05" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="e0a91f8a8c988f7f98fcff6782e7fdcd4a8a4ce4" CHECKSUMTYPE="SHA-1" SIZE="6085025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:52:34"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="7967a9f8a4ee3d20b06e494d744de08954bcdec3"
-				CHECKSUMTYPE="SHA-1" SIZE="6091304">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:52:34" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="7967a9f8a4ee3d20b06e494d744de08954bcdec3" CHECKSUMTYPE="SHA-1" SIZE="6091304">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:53:05"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="53a202116fa2bb8c13b26743fee3db1df3cf8d4c"
-				CHECKSUMTYPE="SHA-1" SIZE="6085026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:53:05" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="53a202116fa2bb8c13b26743fee3db1df3cf8d4c" CHECKSUMTYPE="SHA-1" SIZE="6085026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:53:39"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="fc50a10ba23cfa674fa2a548e090ec30c58b010a"
-				CHECKSUMTYPE="SHA-1" SIZE="6091322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:53:39" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="fc50a10ba23cfa674fa2a548e090ec30c58b010a" CHECKSUMTYPE="SHA-1" SIZE="6091322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:54:09"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="b521d41a3359f9719a19aeccb1fa97070ac6731f"
-				CHECKSUMTYPE="SHA-1" SIZE="6083224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:54:09" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="b521d41a3359f9719a19aeccb1fa97070ac6731f" CHECKSUMTYPE="SHA-1" SIZE="6083224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:54:39"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="00617e46589dc429d350464e1d7df563fe5ab49e"
-				CHECKSUMTYPE="SHA-1" SIZE="6149813">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:54:39" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="00617e46589dc429d350464e1d7df563fe5ab49e" CHECKSUMTYPE="SHA-1" SIZE="6149813">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:55:09"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="eff164b1730b2b0c01082d20f3fde6b9257c6a21"
-				CHECKSUMTYPE="SHA-1" SIZE="6083218">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T19:55:09" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="eff164b1730b2b0c01082d20f3fde6b9257c6a21" CHECKSUMTYPE="SHA-1" SIZE="6083218">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:55:39"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="65781fa2603acdb25a0213e7778265eab4c03278"
-				CHECKSUMTYPE="SHA-1" SIZE="6148925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T19:55:39" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="65781fa2603acdb25a0213e7778265eab4c03278" CHECKSUMTYPE="SHA-1" SIZE="6148925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:56:11"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="3537ccddb9e68043ec276ae75a381782b8e3acb9"
-				CHECKSUMTYPE="SHA-1" SIZE="6083221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T19:56:11" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="3537ccddb9e68043ec276ae75a381782b8e3acb9" CHECKSUMTYPE="SHA-1" SIZE="6083221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:56:41"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="e7e281199fb74a240938e98e9205689df7e5313e"
-				CHECKSUMTYPE="SHA-1" SIZE="6194800">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T19:56:41" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="e7e281199fb74a240938e98e9205689df7e5313e" CHECKSUMTYPE="SHA-1" SIZE="6194800">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:57:15"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="a9375cdb354e808d07e36f7282da86173ce35678"
-				CHECKSUMTYPE="SHA-1" SIZE="6027398">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T19:57:15" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="a9375cdb354e808d07e36f7282da86173ce35678" CHECKSUMTYPE="SHA-1" SIZE="6027398">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:57:49"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="4683a0a59301d2997298e29200391bc1bd15d9b5"
-				CHECKSUMTYPE="SHA-1" SIZE="6194829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T19:57:49" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="4683a0a59301d2997298e29200391bc1bd15d9b5" CHECKSUMTYPE="SHA-1" SIZE="6194829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:58:20"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="d0a0dca120de7d91f508f64b56feff19fb01ec24"
-				CHECKSUMTYPE="SHA-1" SIZE="5967121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T19:58:20" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="d0a0dca120de7d91f508f64b56feff19fb01ec24" CHECKSUMTYPE="SHA-1" SIZE="5967121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:58:53"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="78a1d9da595c06658e58fcadc11a3e378f78f7ad"
-				CHECKSUMTYPE="SHA-1" SIZE="6242529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T19:58:53" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="78a1d9da595c06658e58fcadc11a3e378f78f7ad" CHECKSUMTYPE="SHA-1" SIZE="6242529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:59:25"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="5d8e9a6ad6e2d403ad3bd426929181c3e598a887"
-				CHECKSUMTYPE="SHA-1" SIZE="5938302">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T19:59:25" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="5d8e9a6ad6e2d403ad3bd426929181c3e598a887" CHECKSUMTYPE="SHA-1" SIZE="5938302">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:59:55"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="c01fdb304c0e54beb712dd9e79016e8016defafb"
-				CHECKSUMTYPE="SHA-1" SIZE="6183105">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T19:59:55" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="c01fdb304c0e54beb712dd9e79016e8016defafb" CHECKSUMTYPE="SHA-1" SIZE="6183105">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:00:27"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="fc9499b0079bbf97dd3be0354650c0435b32c22e"
-				CHECKSUMTYPE="SHA-1" SIZE="5969825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:00:27" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="fc9499b0079bbf97dd3be0354650c0435b32c22e" CHECKSUMTYPE="SHA-1" SIZE="5969825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:01:01"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ddab09ebcb2178e996b9dbcd564830e2a278e29c"
-				CHECKSUMTYPE="SHA-1" SIZE="6139923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:01:01" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ddab09ebcb2178e996b9dbcd564830e2a278e29c" CHECKSUMTYPE="SHA-1" SIZE="6139923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/delivery/bmtnabf_1903-05-15_01_0026.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:01:18" MIMETYPE="text/xml"
-				CHECKSUM="3c2260c01c9b4bff5d6b42a0c398392d285032bd" CHECKSUMTYPE="SHA-1" SIZE="4776">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:01:18" MIMETYPE="text/xml" CHECKSUM="3c2260c01c9b4bff5d6b42a0c398392d285032bd" CHECKSUMTYPE="SHA-1" SIZE="4776">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:01:18" MIMETYPE="text/xml"
-				CHECKSUM="17e290da86e102184a07665ac3f1a1188c30c3c0" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:01:18" MIMETYPE="text/xml" CHECKSUM="17e290da86e102184a07665ac3f1a1188c30c3c0" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:01:19" MIMETYPE="text/xml"
-				CHECKSUM="8bb441983f05add636a028fba524167b689338bf" CHECKSUMTYPE="SHA-1" SIZE="9524">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:01:19" MIMETYPE="text/xml" CHECKSUM="8bb441983f05add636a028fba524167b689338bf" CHECKSUMTYPE="SHA-1" SIZE="9524">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:01:19" MIMETYPE="text/xml"
-				CHECKSUM="843a1abfadd6ad4dfbb4cca95091297b0fa11297" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:01:19" MIMETYPE="text/xml" CHECKSUM="843a1abfadd6ad4dfbb4cca95091297b0fa11297" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:01:19" MIMETYPE="text/xml"
-				CHECKSUM="fec6860b4f45aee7cfac8a970f456bc534b35427" CHECKSUMTYPE="SHA-1" SIZE="4384">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:01:19" MIMETYPE="text/xml" CHECKSUM="fec6860b4f45aee7cfac8a970f456bc534b35427" CHECKSUMTYPE="SHA-1" SIZE="4384">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:01:19" MIMETYPE="text/xml"
-				CHECKSUM="bb0c97257c253adbfe7c0b649323d59bc37d316f" CHECKSUMTYPE="SHA-1" SIZE="2010">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:01:19" MIMETYPE="text/xml" CHECKSUM="bb0c97257c253adbfe7c0b649323d59bc37d316f" CHECKSUMTYPE="SHA-1" SIZE="2010">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:01:20" MIMETYPE="text/xml"
-				CHECKSUM="4230deddcc51dcdbfdc07e832eff60a55cfa83dc" CHECKSUMTYPE="SHA-1" SIZE="4392">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:01:20" MIMETYPE="text/xml" CHECKSUM="4230deddcc51dcdbfdc07e832eff60a55cfa83dc" CHECKSUMTYPE="SHA-1" SIZE="4392">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:01:21" MIMETYPE="text/xml"
-				CHECKSUM="7f50481ad702f8fc5dbdf65b0af9899108276030" CHECKSUMTYPE="SHA-1" SIZE="2010">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:01:21" MIMETYPE="text/xml" CHECKSUM="7f50481ad702f8fc5dbdf65b0af9899108276030" CHECKSUMTYPE="SHA-1" SIZE="2010">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:01:21" MIMETYPE="text/xml"
-				CHECKSUM="0e98b7f157598a34b94fae463b2e8adddb51c50b" CHECKSUMTYPE="SHA-1" SIZE="4331">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:01:21" MIMETYPE="text/xml" CHECKSUM="0e98b7f157598a34b94fae463b2e8adddb51c50b" CHECKSUMTYPE="SHA-1" SIZE="4331">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:01:21" MIMETYPE="text/xml"
-				CHECKSUM="76826f42d14ee1a521a95a1b349667f18ad8f059" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:01:21" MIMETYPE="text/xml" CHECKSUM="76826f42d14ee1a521a95a1b349667f18ad8f059" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:01:22" MIMETYPE="text/xml"
-				CHECKSUM="1306f9a4d58bfa299085b2fad4f5874178cb2d58" CHECKSUMTYPE="SHA-1" SIZE="4410">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:01:22" MIMETYPE="text/xml" CHECKSUM="1306f9a4d58bfa299085b2fad4f5874178cb2d58" CHECKSUMTYPE="SHA-1" SIZE="4410">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:01:22" MIMETYPE="text/xml"
-				CHECKSUM="2fb757f1e03781cfe5e46f3da0dfdea9d91b7fba" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:01:22" MIMETYPE="text/xml" CHECKSUM="2fb757f1e03781cfe5e46f3da0dfdea9d91b7fba" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:01:22" MIMETYPE="text/xml"
-				CHECKSUM="5e7b02a90f8afede78fd6a51a31a5ec3f9c3ea39" CHECKSUMTYPE="SHA-1" SIZE="4409">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:01:22" MIMETYPE="text/xml" CHECKSUM="5e7b02a90f8afede78fd6a51a31a5ec3f9c3ea39" CHECKSUMTYPE="SHA-1" SIZE="4409">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:01:23" MIMETYPE="text/xml"
-				CHECKSUM="60f82297034ecf9524a0f4839ef97c537dcee250" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:01:23" MIMETYPE="text/xml" CHECKSUM="60f82297034ecf9524a0f4839ef97c537dcee250" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:01:23" MIMETYPE="text/xml"
-				CHECKSUM="03819ac434f5461ad489276cd449e6e107f37255" CHECKSUMTYPE="SHA-1" SIZE="4413">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:01:23" MIMETYPE="text/xml" CHECKSUM="03819ac434f5461ad489276cd449e6e107f37255" CHECKSUMTYPE="SHA-1" SIZE="4413">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:01:23" MIMETYPE="text/xml"
-				CHECKSUM="369a5044579d5e1529270b32d89d08964d9adb43" CHECKSUMTYPE="SHA-1" SIZE="2021">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:01:23" MIMETYPE="text/xml" CHECKSUM="369a5044579d5e1529270b32d89d08964d9adb43" CHECKSUMTYPE="SHA-1" SIZE="2021">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:01:23" MIMETYPE="text/xml"
-				CHECKSUM="10de65b5ea619301784c3bc6b235f4e6c6ba0e95" CHECKSUMTYPE="SHA-1" SIZE="2019">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:01:23" MIMETYPE="text/xml" CHECKSUM="10de65b5ea619301784c3bc6b235f4e6c6ba0e95" CHECKSUMTYPE="SHA-1" SIZE="2019">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:01:23" MIMETYPE="text/xml"
-				CHECKSUM="6bd0a7cec44a5dd39b8b662152e1ca66820334a8" CHECKSUMTYPE="SHA-1" SIZE="9347">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:01:23" MIMETYPE="text/xml" CHECKSUM="6bd0a7cec44a5dd39b8b662152e1ca66820334a8" CHECKSUMTYPE="SHA-1" SIZE="9347">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:01:24" MIMETYPE="text/xml"
-				CHECKSUM="32ff4f23b2e2847dd62907a35dca5e13e656f7c7" CHECKSUMTYPE="SHA-1" SIZE="8370">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:01:24" MIMETYPE="text/xml" CHECKSUM="32ff4f23b2e2847dd62907a35dca5e13e656f7c7" CHECKSUMTYPE="SHA-1" SIZE="8370">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:01:24" MIMETYPE="text/xml"
-				CHECKSUM="daed290854a799406abe93956e2b35e6c4764f94" CHECKSUMTYPE="SHA-1"
-				SIZE="22219">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:01:24" MIMETYPE="text/xml" CHECKSUM="daed290854a799406abe93956e2b35e6c4764f94" CHECKSUMTYPE="SHA-1" SIZE="22219">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:01:24" MIMETYPE="text/xml"
-				CHECKSUM="561c16ab148a1e9d10e6f834538941e6df6a2d6d" CHECKSUMTYPE="SHA-1"
-				SIZE="22774">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:01:24" MIMETYPE="text/xml" CHECKSUM="561c16ab148a1e9d10e6f834538941e6df6a2d6d" CHECKSUMTYPE="SHA-1" SIZE="22774">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:01:24" MIMETYPE="text/xml"
-				CHECKSUM="1911c6a7604a515593b2cb3b33cbc250ee2286b9" CHECKSUMTYPE="SHA-1"
-				SIZE="15002">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:01:24" MIMETYPE="text/xml" CHECKSUM="1911c6a7604a515593b2cb3b33cbc250ee2286b9" CHECKSUMTYPE="SHA-1" SIZE="15002">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:01:25" MIMETYPE="text/xml"
-				CHECKSUM="6cedc15e0e2291f2f842580b474d9f195c1941b2" CHECKSUMTYPE="SHA-1"
-				SIZE="38340">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:01:25" MIMETYPE="text/xml" CHECKSUM="6cedc15e0e2291f2f842580b474d9f195c1941b2" CHECKSUMTYPE="SHA-1" SIZE="38340">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:01:25" MIMETYPE="text/xml"
-				CHECKSUM="2c0e18d3b7a71b5e0277f230f95c58c8d5a76327" CHECKSUMTYPE="SHA-1" SIZE="7558">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:01:25" MIMETYPE="text/xml" CHECKSUM="2c0e18d3b7a71b5e0277f230f95c58c8d5a76327" CHECKSUMTYPE="SHA-1" SIZE="7558">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:01:25" MIMETYPE="text/xml"
-				CHECKSUM="4d37179a9ea3d33f5ca23eeddc9479c7d7ca3214" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:01:25" MIMETYPE="text/xml" CHECKSUM="4d37179a9ea3d33f5ca23eeddc9479c7d7ca3214" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:01:25" MIMETYPE="text/xml"
-				CHECKSUM="daee5c709290c6098a1edf617ef0714b1cfdc32e" CHECKSUMTYPE="SHA-1" SIZE="7953">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:01:25" MIMETYPE="text/xml" CHECKSUM="daee5c709290c6098a1edf617ef0714b1cfdc32e" CHECKSUMTYPE="SHA-1" SIZE="7953">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-05-15_01_0026.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:01:50" MIMETYPE="application/pdf"
-				CHECKSUM="b4e399142de0dcd77207b57d510db72dcda74514" CHECKSUMTYPE="SHA-1"
-				SIZE="6436045">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/bmtnabf_1903-05-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:01:50" MIMETYPE="application/pdf" CHECKSUM="b4e399142de0dcd77207b57d510db72dcda74514" CHECKSUMTYPE="SHA-1" SIZE="6436045">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/05/15_01/bmtnabf_1903-05-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2809,8 +2639,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -2827,8 +2656,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c004"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c004" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -2845,8 +2673,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005"
-					LABEL="ORIGINAL-HOLZSCHNITT">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005" LABEL="ORIGINAL-HOLZSCHNITT">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -2863,8 +2690,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c006"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c006" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -2881,8 +2707,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c007"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c007" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -2899,8 +2724,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="8" DMDID="c008"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="8" DMDID="c008" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/06/01_01/bmtnabf_1903-06-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/06/01_01/bmtnabf_1903-06-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-06-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-06-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-06-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1903/06/15_01/bmtnabf_1903-06-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/06/15_01/bmtnabf_1903-06-15_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-06-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-06-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-06-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1903/07/01_01/bmtnabf_1903-07-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/07/01_01/bmtnabf_1903-07-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-07-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-07-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-07-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1903/07/15_01/bmtnabf_1903-07-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/07/15_01/bmtnabf_1903-07-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-07-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-07-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-07-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-07-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-07-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2674,417 +2668,204 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:52:47"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="fc1de4f9df32aa722c33e34cdc9722bb1b920629"
-				CHECKSUMTYPE="SHA-1" SIZE="6170509">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:52:47" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="fc1de4f9df32aa722c33e34cdc9722bb1b920629" CHECKSUMTYPE="SHA-1" SIZE="6170509">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:53:19"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="6f1ae31e867d9fc0df5f913bdff4f70205dd4275"
-				CHECKSUMTYPE="SHA-1" SIZE="6035501">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:53:19" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="6f1ae31e867d9fc0df5f913bdff4f70205dd4275" CHECKSUMTYPE="SHA-1" SIZE="6035501">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:53:50"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="853140ddc3837b207d574883c64b8f3ee0b6ae01"
-				CHECKSUMTYPE="SHA-1" SIZE="6170529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:53:50" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="853140ddc3837b207d574883c64b8f3ee0b6ae01" CHECKSUMTYPE="SHA-1" SIZE="6170529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:54:24"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a512ec224e1da0376c64586cde15b12cfe7c4808"
-				CHECKSUMTYPE="SHA-1" SIZE="6100297">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:54:24" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="a512ec224e1da0376c64586cde15b12cfe7c4808" CHECKSUMTYPE="SHA-1" SIZE="6100297">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:54:58"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="629e43b85b2cd7370f8f33146c293b79465b1bb3"
-				CHECKSUMTYPE="SHA-1" SIZE="6075116">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:54:58" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="629e43b85b2cd7370f8f33146c293b79465b1bb3" CHECKSUMTYPE="SHA-1" SIZE="6075116">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:55:28"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="ea4502128fec9d12092f28c0a267b829d4d71504"
-				CHECKSUMTYPE="SHA-1" SIZE="6100329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:55:28" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="ea4502128fec9d12092f28c0a267b829d4d71504" CHECKSUMTYPE="SHA-1" SIZE="6100329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:55:59"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="4238f252f05f0efbf546d800be953c711b9a93d9"
-				CHECKSUMTYPE="SHA-1" SIZE="6101228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:55:59" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="4238f252f05f0efbf546d800be953c711b9a93d9" CHECKSUMTYPE="SHA-1" SIZE="6101228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:56:32"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="2569bef67aa8d8b71917dc53bab6fc34ac484eb1"
-				CHECKSUMTYPE="SHA-1" SIZE="6100322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T19:56:32" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="2569bef67aa8d8b71917dc53bab6fc34ac484eb1" CHECKSUMTYPE="SHA-1" SIZE="6100322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:57:05"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="25fc7d87f4eea2a94dd0b7634b2982254a971092"
-				CHECKSUMTYPE="SHA-1" SIZE="6101227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T19:57:05" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="25fc7d87f4eea2a94dd0b7634b2982254a971092" CHECKSUMTYPE="SHA-1" SIZE="6101227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:57:38"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="1926f2258ebb93b724a6b99b2d01270b3111d373"
-				CHECKSUMTYPE="SHA-1" SIZE="6100317">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T19:57:38" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="1926f2258ebb93b724a6b99b2d01270b3111d373" CHECKSUMTYPE="SHA-1" SIZE="6100317">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:58:10"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="23c03005e2bff29d10e96c41aa4001cbca3268e0"
-				CHECKSUMTYPE="SHA-1" SIZE="6101202">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T19:58:10" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="23c03005e2bff29d10e96c41aa4001cbca3268e0" CHECKSUMTYPE="SHA-1" SIZE="6101202">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:58:43"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="5533ed1dd906a8f30f7e328e9805fb89b2ef9f4d"
-				CHECKSUMTYPE="SHA-1" SIZE="6101229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T19:58:43" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="5533ed1dd906a8f30f7e328e9805fb89b2ef9f4d" CHECKSUMTYPE="SHA-1" SIZE="6101229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:59:16"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="b9be3fe94412f563a32947b1439e7f32bd85a996"
-				CHECKSUMTYPE="SHA-1" SIZE="6101222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T19:59:16" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="b9be3fe94412f563a32947b1439e7f32bd85a996" CHECKSUMTYPE="SHA-1" SIZE="6101222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:59:47"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="4fda170ecf93351a1420806aba5cd78158a7b89d"
-				CHECKSUMTYPE="SHA-1" SIZE="6110221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T19:59:47" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="4fda170ecf93351a1420806aba5cd78158a7b89d" CHECKSUMTYPE="SHA-1" SIZE="6110221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:00:17"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="b0d420ce2dcfa3c333c2effa6e723409e4a3aac5"
-				CHECKSUMTYPE="SHA-1" SIZE="6102121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:00:17" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="b0d420ce2dcfa3c333c2effa6e723409e4a3aac5" CHECKSUMTYPE="SHA-1" SIZE="6102121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:00:51"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="62c7a1a668b6001827834dbaaa78dd2844a9a9b2"
-				CHECKSUMTYPE="SHA-1" SIZE="6110222">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:00:51" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="62c7a1a668b6001827834dbaaa78dd2844a9a9b2" CHECKSUMTYPE="SHA-1" SIZE="6110222">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:01:24"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="61eb0e5dfa6b765062b63f32dcf0976d2ab33a77"
-				CHECKSUMTYPE="SHA-1" SIZE="6102114">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:01:24" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="61eb0e5dfa6b765062b63f32dcf0976d2ab33a77" CHECKSUMTYPE="SHA-1" SIZE="6102114">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:01:52"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="ac97b8e76300467a41c7c370b0f01f2391994920"
-				CHECKSUMTYPE="SHA-1" SIZE="6110226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:01:52" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="ac97b8e76300467a41c7c370b0f01f2391994920" CHECKSUMTYPE="SHA-1" SIZE="6110226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:02:23"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="e74766e4d4b9798a07032f4caf3ce8348dd17fc3"
-				CHECKSUMTYPE="SHA-1" SIZE="6102127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:02:23" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="e74766e4d4b9798a07032f4caf3ce8348dd17fc3" CHECKSUMTYPE="SHA-1" SIZE="6102127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:02:52"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="a30343bd17a33aaa0db79a6d8f2582ca023a1bad"
-				CHECKSUMTYPE="SHA-1" SIZE="6110221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:02:52" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="a30343bd17a33aaa0db79a6d8f2582ca023a1bad" CHECKSUMTYPE="SHA-1" SIZE="6110221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:03:23"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="92f483c4333781a26d460d48134f8b10443e6b20"
-				CHECKSUMTYPE="SHA-1" SIZE="6102120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:03:23" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="92f483c4333781a26d460d48134f8b10443e6b20" CHECKSUMTYPE="SHA-1" SIZE="6102120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:03:53"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="d3e52d4e4c5c5b88dd572ff8e699791207d3f5e2"
-				CHECKSUMTYPE="SHA-1" SIZE="6110229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:03:53" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="d3e52d4e4c5c5b88dd572ff8e699791207d3f5e2" CHECKSUMTYPE="SHA-1" SIZE="6110229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:04:23"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="6704cb8cf0a5c08239b62f0b3d9c2b3a8cb9460f"
-				CHECKSUMTYPE="SHA-1" SIZE="6102121">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:04:23" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="6704cb8cf0a5c08239b62f0b3d9c2b3a8cb9460f" CHECKSUMTYPE="SHA-1" SIZE="6102121">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:04:52"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="b6d14b05c2283e907bf4750845c0412bce50854f"
-				CHECKSUMTYPE="SHA-1" SIZE="6214629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:04:52" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="b6d14b05c2283e907bf4750845c0412bce50854f" CHECKSUMTYPE="SHA-1" SIZE="6214629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:05:21"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="584474d09d71dc3106d6b28451281bf61b15ff32"
-				CHECKSUMTYPE="SHA-1" SIZE="6012124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:05:21" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="584474d09d71dc3106d6b28451281bf61b15ff32" CHECKSUMTYPE="SHA-1" SIZE="6012124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:05:52"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="3f55be23ef94a7e13261b1ba6c318760b35386b3"
-				CHECKSUMTYPE="SHA-1" SIZE="6160621">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:05:52" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="3f55be23ef94a7e13261b1ba6c318760b35386b3" CHECKSUMTYPE="SHA-1" SIZE="6160621">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:06:24"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="8c912ed58e8693e111a34bd302dea03f6edf93ad"
-				CHECKSUMTYPE="SHA-1" SIZE="6012122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:06:24" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="8c912ed58e8693e111a34bd302dea03f6edf93ad" CHECKSUMTYPE="SHA-1" SIZE="6012122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:06:55"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="3b259bc3b5786674c394eea9a919995fd45b8b1c"
-				CHECKSUMTYPE="SHA-1" SIZE="6159726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:06:55" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="3b259bc3b5786674c394eea9a919995fd45b8b1c" CHECKSUMTYPE="SHA-1" SIZE="6159726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T20:07:26"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="7cfe6e5852a92f32462182a83672c93896bb41da"
-				CHECKSUMTYPE="SHA-1" SIZE="6012128">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T20:07:26" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="7cfe6e5852a92f32462182a83672c93896bb41da" CHECKSUMTYPE="SHA-1" SIZE="6012128">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T20:07:56"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="b8b87e7bc755bf864f9781826af2475daa5742b6"
-				CHECKSUMTYPE="SHA-1" SIZE="6159683">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T20:07:56" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="b8b87e7bc755bf864f9781826af2475daa5742b6" CHECKSUMTYPE="SHA-1" SIZE="6159683">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T20:08:26"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="1ecd46c2a583f12449ea1fc99156fe629d0b4f88"
-				CHECKSUMTYPE="SHA-1" SIZE="6012125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T20:08:26" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="1ecd46c2a583f12449ea1fc99156fe629d0b4f88" CHECKSUMTYPE="SHA-1" SIZE="6012125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T20:08:57"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="8e3814e36ea8c6e83d19bac71a3ed05e245637f2"
-				CHECKSUMTYPE="SHA-1" SIZE="6159714">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T20:08:57" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="8e3814e36ea8c6e83d19bac71a3ed05e245637f2" CHECKSUMTYPE="SHA-1" SIZE="6159714">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/delivery/bmtnabf_1903-07-15_01_0032.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:09:14" MIMETYPE="text/xml"
-				CHECKSUM="65470fd6174872c3a468cf590837b47642f0df96" CHECKSUMTYPE="SHA-1" SIZE="5336">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:09:14" MIMETYPE="text/xml" CHECKSUM="65470fd6174872c3a468cf590837b47642f0df96" CHECKSUMTYPE="SHA-1" SIZE="5336">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:09:15" MIMETYPE="text/xml"
-				CHECKSUM="53b4de87b780dced63b2b686518d951033f98721" CHECKSUMTYPE="SHA-1" SIZE="1718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:09:15" MIMETYPE="text/xml" CHECKSUM="53b4de87b780dced63b2b686518d951033f98721" CHECKSUMTYPE="SHA-1" SIZE="1718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:09:15" MIMETYPE="text/xml"
-				CHECKSUM="c37a4fe60c4ed2ead9a040d66eeae649ff372566" CHECKSUMTYPE="SHA-1" SIZE="8287">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:09:15" MIMETYPE="text/xml" CHECKSUM="c37a4fe60c4ed2ead9a040d66eeae649ff372566" CHECKSUMTYPE="SHA-1" SIZE="8287">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:09:15" MIMETYPE="text/xml"
-				CHECKSUM="3c7ec79f3114ab39ecb73ec4d442e416542a5d25" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:09:15" MIMETYPE="text/xml" CHECKSUM="3c7ec79f3114ab39ecb73ec4d442e416542a5d25" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:09:15" MIMETYPE="text/xml"
-				CHECKSUM="84e4cece0d57cd90299bf4a52acbcf70b1d8c75f" CHECKSUMTYPE="SHA-1"
-				SIZE="46382">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:09:15" MIMETYPE="text/xml" CHECKSUM="84e4cece0d57cd90299bf4a52acbcf70b1d8c75f" CHECKSUMTYPE="SHA-1" SIZE="46382">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:09:15" MIMETYPE="text/xml"
-				CHECKSUM="5287d9f64ce1eb29230b7fc9cf9598463483da59" CHECKSUMTYPE="SHA-1"
-				SIZE="69351">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:09:15" MIMETYPE="text/xml" CHECKSUM="5287d9f64ce1eb29230b7fc9cf9598463483da59" CHECKSUMTYPE="SHA-1" SIZE="69351">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:09:16" MIMETYPE="text/xml"
-				CHECKSUM="7631ea1609d68a8c74aa319d2da34c71f1e7ea3c" CHECKSUMTYPE="SHA-1"
-				SIZE="67109">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:09:16" MIMETYPE="text/xml" CHECKSUM="7631ea1609d68a8c74aa319d2da34c71f1e7ea3c" CHECKSUMTYPE="SHA-1" SIZE="67109">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:09:16" MIMETYPE="text/xml"
-				CHECKSUM="861af02af2df77c7b9aaf836418e38733c16498e" CHECKSUMTYPE="SHA-1"
-				SIZE="67510">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:09:16" MIMETYPE="text/xml" CHECKSUM="861af02af2df77c7b9aaf836418e38733c16498e" CHECKSUMTYPE="SHA-1" SIZE="67510">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:09:16" MIMETYPE="text/xml"
-				CHECKSUM="5a0de26c61eac8b5c4350ee4580272f45b77affb" CHECKSUMTYPE="SHA-1" SIZE="4326">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:09:16" MIMETYPE="text/xml" CHECKSUM="5a0de26c61eac8b5c4350ee4580272f45b77affb" CHECKSUMTYPE="SHA-1" SIZE="4326">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:09:16" MIMETYPE="text/xml"
-				CHECKSUM="311571c8241491b01599ed15cf382674178a35a2" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:09:16" MIMETYPE="text/xml" CHECKSUM="311571c8241491b01599ed15cf382674178a35a2" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:09:17" MIMETYPE="text/xml"
-				CHECKSUM="62241d17a413e7e6637ac8e9606098a2745147a6" CHECKSUMTYPE="SHA-1"
-				SIZE="65537">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:09:17" MIMETYPE="text/xml" CHECKSUM="62241d17a413e7e6637ac8e9606098a2745147a6" CHECKSUMTYPE="SHA-1" SIZE="65537">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:09:17" MIMETYPE="text/xml"
-				CHECKSUM="bf4ea343023a068174c964e38408a193f43046ec" CHECKSUMTYPE="SHA-1"
-				SIZE="70522">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:09:17" MIMETYPE="text/xml" CHECKSUM="bf4ea343023a068174c964e38408a193f43046ec" CHECKSUMTYPE="SHA-1" SIZE="70522">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:09:17" MIMETYPE="text/xml"
-				CHECKSUM="09236aa9227f0e68d6205766b299a58359f9b596" CHECKSUMTYPE="SHA-1"
-				SIZE="76497">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:09:17" MIMETYPE="text/xml" CHECKSUM="09236aa9227f0e68d6205766b299a58359f9b596" CHECKSUMTYPE="SHA-1" SIZE="76497">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:09:17" MIMETYPE="text/xml"
-				CHECKSUM="6c7f5b36de93d919596f8a66dd070c7fcff9d00a" CHECKSUMTYPE="SHA-1"
-				SIZE="68637">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:09:17" MIMETYPE="text/xml" CHECKSUM="6c7f5b36de93d919596f8a66dd070c7fcff9d00a" CHECKSUMTYPE="SHA-1" SIZE="68637">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:09:18" MIMETYPE="text/xml"
-				CHECKSUM="e80d38983df463b48b70e1207c8cc326b3148419" CHECKSUMTYPE="SHA-1" SIZE="4350">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:09:18" MIMETYPE="text/xml" CHECKSUM="e80d38983df463b48b70e1207c8cc326b3148419" CHECKSUMTYPE="SHA-1" SIZE="4350">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:09:18" MIMETYPE="text/xml"
-				CHECKSUM="5a11feb1263a9970f06af3324f9981eafcbade1d" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:09:18" MIMETYPE="text/xml" CHECKSUM="5a11feb1263a9970f06af3324f9981eafcbade1d" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:09:18" MIMETYPE="text/xml"
-				CHECKSUM="2d80c333e3607e2008e18d7e0174b46e01801e9f" CHECKSUMTYPE="SHA-1"
-				SIZE="68182">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:09:18" MIMETYPE="text/xml" CHECKSUM="2d80c333e3607e2008e18d7e0174b46e01801e9f" CHECKSUMTYPE="SHA-1" SIZE="68182">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:09:18" MIMETYPE="text/xml"
-				CHECKSUM="22cb831a9e8093c542946213d9f1d0a10b24e86b" CHECKSUMTYPE="SHA-1"
-				SIZE="64741">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:09:18" MIMETYPE="text/xml" CHECKSUM="22cb831a9e8093c542946213d9f1d0a10b24e86b" CHECKSUMTYPE="SHA-1" SIZE="64741">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:09:19" MIMETYPE="text/xml"
-				CHECKSUM="21457cdbb540798b8557c66ea9d3aa4fb093e451" CHECKSUMTYPE="SHA-1"
-				SIZE="70332">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:09:19" MIMETYPE="text/xml" CHECKSUM="21457cdbb540798b8557c66ea9d3aa4fb093e451" CHECKSUMTYPE="SHA-1" SIZE="70332">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:09:19" MIMETYPE="text/xml"
-				CHECKSUM="10e8b9b8eb5b6800593a2bdc2fdf81ea066b10f4" CHECKSUMTYPE="SHA-1"
-				SIZE="66612">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:09:19" MIMETYPE="text/xml" CHECKSUM="10e8b9b8eb5b6800593a2bdc2fdf81ea066b10f4" CHECKSUMTYPE="SHA-1" SIZE="66612">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:09:20" MIMETYPE="text/xml"
-				CHECKSUM="6e56d261d62d99315ccaf3d84d4bfb1da6912030" CHECKSUMTYPE="SHA-1"
-				SIZE="37752">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:09:20" MIMETYPE="text/xml" CHECKSUM="6e56d261d62d99315ccaf3d84d4bfb1da6912030" CHECKSUMTYPE="SHA-1" SIZE="37752">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:09:21" MIMETYPE="text/xml"
-				CHECKSUM="21c08ab9e9bf0fcdcf4c7b8081a848ffe9eaf9f4" CHECKSUMTYPE="SHA-1" SIZE="4573">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:09:21" MIMETYPE="text/xml" CHECKSUM="21c08ab9e9bf0fcdcf4c7b8081a848ffe9eaf9f4" CHECKSUMTYPE="SHA-1" SIZE="4573">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:09:21" MIMETYPE="text/xml"
-				CHECKSUM="f394e9b7faa47db22b5c3cb09fa5fa81c1c70211" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:09:21" MIMETYPE="text/xml" CHECKSUM="f394e9b7faa47db22b5c3cb09fa5fa81c1c70211" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:09:21" MIMETYPE="text/xml"
-				CHECKSUM="35ab398a989eed44acfba1000d8cad43d9a0da26" CHECKSUMTYPE="SHA-1" SIZE="9332">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:09:21" MIMETYPE="text/xml" CHECKSUM="35ab398a989eed44acfba1000d8cad43d9a0da26" CHECKSUMTYPE="SHA-1" SIZE="9332">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:09:22" MIMETYPE="text/xml"
-				CHECKSUM="3a192f8385aa35c40b9f92b9194e85cccd425017" CHECKSUMTYPE="SHA-1" SIZE="8999">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:09:22" MIMETYPE="text/xml" CHECKSUM="3a192f8385aa35c40b9f92b9194e85cccd425017" CHECKSUMTYPE="SHA-1" SIZE="8999">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:09:22" MIMETYPE="text/xml"
-				CHECKSUM="fefb09ba29b3539e9046956ca407d61658c260be" CHECKSUMTYPE="SHA-1"
-				SIZE="22359">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:09:22" MIMETYPE="text/xml" CHECKSUM="fefb09ba29b3539e9046956ca407d61658c260be" CHECKSUMTYPE="SHA-1" SIZE="22359">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:09:24" MIMETYPE="text/xml"
-				CHECKSUM="69dea385c75e990aaa4b9806631f0500c941c11d" CHECKSUMTYPE="SHA-1"
-				SIZE="22787">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:09:24" MIMETYPE="text/xml" CHECKSUM="69dea385c75e990aaa4b9806631f0500c941c11d" CHECKSUMTYPE="SHA-1" SIZE="22787">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:09:25" MIMETYPE="text/xml"
-				CHECKSUM="54afd0efc0e6b103ae7d93749eb1705e48278045" CHECKSUMTYPE="SHA-1"
-				SIZE="13409">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:09:25" MIMETYPE="text/xml" CHECKSUM="54afd0efc0e6b103ae7d93749eb1705e48278045" CHECKSUMTYPE="SHA-1" SIZE="13409">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T20:09:26" MIMETYPE="text/xml"
-				CHECKSUM="cab68d8df17c97ae13f07c976aa32f56e3e1e8c5" CHECKSUMTYPE="SHA-1"
-				SIZE="23325">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T20:09:26" MIMETYPE="text/xml" CHECKSUM="cab68d8df17c97ae13f07c976aa32f56e3e1e8c5" CHECKSUMTYPE="SHA-1" SIZE="23325">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T20:09:26" MIMETYPE="text/xml"
-				CHECKSUM="e7b9f047d10cba5bf81b1c87fb2e4677ff102895" CHECKSUMTYPE="SHA-1" SIZE="7549">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T20:09:26" MIMETYPE="text/xml" CHECKSUM="e7b9f047d10cba5bf81b1c87fb2e4677ff102895" CHECKSUMTYPE="SHA-1" SIZE="7549">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T20:09:26" MIMETYPE="text/xml"
-				CHECKSUM="e77392a74220349e3bb409ffaaebc8bfe02f00f6" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T20:09:26" MIMETYPE="text/xml" CHECKSUM="e77392a74220349e3bb409ffaaebc8bfe02f00f6" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T20:09:27" MIMETYPE="text/xml"
-				CHECKSUM="e31267144cecc3f43c3cdf0fa1f4abe62a2f3656" CHECKSUMTYPE="SHA-1" SIZE="7785">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T20:09:27" MIMETYPE="text/xml" CHECKSUM="e31267144cecc3f43c3cdf0fa1f4abe62a2f3656" CHECKSUMTYPE="SHA-1" SIZE="7785">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-07-15_01_0032.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:10:02" MIMETYPE="application/pdf"
-				CHECKSUM="2d3c7d7ca6ff8c639a6972ea65eb0a0a5f4ec70c" CHECKSUMTYPE="SHA-1"
-				SIZE="9024564">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/bmtnabf_1903-07-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:10:02" MIMETYPE="application/pdf" CHECKSUM="2d3c7d7ca6ff8c639a6972ea65eb0a0a5f4ec70c" CHECKSUMTYPE="SHA-1" SIZE="9024564">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/07/15_01/bmtnabf_1903-07-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3412,8 +3193,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="TextContent" ORDER="3" DMDID="c003"
-					LABEL="AUF UNSERER XV. AUSSTELLUNG ERREGTEN IM POLNISCHEN SAALE">
+				<div ID="L.1.1.4" TYPE="TextContent" ORDER="3" DMDID="c003" LABEL="AUF UNSERER XV. AUSSTELLUNG ERREGTEN IM POLNISCHEN SAALE">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00005"/>
@@ -3437,18 +3217,15 @@
 								<div ID="L.1.1.4.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00007"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.4.5" TYPE="Illustration" ORDER="1" DMDID="c005"
-						LABEL="Original-Holzschnitt">
+					<div ID="L.1.1.4.5" TYPE="Illustration" ORDER="1" DMDID="c005" LABEL="Original-Holzschnitt">
 						<div ID="L.1.1.4.5.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00001"/>
@@ -3466,8 +3243,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="4" DMDID="c006"
-					LABEL="GLOSSEN ÜBER DIE KUNST">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="4" DMDID="c006" LABEL="GLOSSEN ÜBER DIE KUNST">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00009"/>
@@ -3479,10 +3255,8 @@
 								<div ID="L.1.1.5.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00005"
-												BEGIN="P5_TB00010"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00010"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3491,38 +3265,25 @@
 								<div ID="L.1.1.5.2.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00006"
-												BEGIN="P6_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00017"
-												BEGIN="P17_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00018"
-												BEGIN="P18_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00019"
-												BEGIN="P19_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00020"
-												BEGIN="P20_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00021"
-												BEGIN="P21_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00006" BEGIN="P6_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c007"
-						LABEL="Original-Holzschnitt">
+					<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="1" DMDID="c007" LABEL="Original-Holzschnitt">
 						<div ID="L.1.1.5.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00001"/>
@@ -3540,8 +3301,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c008"
-					LABEL="ORIGINAL-HOLZSCHNITT">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c008" LABEL="ORIGINAL-HOLZSCHNITT">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -3558,8 +3318,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c009"
-					LABEL="ORIGINAL-HOLZSCHNITT">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c009" LABEL="ORIGINAL-HOLZSCHNITT">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -3576,8 +3335,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c010"
-					LABEL="ORIGINAL-HOLZSCHNITT">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c010" LABEL="ORIGINAL-HOLZSCHNITT">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/08/01_01/bmtnabf_1903-08-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/08/01_01/bmtnabf_1903-08-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-08-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-08-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-08-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-08-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-08-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2224,332 +2218,168 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:55:41"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="f2f9b7dca5d1f05a599cad84efb31348b2e201fe"
-				CHECKSUMTYPE="SHA-1" SIZE="6152514">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:55:41" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="f2f9b7dca5d1f05a599cad84efb31348b2e201fe" CHECKSUMTYPE="SHA-1" SIZE="6152514">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:56:15"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="f2fc692612873976869562a670ad77d7f51a38ce"
-				CHECKSUMTYPE="SHA-1" SIZE="6229026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:56:15" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="f2fc692612873976869562a670ad77d7f51a38ce" CHECKSUMTYPE="SHA-1" SIZE="6229026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:56:51"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="4319ac7cfc22bb6f7e62a28fdf92143b97b353c8"
-				CHECKSUMTYPE="SHA-1" SIZE="6154329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:56:51" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="4319ac7cfc22bb6f7e62a28fdf92143b97b353c8" CHECKSUMTYPE="SHA-1" SIZE="6154329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:57:32"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="f4f2be7f815f1db707daa698aeb81845c4657303"
-				CHECKSUMTYPE="SHA-1" SIZE="6228108">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:57:32" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="f4f2be7f815f1db707daa698aeb81845c4657303" CHECKSUMTYPE="SHA-1" SIZE="6228108">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:58:16"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="3724a72bea6ed6d305b38d3ffb169c1bfe5996e1"
-				CHECKSUMTYPE="SHA-1" SIZE="6152497">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:58:16" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="3724a72bea6ed6d305b38d3ffb169c1bfe5996e1" CHECKSUMTYPE="SHA-1" SIZE="6152497">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:58:52"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="d55e3b8ae00784244342d716d7728bb923557c54"
-				CHECKSUMTYPE="SHA-1" SIZE="6229020">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T19:58:52" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="d55e3b8ae00784244342d716d7728bb923557c54" CHECKSUMTYPE="SHA-1" SIZE="6229020">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:59:25"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="37e1391c8630700aef1ec686d25b45e934a136ec"
-				CHECKSUMTYPE="SHA-1" SIZE="6152502">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T19:59:25" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="37e1391c8630700aef1ec686d25b45e934a136ec" CHECKSUMTYPE="SHA-1" SIZE="6152502">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:00:02"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="4ac57bfb3b4cd70dae3ccca7c29a05c828b00ad0"
-				CHECKSUMTYPE="SHA-1" SIZE="6149828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:00:02" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="4ac57bfb3b4cd70dae3ccca7c29a05c828b00ad0" CHECKSUMTYPE="SHA-1" SIZE="6149828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:00:37"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="b5d244a05b0c7a495b3ec437a87ff5675f68ea2c"
-				CHECKSUMTYPE="SHA-1" SIZE="6048967">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:00:37" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="b5d244a05b0c7a495b3ec437a87ff5675f68ea2c" CHECKSUMTYPE="SHA-1" SIZE="6048967">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:01:15"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="36e722928946079c56e33bf11dc23b78d6e851f6"
-				CHECKSUMTYPE="SHA-1" SIZE="6149827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:01:15" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="36e722928946079c56e33bf11dc23b78d6e851f6" CHECKSUMTYPE="SHA-1" SIZE="6149827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:01:48"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f8e1291a94e54e4be555d06ba99c2d3f26369abe"
-				CHECKSUMTYPE="SHA-1" SIZE="6049026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:01:48" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f8e1291a94e54e4be555d06ba99c2d3f26369abe" CHECKSUMTYPE="SHA-1" SIZE="6049026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:02:25"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="4b5465707cab9b1d0b77e79c5aa5e76f023267e6"
-				CHECKSUMTYPE="SHA-1" SIZE="6148917">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:02:25" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="4b5465707cab9b1d0b77e79c5aa5e76f023267e6" CHECKSUMTYPE="SHA-1" SIZE="6148917">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:02:59"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="5108b205e5e5eda3c152b3b1378499c7fb1186e1"
-				CHECKSUMTYPE="SHA-1" SIZE="6049029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:02:59" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="5108b205e5e5eda3c152b3b1378499c7fb1186e1" CHECKSUMTYPE="SHA-1" SIZE="6049029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:03:37"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="462cf719d0c9f569d44bea3eabd0473b94411667"
-				CHECKSUMTYPE="SHA-1" SIZE="6148929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:03:37" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="462cf719d0c9f569d44bea3eabd0473b94411667" CHECKSUMTYPE="SHA-1" SIZE="6148929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:04:08"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="3e756b489a9ef5d9eea1f00f78442481a42eab08"
-				CHECKSUMTYPE="SHA-1" SIZE="6049029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:04:08" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="3e756b489a9ef5d9eea1f00f78442481a42eab08" CHECKSUMTYPE="SHA-1" SIZE="6049029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:04:46"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d185e3597eb96c38415226adf7da608caca607a3"
-				CHECKSUMTYPE="SHA-1" SIZE="6148928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:04:46" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d185e3597eb96c38415226adf7da608caca607a3" CHECKSUMTYPE="SHA-1" SIZE="6148928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:05:20"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="98dfe614bebca81eaf9898ad42ce8f0dbde3858f"
-				CHECKSUMTYPE="SHA-1" SIZE="6025440">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:05:20" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="98dfe614bebca81eaf9898ad42ce8f0dbde3858f" CHECKSUMTYPE="SHA-1" SIZE="6025440">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:05:57"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="497ff0048913cda8da5043e1cbd8f41f251d14cd"
-				CHECKSUMTYPE="SHA-1" SIZE="6148917">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:05:57" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="497ff0048913cda8da5043e1cbd8f41f251d14cd" CHECKSUMTYPE="SHA-1" SIZE="6148917">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:06:31"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="52b6d32fe29e18387323582bfa399d36a347d7ac"
-				CHECKSUMTYPE="SHA-1" SIZE="6025581">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:06:31" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="52b6d32fe29e18387323582bfa399d36a347d7ac" CHECKSUMTYPE="SHA-1" SIZE="6025581">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:07:06"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="936edeb580276ed748a8fb4fac9d80c50b802387"
-				CHECKSUMTYPE="SHA-1" SIZE="6148926">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:07:06" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="936edeb580276ed748a8fb4fac9d80c50b802387" CHECKSUMTYPE="SHA-1" SIZE="6148926">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:07:42"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="f0c7226ad40aba58c55e3c3289866a46037a7d21"
-				CHECKSUMTYPE="SHA-1" SIZE="6025600">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:07:42" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="f0c7226ad40aba58c55e3c3289866a46037a7d21" CHECKSUMTYPE="SHA-1" SIZE="6025600">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:08:19"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="b03d89ce47332751391b104d95a793aa8393cb05"
-				CHECKSUMTYPE="SHA-1" SIZE="6175025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:08:19" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="b03d89ce47332751391b104d95a793aa8393cb05" CHECKSUMTYPE="SHA-1" SIZE="6175025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:08:53"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="a4021622cbc375b03581cc64649d217af41a2718"
-				CHECKSUMTYPE="SHA-1" SIZE="6026526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:08:53" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="a4021622cbc375b03581cc64649d217af41a2718" CHECKSUMTYPE="SHA-1" SIZE="6026526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:09:29"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="532b1af0ede87f155d08e8dddb03af6ef2fe01e3"
-				CHECKSUMTYPE="SHA-1" SIZE="6175026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:09:29" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="532b1af0ede87f155d08e8dddb03af6ef2fe01e3" CHECKSUMTYPE="SHA-1" SIZE="6175026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:10:02"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="294a2a1f6dc4ab8608e18c8038f48a658688abd2"
-				CHECKSUMTYPE="SHA-1" SIZE="6026506">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:10:02" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="294a2a1f6dc4ab8608e18c8038f48a658688abd2" CHECKSUMTYPE="SHA-1" SIZE="6026506">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:10:34"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="95641792d4df63ab036b3a40672b7ceec5dd9eb4"
-				CHECKSUMTYPE="SHA-1" SIZE="6175023">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:10:34" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="95641792d4df63ab036b3a40672b7ceec5dd9eb4" CHECKSUMTYPE="SHA-1" SIZE="6175023">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/delivery/bmtnabf_1903-08-01_01_0026.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:10:56" MIMETYPE="text/xml"
-				CHECKSUM="4c0b4d6dfdccd8877a8b00c65ad9bada898a7735" CHECKSUMTYPE="SHA-1" SIZE="4779">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:10:56" MIMETYPE="text/xml" CHECKSUM="4c0b4d6dfdccd8877a8b00c65ad9bada898a7735" CHECKSUMTYPE="SHA-1" SIZE="4779">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:10:56" MIMETYPE="text/xml"
-				CHECKSUM="cb5d12ecc9a32d7b42015b97c296db4f9649468d" CHECKSUMTYPE="SHA-1" SIZE="1720">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:10:56" MIMETYPE="text/xml" CHECKSUM="cb5d12ecc9a32d7b42015b97c296db4f9649468d" CHECKSUMTYPE="SHA-1" SIZE="1720">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:10:56" MIMETYPE="text/xml"
-				CHECKSUM="1862fd86b21afb088278d2a3245c44d7218a61ec" CHECKSUMTYPE="SHA-1" SIZE="8775">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:10:56" MIMETYPE="text/xml" CHECKSUM="1862fd86b21afb088278d2a3245c44d7218a61ec" CHECKSUMTYPE="SHA-1" SIZE="8775">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:10:57" MIMETYPE="text/xml"
-				CHECKSUM="95dcefbf8f563cc06a5539cfe73f2f245eac9533" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:10:57" MIMETYPE="text/xml" CHECKSUM="95dcefbf8f563cc06a5539cfe73f2f245eac9533" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:10:57" MIMETYPE="text/xml"
-				CHECKSUM="e1d129b3f28031b39a5a522b137c6e03b55da36d" CHECKSUMTYPE="SHA-1" SIZE="5279">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:10:57" MIMETYPE="text/xml" CHECKSUM="e1d129b3f28031b39a5a522b137c6e03b55da36d" CHECKSUMTYPE="SHA-1" SIZE="5279">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:10:57" MIMETYPE="text/xml"
-				CHECKSUM="5b139e155c8f0f9396e84ee9fee20b50880a1369" CHECKSUMTYPE="SHA-1" SIZE="2010">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:10:57" MIMETYPE="text/xml" CHECKSUM="5b139e155c8f0f9396e84ee9fee20b50880a1369" CHECKSUMTYPE="SHA-1" SIZE="2010">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:10:57" MIMETYPE="text/xml"
-				CHECKSUM="940646bac6899eb1fb57dcffa20a82b04cf95deb" CHECKSUMTYPE="SHA-1" SIZE="4777">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:10:57" MIMETYPE="text/xml" CHECKSUM="940646bac6899eb1fb57dcffa20a82b04cf95deb" CHECKSUMTYPE="SHA-1" SIZE="4777">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:10:58" MIMETYPE="text/xml"
-				CHECKSUM="e4ee1cbdfcaea1809872871659a1e4b1bfdf2c7f" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:10:58" MIMETYPE="text/xml" CHECKSUM="e4ee1cbdfcaea1809872871659a1e4b1bfdf2c7f" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:10:58" MIMETYPE="text/xml"
-				CHECKSUM="8607ce0ec1508fd86579ef41fbde9b34c2af9662" CHECKSUMTYPE="SHA-1" SIZE="5900">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:10:58" MIMETYPE="text/xml" CHECKSUM="8607ce0ec1508fd86579ef41fbde9b34c2af9662" CHECKSUMTYPE="SHA-1" SIZE="5900">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:10:58" MIMETYPE="text/xml"
-				CHECKSUM="7c63f2b4022630356695dfc230977dcbbc00e774" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:10:58" MIMETYPE="text/xml" CHECKSUM="7c63f2b4022630356695dfc230977dcbbc00e774" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:10:58" MIMETYPE="text/xml"
-				CHECKSUM="4ce42d6efb4a741d727cb8db704b1bb031b7d729" CHECKSUMTYPE="SHA-1" SIZE="5004">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:10:58" MIMETYPE="text/xml" CHECKSUM="4ce42d6efb4a741d727cb8db704b1bb031b7d729" CHECKSUMTYPE="SHA-1" SIZE="5004">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:10:59" MIMETYPE="text/xml"
-				CHECKSUM="883fea0bfabe5b74a62823e174039f6857549e2c" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:10:59" MIMETYPE="text/xml" CHECKSUM="883fea0bfabe5b74a62823e174039f6857549e2c" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:10:59" MIMETYPE="text/xml"
-				CHECKSUM="fc8d7f8b97d36b13a65731124397e7a51cc407b4" CHECKSUMTYPE="SHA-1" SIZE="5483">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:10:59" MIMETYPE="text/xml" CHECKSUM="fc8d7f8b97d36b13a65731124397e7a51cc407b4" CHECKSUMTYPE="SHA-1" SIZE="5483">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:10:59" MIMETYPE="text/xml"
-				CHECKSUM="613aa25ec6c5cde5522df2d2b23eb508a180c99d" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:10:59" MIMETYPE="text/xml" CHECKSUM="613aa25ec6c5cde5522df2d2b23eb508a180c99d" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:10:59" MIMETYPE="text/xml"
-				CHECKSUM="87713bbee8063864085ea4a55ba5c57c9546de3a" CHECKSUMTYPE="SHA-1" SIZE="4756">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:10:59" MIMETYPE="text/xml" CHECKSUM="87713bbee8063864085ea4a55ba5c57c9546de3a" CHECKSUMTYPE="SHA-1" SIZE="4756">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:10:59" MIMETYPE="text/xml"
-				CHECKSUM="486c430797d2484ee5e65019b26a6c17f566f545" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:10:59" MIMETYPE="text/xml" CHECKSUM="486c430797d2484ee5e65019b26a6c17f566f545" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:11:00" MIMETYPE="text/xml"
-				CHECKSUM="b064ee709f99a933bb1f8a0067136160ac1a2862" CHECKSUMTYPE="SHA-1" SIZE="4940">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:11:00" MIMETYPE="text/xml" CHECKSUM="b064ee709f99a933bb1f8a0067136160ac1a2862" CHECKSUMTYPE="SHA-1" SIZE="4940">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:11:00" MIMETYPE="text/xml"
-				CHECKSUM="a053e3c4cfd11004ede381da640543f5faac4b5b" CHECKSUMTYPE="SHA-1" SIZE="2020">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:11:00" MIMETYPE="text/xml" CHECKSUM="a053e3c4cfd11004ede381da640543f5faac4b5b" CHECKSUMTYPE="SHA-1" SIZE="2020">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:11:00" MIMETYPE="text/xml"
-				CHECKSUM="ae5b509406f73aee0392ff32cdb6d58c4aae531d" CHECKSUMTYPE="SHA-1" SIZE="9343">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:11:00" MIMETYPE="text/xml" CHECKSUM="ae5b509406f73aee0392ff32cdb6d58c4aae531d" CHECKSUMTYPE="SHA-1" SIZE="9343">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:11:01" MIMETYPE="text/xml"
-				CHECKSUM="a81033208aee249312daead3180e031ec5f53e30" CHECKSUMTYPE="SHA-1"
-				SIZE="19206">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:11:01" MIMETYPE="text/xml" CHECKSUM="a81033208aee249312daead3180e031ec5f53e30" CHECKSUMTYPE="SHA-1" SIZE="19206">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:11:01" MIMETYPE="text/xml"
-				CHECKSUM="19007ada5d5c8ecc7f48c70f444399283550d244" CHECKSUMTYPE="SHA-1"
-				SIZE="22754">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:11:01" MIMETYPE="text/xml" CHECKSUM="19007ada5d5c8ecc7f48c70f444399283550d244" CHECKSUMTYPE="SHA-1" SIZE="22754">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:11:01" MIMETYPE="text/xml"
-				CHECKSUM="fab504382b76ee85f5a9416438139978a7e23aa7" CHECKSUMTYPE="SHA-1"
-				SIZE="24337">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:11:01" MIMETYPE="text/xml" CHECKSUM="fab504382b76ee85f5a9416438139978a7e23aa7" CHECKSUMTYPE="SHA-1" SIZE="24337">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:11:01" MIMETYPE="text/xml"
-				CHECKSUM="588c54602c04ab06a19d663222dadb6203df7d7a" CHECKSUMTYPE="SHA-1"
-				SIZE="23603">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:11:01" MIMETYPE="text/xml" CHECKSUM="588c54602c04ab06a19d663222dadb6203df7d7a" CHECKSUMTYPE="SHA-1" SIZE="23603">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:11:02" MIMETYPE="text/xml"
-				CHECKSUM="5e2077f55ee766cbd8e1cac2476059a85015306b" CHECKSUMTYPE="SHA-1" SIZE="7551">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:11:02" MIMETYPE="text/xml" CHECKSUM="5e2077f55ee766cbd8e1cac2476059a85015306b" CHECKSUMTYPE="SHA-1" SIZE="7551">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:11:02" MIMETYPE="text/xml"
-				CHECKSUM="b107ea2d6c33125573c9a0a8ed544434ac472dd8" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:11:02" MIMETYPE="text/xml" CHECKSUM="b107ea2d6c33125573c9a0a8ed544434ac472dd8" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:11:02" MIMETYPE="text/xml"
-				CHECKSUM="3c5ad49b5f2ef9d4bacce861ca45f16fedd0a4f4" CHECKSUMTYPE="SHA-1" SIZE="6188">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:11:02" MIMETYPE="text/xml" CHECKSUM="3c5ad49b5f2ef9d4bacce861ca45f16fedd0a4f4" CHECKSUMTYPE="SHA-1" SIZE="6188">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-01_01_0026.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:11:29" MIMETYPE="application/pdf"
-				CHECKSUM="93a8313cdec3144d6fec1f4eefc20a3487668ced" CHECKSUMTYPE="SHA-1"
-				SIZE="7443081">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/bmtnabf_1903-08-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:11:29" MIMETYPE="application/pdf" CHECKSUM="93a8313cdec3144d6fec1f4eefc20a3487668ced" CHECKSUMTYPE="SHA-1" SIZE="7443081">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/01_01/bmtnabf_1903-08-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2824,8 +2654,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003"
-					LABEL="ALTWIENER GARTENHAUS IN DÖBLING">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003" LABEL="ALTWIENER GARTENHAUS IN DÖBLING">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -2869,8 +2698,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005"
-					LABEL="EHEMALIGES WOHNHAUS THEODORS VON KÖRNER IN DÖBLING">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005" LABEL="EHEMALIGES WOHNHAUS THEODORS VON KÖRNER IN DÖBLING">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -2914,8 +2742,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c007"
-					LABEL="WOHNHÄUSER AUF DER HOHEN WARTE">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c007" LABEL="WOHNHÄUSER AUF DER HOHEN WARTE">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/08/15_01/bmtnabf_1903-08-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/08/15_01/bmtnabf_1903-08-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-08-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-08-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-08-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-08-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-08-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2376,356 +2370,180 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:57:11"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="62737ee79a326577269b30b921fa3dc30140882f"
-				CHECKSUMTYPE="SHA-1" SIZE="6229906">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:57:11" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="62737ee79a326577269b30b921fa3dc30140882f" CHECKSUMTYPE="SHA-1" SIZE="6229906">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:57:44"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="4387dc5915718b2d6cbe68adf486451c20a09682"
-				CHECKSUMTYPE="SHA-1" SIZE="6109317">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:57:44" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="4387dc5915718b2d6cbe68adf486451c20a09682" CHECKSUMTYPE="SHA-1" SIZE="6109317">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:58:19"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="fc0739daf2c6098270da9b18ee786a9671def27c"
-				CHECKSUMTYPE="SHA-1" SIZE="6229923">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:58:19" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="fc0739daf2c6098270da9b18ee786a9671def27c" CHECKSUMTYPE="SHA-1" SIZE="6229923">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:58:58"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="4692557548ec72b86aab65b733e4ad19c7835c1c"
-				CHECKSUMTYPE="SHA-1" SIZE="6108429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:58:58" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="4692557548ec72b86aab65b733e4ad19c7835c1c" CHECKSUMTYPE="SHA-1" SIZE="6108429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:59:38"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2caac0595c24331ddc46169f1ca17fb18c1a7b7e"
-				CHECKSUMTYPE="SHA-1" SIZE="6093126">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T19:59:38" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="2caac0595c24331ddc46169f1ca17fb18c1a7b7e" CHECKSUMTYPE="SHA-1" SIZE="6093126">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:00:15"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="fcbd84f351d50c4c4c16ca15bf20eef647fa029f"
-				CHECKSUMTYPE="SHA-1" SIZE="6109326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:00:15" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="fcbd84f351d50c4c4c16ca15bf20eef647fa029f" CHECKSUMTYPE="SHA-1" SIZE="6109326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:00:48"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="a52fb0bf7e12757ca4db338eb3db2fead3063e25"
-				CHECKSUMTYPE="SHA-1" SIZE="6093124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:00:48" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="a52fb0bf7e12757ca4db338eb3db2fead3063e25" CHECKSUMTYPE="SHA-1" SIZE="6093124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:01:23"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="b3006bcdd5076672718951d9528a7be5d0618165"
-				CHECKSUMTYPE="SHA-1" SIZE="6109327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:01:23" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="b3006bcdd5076672718951d9528a7be5d0618165" CHECKSUMTYPE="SHA-1" SIZE="6109327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:02:01"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f880a88b575e74b93e5f2607b66d272a9d61debd"
-				CHECKSUMTYPE="SHA-1" SIZE="6093077">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:02:01" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f880a88b575e74b93e5f2607b66d272a9d61debd" CHECKSUMTYPE="SHA-1" SIZE="6093077">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:02:36"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="497564ea183345b199b7d8dfcb23e9962b703329"
-				CHECKSUMTYPE="SHA-1" SIZE="6109311">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:02:36" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="497564ea183345b199b7d8dfcb23e9962b703329" CHECKSUMTYPE="SHA-1" SIZE="6109311">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:03:12"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="2c51d738e6b419fef68e2ae13bb67db431596527"
-				CHECKSUMTYPE="SHA-1" SIZE="6091324">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:03:12" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="2c51d738e6b419fef68e2ae13bb67db431596527" CHECKSUMTYPE="SHA-1" SIZE="6091324">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:03:47"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="775ca2a6d7b6b874d55060f52abe9afc7b210792"
-				CHECKSUMTYPE="SHA-1" SIZE="6109314">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:03:47" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="775ca2a6d7b6b874d55060f52abe9afc7b210792" CHECKSUMTYPE="SHA-1" SIZE="6109314">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:04:22"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="f15f347eb1aca32730bf018c3d9cdfbc1823aa0c"
-				CHECKSUMTYPE="SHA-1" SIZE="6091282">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:04:22" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="f15f347eb1aca32730bf018c3d9cdfbc1823aa0c" CHECKSUMTYPE="SHA-1" SIZE="6091282">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:04:57"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="325339c1be39bb9147b37bd71e788462ae701e22"
-				CHECKSUMTYPE="SHA-1" SIZE="6132720">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:04:57" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="325339c1be39bb9147b37bd71e788462ae701e22" CHECKSUMTYPE="SHA-1" SIZE="6132720">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:05:31"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="a88d988965c80b097af8fafa397bd6429e1e682b"
-				CHECKSUMTYPE="SHA-1" SIZE="6040929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:05:31" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="a88d988965c80b097af8fafa397bd6429e1e682b" CHECKSUMTYPE="SHA-1" SIZE="6040929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:06:08"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="b197c1d140bcb374f52b449e2b3d8af835c6f5f4"
-				CHECKSUMTYPE="SHA-1" SIZE="6132705">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:06:08" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="b197c1d140bcb374f52b449e2b3d8af835c6f5f4" CHECKSUMTYPE="SHA-1" SIZE="6132705">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:06:41"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="b8f6dd6403adcbdf5eba2bbef0fcd6790339c2d7"
-				CHECKSUMTYPE="SHA-1" SIZE="6040925">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:06:41" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="b8f6dd6403adcbdf5eba2bbef0fcd6790339c2d7" CHECKSUMTYPE="SHA-1" SIZE="6040925">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:07:18"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="963112dfe209365551a2242afd67fefa9e8d0312"
-				CHECKSUMTYPE="SHA-1" SIZE="6160605">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:07:18" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="963112dfe209365551a2242afd67fefa9e8d0312" CHECKSUMTYPE="SHA-1" SIZE="6160605">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:07:54"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7e288f579bc28623339ea7945310e7c5e70fcd13"
-				CHECKSUMTYPE="SHA-1" SIZE="6039992">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:07:54" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="7e288f579bc28623339ea7945310e7c5e70fcd13" CHECKSUMTYPE="SHA-1" SIZE="6039992">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:08:30"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="c5c9ef0b90b223495f6baa80b70112e93a0735c0"
-				CHECKSUMTYPE="SHA-1" SIZE="6160621">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:08:30" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="c5c9ef0b90b223495f6baa80b70112e93a0735c0" CHECKSUMTYPE="SHA-1" SIZE="6160621">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:09:06"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="ef8bb265208449fc8e36f9ec2c8a8df5fcdaf242"
-				CHECKSUMTYPE="SHA-1" SIZE="6022016">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:09:06" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="ef8bb265208449fc8e36f9ec2c8a8df5fcdaf242" CHECKSUMTYPE="SHA-1" SIZE="6022016">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:09:39"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="067eb000759ff3428108bd285f06e71368298f4a"
-				CHECKSUMTYPE="SHA-1" SIZE="6161526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:09:39" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="067eb000759ff3428108bd285f06e71368298f4a" CHECKSUMTYPE="SHA-1" SIZE="6161526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:10:13"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="c7ef4e84a9ae02c2d938ddbb3e6cb10893e33cf6"
-				CHECKSUMTYPE="SHA-1" SIZE="6059823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:10:13" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="c7ef4e84a9ae02c2d938ddbb3e6cb10893e33cf6" CHECKSUMTYPE="SHA-1" SIZE="6059823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:10:49"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="94fbf72b2356b6a336f3b77b832a4b31c44f9550"
-				CHECKSUMTYPE="SHA-1" SIZE="6161528">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:10:49" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="94fbf72b2356b6a336f3b77b832a4b31c44f9550" CHECKSUMTYPE="SHA-1" SIZE="6161528">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:11:24"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="25dc113a912922c66afd7e206c4e63e0a5d06b66"
-				CHECKSUMTYPE="SHA-1" SIZE="6059820">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:11:24" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="25dc113a912922c66afd7e206c4e63e0a5d06b66" CHECKSUMTYPE="SHA-1" SIZE="6059820">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:11:59"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="7b2ecdf2ef2601957e9b1b148c0d4a6672893717"
-				CHECKSUMTYPE="SHA-1" SIZE="6161515">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:11:59" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="7b2ecdf2ef2601957e9b1b148c0d4a6672893717" CHECKSUMTYPE="SHA-1" SIZE="6161515">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:12:35"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="e616dbc0d593263293a94268321e967eca3dc33c"
-				CHECKSUMTYPE="SHA-1" SIZE="6059793">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:12:35" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="e616dbc0d593263293a94268321e967eca3dc33c" CHECKSUMTYPE="SHA-1" SIZE="6059793">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:13:11"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="414a64668cc6428834738487d19877188442bbfb"
-				CHECKSUMTYPE="SHA-1" SIZE="6160629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:13:11" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="414a64668cc6428834738487d19877188442bbfb" CHECKSUMTYPE="SHA-1" SIZE="6160629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/delivery/bmtnabf_1903-08-15_01_0028.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:13:32" MIMETYPE="text/xml"
-				CHECKSUM="bbbc63dac49d3fa6b321b4cb49d9851423c0ee23" CHECKSUMTYPE="SHA-1" SIZE="4647">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:13:32" MIMETYPE="text/xml" CHECKSUM="bbbc63dac49d3fa6b321b4cb49d9851423c0ee23" CHECKSUMTYPE="SHA-1" SIZE="4647">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:13:32" MIMETYPE="text/xml"
-				CHECKSUM="ec9fbb8ed4bf0292a36fd2a5b01560122fdb8835" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:13:32" MIMETYPE="text/xml" CHECKSUM="ec9fbb8ed4bf0292a36fd2a5b01560122fdb8835" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:13:33" MIMETYPE="text/xml"
-				CHECKSUM="d148533f67b404296be0755c051627d3ff90a765" CHECKSUMTYPE="SHA-1" SIZE="8363">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:13:33" MIMETYPE="text/xml" CHECKSUM="d148533f67b404296be0755c051627d3ff90a765" CHECKSUMTYPE="SHA-1" SIZE="8363">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:13:33" MIMETYPE="text/xml"
-				CHECKSUM="8478784bafb4ed1368dd51edc8ea8eb68a2db8ec" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:13:33" MIMETYPE="text/xml" CHECKSUM="8478784bafb4ed1368dd51edc8ea8eb68a2db8ec" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:13:33" MIMETYPE="text/xml"
-				CHECKSUM="040facfbfcee0b930ae7bdc79d6c0fc514f38acb" CHECKSUMTYPE="SHA-1" SIZE="4316">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:13:33" MIMETYPE="text/xml" CHECKSUM="040facfbfcee0b930ae7bdc79d6c0fc514f38acb" CHECKSUMTYPE="SHA-1" SIZE="4316">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:13:33" MIMETYPE="text/xml"
-				CHECKSUM="7592c7ea87bd0bc39b35d6d8306c1e8ec680bee9" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:13:33" MIMETYPE="text/xml" CHECKSUM="7592c7ea87bd0bc39b35d6d8306c1e8ec680bee9" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:13:34" MIMETYPE="text/xml"
-				CHECKSUM="ceab95af9b91463ea398ef8caa3bfc084cc5f440" CHECKSUMTYPE="SHA-1" SIZE="4316">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:13:34" MIMETYPE="text/xml" CHECKSUM="ceab95af9b91463ea398ef8caa3bfc084cc5f440" CHECKSUMTYPE="SHA-1" SIZE="4316">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:13:34" MIMETYPE="text/xml"
-				CHECKSUM="2d51d1cb4faf5bf9a828450af1bc7f6c06e381cb" CHECKSUMTYPE="SHA-1" SIZE="2009">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:13:34" MIMETYPE="text/xml" CHECKSUM="2d51d1cb4faf5bf9a828450af1bc7f6c06e381cb" CHECKSUMTYPE="SHA-1" SIZE="2009">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:13:34" MIMETYPE="text/xml"
-				CHECKSUM="6d4fa38a3e3671f8a4df25c95e7cea586296b5e1" CHECKSUMTYPE="SHA-1" SIZE="4316">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:13:34" MIMETYPE="text/xml" CHECKSUM="6d4fa38a3e3671f8a4df25c95e7cea586296b5e1" CHECKSUMTYPE="SHA-1" SIZE="4316">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:13:34" MIMETYPE="text/xml"
-				CHECKSUM="cdeec5a3a63d1bf0b4568e8447f0e66006635a42" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:13:34" MIMETYPE="text/xml" CHECKSUM="cdeec5a3a63d1bf0b4568e8447f0e66006635a42" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:13:35" MIMETYPE="text/xml"
-				CHECKSUM="616193dea70061b1d7d29fe9300e506bc70a831c" CHECKSUMTYPE="SHA-1" SIZE="4340">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:13:35" MIMETYPE="text/xml" CHECKSUM="616193dea70061b1d7d29fe9300e506bc70a831c" CHECKSUMTYPE="SHA-1" SIZE="4340">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:13:35" MIMETYPE="text/xml"
-				CHECKSUM="c23af2ff5c98f110cec1bb8e2a440cd5b0528691" CHECKSUMTYPE="SHA-1" SIZE="2019">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:13:35" MIMETYPE="text/xml" CHECKSUM="c23af2ff5c98f110cec1bb8e2a440cd5b0528691" CHECKSUMTYPE="SHA-1" SIZE="2019">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:13:35" MIMETYPE="text/xml"
-				CHECKSUM="4c8ddd6b9c0e6850ffb4967273b28d10bfc84962" CHECKSUMTYPE="SHA-1" SIZE="4341">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:13:35" MIMETYPE="text/xml" CHECKSUM="4c8ddd6b9c0e6850ffb4967273b28d10bfc84962" CHECKSUMTYPE="SHA-1" SIZE="4341">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:13:35" MIMETYPE="text/xml"
-				CHECKSUM="138b8f4f4675c7f3f8edb13924e4e6cc2c1cdcaa" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:13:35" MIMETYPE="text/xml" CHECKSUM="138b8f4f4675c7f3f8edb13924e4e6cc2c1cdcaa" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:13:36" MIMETYPE="text/xml"
-				CHECKSUM="10029c62c9d8d43f4ce761cb2b4bf026cee9e623" CHECKSUMTYPE="SHA-1" SIZE="4410">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:13:36" MIMETYPE="text/xml" CHECKSUM="10029c62c9d8d43f4ce761cb2b4bf026cee9e623" CHECKSUMTYPE="SHA-1" SIZE="4410">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:13:36" MIMETYPE="text/xml"
-				CHECKSUM="81add39ec0398f298dcf6f386af9c472af93fed5" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:13:36" MIMETYPE="text/xml" CHECKSUM="81add39ec0398f298dcf6f386af9c472af93fed5" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:13:36" MIMETYPE="text/xml"
-				CHECKSUM="17ad62ba3a5452ed99a51b8b0e36bcaf3106c588" CHECKSUMTYPE="SHA-1" SIZE="4446">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:13:36" MIMETYPE="text/xml" CHECKSUM="17ad62ba3a5452ed99a51b8b0e36bcaf3106c588" CHECKSUMTYPE="SHA-1" SIZE="4446">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:13:36" MIMETYPE="text/xml"
-				CHECKSUM="74d8328fe8713078551ed2329c7f2d87f203808c" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:13:36" MIMETYPE="text/xml" CHECKSUM="74d8328fe8713078551ed2329c7f2d87f203808c" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:13:36" MIMETYPE="text/xml"
-				CHECKSUM="584c7bf51fc43c3439158bc182312d74d00c0b58" CHECKSUMTYPE="SHA-1" SIZE="2019">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:13:36" MIMETYPE="text/xml" CHECKSUM="584c7bf51fc43c3439158bc182312d74d00c0b58" CHECKSUMTYPE="SHA-1" SIZE="2019">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:13:37" MIMETYPE="text/xml"
-				CHECKSUM="c6fee24ac2de5ab97637629756b007018333bd66" CHECKSUMTYPE="SHA-1" SIZE="9320">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:13:37" MIMETYPE="text/xml" CHECKSUM="c6fee24ac2de5ab97637629756b007018333bd66" CHECKSUMTYPE="SHA-1" SIZE="9320">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:13:37" MIMETYPE="text/xml"
-				CHECKSUM="4bc4f05a1556d967f520fde1c4af338f4e815953" CHECKSUMTYPE="SHA-1" SIZE="8645">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:13:37" MIMETYPE="text/xml" CHECKSUM="4bc4f05a1556d967f520fde1c4af338f4e815953" CHECKSUMTYPE="SHA-1" SIZE="8645">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:13:37" MIMETYPE="text/xml"
-				CHECKSUM="107464a32f1b1af7b6c5cfca4cde9b66178313c9" CHECKSUMTYPE="SHA-1"
-				SIZE="17610">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:13:37" MIMETYPE="text/xml" CHECKSUM="107464a32f1b1af7b6c5cfca4cde9b66178313c9" CHECKSUMTYPE="SHA-1" SIZE="17610">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:13:37" MIMETYPE="text/xml"
-				CHECKSUM="ba7b25e22ceb838d433632a90f591efc964f4762" CHECKSUMTYPE="SHA-1"
-				SIZE="21801">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:13:37" MIMETYPE="text/xml" CHECKSUM="ba7b25e22ceb838d433632a90f591efc964f4762" CHECKSUMTYPE="SHA-1" SIZE="21801">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:13:38" MIMETYPE="text/xml"
-				CHECKSUM="b6d2830361c3a6cc1d4e22cbbc4efe6033ba2ff7" CHECKSUMTYPE="SHA-1"
-				SIZE="17105">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:13:38" MIMETYPE="text/xml" CHECKSUM="b6d2830361c3a6cc1d4e22cbbc4efe6033ba2ff7" CHECKSUMTYPE="SHA-1" SIZE="17105">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:13:38" MIMETYPE="text/xml"
-				CHECKSUM="93831c5afaeb3c1773c81375b96b6080bd2faed3" CHECKSUMTYPE="SHA-1"
-				SIZE="35440">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:13:38" MIMETYPE="text/xml" CHECKSUM="93831c5afaeb3c1773c81375b96b6080bd2faed3" CHECKSUMTYPE="SHA-1" SIZE="35440">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:13:38" MIMETYPE="text/xml"
-				CHECKSUM="9ec2f37129e0bf68247e9f61416adf2a06f9e543" CHECKSUMTYPE="SHA-1" SIZE="7551">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:13:38" MIMETYPE="text/xml" CHECKSUM="9ec2f37129e0bf68247e9f61416adf2a06f9e543" CHECKSUMTYPE="SHA-1" SIZE="7551">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:13:39" MIMETYPE="text/xml"
-				CHECKSUM="bd9f258f02182b34cc634d8087acd6570e69433d" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:13:39" MIMETYPE="text/xml" CHECKSUM="bd9f258f02182b34cc634d8087acd6570e69433d" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:13:39" MIMETYPE="text/xml"
-				CHECKSUM="aea683d62b09b863af37e44d3a9e645def6fb05a" CHECKSUMTYPE="SHA-1" SIZE="7770">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:13:39" MIMETYPE="text/xml" CHECKSUM="aea683d62b09b863af37e44d3a9e645def6fb05a" CHECKSUMTYPE="SHA-1" SIZE="7770">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-08-15_01_0028.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:14:05" MIMETYPE="application/pdf"
-				CHECKSUM="5ca0541d662716e9b831d1b62054ca379a522715" CHECKSUMTYPE="SHA-1"
-				SIZE="6814186">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/bmtnabf_1903-08-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:14:05" MIMETYPE="application/pdf" CHECKSUM="5ca0541d662716e9b831d1b62054ca379a522715" CHECKSUMTYPE="SHA-1" SIZE="6814186">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/08/15_01/bmtnabf_1903-08-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3011,8 +2829,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -3029,8 +2846,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c004"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c004" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -3047,8 +2863,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -3065,8 +2880,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c006"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c006" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -3083,8 +2897,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c007"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c007" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -3101,8 +2914,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="8" DMDID="c008"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="8" DMDID="c008" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -3119,8 +2931,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="9" DMDID="c009"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="9" DMDID="c009" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/09/01_01/bmtnabf_1903-09-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/09/01_01/bmtnabf_1903-09-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-09-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-09-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-09-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-09-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-09-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2386,356 +2380,180 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:57:47"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="3a0facfafc3f8184c5bfbbdfcf40d22bb6fe9815"
-				CHECKSUMTYPE="SHA-1" SIZE="6140806">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T19:57:47" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="3a0facfafc3f8184c5bfbbdfcf40d22bb6fe9815" CHECKSUMTYPE="SHA-1" SIZE="6140806">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:58:20"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="e571d865aa22ae5a3a334527ef4b40a42d3d19e8"
-				CHECKSUMTYPE="SHA-1" SIZE="6209022">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T19:58:20" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="e571d865aa22ae5a3a334527ef4b40a42d3d19e8" CHECKSUMTYPE="SHA-1" SIZE="6209022">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:58:53"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c81e774873aee1429bf0d6c5c7c5e46e6f356c73"
-				CHECKSUMTYPE="SHA-1" SIZE="6139929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T19:58:53" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c81e774873aee1429bf0d6c5c7c5e46e6f356c73" CHECKSUMTYPE="SHA-1" SIZE="6139929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:59:32"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="ac581a2840598273c64719b178d599f560ead410"
-				CHECKSUMTYPE="SHA-1" SIZE="6209214">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T19:59:32" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="ac581a2840598273c64719b178d599f560ead410" CHECKSUMTYPE="SHA-1" SIZE="6209214">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:00:14"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="22d2ce9a60e1101e1d672bc9caef57765787624c"
-				CHECKSUMTYPE="SHA-1" SIZE="6139880">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:00:14" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="22d2ce9a60e1101e1d672bc9caef57765787624c" CHECKSUMTYPE="SHA-1" SIZE="6139880">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:00:52"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="7916581659f20186080df04859ce89a9551998ce"
-				CHECKSUMTYPE="SHA-1" SIZE="6209221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:00:52" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="7916581659f20186080df04859ce89a9551998ce" CHECKSUMTYPE="SHA-1" SIZE="6209221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:01:26"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="6545e7997109192d829f10dacb9df28552c6fff0"
-				CHECKSUMTYPE="SHA-1" SIZE="6140806">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:01:26" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="6545e7997109192d829f10dacb9df28552c6fff0" CHECKSUMTYPE="SHA-1" SIZE="6140806">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:02:02"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="578e46410f7fcef8df9b1b929519e3c75ecfd738"
-				CHECKSUMTYPE="SHA-1" SIZE="6209229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:02:02" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="578e46410f7fcef8df9b1b929519e3c75ecfd738" CHECKSUMTYPE="SHA-1" SIZE="6209229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:02:36"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f65ee0b33105397fcbdd68327018a770dc58b3fb"
-				CHECKSUMTYPE="SHA-1" SIZE="6140821">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:02:36" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="f65ee0b33105397fcbdd68327018a770dc58b3fb" CHECKSUMTYPE="SHA-1" SIZE="6140821">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:03:13"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="4a9532eb52f71f64ddbd75f4bd78d4ee8b476763"
-				CHECKSUMTYPE="SHA-1" SIZE="6209201">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:03:13" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="4a9532eb52f71f64ddbd75f4bd78d4ee8b476763" CHECKSUMTYPE="SHA-1" SIZE="6209201">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:03:47"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f1ef68cc6aa21d55e6e3350e01ec508008f39288"
-				CHECKSUMTYPE="SHA-1" SIZE="6140828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:03:47" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="f1ef68cc6aa21d55e6e3350e01ec508008f39288" CHECKSUMTYPE="SHA-1" SIZE="6140828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:04:23"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="9f0b4f489408d4d27fdd53f46fccdb5ab6f969f0"
-				CHECKSUMTYPE="SHA-1" SIZE="6210108">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:04:23" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="9f0b4f489408d4d27fdd53f46fccdb5ab6f969f0" CHECKSUMTYPE="SHA-1" SIZE="6210108">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:04:53"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="210d1d1c6a2c5d3377c2e514fac0e7b25ea5e2dd"
-				CHECKSUMTYPE="SHA-1" SIZE="6140829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:04:53" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="210d1d1c6a2c5d3377c2e514fac0e7b25ea5e2dd" CHECKSUMTYPE="SHA-1" SIZE="6140829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:05:31"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="43ba3598060270c262d526888e6dcccf366c6d5d"
-				CHECKSUMTYPE="SHA-1" SIZE="6209221">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:05:31" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="43ba3598060270c262d526888e6dcccf366c6d5d" CHECKSUMTYPE="SHA-1" SIZE="6209221">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:06:08"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="ad31f2b03f78cbd7bd965e9fb5ff10e89d2509aa"
-				CHECKSUMTYPE="SHA-1" SIZE="5990514">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:06:08" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="ad31f2b03f78cbd7bd965e9fb5ff10e89d2509aa" CHECKSUMTYPE="SHA-1" SIZE="5990514">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:06:45"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="dd5026fa3e91323cd362971327d2c21020d48073"
-				CHECKSUMTYPE="SHA-1" SIZE="6209199">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:06:45" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="dd5026fa3e91323cd362971327d2c21020d48073" CHECKSUMTYPE="SHA-1" SIZE="6209199">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:07:17"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="6f96570da1a2985279f0ba316ae0a89ff10da21c"
-				CHECKSUMTYPE="SHA-1" SIZE="5990526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:07:17" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="6f96570da1a2985279f0ba316ae0a89ff10da21c" CHECKSUMTYPE="SHA-1" SIZE="5990526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:07:50"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="cdc781b169ae3e5afb3a4aa8b1475fadfd95b8cc"
-				CHECKSUMTYPE="SHA-1" SIZE="6209207">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:07:50" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="cdc781b169ae3e5afb3a4aa8b1475fadfd95b8cc" CHECKSUMTYPE="SHA-1" SIZE="6209207">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:08:24"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="16f3482f7e192b16114f74d9e44614db7af246ee"
-				CHECKSUMTYPE="SHA-1" SIZE="6004025">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:08:24" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="16f3482f7e192b16114f74d9e44614db7af246ee" CHECKSUMTYPE="SHA-1" SIZE="6004025">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:08:59"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="887b6aaf100a5de7b3297bad5dc1455b3ec17d2e"
-				CHECKSUMTYPE="SHA-1" SIZE="6209226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:08:59" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="887b6aaf100a5de7b3297bad5dc1455b3ec17d2e" CHECKSUMTYPE="SHA-1" SIZE="6209226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:09:30"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="208c8689089deb66a37e9ceaa81134a3e51c863d"
-				CHECKSUMTYPE="SHA-1" SIZE="6004024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:09:30" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="208c8689089deb66a37e9ceaa81134a3e51c863d" CHECKSUMTYPE="SHA-1" SIZE="6004024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:10:04"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="98e498036248a06e4ccd6c044f1ce0259f4b29e2"
-				CHECKSUMTYPE="SHA-1" SIZE="6209228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:10:04" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="98e498036248a06e4ccd6c044f1ce0259f4b29e2" CHECKSUMTYPE="SHA-1" SIZE="6209228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:10:39"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="10225006410e46f91bb69b42aec2e45df3d68ab8"
-				CHECKSUMTYPE="SHA-1" SIZE="6004007">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:10:39" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="10225006410e46f91bb69b42aec2e45df3d68ab8" CHECKSUMTYPE="SHA-1" SIZE="6004007">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:11:13"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="3d4f5a91092d62b5a1b2968c75df034943a29c69"
-				CHECKSUMTYPE="SHA-1" SIZE="6209229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:11:13" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="3d4f5a91092d62b5a1b2968c75df034943a29c69" CHECKSUMTYPE="SHA-1" SIZE="6209229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:11:48"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="53f95807feac11b7cb4ecf1f2aa6ad9aaf50e6fe"
-				CHECKSUMTYPE="SHA-1" SIZE="6004027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:11:48" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="53f95807feac11b7cb4ecf1f2aa6ad9aaf50e6fe" CHECKSUMTYPE="SHA-1" SIZE="6004027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:12:24"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="6d7c3f77d482ce725428c963957f843e983f67a3"
-				CHECKSUMTYPE="SHA-1" SIZE="6209228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:12:24" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="6d7c3f77d482ce725428c963957f843e983f67a3" CHECKSUMTYPE="SHA-1" SIZE="6209228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:12:59"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="9c501e55e2c979a3f3942b809f9ab36397170901"
-				CHECKSUMTYPE="SHA-1" SIZE="6003972">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:12:59" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="9c501e55e2c979a3f3942b809f9ab36397170901" CHECKSUMTYPE="SHA-1" SIZE="6003972">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:13:35"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="5a68e0fcede17d2fc06fcb3334e7f3c5131f56b1"
-				CHECKSUMTYPE="SHA-1" SIZE="6256927">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:13:35" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="5a68e0fcede17d2fc06fcb3334e7f3c5131f56b1" CHECKSUMTYPE="SHA-1" SIZE="6256927">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/delivery/bmtnabf_1903-09-01_01_0028.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:13:59" MIMETYPE="text/xml"
-				CHECKSUM="cbf254c88cb246f0827bc22c171a2276e75d4214" CHECKSUMTYPE="SHA-1" SIZE="4774">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:13:59" MIMETYPE="text/xml" CHECKSUM="cbf254c88cb246f0827bc22c171a2276e75d4214" CHECKSUMTYPE="SHA-1" SIZE="4774">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:13:59" MIMETYPE="text/xml"
-				CHECKSUM="a91a31e05f79dcd3168cfce2abf55ebb15cb3599" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:13:59" MIMETYPE="text/xml" CHECKSUM="a91a31e05f79dcd3168cfce2abf55ebb15cb3599" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:13:59" MIMETYPE="text/xml"
-				CHECKSUM="c28b0a29ca99c6e283a4d5aab286b09b3d795510" CHECKSUMTYPE="SHA-1" SIZE="8467">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:13:59" MIMETYPE="text/xml" CHECKSUM="c28b0a29ca99c6e283a4d5aab286b09b3d795510" CHECKSUMTYPE="SHA-1" SIZE="8467">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:13:59" MIMETYPE="text/xml"
-				CHECKSUM="69489e8b060c8f2f1da19f181e733c41276f320f" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:13:59" MIMETYPE="text/xml" CHECKSUM="69489e8b060c8f2f1da19f181e733c41276f320f" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:14:00" MIMETYPE="text/xml"
-				CHECKSUM="88f7c0bf8ea98b60e11d18e974eebd045bdd11dc" CHECKSUMTYPE="SHA-1" SIZE="4944">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:14:00" MIMETYPE="text/xml" CHECKSUM="88f7c0bf8ea98b60e11d18e974eebd045bdd11dc" CHECKSUMTYPE="SHA-1" SIZE="4944">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:14:00" MIMETYPE="text/xml"
-				CHECKSUM="dd47856ce1743d7f46eae3b66a249ee09cd39220" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:14:00" MIMETYPE="text/xml" CHECKSUM="dd47856ce1743d7f46eae3b66a249ee09cd39220" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:14:00" MIMETYPE="text/xml"
-				CHECKSUM="cd02291b2e2ffcd436c5c36f72ad8403d70aaafd" CHECKSUMTYPE="SHA-1" SIZE="4509">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:14:00" MIMETYPE="text/xml" CHECKSUM="cd02291b2e2ffcd436c5c36f72ad8403d70aaafd" CHECKSUMTYPE="SHA-1" SIZE="4509">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:14:00" MIMETYPE="text/xml"
-				CHECKSUM="0c1559df262b742df621826ddfdadca0a497c1ea" CHECKSUMTYPE="SHA-1" SIZE="2012">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:14:00" MIMETYPE="text/xml" CHECKSUM="0c1559df262b742df621826ddfdadca0a497c1ea" CHECKSUMTYPE="SHA-1" SIZE="2012">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:14:01" MIMETYPE="text/xml"
-				CHECKSUM="40d805241f3e2391752818d3be147e3fc8bde0c5" CHECKSUMTYPE="SHA-1" SIZE="4874">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:14:01" MIMETYPE="text/xml" CHECKSUM="40d805241f3e2391752818d3be147e3fc8bde0c5" CHECKSUMTYPE="SHA-1" SIZE="4874">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:14:01" MIMETYPE="text/xml"
-				CHECKSUM="930707620f110bd0add45d848c3b38a1b61a8126" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:14:01" MIMETYPE="text/xml" CHECKSUM="930707620f110bd0add45d848c3b38a1b61a8126" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:14:01" MIMETYPE="text/xml"
-				CHECKSUM="83eebe61eb64a87c9e60efafe22f9e6b3fe09e89" CHECKSUMTYPE="SHA-1" SIZE="5187">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:14:01" MIMETYPE="text/xml" CHECKSUM="83eebe61eb64a87c9e60efafe22f9e6b3fe09e89" CHECKSUMTYPE="SHA-1" SIZE="5187">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:14:01" MIMETYPE="text/xml"
-				CHECKSUM="4f22b065415060908b3218741a0306020f801bbc" CHECKSUMTYPE="SHA-1" SIZE="2019">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:14:01" MIMETYPE="text/xml" CHECKSUM="4f22b065415060908b3218741a0306020f801bbc" CHECKSUMTYPE="SHA-1" SIZE="2019">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:14:01" MIMETYPE="text/xml"
-				CHECKSUM="56401e493eceb642750dbdc2e150d7d8edf072d5" CHECKSUMTYPE="SHA-1" SIZE="4602">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:14:01" MIMETYPE="text/xml" CHECKSUM="56401e493eceb642750dbdc2e150d7d8edf072d5" CHECKSUMTYPE="SHA-1" SIZE="4602">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:14:02" MIMETYPE="text/xml"
-				CHECKSUM="e63da201963817ab7e9a5b64ad1d074e5462b7b2" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:14:02" MIMETYPE="text/xml" CHECKSUM="e63da201963817ab7e9a5b64ad1d074e5462b7b2" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:14:02" MIMETYPE="text/xml"
-				CHECKSUM="ad60219ccec174bfb7205d1a5fa40d251f56ad34" CHECKSUMTYPE="SHA-1" SIZE="4533">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:14:02" MIMETYPE="text/xml" CHECKSUM="ad60219ccec174bfb7205d1a5fa40d251f56ad34" CHECKSUMTYPE="SHA-1" SIZE="4533">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:14:02" MIMETYPE="text/xml"
-				CHECKSUM="a1ee2a75a7ec92d1c8c527b5eb70f5a57ca84ef1" CHECKSUMTYPE="SHA-1" SIZE="2020">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:14:02" MIMETYPE="text/xml" CHECKSUM="a1ee2a75a7ec92d1c8c527b5eb70f5a57ca84ef1" CHECKSUMTYPE="SHA-1" SIZE="2020">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:14:02" MIMETYPE="text/xml"
-				CHECKSUM="39ac7faaa055b7d602ab0978b27167fd78c66c82" CHECKSUMTYPE="SHA-1" SIZE="4533">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:14:02" MIMETYPE="text/xml" CHECKSUM="39ac7faaa055b7d602ab0978b27167fd78c66c82" CHECKSUMTYPE="SHA-1" SIZE="4533">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:14:03" MIMETYPE="text/xml"
-				CHECKSUM="471f0f68c467ec92cdbb384594b8c12f72f9b6a2" CHECKSUMTYPE="SHA-1" SIZE="2021">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:14:03" MIMETYPE="text/xml" CHECKSUM="471f0f68c467ec92cdbb384594b8c12f72f9b6a2" CHECKSUMTYPE="SHA-1" SIZE="2021">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:14:03" MIMETYPE="text/xml"
-				CHECKSUM="add84cab7c1fa4e7819fda21cb79b23da17155cf" CHECKSUMTYPE="SHA-1" SIZE="4950">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:14:03" MIMETYPE="text/xml" CHECKSUM="add84cab7c1fa4e7819fda21cb79b23da17155cf" CHECKSUMTYPE="SHA-1" SIZE="4950">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:14:03" MIMETYPE="text/xml"
-				CHECKSUM="6c4694b79be49c838bcbbf067091201f887c8818" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:14:03" MIMETYPE="text/xml" CHECKSUM="6c4694b79be49c838bcbbf067091201f887c8818" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:14:03" MIMETYPE="text/xml"
-				CHECKSUM="299c73d0cdc85449afcf607fdb44036e99c1be33" CHECKSUMTYPE="SHA-1" SIZE="8597">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:14:03" MIMETYPE="text/xml" CHECKSUM="299c73d0cdc85449afcf607fdb44036e99c1be33" CHECKSUMTYPE="SHA-1" SIZE="8597">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:14:04" MIMETYPE="text/xml"
-				CHECKSUM="935db1795e5aa4a3dd5e2318106b6fa266ac21e1" CHECKSUMTYPE="SHA-1"
-				SIZE="22149">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:14:04" MIMETYPE="text/xml" CHECKSUM="935db1795e5aa4a3dd5e2318106b6fa266ac21e1" CHECKSUMTYPE="SHA-1" SIZE="22149">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:14:04" MIMETYPE="text/xml"
-				CHECKSUM="af1202fca00a699171e266b3101519b1f139e23f" CHECKSUMTYPE="SHA-1"
-				SIZE="24491">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:14:04" MIMETYPE="text/xml" CHECKSUM="af1202fca00a699171e266b3101519b1f139e23f" CHECKSUMTYPE="SHA-1" SIZE="24491">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:14:04" MIMETYPE="text/xml"
-				CHECKSUM="16b0c9658afa4f4f8b2d8a45b0199d7be5058df5" CHECKSUMTYPE="SHA-1"
-				SIZE="13590">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:14:04" MIMETYPE="text/xml" CHECKSUM="16b0c9658afa4f4f8b2d8a45b0199d7be5058df5" CHECKSUMTYPE="SHA-1" SIZE="13590">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:14:04" MIMETYPE="text/xml"
-				CHECKSUM="5c1bcfa0f926d7ecc69470bcc0b7a6be7bd166d0" CHECKSUMTYPE="SHA-1"
-				SIZE="17246">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:14:04" MIMETYPE="text/xml" CHECKSUM="5c1bcfa0f926d7ecc69470bcc0b7a6be7bd166d0" CHECKSUMTYPE="SHA-1" SIZE="17246">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:14:04" MIMETYPE="text/xml"
-				CHECKSUM="b73bd40254d0a2536a15e84e7485584c4bc30986" CHECKSUMTYPE="SHA-1" SIZE="8891">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:14:04" MIMETYPE="text/xml" CHECKSUM="b73bd40254d0a2536a15e84e7485584c4bc30986" CHECKSUMTYPE="SHA-1" SIZE="8891">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:14:05" MIMETYPE="text/xml"
-				CHECKSUM="6a8326088a9ea5557862b8a5dd268fdd5c268916" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:14:05" MIMETYPE="text/xml" CHECKSUM="6a8326088a9ea5557862b8a5dd268fdd5c268916" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:14:05" MIMETYPE="text/xml"
-				CHECKSUM="4f615f6308984c54a6d43a11ecb42d1bc0cd816f" CHECKSUMTYPE="SHA-1" SIZE="7437">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:14:05" MIMETYPE="text/xml" CHECKSUM="4f615f6308984c54a6d43a11ecb42d1bc0cd816f" CHECKSUMTYPE="SHA-1" SIZE="7437">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-01_01_0028.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:14:29" MIMETYPE="application/pdf"
-				CHECKSUM="d809fb10d2d0dcb51ea0428a67aabbbc03a503f2" CHECKSUMTYPE="SHA-1"
-				SIZE="6802376">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/bmtnabf_1903-09-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:14:29" MIMETYPE="application/pdf" CHECKSUM="d809fb10d2d0dcb51ea0428a67aabbbc03a503f2" CHECKSUMTYPE="SHA-1" SIZE="6802376">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/01_01/bmtnabf_1903-09-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3026,8 +2844,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003"
-					LABEL="Weidenstumpf im Schnee">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003" LABEL="Weidenstumpf im Schnee">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -3071,8 +2888,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005"
-					LABEL="Weidenbüsche im Schnee">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005" LABEL="Weidenbüsche im Schnee">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -3094,8 +2910,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c006"
-					LABEL="Kreuzweg aus Heiligenkreuz">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c006" LABEL="Kreuzweg aus Heiligenkreuz">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/09/15_01/bmtnabf_1903-09-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/09/15_01/bmtnabf_1903-09-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-09-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-09-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-09-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-09-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-09-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2242,343 +2236,168 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T20:03:05"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="0b4b7b7cbf2f532f717fc3e521717fcc8ed87ffa"
-				CHECKSUMTYPE="SHA-1" SIZE="6290214">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T20:03:05" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="0b4b7b7cbf2f532f717fc3e521717fcc8ed87ffa" CHECKSUMTYPE="SHA-1" SIZE="6290214">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T20:03:36"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="db971e360f624ad761c84705981da82c53202332"
-				CHECKSUMTYPE="SHA-1" SIZE="6310924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T20:03:36" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="db971e360f624ad761c84705981da82c53202332" CHECKSUMTYPE="SHA-1" SIZE="6310924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T20:04:08"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="de9828d1bb5d7aebbb4667e3e00c1a02d922b67b"
-				CHECKSUMTYPE="SHA-1" SIZE="6290217">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T20:04:08" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="de9828d1bb5d7aebbb4667e3e00c1a02d922b67b" CHECKSUMTYPE="SHA-1" SIZE="6290217">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T20:04:41"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="5e64a5b091f0afe912200ebafebbc0fc0a63a61f"
-				CHECKSUMTYPE="SHA-1" SIZE="6310889">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T20:04:41" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="5e64a5b091f0afe912200ebafebbc0fc0a63a61f" CHECKSUMTYPE="SHA-1" SIZE="6310889">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:05:15"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="4315d2eaec76efe7feb77633f7e716cf21d417b7"
-				CHECKSUMTYPE="SHA-1" SIZE="6270428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:05:15" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="4315d2eaec76efe7feb77633f7e716cf21d417b7" CHECKSUMTYPE="SHA-1" SIZE="6270428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:05:47"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="13ec37be7ea4108388501964abe764e501375c80"
-				CHECKSUMTYPE="SHA-1" SIZE="6310918">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:05:47" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="13ec37be7ea4108388501964abe764e501375c80" CHECKSUMTYPE="SHA-1" SIZE="6310918">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:06:18"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="892a700e2271cda9a1181c98c6471479fa354860"
-				CHECKSUMTYPE="SHA-1" SIZE="6269522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:06:18" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="892a700e2271cda9a1181c98c6471479fa354860" CHECKSUMTYPE="SHA-1" SIZE="6269522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:06:48"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="7c30c2ce8b07d2ae7b98ea857cff05fbf70a873c"
-				CHECKSUMTYPE="SHA-1" SIZE="6310915">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:06:48" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="7c30c2ce8b07d2ae7b98ea857cff05fbf70a873c" CHECKSUMTYPE="SHA-1" SIZE="6310915">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:07:20"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="a5faf644246d9bf2185147d1d5e494130fe7c062"
-				CHECKSUMTYPE="SHA-1" SIZE="6205580">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:07:20" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="a5faf644246d9bf2185147d1d5e494130fe7c062" CHECKSUMTYPE="SHA-1" SIZE="6205580">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:07:50"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="51f1d4e93df98bba5d6c7bfc563330e33c2bf675"
-				CHECKSUMTYPE="SHA-1" SIZE="6310878">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:07:50" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="51f1d4e93df98bba5d6c7bfc563330e33c2bf675" CHECKSUMTYPE="SHA-1" SIZE="6310878">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:08:22"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="8cae3d18aa2018f41dc2cfca9154b1b38d6bb24c"
-				CHECKSUMTYPE="SHA-1" SIZE="6205623">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:08:22" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="8cae3d18aa2018f41dc2cfca9154b1b38d6bb24c" CHECKSUMTYPE="SHA-1" SIZE="6205623">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:08:57"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="74d0cb2773fbac406bd66b56b6acdbf536e6ec7d"
-				CHECKSUMTYPE="SHA-1" SIZE="6310928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:08:57" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="74d0cb2773fbac406bd66b56b6acdbf536e6ec7d" CHECKSUMTYPE="SHA-1" SIZE="6310928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:09:28"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="0c8d3d0d2f3b7ea66cf01392f876b2fd0189b2b4"
-				CHECKSUMTYPE="SHA-1" SIZE="6119226">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:09:28" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="0c8d3d0d2f3b7ea66cf01392f876b2fd0189b2b4" CHECKSUMTYPE="SHA-1" SIZE="6119226">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:10:01"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="98eb09e5c88ff57146934e2505384cbbe9b63fea"
-				CHECKSUMTYPE="SHA-1" SIZE="6310024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:10:01" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="98eb09e5c88ff57146934e2505384cbbe9b63fea" CHECKSUMTYPE="SHA-1" SIZE="6310024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:10:33"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="fd5c540cec2f43f1190b7027882338f9413a7d04"
-				CHECKSUMTYPE="SHA-1" SIZE="6120122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:10:33" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="fd5c540cec2f43f1190b7027882338f9413a7d04" CHECKSUMTYPE="SHA-1" SIZE="6120122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:11:02"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ff7afe13a3144798fcdcd82d0dbbba060ee5be92"
-				CHECKSUMTYPE="SHA-1" SIZE="6310018">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:11:02" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ff7afe13a3144798fcdcd82d0dbbba060ee5be92" CHECKSUMTYPE="SHA-1" SIZE="6310018">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:11:35"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="fde74efc04ccee5e383270cf0ec8de02d7eab086"
-				CHECKSUMTYPE="SHA-1" SIZE="6120116">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:11:35" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="fde74efc04ccee5e383270cf0ec8de02d7eab086" CHECKSUMTYPE="SHA-1" SIZE="6120116">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:12:07"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="af93298b39e1989e4caa9051bd8ef612b8629dbf"
-				CHECKSUMTYPE="SHA-1" SIZE="6367619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:12:07" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="af93298b39e1989e4caa9051bd8ef612b8629dbf" CHECKSUMTYPE="SHA-1" SIZE="6367619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:12:41"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="e56e3668b10dfe209c83c7845da69397d755c2c8"
-				CHECKSUMTYPE="SHA-1" SIZE="5987806">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:12:41" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="e56e3668b10dfe209c83c7845da69397d755c2c8" CHECKSUMTYPE="SHA-1" SIZE="5987806">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:13:14"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="4e317c3714662a09f6dd474fa164756c6dd09edf"
-				CHECKSUMTYPE="SHA-1" SIZE="6224519">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:13:14" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="4e317c3714662a09f6dd474fa164756c6dd09edf" CHECKSUMTYPE="SHA-1" SIZE="6224519">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:13:47"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="e852f832a2bc9338c26a5f514dd19f350f7303b0"
-				CHECKSUMTYPE="SHA-1" SIZE="6082329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:13:47" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="e852f832a2bc9338c26a5f514dd19f350f7303b0" CHECKSUMTYPE="SHA-1" SIZE="6082329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:14:16"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="0d5677e667a90e0453e5ae7693c6ba9bc447d383"
-				CHECKSUMTYPE="SHA-1" SIZE="6224518">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:14:16" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="0d5677e667a90e0453e5ae7693c6ba9bc447d383" CHECKSUMTYPE="SHA-1" SIZE="6224518">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:14:47"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="46a4fde325349ca486c7025312d1ef4b07e14f46"
-				CHECKSUMTYPE="SHA-1" SIZE="6153426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:14:47" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="46a4fde325349ca486c7025312d1ef4b07e14f46" CHECKSUMTYPE="SHA-1" SIZE="6153426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:15:22"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="4ca3487daea534885f3de0f0052c2855d417edd7"
-				CHECKSUMTYPE="SHA-1" SIZE="6224526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:15:22" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="4ca3487daea534885f3de0f0052c2855d417edd7" CHECKSUMTYPE="SHA-1" SIZE="6224526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:15:54"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="aaee9fd4040a9e17ad46827de3a71ea6ae858c12"
-				CHECKSUMTYPE="SHA-1" SIZE="6153407">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:15:54" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="aaee9fd4040a9e17ad46827de3a71ea6ae858c12" CHECKSUMTYPE="SHA-1" SIZE="6153407">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:16:24"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ecc2d0c1aeb10c39645c3db695329e3182840f27"
-				CHECKSUMTYPE="SHA-1" SIZE="6224527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:16:24" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="ecc2d0c1aeb10c39645c3db695329e3182840f27" CHECKSUMTYPE="SHA-1" SIZE="6224527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/delivery/bmtnabf_1903-09-15_01_0026.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:16:42" MIMETYPE="text/xml"
-				CHECKSUM="053dcf944cf408a6b34df28f9cfaa84ad5b60333" CHECKSUMTYPE="SHA-1" SIZE="4790">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:16:42" MIMETYPE="text/xml" CHECKSUM="053dcf944cf408a6b34df28f9cfaa84ad5b60333" CHECKSUMTYPE="SHA-1" SIZE="4790">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:16:43" MIMETYPE="text/xml"
-				CHECKSUM="1bfcb7c77d0b668ffc91fc3a479b920abd933c8b" CHECKSUMTYPE="SHA-1" SIZE="1718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:16:43" MIMETYPE="text/xml" CHECKSUM="1bfcb7c77d0b668ffc91fc3a479b920abd933c8b" CHECKSUMTYPE="SHA-1" SIZE="1718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:16:43" MIMETYPE="text/xml"
-				CHECKSUM="211e1ed5917ebb1a9f2047ac6119c19017004764" CHECKSUMTYPE="SHA-1" SIZE="8299">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:16:43" MIMETYPE="text/xml" CHECKSUM="211e1ed5917ebb1a9f2047ac6119c19017004764" CHECKSUMTYPE="SHA-1" SIZE="8299">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:16:43" MIMETYPE="text/xml"
-				CHECKSUM="acb65e550bd5ecb94a2ecb2968e081be48572e17" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:16:43" MIMETYPE="text/xml" CHECKSUM="acb65e550bd5ecb94a2ecb2968e081be48572e17" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:16:43" MIMETYPE="text/xml"
-				CHECKSUM="90ce6a4bcb6e385339eb567be157966218952ba6" CHECKSUMTYPE="SHA-1" SIZE="3668">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:16:43" MIMETYPE="text/xml" CHECKSUM="90ce6a4bcb6e385339eb567be157966218952ba6" CHECKSUMTYPE="SHA-1" SIZE="3668">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:16:43" MIMETYPE="text/xml"
-				CHECKSUM="49c0de38b007df933ce70972e0c7f766de0719c3" CHECKSUMTYPE="SHA-1" SIZE="1718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:16:43" MIMETYPE="text/xml" CHECKSUM="49c0de38b007df933ce70972e0c7f766de0719c3" CHECKSUMTYPE="SHA-1" SIZE="1718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:16:44" MIMETYPE="text/xml"
-				CHECKSUM="2a35be5881bdce4033a74b6345b384b33c5911f6" CHECKSUMTYPE="SHA-1"
-				SIZE="52354">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:16:44" MIMETYPE="text/xml" CHECKSUM="2a35be5881bdce4033a74b6345b384b33c5911f6" CHECKSUMTYPE="SHA-1" SIZE="52354">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:16:44" MIMETYPE="text/xml"
-				CHECKSUM="7a3707a7bc16c1fe6a59987481474f534451b4dd" CHECKSUMTYPE="SHA-1"
-				SIZE="71898">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:16:44" MIMETYPE="text/xml" CHECKSUM="7a3707a7bc16c1fe6a59987481474f534451b4dd" CHECKSUMTYPE="SHA-1" SIZE="71898">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:16:44" MIMETYPE="text/xml"
-				CHECKSUM="d352a62d8c939bd7a073fef1e65fe54748b59d6e" CHECKSUMTYPE="SHA-1"
-				SIZE="71574">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:16:44" MIMETYPE="text/xml" CHECKSUM="d352a62d8c939bd7a073fef1e65fe54748b59d6e" CHECKSUMTYPE="SHA-1" SIZE="71574">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:16:45" MIMETYPE="text/xml"
-				CHECKSUM="d60072f14078b644c29788cd7be717f7ba6c94ed" CHECKSUMTYPE="SHA-1"
-				SIZE="49414">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:16:45" MIMETYPE="text/xml" CHECKSUM="d60072f14078b644c29788cd7be717f7ba6c94ed" CHECKSUMTYPE="SHA-1" SIZE="49414">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:16:45" MIMETYPE="text/xml"
-				CHECKSUM="74606f94495fe17a9ec96bfc1e601d470a3ee661" CHECKSUMTYPE="SHA-1"
-				SIZE="52952">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:16:45" MIMETYPE="text/xml" CHECKSUM="74606f94495fe17a9ec96bfc1e601d470a3ee661" CHECKSUMTYPE="SHA-1" SIZE="52952">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:16:45" MIMETYPE="text/xml"
-				CHECKSUM="f2b176a82389ebb16db763f99813cc9ab8138529" CHECKSUMTYPE="SHA-1"
-				SIZE="66556">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:16:45" MIMETYPE="text/xml" CHECKSUM="f2b176a82389ebb16db763f99813cc9ab8138529" CHECKSUMTYPE="SHA-1" SIZE="66556">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:16:45" MIMETYPE="text/xml"
-				CHECKSUM="b4fb215f578e973d78bb6c32943fd896803fe75e" CHECKSUMTYPE="SHA-1"
-				SIZE="65956">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:16:45" MIMETYPE="text/xml" CHECKSUM="b4fb215f578e973d78bb6c32943fd896803fe75e" CHECKSUMTYPE="SHA-1" SIZE="65956">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:16:46" MIMETYPE="text/xml"
-				CHECKSUM="7a9780a500d798067532cb8f59786008e9a64f9f" CHECKSUMTYPE="SHA-1"
-				SIZE="62167">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:16:46" MIMETYPE="text/xml" CHECKSUM="7a9780a500d798067532cb8f59786008e9a64f9f" CHECKSUMTYPE="SHA-1" SIZE="62167">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:16:46" MIMETYPE="text/xml"
-				CHECKSUM="aef57e167e635ca83db18627fc6ae4aee02ee686" CHECKSUMTYPE="SHA-1"
-				SIZE="49790">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:16:46" MIMETYPE="text/xml" CHECKSUM="aef57e167e635ca83db18627fc6ae4aee02ee686" CHECKSUMTYPE="SHA-1" SIZE="49790">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:16:46" MIMETYPE="text/xml"
-				CHECKSUM="18121842b31ca9e736cf33b7ec1e3988da88205c" CHECKSUMTYPE="SHA-1"
-				SIZE="42320">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:16:46" MIMETYPE="text/xml" CHECKSUM="18121842b31ca9e736cf33b7ec1e3988da88205c" CHECKSUMTYPE="SHA-1" SIZE="42320">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:16:46" MIMETYPE="text/xml"
-				CHECKSUM="d1c6b071c31fbfdf2b92a17823d0c76d09b356dc" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:16:46" MIMETYPE="text/xml" CHECKSUM="d1c6b071c31fbfdf2b92a17823d0c76d09b356dc" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:16:47" MIMETYPE="text/xml"
-				CHECKSUM="aeb6b9dae0265fccf8d72250132b92b65691c61d" CHECKSUMTYPE="SHA-1" SIZE="9344">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:16:47" MIMETYPE="text/xml" CHECKSUM="aeb6b9dae0265fccf8d72250132b92b65691c61d" CHECKSUMTYPE="SHA-1" SIZE="9344">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:16:47" MIMETYPE="text/xml"
-				CHECKSUM="1c3cfc93c80690c477ffe7fe1686b6a955eda4fe" CHECKSUMTYPE="SHA-1" SIZE="8640">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:16:47" MIMETYPE="text/xml" CHECKSUM="1c3cfc93c80690c477ffe7fe1686b6a955eda4fe" CHECKSUMTYPE="SHA-1" SIZE="8640">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:16:47" MIMETYPE="text/xml"
-				CHECKSUM="95e4ee56fb07d6c5464299b1311a452a0a0cc89e" CHECKSUMTYPE="SHA-1"
-				SIZE="29618">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:16:47" MIMETYPE="text/xml" CHECKSUM="95e4ee56fb07d6c5464299b1311a452a0a0cc89e" CHECKSUMTYPE="SHA-1" SIZE="29618">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:16:47" MIMETYPE="text/xml"
-				CHECKSUM="529c399f32dda231963b5aeaafa1105c7ddf6d16" CHECKSUMTYPE="SHA-1"
-				SIZE="26259">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:16:47" MIMETYPE="text/xml" CHECKSUM="529c399f32dda231963b5aeaafa1105c7ddf6d16" CHECKSUMTYPE="SHA-1" SIZE="26259">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:16:48" MIMETYPE="text/xml"
-				CHECKSUM="67f4eccbb72018f64f9a634cfd160b03929e8396" CHECKSUMTYPE="SHA-1"
-				SIZE="13184">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:16:48" MIMETYPE="text/xml" CHECKSUM="67f4eccbb72018f64f9a634cfd160b03929e8396" CHECKSUMTYPE="SHA-1" SIZE="13184">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:16:48" MIMETYPE="text/xml"
-				CHECKSUM="403093637f240a8cd62d5795c24d8fd113cf597c" CHECKSUMTYPE="SHA-1"
-				SIZE="20495">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:16:48" MIMETYPE="text/xml" CHECKSUM="403093637f240a8cd62d5795c24d8fd113cf597c" CHECKSUMTYPE="SHA-1" SIZE="20495">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:16:48" MIMETYPE="text/xml"
-				CHECKSUM="a396fa00b0f01dd4f0e3060a72c69f35d58c8e3e" CHECKSUMTYPE="SHA-1"
-				SIZE="11678">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:16:48" MIMETYPE="text/xml" CHECKSUM="a396fa00b0f01dd4f0e3060a72c69f35d58c8e3e" CHECKSUMTYPE="SHA-1" SIZE="11678">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:16:49" MIMETYPE="text/xml"
-				CHECKSUM="081bc38153c6ca5eecab98029dbbb12f7dd8749b" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:16:49" MIMETYPE="text/xml" CHECKSUM="081bc38153c6ca5eecab98029dbbb12f7dd8749b" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:16:49" MIMETYPE="text/xml"
-				CHECKSUM="cb537d6451238a9365bc5cdb029d580ebb8e21c4" CHECKSUMTYPE="SHA-1" SIZE="7762">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:16:49" MIMETYPE="text/xml" CHECKSUM="cb537d6451238a9365bc5cdb029d580ebb8e21c4" CHECKSUMTYPE="SHA-1" SIZE="7762">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-09-15_01_0026.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:17:19" MIMETYPE="application/pdf"
-				CHECKSUM="d52b87bb84c1d8d0410b6f1426fbc73968e7ec38" CHECKSUMTYPE="SHA-1"
-				SIZE="7849787">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/bmtnabf_1903-09-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:17:19" MIMETYPE="application/pdf" CHECKSUM="d52b87bb84c1d8d0410b6f1426fbc73968e7ec38" CHECKSUMTYPE="SHA-1" SIZE="7849787">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/09/15_01/bmtnabf_1903-09-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2853,8 +2672,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00001"/>
@@ -2871,8 +2689,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="TextContent" ORDER="4" DMDID="c004"
-					LABEL="GEDANKEN ÜBER DIE PSYCHOLOGIE DER ZEICHNENDEN KÜNSTE">
+				<div ID="L.1.1.5" TYPE="TextContent" ORDER="4" DMDID="c004" LABEL="GEDANKEN ÜBER DIE PSYCHOLOGIE DER ZEICHNENDEN KÜNSTE">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -2896,14 +2713,10 @@
 								<div ID="L.1.1.5.4.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00007"
-												BEGIN="P7_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00008"
-												BEGIN="P8_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
@@ -2912,30 +2725,21 @@
 								<div ID="L.1.1.5.4.1.2.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00012"
-												BEGIN="P12_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00013"
-												BEGIN="P13_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00014"
-												BEGIN="P14_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00015"
-												BEGIN="P15_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00016"
-												BEGIN="P16_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_TB00002"/>
 										</seq>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="1" DMDID="c006"
-						LABEL="Untitled Image by Friedr. König OM">
+					<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="1" DMDID="c006" LABEL="Untitled Image by Friedr. König OM">
 						<div ID="L.1.1.5.5.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00004"/>
@@ -2947,8 +2751,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="2" DMDID="c007"
-						LABEL="Untitled Image by Friedr. König OM">
+					<div ID="L.1.1.5.6" TYPE="Illustration" ORDER="2" DMDID="c007" LABEL="Untitled Image by Friedr. König OM">
 						<div ID="L.1.1.5.6.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00003"/>
@@ -2960,8 +2763,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="3" DMDID="c008"
-						LABEL="Untitled Image by Friedr. König OM">
+					<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="3" DMDID="c008" LABEL="Untitled Image by Friedr. König OM">
 						<div ID="L.1.1.5.7.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
@@ -2973,8 +2775,7 @@
 							</fptr>
 						</div>
 					</div>
-					<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="4" DMDID="c009"
-						LABEL="Untitled Image by Friedr. König OM">
+					<div ID="L.1.1.5.8" TYPE="Illustration" ORDER="4" DMDID="c009" LABEL="Untitled Image by Friedr. König OM">
 						<div ID="L.1.1.5.8.1" TYPE="Byline">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_TB00005"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/10/01_01/bmtnabf_1903-10-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/10/01_01/bmtnabf_1903-10-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-10-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-10-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-10-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1903/10/15_01/bmtnabf_1903-10-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/10/15_01/bmtnabf_1903-10-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-10-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-10-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-10-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-10-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-10-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2555,380 +2549,192 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T20:06:07"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="64397b4f333294ed993bb18aaaaae5194b2833ae"
-				CHECKSUMTYPE="SHA-1" SIZE="6227229">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T20:06:07" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="64397b4f333294ed993bb18aaaaae5194b2833ae" CHECKSUMTYPE="SHA-1" SIZE="6227229">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T20:06:38"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="48c54010c76797a879ea8454de45ac294d973000"
-				CHECKSUMTYPE="SHA-1" SIZE="6244315">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T20:06:38" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="48c54010c76797a879ea8454de45ac294d973000" CHECKSUMTYPE="SHA-1" SIZE="6244315">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T20:07:07"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="626f804aa9eb8db29a5c6973de9a74439ce53910"
-				CHECKSUMTYPE="SHA-1" SIZE="6227224">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T20:07:07" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="626f804aa9eb8db29a5c6973de9a74439ce53910" CHECKSUMTYPE="SHA-1" SIZE="6227224">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T20:07:45"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="37c8e4090de0f2c871a879761fa2a63ee541f04c"
-				CHECKSUMTYPE="SHA-1" SIZE="6244322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T20:07:45" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="37c8e4090de0f2c871a879761fa2a63ee541f04c" CHECKSUMTYPE="SHA-1" SIZE="6244322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:08:22"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="5a04ba4dd105a432e887ee3e76a96c013efefa73"
-				CHECKSUMTYPE="SHA-1" SIZE="6228120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:08:22" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="5a04ba4dd105a432e887ee3e76a96c013efefa73" CHECKSUMTYPE="SHA-1" SIZE="6228120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:08:55"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="2cbd972535fdde04ce5105415e32dfbf1dcbfadf"
-				CHECKSUMTYPE="SHA-1" SIZE="6244326">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:08:55" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="2cbd972535fdde04ce5105415e32dfbf1dcbfadf" CHECKSUMTYPE="SHA-1" SIZE="6244326">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:09:27"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="4c5855e713bd4b21754b5c4f79532a018325c340"
-				CHECKSUMTYPE="SHA-1" SIZE="6228116">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:09:27" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="4c5855e713bd4b21754b5c4f79532a018325c340" CHECKSUMTYPE="SHA-1" SIZE="6228116">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:09:59"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="898fbc4322e571b1c647fa7720ff8fb968a7957e"
-				CHECKSUMTYPE="SHA-1" SIZE="6244297">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:09:59" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="898fbc4322e571b1c647fa7720ff8fb968a7957e" CHECKSUMTYPE="SHA-1" SIZE="6244297">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:10:28"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="8c3c1f4c9c33229043424f994fa1aebccd77eb25"
-				CHECKSUMTYPE="SHA-1" SIZE="6228125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:10:28" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="8c3c1f4c9c33229043424f994fa1aebccd77eb25" CHECKSUMTYPE="SHA-1" SIZE="6228125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:11:03"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="79a6dd4258ed7553ade4f90c1fd18443fc2980b4"
-				CHECKSUMTYPE="SHA-1" SIZE="6243419">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:11:03" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="79a6dd4258ed7553ade4f90c1fd18443fc2980b4" CHECKSUMTYPE="SHA-1" SIZE="6243419">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:11:35"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="7ba635391aef80e6713a713ac20d836ea8148634"
-				CHECKSUMTYPE="SHA-1" SIZE="6228124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:11:35" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="7ba635391aef80e6713a713ac20d836ea8148634" CHECKSUMTYPE="SHA-1" SIZE="6228124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:12:07"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="c75d26b5fd0f18f1c2c867f7fab63bd3633416fd"
-				CHECKSUMTYPE="SHA-1" SIZE="6242527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:12:07" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="c75d26b5fd0f18f1c2c867f7fab63bd3633416fd" CHECKSUMTYPE="SHA-1" SIZE="6242527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:12:39"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="ec5e3502e7d98a3a50ae8da5e270b5bda7cdbf7b"
-				CHECKSUMTYPE="SHA-1" SIZE="6204724">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:12:39" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="ec5e3502e7d98a3a50ae8da5e270b5bda7cdbf7b" CHECKSUMTYPE="SHA-1" SIZE="6204724">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:13:10"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="ffb378114db717be0d58353d2102bb8adb875ed2"
-				CHECKSUMTYPE="SHA-1" SIZE="6242524">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:13:10" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="ffb378114db717be0d58353d2102bb8adb875ed2" CHECKSUMTYPE="SHA-1" SIZE="6242524">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:13:43"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="470c8d60dfd73e420c2129d34be6b138b2411611"
-				CHECKSUMTYPE="SHA-1" SIZE="6204703">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:13:43" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="470c8d60dfd73e420c2129d34be6b138b2411611" CHECKSUMTYPE="SHA-1" SIZE="6204703">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:14:13"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="c02fee785e39411620806c9d6a6bc740c1e75aa8"
-				CHECKSUMTYPE="SHA-1" SIZE="6242519">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:14:13" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="c02fee785e39411620806c9d6a6bc740c1e75aa8" CHECKSUMTYPE="SHA-1" SIZE="6242519">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:14:45"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="6d85004710946169b40b93b4dfd9836f7addfccd"
-				CHECKSUMTYPE="SHA-1" SIZE="6180424">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:14:45" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="6d85004710946169b40b93b4dfd9836f7addfccd" CHECKSUMTYPE="SHA-1" SIZE="6180424">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:15:22"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="9094fbd3ea1341de8bba4db97f87fa485a8e8c43"
-				CHECKSUMTYPE="SHA-1" SIZE="6242526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:15:22" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="9094fbd3ea1341de8bba4db97f87fa485a8e8c43" CHECKSUMTYPE="SHA-1" SIZE="6242526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:15:54"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="05d2d6464273a6d29ba40072f88b02c0719d4077"
-				CHECKSUMTYPE="SHA-1" SIZE="6180415">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:15:54" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="05d2d6464273a6d29ba40072f88b02c0719d4077" CHECKSUMTYPE="SHA-1" SIZE="6180415">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:16:27"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="03cac6e4f10fcf5cf4b58e3109c6bdc7087faa3c"
-				CHECKSUMTYPE="SHA-1" SIZE="6242529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:16:27" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="03cac6e4f10fcf5cf4b58e3109c6bdc7087faa3c" CHECKSUMTYPE="SHA-1" SIZE="6242529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:16:58"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="d8632ab8f2f8167e7a9dad88709207fed86d2a30"
-				CHECKSUMTYPE="SHA-1" SIZE="6180397">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:16:58" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="d8632ab8f2f8167e7a9dad88709207fed86d2a30" CHECKSUMTYPE="SHA-1" SIZE="6180397">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:17:30"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="0b8b5b4fbaddbe3c632f810e3f166f5fe52f5b28"
-				CHECKSUMTYPE="SHA-1" SIZE="6242515">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:17:30" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="0b8b5b4fbaddbe3c632f810e3f166f5fe52f5b28" CHECKSUMTYPE="SHA-1" SIZE="6242515">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:18:00"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="ee2ecf2bfb13e0b50073a65de882d157967fb6e8"
-				CHECKSUMTYPE="SHA-1" SIZE="6180428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:18:00" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="ee2ecf2bfb13e0b50073a65de882d157967fb6e8" CHECKSUMTYPE="SHA-1" SIZE="6180428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:18:31"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="a9aca5ddc77f2d956472e211f289ce8f97866cd2"
-				CHECKSUMTYPE="SHA-1" SIZE="6242525">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:18:31" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="a9aca5ddc77f2d956472e211f289ce8f97866cd2" CHECKSUMTYPE="SHA-1" SIZE="6242525">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:19:01"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="ac9c75384144bf663f3bbc5d416123aa79af3071"
-				CHECKSUMTYPE="SHA-1" SIZE="6181268">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:19:01" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="ac9c75384144bf663f3bbc5d416123aa79af3071" CHECKSUMTYPE="SHA-1" SIZE="6181268">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:19:34"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="f403750c3ec1ac14f6c1dcfa7342c6de0ce44f30"
-				CHECKSUMTYPE="SHA-1" SIZE="6305517">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:19:34" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="f403750c3ec1ac14f6c1dcfa7342c6de0ce44f30" CHECKSUMTYPE="SHA-1" SIZE="6305517">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:20:07"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="eb6d12ed8c82a86448b148deb441ba64f7d1c438"
-				CHECKSUMTYPE="SHA-1" SIZE="6110145">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:20:07" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="eb6d12ed8c82a86448b148deb441ba64f7d1c438" CHECKSUMTYPE="SHA-1" SIZE="6110145">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:20:37"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="2cee0a2473351df2c554c1c827056a7f39c8e607"
-				CHECKSUMTYPE="SHA-1" SIZE="6253322">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:20:37" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="2cee0a2473351df2c554c1c827056a7f39c8e607" CHECKSUMTYPE="SHA-1" SIZE="6253322">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T20:21:09"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="12b4c0accf372219271589073ffe50457b1caa00"
-				CHECKSUMTYPE="SHA-1" SIZE="6109924">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T20:21:09" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="12b4c0accf372219271589073ffe50457b1caa00" CHECKSUMTYPE="SHA-1" SIZE="6109924">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T20:21:40"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="71e644cadc6287d3f5b5092172a0e4e72c65ca03"
-				CHECKSUMTYPE="SHA-1" SIZE="6233526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T20:21:40" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="71e644cadc6287d3f5b5092172a0e4e72c65ca03" CHECKSUMTYPE="SHA-1" SIZE="6233526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/delivery/bmtnabf_1903-10-15_01_0030.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:21:56" MIMETYPE="text/xml"
-				CHECKSUM="00860e7f8e9af53ee27b14393f6225b9d1daa9f2" CHECKSUMTYPE="SHA-1" SIZE="5290">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:21:56" MIMETYPE="text/xml" CHECKSUM="00860e7f8e9af53ee27b14393f6225b9d1daa9f2" CHECKSUMTYPE="SHA-1" SIZE="5290">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:21:57" MIMETYPE="text/xml"
-				CHECKSUM="682379e34232d327deecbbab2f0a8b3bb2151e97" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:21:57" MIMETYPE="text/xml" CHECKSUM="682379e34232d327deecbbab2f0a8b3bb2151e97" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:21:57" MIMETYPE="text/xml"
-				CHECKSUM="077fa625681d5a2a72e29ac265ebfade8bb97e86" CHECKSUMTYPE="SHA-1" SIZE="8309">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:21:57" MIMETYPE="text/xml" CHECKSUM="077fa625681d5a2a72e29ac265ebfade8bb97e86" CHECKSUMTYPE="SHA-1" SIZE="8309">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:21:57" MIMETYPE="text/xml"
-				CHECKSUM="f49a3254105c8ad57a35b367dc21a03950269f25" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:21:57" MIMETYPE="text/xml" CHECKSUM="f49a3254105c8ad57a35b367dc21a03950269f25" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:21:57" MIMETYPE="text/xml"
-				CHECKSUM="99d985811c83a1c4f85583c08dedf5aadc3814d8" CHECKSUMTYPE="SHA-1" SIZE="5151">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:21:57" MIMETYPE="text/xml" CHECKSUM="99d985811c83a1c4f85583c08dedf5aadc3814d8" CHECKSUMTYPE="SHA-1" SIZE="5151">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:21:58" MIMETYPE="text/xml"
-				CHECKSUM="c9492316d48556a097d47693878ad6a85e7c5029" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:21:58" MIMETYPE="text/xml" CHECKSUM="c9492316d48556a097d47693878ad6a85e7c5029" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:21:58" MIMETYPE="text/xml"
-				CHECKSUM="943227909bd47c38676b2bc83721786041deeb72" CHECKSUMTYPE="SHA-1" SIZE="5261">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:21:58" MIMETYPE="text/xml" CHECKSUM="943227909bd47c38676b2bc83721786041deeb72" CHECKSUMTYPE="SHA-1" SIZE="5261">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:21:58" MIMETYPE="text/xml"
-				CHECKSUM="c1d5513f8ea9df7d394b5bc6ef9cbc3911b86dfc" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:21:58" MIMETYPE="text/xml" CHECKSUM="c1d5513f8ea9df7d394b5bc6ef9cbc3911b86dfc" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:21:58" MIMETYPE="text/xml"
-				CHECKSUM="0478f81a9e11e58f1babe6ed9ea6bd114c4e1e3e" CHECKSUMTYPE="SHA-1" SIZE="4744">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:21:58" MIMETYPE="text/xml" CHECKSUM="0478f81a9e11e58f1babe6ed9ea6bd114c4e1e3e" CHECKSUMTYPE="SHA-1" SIZE="4744">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:21:59" MIMETYPE="text/xml"
-				CHECKSUM="e2e4ef4c61940dad384545f3ad77f4591170d1fe" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:21:59" MIMETYPE="text/xml" CHECKSUM="e2e4ef4c61940dad384545f3ad77f4591170d1fe" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:21:59" MIMETYPE="text/xml"
-				CHECKSUM="d41b59ae8ec358cd54c6b07885ba09576a567018" CHECKSUMTYPE="SHA-1" SIZE="5465">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:21:59" MIMETYPE="text/xml" CHECKSUM="d41b59ae8ec358cd54c6b07885ba09576a567018" CHECKSUMTYPE="SHA-1" SIZE="5465">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:22:00" MIMETYPE="text/xml"
-				CHECKSUM="38dd77922bcd6b547517fd5d8e9dcf5e80053245" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:22:00" MIMETYPE="text/xml" CHECKSUM="38dd77922bcd6b547517fd5d8e9dcf5e80053245" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:22:00" MIMETYPE="text/xml"
-				CHECKSUM="b1848505530325048aa691004bdd39602ce64276" CHECKSUMTYPE="SHA-1" SIZE="5884">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:22:00" MIMETYPE="text/xml" CHECKSUM="b1848505530325048aa691004bdd39602ce64276" CHECKSUMTYPE="SHA-1" SIZE="5884">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:22:01" MIMETYPE="text/xml"
-				CHECKSUM="159c16f89a55d2d3c3f75a47d0f9ca05bc390ccd" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:22:01" MIMETYPE="text/xml" CHECKSUM="159c16f89a55d2d3c3f75a47d0f9ca05bc390ccd" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:22:01" MIMETYPE="text/xml"
-				CHECKSUM="6527536c6f75a33785a5edfdb3700338b7731a62" CHECKSUMTYPE="SHA-1" SIZE="4931">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:22:01" MIMETYPE="text/xml" CHECKSUM="6527536c6f75a33785a5edfdb3700338b7731a62" CHECKSUMTYPE="SHA-1" SIZE="4931">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:22:01" MIMETYPE="text/xml"
-				CHECKSUM="9e2f767dc7dbc6665913e0b477b5775ae8fa9dad" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:22:01" MIMETYPE="text/xml" CHECKSUM="9e2f767dc7dbc6665913e0b477b5775ae8fa9dad" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:22:02" MIMETYPE="text/xml"
-				CHECKSUM="4c97bb2b7cc91f89e1d4f5668c0f0c54c1946fb4" CHECKSUMTYPE="SHA-1" SIZE="5413">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:22:02" MIMETYPE="text/xml" CHECKSUM="4c97bb2b7cc91f89e1d4f5668c0f0c54c1946fb4" CHECKSUMTYPE="SHA-1" SIZE="5413">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:22:02" MIMETYPE="text/xml"
-				CHECKSUM="6dabd3b69fb62234db958b69e37501ba04b2ccc3" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:22:02" MIMETYPE="text/xml" CHECKSUM="6dabd3b69fb62234db958b69e37501ba04b2ccc3" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:22:02" MIMETYPE="text/xml"
-				CHECKSUM="e7b871eb501234a4fb6603226ca84fa2b20240d3" CHECKSUMTYPE="SHA-1" SIZE="4754">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:22:02" MIMETYPE="text/xml" CHECKSUM="e7b871eb501234a4fb6603226ca84fa2b20240d3" CHECKSUMTYPE="SHA-1" SIZE="4754">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:22:02" MIMETYPE="text/xml"
-				CHECKSUM="fbae2f2618bac1c1566fcbfb674670a15b9246d6" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:22:02" MIMETYPE="text/xml" CHECKSUM="fbae2f2618bac1c1566fcbfb674670a15b9246d6" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:22:03" MIMETYPE="text/xml"
-				CHECKSUM="fbe14319b5be6b903f711b579ce572ba1af222bc" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:22:03" MIMETYPE="text/xml" CHECKSUM="fbe14319b5be6b903f711b579ce572ba1af222bc" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:22:03" MIMETYPE="text/xml"
-				CHECKSUM="11f5cc07289c4a116d8ac98444294ae78e03e5de" CHECKSUMTYPE="SHA-1" SIZE="8665">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:22:03" MIMETYPE="text/xml" CHECKSUM="11f5cc07289c4a116d8ac98444294ae78e03e5de" CHECKSUMTYPE="SHA-1" SIZE="8665">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:22:03" MIMETYPE="text/xml"
-				CHECKSUM="04beeff893b86a439370656dbdfdd0aeb0c11862" CHECKSUMTYPE="SHA-1" SIZE="9718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:22:03" MIMETYPE="text/xml" CHECKSUM="04beeff893b86a439370656dbdfdd0aeb0c11862" CHECKSUMTYPE="SHA-1" SIZE="9718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:22:03" MIMETYPE="text/xml"
-				CHECKSUM="1a2ab2b84c16b1fcb04eda34716aed240cf76124" CHECKSUMTYPE="SHA-1"
-				SIZE="18786">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:22:03" MIMETYPE="text/xml" CHECKSUM="1a2ab2b84c16b1fcb04eda34716aed240cf76124" CHECKSUMTYPE="SHA-1" SIZE="18786">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:22:04" MIMETYPE="text/xml"
-				CHECKSUM="01cade46d2e162a61bfdf4307ca32e90d979ec3f" CHECKSUMTYPE="SHA-1"
-				SIZE="29300">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:22:04" MIMETYPE="text/xml" CHECKSUM="01cade46d2e162a61bfdf4307ca32e90d979ec3f" CHECKSUMTYPE="SHA-1" SIZE="29300">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:22:04" MIMETYPE="text/xml"
-				CHECKSUM="649940455285e471e5f42df5b6f13e099e1b7d47" CHECKSUMTYPE="SHA-1"
-				SIZE="16897">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:22:04" MIMETYPE="text/xml" CHECKSUM="649940455285e471e5f42df5b6f13e099e1b7d47" CHECKSUMTYPE="SHA-1" SIZE="16897">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:22:04" MIMETYPE="text/xml"
-				CHECKSUM="b2ed4c9a62a4a2803d091739539001e798de8c75" CHECKSUMTYPE="SHA-1"
-				SIZE="37730">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:22:04" MIMETYPE="text/xml" CHECKSUM="b2ed4c9a62a4a2803d091739539001e798de8c75" CHECKSUMTYPE="SHA-1" SIZE="37730">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:22:04" MIMETYPE="text/xml"
-				CHECKSUM="5d894b76a21c9201cbbdd948a69c500308f43a7b" CHECKSUMTYPE="SHA-1" SIZE="8084">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:22:04" MIMETYPE="text/xml" CHECKSUM="5d894b76a21c9201cbbdd948a69c500308f43a7b" CHECKSUMTYPE="SHA-1" SIZE="8084">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T20:22:05" MIMETYPE="text/xml"
-				CHECKSUM="75fe9d5969d4d76cc5a8890b36d24a564314fa29" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T20:22:05" MIMETYPE="text/xml" CHECKSUM="75fe9d5969d4d76cc5a8890b36d24a564314fa29" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T20:22:05" MIMETYPE="text/xml"
-				CHECKSUM="fd27c5006dbec4ed58516281031fff6270a4d1ea" CHECKSUMTYPE="SHA-1" SIZE="8128">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T20:22:05" MIMETYPE="text/xml" CHECKSUM="fd27c5006dbec4ed58516281031fff6270a4d1ea" CHECKSUMTYPE="SHA-1" SIZE="8128">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-10-15_01_0030.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:22:33" MIMETYPE="application/pdf"
-				CHECKSUM="bd0d8caa3b58fdb78c80e4bbf62a168dfca3b834" CHECKSUMTYPE="SHA-1"
-				SIZE="8507242">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/bmtnabf_1903-10-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:22:33" MIMETYPE="application/pdf" CHECKSUM="bd0d8caa3b58fdb78c80e4bbf62a168dfca3b834" CHECKSUMTYPE="SHA-1" SIZE="8507242">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/10/15_01/bmtnabf_1903-10-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>

--- a/metadata/periodicals/bmtnabf/issues/1903/11/01_01/bmtnabf_1903-11-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/11/01_01/bmtnabf_1903-11-01_01.mets.xml
@@ -14,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-11-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-11-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -47,7 +47,7 @@
 					</location>
 					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-11-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">

--- a/metadata/periodicals/bmtnabf/issues/1903/11/15_01/bmtnabf_1903-11-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/11/15_01/bmtnabf_1903-11-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-11-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-11-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-11-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-11-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-11-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3205,478 +3199,240 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T20:11:43"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="55d21d2428e5e986c07a0674df5bc54510677feb"
-				CHECKSUMTYPE="SHA-1" SIZE="6206520">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T20:11:43" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="55d21d2428e5e986c07a0674df5bc54510677feb" CHECKSUMTYPE="SHA-1" SIZE="6206520">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T20:12:19"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="bc0bdb9f21a2df41ec1ba5b5b32109fe9513bf8b"
-				CHECKSUMTYPE="SHA-1" SIZE="6304628">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T20:12:19" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="bc0bdb9f21a2df41ec1ba5b5b32109fe9513bf8b" CHECKSUMTYPE="SHA-1" SIZE="6304628">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T20:12:54"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="dd3b0dabe2be1c133d22b3c92ef1c9d27d467956"
-				CHECKSUMTYPE="SHA-1" SIZE="6310026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T20:12:54" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="dd3b0dabe2be1c133d22b3c92ef1c9d27d467956" CHECKSUMTYPE="SHA-1" SIZE="6310026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T20:13:41"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="33c1dfd5982eeedc6c1b870254875a3d09558f89"
-				CHECKSUMTYPE="SHA-1" SIZE="6304624">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T20:13:41" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="33c1dfd5982eeedc6c1b870254875a3d09558f89" CHECKSUMTYPE="SHA-1" SIZE="6304624">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:14:20"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="726edb620b25d41d34a4734658a7b82d44779d8e"
-				CHECKSUMTYPE="SHA-1" SIZE="6200216">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:14:20" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="726edb620b25d41d34a4734658a7b82d44779d8e" CHECKSUMTYPE="SHA-1" SIZE="6200216">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:14:54"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="db8c35d11d7daa1ebc736e1005937513a9614ee5"
-				CHECKSUMTYPE="SHA-1" SIZE="6304615">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:14:54" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="db8c35d11d7daa1ebc736e1005937513a9614ee5" CHECKSUMTYPE="SHA-1" SIZE="6304615">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:15:28"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="77b5f103eb4d7d852405ab0233f6fa31b0b80a53"
-				CHECKSUMTYPE="SHA-1" SIZE="6111129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:15:28" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="77b5f103eb4d7d852405ab0233f6fa31b0b80a53" CHECKSUMTYPE="SHA-1" SIZE="6111129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:16:05"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="1707812f2aaf78715049b7696fc6eedaae6befa1"
-				CHECKSUMTYPE="SHA-1" SIZE="6304629">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:16:05" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="1707812f2aaf78715049b7696fc6eedaae6befa1" CHECKSUMTYPE="SHA-1" SIZE="6304629">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:16:40"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="a7a2ff7a72ae9532810db6187481f50d6376d736"
-				CHECKSUMTYPE="SHA-1" SIZE="6111070">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:16:40" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="a7a2ff7a72ae9532810db6187481f50d6376d736" CHECKSUMTYPE="SHA-1" SIZE="6111070">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:17:11"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="2bbfd93a8281d0142b07c744dd1a34de9942873d"
-				CHECKSUMTYPE="SHA-1" SIZE="6304619">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:17:11" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="2bbfd93a8281d0142b07c744dd1a34de9942873d" CHECKSUMTYPE="SHA-1" SIZE="6304619">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:17:43"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="985384447d1384658a6824d2b5e06f476d9f4d3a"
-				CHECKSUMTYPE="SHA-1" SIZE="6111127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:17:43" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="985384447d1384658a6824d2b5e06f476d9f4d3a" CHECKSUMTYPE="SHA-1" SIZE="6111127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:18:15"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="8dc8eda14d4bb671ee4249ce1949535b60c88f38"
-				CHECKSUMTYPE="SHA-1" SIZE="6304527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:18:15" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="8dc8eda14d4bb671ee4249ce1949535b60c88f38" CHECKSUMTYPE="SHA-1" SIZE="6304527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:18:46"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="1a29b98e5805d3bf0ab4ee27c1b3b2869f39dce6"
-				CHECKSUMTYPE="SHA-1" SIZE="6111129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:18:46" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="1a29b98e5805d3bf0ab4ee27c1b3b2869f39dce6" CHECKSUMTYPE="SHA-1" SIZE="6111129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:19:18"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="f02659e8241fb008b2d321ecbc282cbfb86a61ba"
-				CHECKSUMTYPE="SHA-1" SIZE="6304598">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:19:18" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="f02659e8241fb008b2d321ecbc282cbfb86a61ba" CHECKSUMTYPE="SHA-1" SIZE="6304598">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:19:54"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="ad61fc6a040860710fa20f143c367c93fe934490"
-				CHECKSUMTYPE="SHA-1" SIZE="6111094">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:19:54" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="ad61fc6a040860710fa20f143c367c93fe934490" CHECKSUMTYPE="SHA-1" SIZE="6111094">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:20:27"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d2102ef4af7bbfe1f18691e730ad3d96325ee8c8"
-				CHECKSUMTYPE="SHA-1" SIZE="6304606">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:20:27" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="d2102ef4af7bbfe1f18691e730ad3d96325ee8c8" CHECKSUMTYPE="SHA-1" SIZE="6304606">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:21:00"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="8019d66c34c8445d527e174001404b58af30ccc5"
-				CHECKSUMTYPE="SHA-1" SIZE="6111129">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:21:00" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="8019d66c34c8445d527e174001404b58af30ccc5" CHECKSUMTYPE="SHA-1" SIZE="6111129">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:21:34"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="89fbf5f54e0045504275bea802e486fae0c8d88a"
-				CHECKSUMTYPE="SHA-1" SIZE="6304620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:21:34" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="89fbf5f54e0045504275bea802e486fae0c8d88a" CHECKSUMTYPE="SHA-1" SIZE="6304620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:22:06"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="2ff2ae320ff9fe8fae121aa5e8b52c0b0e15472d"
-				CHECKSUMTYPE="SHA-1" SIZE="6111102">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:22:06" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="2ff2ae320ff9fe8fae121aa5e8b52c0b0e15472d" CHECKSUMTYPE="SHA-1" SIZE="6111102">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:22:39"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="cf644eef1ec5352dc75b25c7ff97f2bc0cdb1c4e"
-				CHECKSUMTYPE="SHA-1" SIZE="6304609">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:22:39" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="cf644eef1ec5352dc75b25c7ff97f2bc0cdb1c4e" CHECKSUMTYPE="SHA-1" SIZE="6304609">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:23:13"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="27bf3ab1cb04298ad09a42be22eb6890c2107440"
-				CHECKSUMTYPE="SHA-1" SIZE="6112026">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:23:13" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="27bf3ab1cb04298ad09a42be22eb6890c2107440" CHECKSUMTYPE="SHA-1" SIZE="6112026">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:23:48"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="8ec3366a3732f3c0c212aa111201b3dfd59f5227"
-				CHECKSUMTYPE="SHA-1" SIZE="6304625">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:23:48" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="8ec3366a3732f3c0c212aa111201b3dfd59f5227" CHECKSUMTYPE="SHA-1" SIZE="6304625">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:24:20"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="ab8ca41a1df7e7eb4cad50974d5cae19cd1727f8"
-				CHECKSUMTYPE="SHA-1" SIZE="6111120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:24:20" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="ab8ca41a1df7e7eb4cad50974d5cae19cd1727f8" CHECKSUMTYPE="SHA-1" SIZE="6111120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:24:52"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="d1802ecae2043b2820ecb50142d7b64e29b4d765"
-				CHECKSUMTYPE="SHA-1" SIZE="6304620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:24:52" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="d1802ecae2043b2820ecb50142d7b64e29b4d765" CHECKSUMTYPE="SHA-1" SIZE="6304620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:25:26"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="849743532e0b0c946de187b512f6ed44f582b6ac"
-				CHECKSUMTYPE="SHA-1" SIZE="6112021">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:25:26" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="849743532e0b0c946de187b512f6ed44f582b6ac" CHECKSUMTYPE="SHA-1" SIZE="6112021">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:25:59"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="9509d57f8a56dbc5755eeb9db0cb70e86c8c4c71"
-				CHECKSUMTYPE="SHA-1" SIZE="6304620">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:25:59" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="9509d57f8a56dbc5755eeb9db0cb70e86c8c4c71" CHECKSUMTYPE="SHA-1" SIZE="6304620">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:26:34"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="8d4e5f38715b3ca6ba8b87fe8f9c4bcd7bfc96c8"
-				CHECKSUMTYPE="SHA-1" SIZE="6112028">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:26:34" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="8d4e5f38715b3ca6ba8b87fe8f9c4bcd7bfc96c8" CHECKSUMTYPE="SHA-1" SIZE="6112028">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:27:10"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="adef0f6de21bad57e9dd3d689a1212da175b2198"
-				CHECKSUMTYPE="SHA-1" SIZE="6305497">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:27:10" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="adef0f6de21bad57e9dd3d689a1212da175b2198" CHECKSUMTYPE="SHA-1" SIZE="6305497">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T20:27:44"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="a78563e65f8d4c7e7db00e600f5828ae37086357"
-				CHECKSUMTYPE="SHA-1" SIZE="6112029">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T20:27:44" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="a78563e65f8d4c7e7db00e600f5828ae37086357" CHECKSUMTYPE="SHA-1" SIZE="6112029">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T20:28:20"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="454c6e2696906f0af0d1ef777760a8152e1a5487"
-				CHECKSUMTYPE="SHA-1" SIZE="6426971">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T20:28:20" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="454c6e2696906f0af0d1ef777760a8152e1a5487" CHECKSUMTYPE="SHA-1" SIZE="6426971">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T20:28:56"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="6fdd3e15c0c0502e4df88f68f6797b10a2b1f8d8"
-				CHECKSUMTYPE="SHA-1" SIZE="6019312">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T20:28:56" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="6fdd3e15c0c0502e4df88f68f6797b10a2b1f8d8" CHECKSUMTYPE="SHA-1" SIZE="6019312">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T20:29:32"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="95cbd40ff08b9276b1501405bc94fc7f5f56112d"
-				CHECKSUMTYPE="SHA-1" SIZE="6356824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T20:29:32" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="95cbd40ff08b9276b1501405bc94fc7f5f56112d" CHECKSUMTYPE="SHA-1" SIZE="6356824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T20:30:08"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="fe9b35daae192b2034809a9c9d3f1b4b5dd24dd4"
-				CHECKSUMTYPE="SHA-1" SIZE="6118329">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T20:30:08" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="fe9b35daae192b2034809a9c9d3f1b4b5dd24dd4" CHECKSUMTYPE="SHA-1" SIZE="6118329">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T20:30:43"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="c534fe36c2333c67e20588dafd5cedce6ef182ca"
-				CHECKSUMTYPE="SHA-1" SIZE="6372124">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T20:30:43" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="c534fe36c2333c67e20588dafd5cedce6ef182ca" CHECKSUMTYPE="SHA-1" SIZE="6372124">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0034.jp2"/>
 			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T20:31:19"
-				MIMETYPE="image/jp2" SEQ="35" CHECKSUM="931cc10f40ffd068cd8c476238586a303faffc2a"
-				CHECKSUMTYPE="SHA-1" SIZE="6118323">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0035.jp2"
-				/>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T20:31:19" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="931cc10f40ffd068cd8c476238586a303faffc2a" CHECKSUMTYPE="SHA-1" SIZE="6118323">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0035.jp2"/>
 			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T20:31:55"
-				MIMETYPE="image/jp2" SEQ="36" CHECKSUM="dbbf7780d56b0c8401d0755b45d232c46fccc83f"
-				CHECKSUMTYPE="SHA-1" SIZE="6372114">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0036.jp2"
-				/>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T20:31:55" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="dbbf7780d56b0c8401d0755b45d232c46fccc83f" CHECKSUMTYPE="SHA-1" SIZE="6372114">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0036.jp2"/>
 			</file>
-			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T20:32:29"
-				MIMETYPE="image/jp2" SEQ="37" CHECKSUM="7351c9321da5b239a34d130a6d4c123312f03dfc"
-				CHECKSUMTYPE="SHA-1" SIZE="6118325">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0037.jp2"
-				/>
+			<file ID="IMG00037" ADMID="techmd37" GROUPID="page37" CREATED="2015-10-09T20:32:29" MIMETYPE="image/jp2" SEQ="37" CHECKSUM="7351c9321da5b239a34d130a6d4c123312f03dfc" CHECKSUMTYPE="SHA-1" SIZE="6118325">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0037.jp2"/>
 			</file>
-			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T20:33:03"
-				MIMETYPE="image/jp2" SEQ="38" CHECKSUM="80f7ef8c1c300993311f33d07fed23ca156867f2"
-				CHECKSUMTYPE="SHA-1" SIZE="6212828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0038.jp2"
-				/>
+			<file ID="IMG00038" ADMID="techmd38" GROUPID="page38" CREATED="2015-10-09T20:33:03" MIMETYPE="image/jp2" SEQ="38" CHECKSUM="80f7ef8c1c300993311f33d07fed23ca156867f2" CHECKSUMTYPE="SHA-1" SIZE="6212828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/delivery/bmtnabf_1903-11-15_01_0038.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:33:27" MIMETYPE="text/xml"
-				CHECKSUM="2aab44ed61862891774d9c057f35648025a1cbbd" CHECKSUMTYPE="SHA-1" SIZE="4709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:33:27" MIMETYPE="text/xml" CHECKSUM="2aab44ed61862891774d9c057f35648025a1cbbd" CHECKSUMTYPE="SHA-1" SIZE="4709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:33:28" MIMETYPE="text/xml"
-				CHECKSUM="be109d0555ad5b0995bbe23e87363923e5d90232" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:33:28" MIMETYPE="text/xml" CHECKSUM="be109d0555ad5b0995bbe23e87363923e5d90232" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:33:28" MIMETYPE="text/xml"
-				CHECKSUM="909c8ccb6f6c9e5051fcecb3eb9d1a7bb73c4183" CHECKSUMTYPE="SHA-1" SIZE="8491">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:33:28" MIMETYPE="text/xml" CHECKSUM="909c8ccb6f6c9e5051fcecb3eb9d1a7bb73c4183" CHECKSUMTYPE="SHA-1" SIZE="8491">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:33:28" MIMETYPE="text/xml"
-				CHECKSUM="902033fbcc52f6c170e795d4cd09f350ea204ddb" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:33:28" MIMETYPE="text/xml" CHECKSUM="902033fbcc52f6c170e795d4cd09f350ea204ddb" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:33:28" MIMETYPE="text/xml"
-				CHECKSUM="8d33b87175fd5953e6c4db543174a348986b2d59" CHECKSUMTYPE="SHA-1" SIZE="4001">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:33:28" MIMETYPE="text/xml" CHECKSUM="8d33b87175fd5953e6c4db543174a348986b2d59" CHECKSUMTYPE="SHA-1" SIZE="4001">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:33:29" MIMETYPE="text/xml"
-				CHECKSUM="2c855248710e9feac6bea41217cc4c07a3b68463" CHECKSUMTYPE="SHA-1" SIZE="2013">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:33:29" MIMETYPE="text/xml" CHECKSUM="2c855248710e9feac6bea41217cc4c07a3b68463" CHECKSUMTYPE="SHA-1" SIZE="2013">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:33:29" MIMETYPE="text/xml"
-				CHECKSUM="ea4dee538e4be432646413c0e35d8e1d4dcc7a9a" CHECKSUMTYPE="SHA-1" SIZE="4005">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:33:29" MIMETYPE="text/xml" CHECKSUM="ea4dee538e4be432646413c0e35d8e1d4dcc7a9a" CHECKSUMTYPE="SHA-1" SIZE="4005">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:33:29" MIMETYPE="text/xml"
-				CHECKSUM="bed38bf416024dc7b24fad7856bd6eddec2d588c" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:33:29" MIMETYPE="text/xml" CHECKSUM="bed38bf416024dc7b24fad7856bd6eddec2d588c" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:33:29" MIMETYPE="text/xml"
-				CHECKSUM="0bde467972d8cd4d90773a87fe24df4a7072a8d4" CHECKSUMTYPE="SHA-1" SIZE="4008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:33:29" MIMETYPE="text/xml" CHECKSUM="0bde467972d8cd4d90773a87fe24df4a7072a8d4" CHECKSUMTYPE="SHA-1" SIZE="4008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:33:30" MIMETYPE="text/xml"
-				CHECKSUM="b0a0740fd422a2496cc627d2203f89d567336b64" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:33:30" MIMETYPE="text/xml" CHECKSUM="b0a0740fd422a2496cc627d2203f89d567336b64" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:33:30" MIMETYPE="text/xml"
-				CHECKSUM="d32138f9adf9ecb649e7c3359c973a6a3d779733" CHECKSUMTYPE="SHA-1" SIZE="4022">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:33:30" MIMETYPE="text/xml" CHECKSUM="d32138f9adf9ecb649e7c3359c973a6a3d779733" CHECKSUMTYPE="SHA-1" SIZE="4022">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:33:30" MIMETYPE="text/xml"
-				CHECKSUM="43a21c433f8ea5e2a65590189218551d961eecb6" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:33:30" MIMETYPE="text/xml" CHECKSUM="43a21c433f8ea5e2a65590189218551d961eecb6" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:33:30" MIMETYPE="text/xml"
-				CHECKSUM="b8502491492ee9a180daba9171f9ae925762dd7a" CHECKSUMTYPE="SHA-1" SIZE="4024">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:33:30" MIMETYPE="text/xml" CHECKSUM="b8502491492ee9a180daba9171f9ae925762dd7a" CHECKSUMTYPE="SHA-1" SIZE="4024">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:33:30" MIMETYPE="text/xml"
-				CHECKSUM="191fa11bd04e9f2cfcee1caed4b11d525c6b7c1c" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:33:30" MIMETYPE="text/xml" CHECKSUM="191fa11bd04e9f2cfcee1caed4b11d525c6b7c1c" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:33:31" MIMETYPE="text/xml"
-				CHECKSUM="934c3bb0a672b9dfc56a015f513c4ec88dcb48dc" CHECKSUMTYPE="SHA-1" SIZE="4022">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:33:31" MIMETYPE="text/xml" CHECKSUM="934c3bb0a672b9dfc56a015f513c4ec88dcb48dc" CHECKSUMTYPE="SHA-1" SIZE="4022">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:33:31" MIMETYPE="text/xml"
-				CHECKSUM="7f0a1e44b6f54e4efaec8e16ef86bb9bd382abd8" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:33:31" MIMETYPE="text/xml" CHECKSUM="7f0a1e44b6f54e4efaec8e16ef86bb9bd382abd8" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:33:31" MIMETYPE="text/xml"
-				CHECKSUM="45629657f95633f1185e524030ac44bd6f5b6ef8" CHECKSUMTYPE="SHA-1" SIZE="4024">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:33:31" MIMETYPE="text/xml" CHECKSUM="45629657f95633f1185e524030ac44bd6f5b6ef8" CHECKSUMTYPE="SHA-1" SIZE="4024">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:33:31" MIMETYPE="text/xml"
-				CHECKSUM="c6043c92d6348b560d3a246dad788c126c330352" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:33:31" MIMETYPE="text/xml" CHECKSUM="c6043c92d6348b560d3a246dad788c126c330352" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:33:32" MIMETYPE="text/xml"
-				CHECKSUM="40c5b580ca0864534ced691795c2df6d01e06599" CHECKSUMTYPE="SHA-1" SIZE="4023">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:33:32" MIMETYPE="text/xml" CHECKSUM="40c5b580ca0864534ced691795c2df6d01e06599" CHECKSUMTYPE="SHA-1" SIZE="4023">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:33:32" MIMETYPE="text/xml"
-				CHECKSUM="cf64bfc2b6f60ce44e071aad466f35779c2e2d78" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:33:32" MIMETYPE="text/xml" CHECKSUM="cf64bfc2b6f60ce44e071aad466f35779c2e2d78" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:33:32" MIMETYPE="text/xml"
-				CHECKSUM="c032721239e47d15922c702a2c3f804be6e3a99a" CHECKSUMTYPE="SHA-1" SIZE="4018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:33:32" MIMETYPE="text/xml" CHECKSUM="c032721239e47d15922c702a2c3f804be6e3a99a" CHECKSUMTYPE="SHA-1" SIZE="4018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:33:32" MIMETYPE="text/xml"
-				CHECKSUM="cc86c6fd414e3b53126dfa1d0c96a2771ef04e10" CHECKSUMTYPE="SHA-1" SIZE="2020">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:33:32" MIMETYPE="text/xml" CHECKSUM="cc86c6fd414e3b53126dfa1d0c96a2771ef04e10" CHECKSUMTYPE="SHA-1" SIZE="2020">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:33:33" MIMETYPE="text/xml"
-				CHECKSUM="6637191ad7ee2f703f343d6fac17b0baf1357d34" CHECKSUMTYPE="SHA-1" SIZE="4022">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:33:33" MIMETYPE="text/xml" CHECKSUM="6637191ad7ee2f703f343d6fac17b0baf1357d34" CHECKSUMTYPE="SHA-1" SIZE="4022">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:33:33" MIMETYPE="text/xml"
-				CHECKSUM="4ac42823a4abbebfd40ab7dff64dc12ad6480908" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:33:33" MIMETYPE="text/xml" CHECKSUM="4ac42823a4abbebfd40ab7dff64dc12ad6480908" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:33:33" MIMETYPE="text/xml"
-				CHECKSUM="f618b73254c877c7ead6e0deb0f8ba2764af29b5" CHECKSUMTYPE="SHA-1" SIZE="4023">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:33:33" MIMETYPE="text/xml" CHECKSUM="f618b73254c877c7ead6e0deb0f8ba2764af29b5" CHECKSUMTYPE="SHA-1" SIZE="4023">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:33:33" MIMETYPE="text/xml"
-				CHECKSUM="dfe38ce1a177840b961c8585871327202314a01d" CHECKSUMTYPE="SHA-1" SIZE="2020">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:33:33" MIMETYPE="text/xml" CHECKSUM="dfe38ce1a177840b961c8585871327202314a01d" CHECKSUMTYPE="SHA-1" SIZE="2020">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:33:34" MIMETYPE="text/xml"
-				CHECKSUM="6520be1f154baad7876f42414eac45a25aeac680" CHECKSUMTYPE="SHA-1" SIZE="4022">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:33:34" MIMETYPE="text/xml" CHECKSUM="6520be1f154baad7876f42414eac45a25aeac680" CHECKSUMTYPE="SHA-1" SIZE="4022">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:33:34" MIMETYPE="text/xml"
-				CHECKSUM="5a068fb24a8d133abe2b7b40e1c31800cdbb80cc" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:33:34" MIMETYPE="text/xml" CHECKSUM="5a068fb24a8d133abe2b7b40e1c31800cdbb80cc" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T20:33:34" MIMETYPE="text/xml"
-				CHECKSUM="0bcb821708ed73e9891ae6d300fa46da36c6a72f" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T20:33:34" MIMETYPE="text/xml" CHECKSUM="0bcb821708ed73e9891ae6d300fa46da36c6a72f" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T20:33:34" MIMETYPE="text/xml"
-				CHECKSUM="726767d6f4378e268f9541867a55951317d1932e" CHECKSUMTYPE="SHA-1" SIZE="9353">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T20:33:34" MIMETYPE="text/xml" CHECKSUM="726767d6f4378e268f9541867a55951317d1932e" CHECKSUMTYPE="SHA-1" SIZE="9353">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T20:33:35" MIMETYPE="text/xml"
-				CHECKSUM="5aecd4d453cd9f320578503e7abba9a098f60183" CHECKSUMTYPE="SHA-1"
-				SIZE="10170">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T20:33:35" MIMETYPE="text/xml" CHECKSUM="5aecd4d453cd9f320578503e7abba9a098f60183" CHECKSUMTYPE="SHA-1" SIZE="10170">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T20:33:35" MIMETYPE="text/xml"
-				CHECKSUM="7736ee20eeac283b8f244909cd68dbcd84d8cb9b" CHECKSUMTYPE="SHA-1"
-				SIZE="18733">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T20:33:35" MIMETYPE="text/xml" CHECKSUM="7736ee20eeac283b8f244909cd68dbcd84d8cb9b" CHECKSUMTYPE="SHA-1" SIZE="18733">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T20:33:35" MIMETYPE="text/xml"
-				CHECKSUM="ee8fddc08f05dedaa91cdc2b977b426e4cf971fe" CHECKSUMTYPE="SHA-1"
-				SIZE="24963">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0033.alto.xml"
-				/>
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T20:33:35" MIMETYPE="text/xml" CHECKSUM="ee8fddc08f05dedaa91cdc2b977b426e4cf971fe" CHECKSUMTYPE="SHA-1" SIZE="24963">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T20:33:35" MIMETYPE="text/xml"
-				CHECKSUM="75be8427be75b433d929ba9bdc2fb835eccc17d4" CHECKSUMTYPE="SHA-1"
-				SIZE="16226">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0034.alto.xml"
-				/>
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T20:33:35" MIMETYPE="text/xml" CHECKSUM="75be8427be75b433d929ba9bdc2fb835eccc17d4" CHECKSUMTYPE="SHA-1" SIZE="16226">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T20:33:36" MIMETYPE="text/xml"
-				CHECKSUM="c8eb25773fb7b12d2c99ec72d5fcae671126a7ef" CHECKSUMTYPE="SHA-1"
-				SIZE="35527">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0035.alto.xml"
-				/>
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T20:33:36" MIMETYPE="text/xml" CHECKSUM="c8eb25773fb7b12d2c99ec72d5fcae671126a7ef" CHECKSUMTYPE="SHA-1" SIZE="35527">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T20:33:36" MIMETYPE="text/xml"
-				CHECKSUM="2b0d04cd2ad5fcdcd394e9be5f9d4c89155f1df7" CHECKSUMTYPE="SHA-1"
-				SIZE="11535">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0036.alto.xml"
-				/>
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T20:33:36" MIMETYPE="text/xml" CHECKSUM="2b0d04cd2ad5fcdcd394e9be5f9d4c89155f1df7" CHECKSUMTYPE="SHA-1" SIZE="11535">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0036.alto.xml"/>
 			</file>
-			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T20:33:36" MIMETYPE="text/xml"
-				CHECKSUM="6ecedbc7963686dec58b7e8543d68412483f3237" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0037.alto.xml"
-				/>
+			<file ID="ALTO00037" GROUPID="page37" CREATED="2015-10-09T20:33:36" MIMETYPE="text/xml" CHECKSUM="6ecedbc7963686dec58b7e8543d68412483f3237" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0037.alto.xml"/>
 			</file>
-			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T20:33:37" MIMETYPE="text/xml"
-				CHECKSUM="cc19b1d775bc7c622582f994512d0373c18cdac8" CHECKSUMTYPE="SHA-1" SIZE="7627">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0038.alto.xml"
-				/>
+			<file ID="ALTO00038" GROUPID="page38" CREATED="2015-10-09T20:33:37" MIMETYPE="text/xml" CHECKSUM="cc19b1d775bc7c622582f994512d0373c18cdac8" CHECKSUMTYPE="SHA-1" SIZE="7627">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-11-15_01_0038.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:34:09" MIMETYPE="application/pdf"
-				CHECKSUM="e405c5710dc6250e1632ebcad1ca14e60dfc7d1a" CHECKSUMTYPE="SHA-1"
-				SIZE="8771080">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/bmtnabf_1903-11-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:34:09" MIMETYPE="application/pdf" CHECKSUM="e405c5710dc6250e1632ebcad1ca14e60dfc7d1a" CHECKSUMTYPE="SHA-1" SIZE="8771080">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/11/15_01/bmtnabf_1903-11-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>

--- a/metadata/periodicals/bmtnabf/issues/1903/12/01_01/bmtnabf_1903-12-01_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/12/01_01/bmtnabf_1903-12-01_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-12-01_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-12-01_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-12-01_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-12-01_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-12-01_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -2050,308 +2044,156 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:04:17"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="0aa3bf6c87cd6dd9e70400e5f3180515675e9e42"
-				CHECKSUMTYPE="SHA-1" SIZE="6146104">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T16:04:17" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="0aa3bf6c87cd6dd9e70400e5f3180515675e9e42" CHECKSUMTYPE="SHA-1" SIZE="6146104">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:04:53"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="2ff483f31874e830964e371691e5e43c19cd8187"
-				CHECKSUMTYPE="SHA-1" SIZE="6090428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T16:04:53" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="2ff483f31874e830964e371691e5e43c19cd8187" CHECKSUMTYPE="SHA-1" SIZE="6090428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:05:28"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c6060e24ba2ff0af3a142c152dd93267ca0cbe4f"
-				CHECKSUMTYPE="SHA-1" SIZE="6146228">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T16:05:28" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="c6060e24ba2ff0af3a142c152dd93267ca0cbe4f" CHECKSUMTYPE="SHA-1" SIZE="6146228">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:06:11"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="ee1f96be544e37939e9c8392a94e2dcef3f6c26d"
-				CHECKSUMTYPE="SHA-1" SIZE="6090408">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T16:06:11" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="ee1f96be544e37939e9c8392a94e2dcef3f6c26d" CHECKSUMTYPE="SHA-1" SIZE="6090408">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:06:54"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="94f3b32bac6440ed78e094285663999340f6d853"
-				CHECKSUMTYPE="SHA-1" SIZE="6146223">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T16:06:54" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="94f3b32bac6440ed78e094285663999340f6d853" CHECKSUMTYPE="SHA-1" SIZE="6146223">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:07:30"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="e3abce8b72092d4ae62f49fe935045a64fb7de49"
-				CHECKSUMTYPE="SHA-1" SIZE="6139928">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T16:07:30" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="e3abce8b72092d4ae62f49fe935045a64fb7de49" CHECKSUMTYPE="SHA-1" SIZE="6139928">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:08:05"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="ae56e0269b13c16ce8922a29907df048ea9eaa81"
-				CHECKSUMTYPE="SHA-1" SIZE="6087716">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T16:08:05" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="ae56e0269b13c16ce8922a29907df048ea9eaa81" CHECKSUMTYPE="SHA-1" SIZE="6087716">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:08:39"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="43f4e702a47befbc516fc206f9a3c3253d2adf32"
-				CHECKSUMTYPE="SHA-1" SIZE="6192120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T16:08:39" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="43f4e702a47befbc516fc206f9a3c3253d2adf32" CHECKSUMTYPE="SHA-1" SIZE="6192120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:09:13"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="654c69a8bf9cc0fca396eafc36b4b56ac095437b"
-				CHECKSUMTYPE="SHA-1" SIZE="6087726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T16:09:13" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="654c69a8bf9cc0fca396eafc36b4b56ac095437b" CHECKSUMTYPE="SHA-1" SIZE="6087726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:09:48"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="ccc0cb8774b307f4e943b7bdfd3f39c013513691"
-				CHECKSUMTYPE="SHA-1" SIZE="6192091">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T16:09:48" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="ccc0cb8774b307f4e943b7bdfd3f39c013513691" CHECKSUMTYPE="SHA-1" SIZE="6192091">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:10:22"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="eb6d6116859cb1fa01103eb8fa315457639c4622"
-				CHECKSUMTYPE="SHA-1" SIZE="6087719">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T16:10:22" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="eb6d6116859cb1fa01103eb8fa315457639c4622" CHECKSUMTYPE="SHA-1" SIZE="6087719">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:10:59"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="0f569fba71a1e0707ffdf1339ef08cff395ad31e"
-				CHECKSUMTYPE="SHA-1" SIZE="6192112">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T16:10:59" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="0f569fba71a1e0707ffdf1339ef08cff395ad31e" CHECKSUMTYPE="SHA-1" SIZE="6192112">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:11:33"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="018e1943129ccee77f7785ee91c958eb7cb50ad9"
-				CHECKSUMTYPE="SHA-1" SIZE="6053526">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T16:11:33" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="018e1943129ccee77f7785ee91c958eb7cb50ad9" CHECKSUMTYPE="SHA-1" SIZE="6053526">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:12:11"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="debf970e8899ca9697aed9fce6107f3e9e82223b"
-				CHECKSUMTYPE="SHA-1" SIZE="6192091">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T16:12:11" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="debf970e8899ca9697aed9fce6107f3e9e82223b" CHECKSUMTYPE="SHA-1" SIZE="6192091">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:12:50"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="794b38ed313374f75ee933cac48e9a2f49a56603"
-				CHECKSUMTYPE="SHA-1" SIZE="6053522">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T16:12:50" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="794b38ed313374f75ee933cac48e9a2f49a56603" CHECKSUMTYPE="SHA-1" SIZE="6053522">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:13:29"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ecd5682d7ade126d82b552c7aeb3a1cd12f5a9f4"
-				CHECKSUMTYPE="SHA-1" SIZE="6192120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T16:13:29" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="ecd5682d7ade126d82b552c7aeb3a1cd12f5a9f4" CHECKSUMTYPE="SHA-1" SIZE="6192120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:14:02"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="6393b4730f4ea97382739fd77bc77b92daabe4e7"
-				CHECKSUMTYPE="SHA-1" SIZE="6053510">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T16:14:02" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="6393b4730f4ea97382739fd77bc77b92daabe4e7" CHECKSUMTYPE="SHA-1" SIZE="6053510">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:14:39"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="e17d4cc07d648682b254f3de0772bf575b961943"
-				CHECKSUMTYPE="SHA-1" SIZE="6192125">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T16:14:39" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="e17d4cc07d648682b254f3de0772bf575b961943" CHECKSUMTYPE="SHA-1" SIZE="6192125">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:15:13"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="a9e720833c096d14ff72ec8e7ade7b376607fb8c"
-				CHECKSUMTYPE="SHA-1" SIZE="6053486">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T16:15:13" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="a9e720833c096d14ff72ec8e7ade7b376607fb8c" CHECKSUMTYPE="SHA-1" SIZE="6053486">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:15:48"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="caee4ed5c15093c0f3c98497d9f5f8e767c8c6a6"
-				CHECKSUMTYPE="SHA-1" SIZE="6211011">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T16:15:48" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="caee4ed5c15093c0f3c98497d9f5f8e767c8c6a6" CHECKSUMTYPE="SHA-1" SIZE="6211011">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:16:23"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="eb1115d83bf2091aa7a9c6807f24b9f57db75b75"
-				CHECKSUMTYPE="SHA-1" SIZE="6053527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T16:16:23" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="eb1115d83bf2091aa7a9c6807f24b9f57db75b75" CHECKSUMTYPE="SHA-1" SIZE="6053527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:16:59"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="120bcd9c0dbdec9ccd05759422be16bd1dfd5bd4"
-				CHECKSUMTYPE="SHA-1" SIZE="6211027">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T16:16:59" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="120bcd9c0dbdec9ccd05759422be16bd1dfd5bd4" CHECKSUMTYPE="SHA-1" SIZE="6211027">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:17:35"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="24385087a8522204794845b4045df447f48e4faa"
-				CHECKSUMTYPE="SHA-1" SIZE="6053512">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T16:17:35" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="24385087a8522204794845b4045df447f48e4faa" CHECKSUMTYPE="SHA-1" SIZE="6053512">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:18:08"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="aa30fd9e10171ba0daded5c9cb61097dd11a849d"
-				CHECKSUMTYPE="SHA-1" SIZE="6187568">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T16:18:08" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="aa30fd9e10171ba0daded5c9cb61097dd11a849d" CHECKSUMTYPE="SHA-1" SIZE="6187568">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/delivery/bmtnabf_1903-12-01_01_0024.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:18:29" MIMETYPE="text/xml"
-				CHECKSUM="cb93bc07463829f7d63e4ea0656589bd16ccc7b2" CHECKSUMTYPE="SHA-1" SIZE="4943">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T16:18:29" MIMETYPE="text/xml" CHECKSUM="cb93bc07463829f7d63e4ea0656589bd16ccc7b2" CHECKSUMTYPE="SHA-1" SIZE="4943">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:18:29" MIMETYPE="text/xml"
-				CHECKSUM="8d37b372f150c79cda828f7d56715f46b210987b" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T16:18:29" MIMETYPE="text/xml" CHECKSUM="8d37b372f150c79cda828f7d56715f46b210987b" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:18:30" MIMETYPE="text/xml"
-				CHECKSUM="330a7d525575d16a42a3869ccdf436b8570b60ed" CHECKSUMTYPE="SHA-1" SIZE="8057">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T16:18:30" MIMETYPE="text/xml" CHECKSUM="330a7d525575d16a42a3869ccdf436b8570b60ed" CHECKSUMTYPE="SHA-1" SIZE="8057">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:18:30" MIMETYPE="text/xml"
-				CHECKSUM="6f59f9a4962ffed4eb75a623efb82b52d5812b01" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T16:18:30" MIMETYPE="text/xml" CHECKSUM="6f59f9a4962ffed4eb75a623efb82b52d5812b01" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:18:30" MIMETYPE="text/xml"
-				CHECKSUM="9c5578770f90379399a247af3b3fde11072970ad" CHECKSUMTYPE="SHA-1" SIZE="4379">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T16:18:30" MIMETYPE="text/xml" CHECKSUM="9c5578770f90379399a247af3b3fde11072970ad" CHECKSUMTYPE="SHA-1" SIZE="4379">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:18:30" MIMETYPE="text/xml"
-				CHECKSUM="ea6c3df5433cfaea106c8ae337b13cce967dc139" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T16:18:30" MIMETYPE="text/xml" CHECKSUM="ea6c3df5433cfaea106c8ae337b13cce967dc139" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:18:31" MIMETYPE="text/xml"
-				CHECKSUM="0ad24ec46e20fff279898145f1de64986e381718" CHECKSUMTYPE="SHA-1" SIZE="4311">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T16:18:31" MIMETYPE="text/xml" CHECKSUM="0ad24ec46e20fff279898145f1de64986e381718" CHECKSUMTYPE="SHA-1" SIZE="4311">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:18:31" MIMETYPE="text/xml"
-				CHECKSUM="9eb0ec306633b678946e8d59e2765308088a5dee" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T16:18:31" MIMETYPE="text/xml" CHECKSUM="9eb0ec306633b678946e8d59e2765308088a5dee" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:18:31" MIMETYPE="text/xml"
-				CHECKSUM="25d75274c685038fc199179685c0e3c506379964" CHECKSUMTYPE="SHA-1" SIZE="4310">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T16:18:31" MIMETYPE="text/xml" CHECKSUM="25d75274c685038fc199179685c0e3c506379964" CHECKSUMTYPE="SHA-1" SIZE="4310">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:18:31" MIMETYPE="text/xml"
-				CHECKSUM="acb3078ec9f906e1b290d456b46cdf7f1d97fea2" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T16:18:31" MIMETYPE="text/xml" CHECKSUM="acb3078ec9f906e1b290d456b46cdf7f1d97fea2" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:18:32" MIMETYPE="text/xml"
-				CHECKSUM="3f36668c421096f821d9ddc772b05efe0739c94b" CHECKSUMTYPE="SHA-1" SIZE="4335">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T16:18:32" MIMETYPE="text/xml" CHECKSUM="3f36668c421096f821d9ddc772b05efe0739c94b" CHECKSUMTYPE="SHA-1" SIZE="4335">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:18:32" MIMETYPE="text/xml"
-				CHECKSUM="537d226d420653837bbf5e36f8981883815e35a7" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T16:18:32" MIMETYPE="text/xml" CHECKSUM="537d226d420653837bbf5e36f8981883815e35a7" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:18:32" MIMETYPE="text/xml"
-				CHECKSUM="977c7835b707176956ed83756ae2976e5766bd3f" CHECKSUMTYPE="SHA-1" SIZE="4334">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T16:18:32" MIMETYPE="text/xml" CHECKSUM="977c7835b707176956ed83756ae2976e5766bd3f" CHECKSUMTYPE="SHA-1" SIZE="4334">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:18:32" MIMETYPE="text/xml"
-				CHECKSUM="9bb35b76779d21ea3852d0e7be1f47342968baff" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T16:18:32" MIMETYPE="text/xml" CHECKSUM="9bb35b76779d21ea3852d0e7be1f47342968baff" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:18:33" MIMETYPE="text/xml"
-				CHECKSUM="c57071fe9ac4c718e6ff3484f19946e4967fabfb" CHECKSUMTYPE="SHA-1" SIZE="4338">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T16:18:33" MIMETYPE="text/xml" CHECKSUM="c57071fe9ac4c718e6ff3484f19946e4967fabfb" CHECKSUMTYPE="SHA-1" SIZE="4338">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:18:33" MIMETYPE="text/xml"
-				CHECKSUM="5ef72b328dfa26ef6449d4d6738f3a5b3767d7ce" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T16:18:33" MIMETYPE="text/xml" CHECKSUM="5ef72b328dfa26ef6449d4d6738f3a5b3767d7ce" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:18:33" MIMETYPE="text/xml"
-				CHECKSUM="59b8e2143d349400ff10e9666994cd1afde6307c" CHECKSUMTYPE="SHA-1" SIZE="9419">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T16:18:33" MIMETYPE="text/xml" CHECKSUM="59b8e2143d349400ff10e9666994cd1afde6307c" CHECKSUMTYPE="SHA-1" SIZE="9419">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:18:33" MIMETYPE="text/xml"
-				CHECKSUM="1a0acfc483f1f6bb6d3f3ef7c1f3fe1574c8e05b" CHECKSUMTYPE="SHA-1"
-				SIZE="19684">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T16:18:33" MIMETYPE="text/xml" CHECKSUM="1a0acfc483f1f6bb6d3f3ef7c1f3fe1574c8e05b" CHECKSUMTYPE="SHA-1" SIZE="19684">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:18:33" MIMETYPE="text/xml"
-				CHECKSUM="0a583d2743876dfa0234d7f6bd605324062a3807" CHECKSUMTYPE="SHA-1"
-				SIZE="31823">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T16:18:33" MIMETYPE="text/xml" CHECKSUM="0a583d2743876dfa0234d7f6bd605324062a3807" CHECKSUMTYPE="SHA-1" SIZE="31823">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:18:34" MIMETYPE="text/xml"
-				CHECKSUM="cccdbb982218614e9a0413f53defdc077c67ee89" CHECKSUMTYPE="SHA-1"
-				SIZE="14359">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T16:18:34" MIMETYPE="text/xml" CHECKSUM="cccdbb982218614e9a0413f53defdc077c67ee89" CHECKSUMTYPE="SHA-1" SIZE="14359">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:18:34" MIMETYPE="text/xml"
-				CHECKSUM="94b97b3dff096fc088c6f6c0d8876dc02fb4dc98" CHECKSUMTYPE="SHA-1"
-				SIZE="22404">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T16:18:34" MIMETYPE="text/xml" CHECKSUM="94b97b3dff096fc088c6f6c0d8876dc02fb4dc98" CHECKSUMTYPE="SHA-1" SIZE="22404">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:18:34" MIMETYPE="text/xml"
-				CHECKSUM="e6833061bb44ca1c6cbef25a8b8f879c156fc1d3" CHECKSUMTYPE="SHA-1" SIZE="7551">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T16:18:34" MIMETYPE="text/xml" CHECKSUM="e6833061bb44ca1c6cbef25a8b8f879c156fc1d3" CHECKSUMTYPE="SHA-1" SIZE="7551">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:18:34" MIMETYPE="text/xml"
-				CHECKSUM="2ee2f9486a5e2fcf13016f13b56ca19904d4fc4a" CHECKSUMTYPE="SHA-1" SIZE="2016">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T16:18:34" MIMETYPE="text/xml" CHECKSUM="2ee2f9486a5e2fcf13016f13b56ca19904d4fc4a" CHECKSUMTYPE="SHA-1" SIZE="2016">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:18:35" MIMETYPE="text/xml"
-				CHECKSUM="df12d660a1b2d6a81feb0e44eebadf57ecbdbcf9" CHECKSUMTYPE="SHA-1" SIZE="6301">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T16:18:35" MIMETYPE="text/xml" CHECKSUM="df12d660a1b2d6a81feb0e44eebadf57ecbdbcf9" CHECKSUMTYPE="SHA-1" SIZE="6301">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-01_01_0024.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:19:01" MIMETYPE="application/pdf"
-				CHECKSUM="4beac3a598508a351046bc4387e1620c07518a2f" CHECKSUMTYPE="SHA-1"
-				SIZE="6268664">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/bmtnabf_1903-12-01_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T16:19:01" MIMETYPE="application/pdf" CHECKSUM="4beac3a598508a351046bc4387e1620c07518a2f" CHECKSUMTYPE="SHA-1" SIZE="6268664">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/01_01/bmtnabf_1903-12-01_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -2610,8 +2452,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003"
-					LABEL="ORIGINAL-HOLZSCHNITT">
+				<div ID="L.1.1.4" TYPE="Illustration" ORDER="3" DMDID="c003" LABEL="ORIGINAL-HOLZSCHNITT">
 					<div ID="L.1.1.4.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00005" BEGIN="P5_TB00002"/>
@@ -2628,8 +2469,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c004"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c004" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -2646,8 +2486,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.6" TYPE="Illustration" ORDER="5" DMDID="c005" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.6.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
@@ -2664,8 +2503,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c006"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.7" TYPE="Illustration" ORDER="6" DMDID="c006" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
@@ -2682,8 +2520,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c007"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c007" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -2700,8 +2537,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="8" DMDID="c008"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="8" DMDID="c008" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>

--- a/metadata/periodicals/bmtnabf/issues/1903/12/15_01/bmtnabf_1903-12-15_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903/12/15_01/bmtnabf_1903-12-15_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-12-15_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903-12-15_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-12-15_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903-12-15_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903-12-15_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3095,458 +3089,228 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T20:14:47"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="9f31b593d6cd02dc7d1f496c1e187259d585a23c"
-				CHECKSUMTYPE="SHA-1" SIZE="6204723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T20:14:47" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="9f31b593d6cd02dc7d1f496c1e187259d585a23c" CHECKSUMTYPE="SHA-1" SIZE="6204723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T20:15:21"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="e4095a654f697d187bd786d8cc81a418ed75c01c"
-				CHECKSUMTYPE="SHA-1" SIZE="6163316">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T20:15:21" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="e4095a654f697d187bd786d8cc81a418ed75c01c" CHECKSUMTYPE="SHA-1" SIZE="6163316">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T20:15:58"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="430c57a99f90b424c4d0bd3f9e28aae45250413d"
-				CHECKSUMTYPE="SHA-1" SIZE="6202912">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T20:15:58" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="430c57a99f90b424c4d0bd3f9e28aae45250413d" CHECKSUMTYPE="SHA-1" SIZE="6202912">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T20:16:41"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="ca560f68762a2ebed02ab00e86f50e367353c5b6"
-				CHECKSUMTYPE="SHA-1" SIZE="6164179">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T20:16:41" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="ca560f68762a2ebed02ab00e86f50e367353c5b6" CHECKSUMTYPE="SHA-1" SIZE="6164179">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:17:20"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="123784db9a8d44782ac6d715aed3b7be4404fb2f"
-				CHECKSUMTYPE="SHA-1" SIZE="6153384">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:17:20" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="123784db9a8d44782ac6d715aed3b7be4404fb2f" CHECKSUMTYPE="SHA-1" SIZE="6153384">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:17:52"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="3e83cfb4370608439afad9569abffad1dd09a353"
-				CHECKSUMTYPE="SHA-1" SIZE="6164207">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:17:52" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="3e83cfb4370608439afad9569abffad1dd09a353" CHECKSUMTYPE="SHA-1" SIZE="6164207">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:18:24"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="cb78dc48e5274b563d93b7cb114be895df2a39a9"
-				CHECKSUMTYPE="SHA-1" SIZE="6154328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:18:24" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="cb78dc48e5274b563d93b7cb114be895df2a39a9" CHECKSUMTYPE="SHA-1" SIZE="6154328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:19:02"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="e16e30f05f7d64481907fb4ad7f005e96e53e2f9"
-				CHECKSUMTYPE="SHA-1" SIZE="6222726">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:19:02" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="e16e30f05f7d64481907fb4ad7f005e96e53e2f9" CHECKSUMTYPE="SHA-1" SIZE="6222726">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:19:35"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="4dab0fd0e58031017e4797ab5abe4c9ff27a6e5f"
-				CHECKSUMTYPE="SHA-1" SIZE="6095828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:19:35" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="4dab0fd0e58031017e4797ab5abe4c9ff27a6e5f" CHECKSUMTYPE="SHA-1" SIZE="6095828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:20:08"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="a72f3498cebcfea38f6f1c1ed990bb2d8d9715fb"
-				CHECKSUMTYPE="SHA-1" SIZE="6222704">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:20:08" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="a72f3498cebcfea38f6f1c1ed990bb2d8d9715fb" CHECKSUMTYPE="SHA-1" SIZE="6222704">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:20:40"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="d3dd5597cdde456a93253ebfb958997b523b17ff"
-				CHECKSUMTYPE="SHA-1" SIZE="6095788">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:20:40" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="d3dd5597cdde456a93253ebfb958997b523b17ff" CHECKSUMTYPE="SHA-1" SIZE="6095788">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:21:13"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="fc97b21e420b38770444fc9f45c50dff77d6f79d"
-				CHECKSUMTYPE="SHA-1" SIZE="6222716">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:21:13" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="fc97b21e420b38770444fc9f45c50dff77d6f79d" CHECKSUMTYPE="SHA-1" SIZE="6222716">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:21:47"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="e206a85fe37ef9ed9f90f01504ffa5d9790346ab"
-				CHECKSUMTYPE="SHA-1" SIZE="6095810">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:21:47" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="e206a85fe37ef9ed9f90f01504ffa5d9790346ab" CHECKSUMTYPE="SHA-1" SIZE="6095810">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:22:20"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="3c14c90de81d5ebb845cf1ef1874972db1bd9d4b"
-				CHECKSUMTYPE="SHA-1" SIZE="6222718">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:22:20" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="3c14c90de81d5ebb845cf1ef1874972db1bd9d4b" CHECKSUMTYPE="SHA-1" SIZE="6222718">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:22:51"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="8d7055cd9587e82846a3a04d2baab5d28825c09b"
-				CHECKSUMTYPE="SHA-1" SIZE="6095824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:22:51" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="8d7055cd9587e82846a3a04d2baab5d28825c09b" CHECKSUMTYPE="SHA-1" SIZE="6095824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:23:27"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="e75feb3f8ead313ecea8231454e95fd25c6aad7b"
-				CHECKSUMTYPE="SHA-1" SIZE="6222728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:23:27" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="e75feb3f8ead313ecea8231454e95fd25c6aad7b" CHECKSUMTYPE="SHA-1" SIZE="6222728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:24:00"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e56474e334188c564d833aecc55db5c21a7939de"
-				CHECKSUMTYPE="SHA-1" SIZE="6095827">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:24:00" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="e56474e334188c564d833aecc55db5c21a7939de" CHECKSUMTYPE="SHA-1" SIZE="6095827">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:24:38"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="d0a205f5c21d911ae17442becde917e269dd231f"
-				CHECKSUMTYPE="SHA-1" SIZE="6222689">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:24:38" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="d0a205f5c21d911ae17442becde917e269dd231f" CHECKSUMTYPE="SHA-1" SIZE="6222689">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:25:11"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="eb1d86ea8a18027a8a5862a64b51bb404800b825"
-				CHECKSUMTYPE="SHA-1" SIZE="6095826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:25:11" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="eb1d86ea8a18027a8a5862a64b51bb404800b825" CHECKSUMTYPE="SHA-1" SIZE="6095826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:25:48"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="1aee2b96f045b92b20278ed4f71957856aa3ca30"
-				CHECKSUMTYPE="SHA-1" SIZE="6291127">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:25:48" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="1aee2b96f045b92b20278ed4f71957856aa3ca30" CHECKSUMTYPE="SHA-1" SIZE="6291127">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:26:23"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="40d6844d4d3f60cf0a792314a34527f73645549d"
-				CHECKSUMTYPE="SHA-1" SIZE="6184024">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:26:23" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="40d6844d4d3f60cf0a792314a34527f73645549d" CHECKSUMTYPE="SHA-1" SIZE="6184024">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:26:59"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="2062358191ed07f2e55762b3a9672990caa46a02"
-				CHECKSUMTYPE="SHA-1" SIZE="6291120">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:26:59" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="2062358191ed07f2e55762b3a9672990caa46a02" CHECKSUMTYPE="SHA-1" SIZE="6291120">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:27:34"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="6185413f60837e7dbb8e947ac421d6cc77e8ff21"
-				CHECKSUMTYPE="SHA-1" SIZE="6154328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:27:34" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="6185413f60837e7dbb8e947ac421d6cc77e8ff21" CHECKSUMTYPE="SHA-1" SIZE="6154328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:28:09"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="a553068cbd689ed3867b71694ef00d7fc1cd702b"
-				CHECKSUMTYPE="SHA-1" SIZE="6291118">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:28:09" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="a553068cbd689ed3867b71694ef00d7fc1cd702b" CHECKSUMTYPE="SHA-1" SIZE="6291118">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:28:42"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="9908d551ddf4e31498a8161bf62d3560518515b9"
-				CHECKSUMTYPE="SHA-1" SIZE="6154327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:28:42" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="9908d551ddf4e31498a8161bf62d3560518515b9" CHECKSUMTYPE="SHA-1" SIZE="6154327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:29:19"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="d2f048372053c62d84e2e72b3d7708244ecf6c81"
-				CHECKSUMTYPE="SHA-1" SIZE="6291094">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:29:19" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="d2f048372053c62d84e2e72b3d7708244ecf6c81" CHECKSUMTYPE="SHA-1" SIZE="6291094">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:29:54"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="8e3199772b0b5daa770fcdfabd4cf0f0d90793c8"
-				CHECKSUMTYPE="SHA-1" SIZE="6180291">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:29:54" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="8e3199772b0b5daa770fcdfabd4cf0f0d90793c8" CHECKSUMTYPE="SHA-1" SIZE="6180291">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:30:31"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="4d578625ea95fc72c88a94c589c58b6ca33934f7"
-				CHECKSUMTYPE="SHA-1" SIZE="6305529">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:30:31" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="4d578625ea95fc72c88a94c589c58b6ca33934f7" CHECKSUMTYPE="SHA-1" SIZE="6305529">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T20:31:07"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="7c73532edbf56cc9973ce1d16d2ebf26de186bd3"
-				CHECKSUMTYPE="SHA-1" SIZE="6180427">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T20:31:07" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="7c73532edbf56cc9973ce1d16d2ebf26de186bd3" CHECKSUMTYPE="SHA-1" SIZE="6180427">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T20:31:43"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="2cfa09fbb0aa281b33bccda8ba4f2ea0df870d8e"
-				CHECKSUMTYPE="SHA-1" SIZE="6373922">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T20:31:43" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="2cfa09fbb0aa281b33bccda8ba4f2ea0df870d8e" CHECKSUMTYPE="SHA-1" SIZE="6373922">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T20:32:17"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="bebc8ff0b9364d67100c1665c0772f81a60722b4"
-				CHECKSUMTYPE="SHA-1" SIZE="6180426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T20:32:17" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="bebc8ff0b9364d67100c1665c0772f81a60722b4" CHECKSUMTYPE="SHA-1" SIZE="6180426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T20:32:53"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="28bc473712743341645c3f7cb23cbf527c126fa3"
-				CHECKSUMTYPE="SHA-1" SIZE="6373903">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T20:32:53" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="28bc473712743341645c3f7cb23cbf527c126fa3" CHECKSUMTYPE="SHA-1" SIZE="6373903">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T20:33:28"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="7d008a11d21c206754b1d69123e7702a705fbeff"
-				CHECKSUMTYPE="SHA-1" SIZE="6180426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T20:33:28" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="7d008a11d21c206754b1d69123e7702a705fbeff" CHECKSUMTYPE="SHA-1" SIZE="6180426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T20:34:03"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="152d69620daa0caf8e69c4abf58a75b74d84c3d9"
-				CHECKSUMTYPE="SHA-1" SIZE="6354122">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T20:34:03" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="152d69620daa0caf8e69c4abf58a75b74d84c3d9" CHECKSUMTYPE="SHA-1" SIZE="6354122">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0034.jp2"/>
 			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T20:34:36"
-				MIMETYPE="image/jp2" SEQ="35" CHECKSUM="6bdb38a3b2739875259020b6d40ed05ae88c0a73"
-				CHECKSUMTYPE="SHA-1" SIZE="6180425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0035.jp2"
-				/>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T20:34:36" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="6bdb38a3b2739875259020b6d40ed05ae88c0a73" CHECKSUMTYPE="SHA-1" SIZE="6180425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0035.jp2"/>
 			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T20:35:13"
-				MIMETYPE="image/jp2" SEQ="36" CHECKSUM="ead15fbc839b7a04798e7dcb3914e065e5d0b1e4"
-				CHECKSUMTYPE="SHA-1" SIZE="6289319">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0036.jp2"
-				/>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T20:35:13" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="ead15fbc839b7a04798e7dcb3914e065e5d0b1e4" CHECKSUMTYPE="SHA-1" SIZE="6289319">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/delivery/bmtnabf_1903-12-15_01_0036.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:35:34" MIMETYPE="text/xml"
-				CHECKSUM="f7c5da826709e741a650b4c93a7f40d6b481b594" CHECKSUMTYPE="SHA-1" SIZE="4590">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0001.alto.xml"
-				/>
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:35:34" MIMETYPE="text/xml" CHECKSUM="f7c5da826709e741a650b4c93a7f40d6b481b594" CHECKSUMTYPE="SHA-1" SIZE="4590">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:35:35" MIMETYPE="text/xml"
-				CHECKSUM="733c6885f79a8bc917b6b609cfa4d2d17332675e" CHECKSUMTYPE="SHA-1" SIZE="1717">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0002.alto.xml"
-				/>
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:35:35" MIMETYPE="text/xml" CHECKSUM="733c6885f79a8bc917b6b609cfa4d2d17332675e" CHECKSUMTYPE="SHA-1" SIZE="1717">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:35:35" MIMETYPE="text/xml"
-				CHECKSUM="14d9157fd44ab8ebc58db811206fc7f06a62c415" CHECKSUMTYPE="SHA-1" SIZE="8911">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0003.alto.xml"
-				/>
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:35:35" MIMETYPE="text/xml" CHECKSUM="14d9157fd44ab8ebc58db811206fc7f06a62c415" CHECKSUMTYPE="SHA-1" SIZE="8911">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:35:35" MIMETYPE="text/xml"
-				CHECKSUM="36b0781be93ea7f2fe4b9018dc49007c34d3c3b2" CHECKSUMTYPE="SHA-1" SIZE="1709">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0004.alto.xml"
-				/>
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:35:35" MIMETYPE="text/xml" CHECKSUM="36b0781be93ea7f2fe4b9018dc49007c34d3c3b2" CHECKSUMTYPE="SHA-1" SIZE="1709">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:35:35" MIMETYPE="text/xml"
-				CHECKSUM="358ca353cbec81b07114e1703f8fd4121f385fd3" CHECKSUMTYPE="SHA-1" SIZE="4732">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0005.alto.xml"
-				/>
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:35:35" MIMETYPE="text/xml" CHECKSUM="358ca353cbec81b07114e1703f8fd4121f385fd3" CHECKSUMTYPE="SHA-1" SIZE="4732">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:35:36" MIMETYPE="text/xml"
-				CHECKSUM="c6d18c6b386fd063baf769e1d29b879f86246f97" CHECKSUMTYPE="SHA-1" SIZE="1718">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0006.alto.xml"
-				/>
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:35:36" MIMETYPE="text/xml" CHECKSUM="c6d18c6b386fd063baf769e1d29b879f86246f97" CHECKSUMTYPE="SHA-1" SIZE="1718">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:35:36" MIMETYPE="text/xml"
-				CHECKSUM="0b090582b2d216d08d891ffafb4e2928b7ba3248" CHECKSUMTYPE="SHA-1" SIZE="4312">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0007.alto.xml"
-				/>
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:35:36" MIMETYPE="text/xml" CHECKSUM="0b090582b2d216d08d891ffafb4e2928b7ba3248" CHECKSUMTYPE="SHA-1" SIZE="4312">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:35:36" MIMETYPE="text/xml"
-				CHECKSUM="6cfe80dddbe21628c71976bee5eb487c4c2ac7df" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0008.alto.xml"
-				/>
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:35:36" MIMETYPE="text/xml" CHECKSUM="6cfe80dddbe21628c71976bee5eb487c4c2ac7df" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:35:36" MIMETYPE="text/xml"
-				CHECKSUM="8a133b049f5a140252f33ba57ea4a004211abd86" CHECKSUMTYPE="SHA-1"
-				SIZE="45040">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0009.alto.xml"
-				/>
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:35:36" MIMETYPE="text/xml" CHECKSUM="8a133b049f5a140252f33ba57ea4a004211abd86" CHECKSUMTYPE="SHA-1" SIZE="45040">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:35:37" MIMETYPE="text/xml"
-				CHECKSUM="1e4d9c9781557af61c9093c1d017e01117c8fc2c" CHECKSUMTYPE="SHA-1"
-				SIZE="47441">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0010.alto.xml"
-				/>
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:35:37" MIMETYPE="text/xml" CHECKSUM="1e4d9c9781557af61c9093c1d017e01117c8fc2c" CHECKSUMTYPE="SHA-1" SIZE="47441">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:35:37" MIMETYPE="text/xml"
-				CHECKSUM="188a3ef0bf1de904bb19aee6b11da05b35ff8618" CHECKSUMTYPE="SHA-1"
-				SIZE="33970">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0011.alto.xml"
-				/>
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:35:37" MIMETYPE="text/xml" CHECKSUM="188a3ef0bf1de904bb19aee6b11da05b35ff8618" CHECKSUMTYPE="SHA-1" SIZE="33970">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:35:37" MIMETYPE="text/xml"
-				CHECKSUM="f7164dd5992cd0767f2b09a50d4c78e8543229b3" CHECKSUMTYPE="SHA-1"
-				SIZE="18543">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0012.alto.xml"
-				/>
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:35:37" MIMETYPE="text/xml" CHECKSUM="f7164dd5992cd0767f2b09a50d4c78e8543229b3" CHECKSUMTYPE="SHA-1" SIZE="18543">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:35:38" MIMETYPE="text/xml"
-				CHECKSUM="1a42f784641a3190fbe086da979af58c52adf943" CHECKSUMTYPE="SHA-1" SIZE="4411">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0013.alto.xml"
-				/>
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:35:38" MIMETYPE="text/xml" CHECKSUM="1a42f784641a3190fbe086da979af58c52adf943" CHECKSUMTYPE="SHA-1" SIZE="4411">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:35:38" MIMETYPE="text/xml"
-				CHECKSUM="d6b8856fbfe120b444f5e5d0b1f6ce4265826b88" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0014.alto.xml"
-				/>
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:35:38" MIMETYPE="text/xml" CHECKSUM="d6b8856fbfe120b444f5e5d0b1f6ce4265826b88" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:35:38" MIMETYPE="text/xml"
-				CHECKSUM="12039959806d8a230adbadbfd0ee23e5eadbd526" CHECKSUMTYPE="SHA-1" SIZE="4232">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0015.alto.xml"
-				/>
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:35:38" MIMETYPE="text/xml" CHECKSUM="12039959806d8a230adbadbfd0ee23e5eadbd526" CHECKSUMTYPE="SHA-1" SIZE="4232">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:35:39" MIMETYPE="text/xml"
-				CHECKSUM="b9fe98796566c82c097b4b0affacea6379aacc8e" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0016.alto.xml"
-				/>
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:35:39" MIMETYPE="text/xml" CHECKSUM="b9fe98796566c82c097b4b0affacea6379aacc8e" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:35:39" MIMETYPE="text/xml"
-				CHECKSUM="9784f39c948368f44f4ea177af030dce80331a48" CHECKSUMTYPE="SHA-1" SIZE="4180">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0017.alto.xml"
-				/>
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:35:39" MIMETYPE="text/xml" CHECKSUM="9784f39c948368f44f4ea177af030dce80331a48" CHECKSUMTYPE="SHA-1" SIZE="4180">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:35:39" MIMETYPE="text/xml"
-				CHECKSUM="eab453a24d4cd932d5d193e42eff219c36273886" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0018.alto.xml"
-				/>
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:35:39" MIMETYPE="text/xml" CHECKSUM="eab453a24d4cd932d5d193e42eff219c36273886" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:35:39" MIMETYPE="text/xml"
-				CHECKSUM="2ed6bdd34a7475a32ee6536b7497f874ed6dacfb" CHECKSUMTYPE="SHA-1" SIZE="4425">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0019.alto.xml"
-				/>
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:35:39" MIMETYPE="text/xml" CHECKSUM="2ed6bdd34a7475a32ee6536b7497f874ed6dacfb" CHECKSUMTYPE="SHA-1" SIZE="4425">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:35:39" MIMETYPE="text/xml"
-				CHECKSUM="e484d77fbb3e92303b6984223ced026dc7821ec3" CHECKSUMTYPE="SHA-1" SIZE="2015">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0020.alto.xml"
-				/>
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:35:39" MIMETYPE="text/xml" CHECKSUM="e484d77fbb3e92303b6984223ced026dc7821ec3" CHECKSUMTYPE="SHA-1" SIZE="2015">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:35:40" MIMETYPE="text/xml"
-				CHECKSUM="0a6a186bb4f8f47084f3d31db04a0e0233901ace" CHECKSUMTYPE="SHA-1" SIZE="4407">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0021.alto.xml"
-				/>
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:35:40" MIMETYPE="text/xml" CHECKSUM="0a6a186bb4f8f47084f3d31db04a0e0233901ace" CHECKSUMTYPE="SHA-1" SIZE="4407">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:35:40" MIMETYPE="text/xml"
-				CHECKSUM="5529f6da5dde25472b56082634210931937ff296" CHECKSUMTYPE="SHA-1" SIZE="2017">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0022.alto.xml"
-				/>
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:35:40" MIMETYPE="text/xml" CHECKSUM="5529f6da5dde25472b56082634210931937ff296" CHECKSUMTYPE="SHA-1" SIZE="2017">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:35:40" MIMETYPE="text/xml"
-				CHECKSUM="8d5cf327a1803b61032f13c3766af63c30fcfbb9" CHECKSUMTYPE="SHA-1" SIZE="4341">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0023.alto.xml"
-				/>
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:35:40" MIMETYPE="text/xml" CHECKSUM="8d5cf327a1803b61032f13c3766af63c30fcfbb9" CHECKSUMTYPE="SHA-1" SIZE="4341">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:35:40" MIMETYPE="text/xml"
-				CHECKSUM="595b4471c75288a4c9e9dbd5151c67f4f8c358e5" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0024.alto.xml"
-				/>
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:35:40" MIMETYPE="text/xml" CHECKSUM="595b4471c75288a4c9e9dbd5151c67f4f8c358e5" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:35:41" MIMETYPE="text/xml"
-				CHECKSUM="88e4feb6d82ec66406fce8b5dc5f3fd7cf56f32e" CHECKSUMTYPE="SHA-1"
-				SIZE="50803">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0025.alto.xml"
-				/>
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:35:41" MIMETYPE="text/xml" CHECKSUM="88e4feb6d82ec66406fce8b5dc5f3fd7cf56f32e" CHECKSUMTYPE="SHA-1" SIZE="50803">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:35:41" MIMETYPE="text/xml"
-				CHECKSUM="1b682e2724875eae67cdb8258c10271c07389405" CHECKSUMTYPE="SHA-1"
-				SIZE="32833">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0026.alto.xml"
-				/>
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:35:41" MIMETYPE="text/xml" CHECKSUM="1b682e2724875eae67cdb8258c10271c07389405" CHECKSUMTYPE="SHA-1" SIZE="32833">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:35:41" MIMETYPE="text/xml"
-				CHECKSUM="4adcf3a4789d9f18902ff07059462dffb8284660" CHECKSUMTYPE="SHA-1" SIZE="2008">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0027.alto.xml"
-				/>
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:35:41" MIMETYPE="text/xml" CHECKSUM="4adcf3a4789d9f18902ff07059462dffb8284660" CHECKSUMTYPE="SHA-1" SIZE="2008">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:35:41" MIMETYPE="text/xml"
-				CHECKSUM="3db11db5de65a8f2218be02054cbdbf8c759f7e2" CHECKSUMTYPE="SHA-1" SIZE="9279">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0028.alto.xml"
-				/>
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:35:41" MIMETYPE="text/xml" CHECKSUM="3db11db5de65a8f2218be02054cbdbf8c759f7e2" CHECKSUMTYPE="SHA-1" SIZE="9279">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T20:35:42" MIMETYPE="text/xml"
-				CHECKSUM="4cb73b0a2ada5589faa317ca0b16c232ab2d61d4" CHECKSUMTYPE="SHA-1" SIZE="8606">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0029.alto.xml"
-				/>
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T20:35:42" MIMETYPE="text/xml" CHECKSUM="4cb73b0a2ada5589faa317ca0b16c232ab2d61d4" CHECKSUMTYPE="SHA-1" SIZE="8606">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T20:35:42" MIMETYPE="text/xml"
-				CHECKSUM="5419d50d79abe701394e135c75a05a459575c768" CHECKSUMTYPE="SHA-1"
-				SIZE="22290">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0030.alto.xml"
-				/>
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T20:35:42" MIMETYPE="text/xml" CHECKSUM="5419d50d79abe701394e135c75a05a459575c768" CHECKSUMTYPE="SHA-1" SIZE="22290">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T20:35:42" MIMETYPE="text/xml"
-				CHECKSUM="4bb77e492a5d9ff89099cc7346ecf63341b7cc40" CHECKSUMTYPE="SHA-1"
-				SIZE="29060">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0031.alto.xml"
-				/>
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T20:35:42" MIMETYPE="text/xml" CHECKSUM="4bb77e492a5d9ff89099cc7346ecf63341b7cc40" CHECKSUMTYPE="SHA-1" SIZE="29060">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T20:35:42" MIMETYPE="text/xml"
-				CHECKSUM="9bc81b7039daca8c29e61c5a9db88fc02d7595fd" CHECKSUMTYPE="SHA-1"
-				SIZE="17046">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0032.alto.xml"
-				/>
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T20:35:42" MIMETYPE="text/xml" CHECKSUM="9bc81b7039daca8c29e61c5a9db88fc02d7595fd" CHECKSUMTYPE="SHA-1" SIZE="17046">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T20:35:43" MIMETYPE="text/xml"
-				CHECKSUM="75ba588230296e59a313520080767a4c3d837796" CHECKSUMTYPE="SHA-1"
-				SIZE="23288">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0033.alto.xml"
-				/>
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T20:35:43" MIMETYPE="text/xml" CHECKSUM="75ba588230296e59a313520080767a4c3d837796" CHECKSUMTYPE="SHA-1" SIZE="23288">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T20:35:43" MIMETYPE="text/xml"
-				CHECKSUM="7b128073b3ddbc1a879ee31bbae48577b4fac255" CHECKSUMTYPE="SHA-1" SIZE="8284">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0034.alto.xml"
-				/>
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T20:35:43" MIMETYPE="text/xml" CHECKSUM="7b128073b3ddbc1a879ee31bbae48577b4fac255" CHECKSUMTYPE="SHA-1" SIZE="8284">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T20:35:43" MIMETYPE="text/xml"
-				CHECKSUM="174b8b6fb94fb2faa347b4c0e7981cc6888f07ae" CHECKSUMTYPE="SHA-1" SIZE="2018">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0035.alto.xml"
-				/>
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T20:35:43" MIMETYPE="text/xml" CHECKSUM="174b8b6fb94fb2faa347b4c0e7981cc6888f07ae" CHECKSUMTYPE="SHA-1" SIZE="2018">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T20:35:43" MIMETYPE="text/xml"
-				CHECKSUM="70d7ab204db355d7f2b12e0cbf17d8f4da0f6c06" CHECKSUMTYPE="SHA-1" SIZE="7446">
-				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0036.alto.xml"
-				/>
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T20:35:43" MIMETYPE="text/xml" CHECKSUM="70d7ab204db355d7f2b12e0cbf17d8f4da0f6c06" CHECKSUMTYPE="SHA-1" SIZE="7446">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903-12-15_01_0036.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:36:19" MIMETYPE="application/pdf"
-				CHECKSUM="71a79dc7721a1497d6978d6c3bdaf3f4fdd2586d" CHECKSUMTYPE="SHA-1"
-				SIZE="9879953">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/bmtnabf_1903-12-15_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:36:19" MIMETYPE="application/pdf" CHECKSUM="71a79dc7721a1497d6978d6c3bdaf3f4fdd2586d" CHECKSUMTYPE="SHA-1" SIZE="9879953">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903/12/15_01/bmtnabf_1903-12-15_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -3918,8 +3682,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c004"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="4" DMDID="c004" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00002"/>
@@ -3936,8 +3699,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="TextContent" ORDER="5" DMDID="c005"
-					LABEL="Untitled text by DAS VER SACRUM KOMITEE 1903">
+				<div ID="L.1.1.6" TYPE="TextContent" ORDER="5" DMDID="c005" LABEL="Untitled text by DAS VER SACRUM KOMITEE 1903">
 					<div ID="L.1.1.6.1" TYPE="Illustration" ORDER="1" DMDID="c006" LABEL="[Initial]">
 						<div ID="L.1.1.6.1.1" TYPE="Image">
 							<fptr>
@@ -3951,16 +3713,11 @@
 								<div ID="L.1.1.6.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00009"
-												BEGIN="P9_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00010"
-												BEGIN="P10_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00011"
-												BEGIN="P11_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00004"/>
 										</seq>
 									</fptr>
 								</div>
@@ -3968,15 +3725,13 @@
 							<div ID="L.1.1.6.2.1.2" TYPE="Paragraph" ORDER="2">
 								<div ID="L.1.1.6.2.1.2.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00005"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00005"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.6.3" TYPE="Illustration" ORDER="1" DMDID="c007"
-						LABEL="Original-Holzschnitt">
+					<div ID="L.1.1.6.3" TYPE="Illustration" ORDER="1" DMDID="c007" LABEL="Original-Holzschnitt">
 						<div ID="L.1.1.6.3.1" TYPE="Head">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00006"/>
@@ -3994,8 +3749,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="TextContent" ORDER="6" DMDID="c008"
-					LABEL="Untitled text by ADMINISTRATION &#34;VER SACRUM&#34;">
+				<div ID="L.1.1.7" TYPE="TextContent" ORDER="6" DMDID="c008" LABEL="Untitled text by ADMINISTRATION &#34;VER SACRUM&#34;">
 					<div ID="L.1.1.7.1" TYPE="Illustration" ORDER="1" DMDID="c009" LABEL="[Initial]">
 						<div ID="L.1.1.7.1.1" TYPE="Image">
 							<fptr>
@@ -4008,8 +3762,7 @@
 							<div ID="L.1.1.7.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.7.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_TB00002"/>
 									</fptr>
 								</div>
 							</div>
@@ -4033,8 +3786,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c011"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.8" TYPE="Illustration" ORDER="7" DMDID="c011" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.8.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00002"/>
@@ -4051,8 +3803,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.9" TYPE="Illustration" ORDER="8" DMDID="c012"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.9" TYPE="Illustration" ORDER="8" DMDID="c012" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.9.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00002"/>
@@ -4069,8 +3820,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.10" TYPE="Illustration" ORDER="9" DMDID="c013"
-					LABEL="ORIGINAL-HOLZSCHNITT">
+				<div ID="L.1.1.10" TYPE="Illustration" ORDER="9" DMDID="c013" LABEL="ORIGINAL-HOLZSCHNITT">
 					<div ID="L.1.1.10.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00003"/>
@@ -4087,8 +3837,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.11" TYPE="Illustration" ORDER="10" DMDID="c014"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.11" TYPE="Illustration" ORDER="10" DMDID="c014" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.11.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00002"/>
@@ -4105,8 +3854,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.12" TYPE="Illustration" ORDER="11" DMDID="c015"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.12" TYPE="Illustration" ORDER="11" DMDID="c015" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.12.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00002"/>
@@ -4123,8 +3871,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.13" TYPE="Illustration" ORDER="12" DMDID="c016"
-					LABEL="Original-Holzschnitt">
+				<div ID="L.1.1.13" TYPE="Illustration" ORDER="12" DMDID="c016" LABEL="Original-Holzschnitt">
 					<div ID="L.1.1.13.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00002"/>
@@ -4153,26 +3900,16 @@
 								<div ID="L.1.1.14.2.1.1.1" TYPE="Text">
 									<fptr>
 										<seq>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00025"
-												BEGIN="P25_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00002"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00003"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00004"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00005"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00006"/>
-											<area BETYPE="IDREF" FILEID="ALTO00026"
-												BEGIN="P26_TB00007"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00002"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00003"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00004"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00005"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00006"/>
+											<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_TB00007"/>
 										</seq>
 									</fptr>
 								</div>

--- a/metadata/periodicals/bmtnabf/issues/1903_01/bmtnabf_1903_01.mets.xml
+++ b/metadata/periodicals/bmtnabf/issues/1903_01/bmtnabf_1903_01.mets.xml
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/"
-	xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3"
-	xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
-	TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903_01">
+<?xml version="1.0" encoding="UTF-8"?><mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:local="http://diglib.princeton.edu" xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/ http://schema.ccs-gmbh.com/docworks/version20/mix_jp2.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" TYPE="Magazine" OBJID="urn:PUL:periodicals:bluemountain:bmtnabf_1903_01">
 	<metsHdr>
 		<agent ROLE="CREATOR" TYPE="ORGANIZATION">
 			<name>Princeton University Library, Digital Initiatives</name>
@@ -19,9 +14,9 @@
 			<xmlData>
 				<mods xmlns="http://www.loc.gov/mods/v3">
 					<recordInfo>
-						<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+						<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903_01</mods:recordIdentifier>
 					</recordInfo>
-					<identifier type="bmtn">urn:PUL:bluemountain:bmtnabf</identifier>
+					<mods:identifier type="bmtn">urn:PUL:bluemountain:bmtnabf_1903_01</mods:identifier>
 					<typeOfResource>text</typeOfResource>
 					<genre>Periodicals-Issue</genre>
 					<titleInfo>
@@ -50,10 +45,9 @@
 							</copyInformation>
 						</holdingSimple>
 					</location>
-					<relatedItem type="host" xlink:type="simple"
-						xlink:href="urn:PUL:bluemountain:bmtnabf">
+					<relatedItem type="host" xlink:type="simple" xlink:href="urn:PUL:bluemountain:bmtnabf">
 						<recordInfo>
-							<recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf</recordIdentifier>
+							<mods:recordIdentifier>urn:PUL:bluemountain:dmd:bmtnabf_1903_01</mods:recordIdentifier>
 						</recordInfo>
 					</relatedItem>
 					<relatedItem type="constituent" ID="c001">
@@ -3286,414 +3280,228 @@
 	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
-			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T20:16:22"
-				MIMETYPE="image/jp2" SEQ="1" CHECKSUM="4c5f72d460051b23bd68ba34d3a1d321e6cefa9d"
-				CHECKSUMTYPE="SHA-1" SIZE="6189429">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0001.jp2"
-				/>
+			<file ID="IMG00001" ADMID="techmd1" GROUPID="page1" CREATED="2015-10-09T20:16:22" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="4c5f72d460051b23bd68ba34d3a1d321e6cefa9d" CHECKSUMTYPE="SHA-1" SIZE="6189429">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0001.jp2"/>
 			</file>
-			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T20:16:56"
-				MIMETYPE="image/jp2" SEQ="2" CHECKSUM="bed43573f6dcdbebbd10c8bb587771c9831ec3eb"
-				CHECKSUMTYPE="SHA-1" SIZE="6122811">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0002.jp2"
-				/>
+			<file ID="IMG00002" ADMID="techmd2" GROUPID="page2" CREATED="2015-10-09T20:16:56" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="bed43573f6dcdbebbd10c8bb587771c9831ec3eb" CHECKSUMTYPE="SHA-1" SIZE="6122811">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0002.jp2"/>
 			</file>
-			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T20:17:26"
-				MIMETYPE="image/jp2" SEQ="3" CHECKSUM="89af9270ba0bad94959bbcda5bfc8a9e6c08ade0"
-				CHECKSUMTYPE="SHA-1" SIZE="6150729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0003.jp2"
-				/>
+			<file ID="IMG00003" ADMID="techmd3" GROUPID="page3" CREATED="2015-10-09T20:17:26" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="89af9270ba0bad94959bbcda5bfc8a9e6c08ade0" CHECKSUMTYPE="SHA-1" SIZE="6150729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0003.jp2"/>
 			</file>
-			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T20:17:59"
-				MIMETYPE="image/jp2" SEQ="4" CHECKSUM="e3ba1eea631db381de6f576d9bdd46800c367231"
-				CHECKSUMTYPE="SHA-1" SIZE="6122823">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0004.jp2"
-				/>
+			<file ID="IMG00004" ADMID="techmd4" GROUPID="page4" CREATED="2015-10-09T20:17:59" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="e3ba1eea631db381de6f576d9bdd46800c367231" CHECKSUMTYPE="SHA-1" SIZE="6122823">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0004.jp2"/>
 			</file>
-			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:18:32"
-				MIMETYPE="image/jp2" SEQ="5" CHECKSUM="6428a02bf14fc3c3f0b347ad1ecc41a535ba855d"
-				CHECKSUMTYPE="SHA-1" SIZE="6128227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0005.jp2"
-				/>
+			<file ID="IMG00005" ADMID="techmd5" GROUPID="page5" CREATED="2015-10-09T20:18:32" MIMETYPE="image/jp2" SEQ="5" CHECKSUM="6428a02bf14fc3c3f0b347ad1ecc41a535ba855d" CHECKSUMTYPE="SHA-1" SIZE="6128227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0005.jp2"/>
 			</file>
-			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:19:01"
-				MIMETYPE="image/jp2" SEQ="6" CHECKSUM="d6f4cb4ce2399bcb3ce44d02913c4c241ddf13ce"
-				CHECKSUMTYPE="SHA-1" SIZE="6122829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0006.jp2"
-				/>
+			<file ID="IMG00006" ADMID="techmd6" GROUPID="page6" CREATED="2015-10-09T20:19:01" MIMETYPE="image/jp2" SEQ="6" CHECKSUM="d6f4cb4ce2399bcb3ce44d02913c4c241ddf13ce" CHECKSUMTYPE="SHA-1" SIZE="6122829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0006.jp2"/>
 			</file>
-			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:19:30"
-				MIMETYPE="image/jp2" SEQ="7" CHECKSUM="7050f1a46f77ab6891ba4d277f3f9fbc5fbf76b0"
-				CHECKSUMTYPE="SHA-1" SIZE="6087728">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0007.jp2"
-				/>
+			<file ID="IMG00007" ADMID="techmd7" GROUPID="page7" CREATED="2015-10-09T20:19:30" MIMETYPE="image/jp2" SEQ="7" CHECKSUM="7050f1a46f77ab6891ba4d277f3f9fbc5fbf76b0" CHECKSUMTYPE="SHA-1" SIZE="6087728">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0007.jp2"/>
 			</file>
-			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:20:01"
-				MIMETYPE="image/jp2" SEQ="8" CHECKSUM="415babee38d2d6fd94cad267a0f16b01dfd93a0f"
-				CHECKSUMTYPE="SHA-1" SIZE="6150719">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0008.jp2"
-				/>
+			<file ID="IMG00008" ADMID="techmd8" GROUPID="page8" CREATED="2015-10-09T20:20:01" MIMETYPE="image/jp2" SEQ="8" CHECKSUM="415babee38d2d6fd94cad267a0f16b01dfd93a0f" CHECKSUMTYPE="SHA-1" SIZE="6150719">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0008.jp2"/>
 			</file>
-			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:20:33"
-				MIMETYPE="image/jp2" SEQ="9" CHECKSUM="77748802398f439a28d0d79739d197c268c4fe2d"
-				CHECKSUMTYPE="SHA-1" SIZE="6108425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0009.jp2"
-				/>
+			<file ID="IMG00009" ADMID="techmd9" GROUPID="page9" CREATED="2015-10-09T20:20:33" MIMETYPE="image/jp2" SEQ="9" CHECKSUM="77748802398f439a28d0d79739d197c268c4fe2d" CHECKSUMTYPE="SHA-1" SIZE="6108425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0009.jp2"/>
 			</file>
-			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:21:05"
-				MIMETYPE="image/jp2" SEQ="10" CHECKSUM="5ecb96c26a4a422e722f261fe7a6372ab87338f2"
-				CHECKSUMTYPE="SHA-1" SIZE="6150729">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0010.jp2"
-				/>
+			<file ID="IMG00010" ADMID="techmd10" GROUPID="page10" CREATED="2015-10-09T20:21:05" MIMETYPE="image/jp2" SEQ="10" CHECKSUM="5ecb96c26a4a422e722f261fe7a6372ab87338f2" CHECKSUMTYPE="SHA-1" SIZE="6150729">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0010.jp2"/>
 			</file>
-			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:21:39"
-				MIMETYPE="image/jp2" SEQ="11" CHECKSUM="fbd3e8bcdcc0a2f84f6081674bb51e514616cac5"
-				CHECKSUMTYPE="SHA-1" SIZE="6108423">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0011.jp2"
-				/>
+			<file ID="IMG00011" ADMID="techmd11" GROUPID="page11" CREATED="2015-10-09T20:21:39" MIMETYPE="image/jp2" SEQ="11" CHECKSUM="fbd3e8bcdcc0a2f84f6081674bb51e514616cac5" CHECKSUMTYPE="SHA-1" SIZE="6108423">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0011.jp2"/>
 			</file>
-			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:22:13"
-				MIMETYPE="image/jp2" SEQ="12" CHECKSUM="219c8ab77a00fe98c566b47419109e9909523b4d"
-				CHECKSUMTYPE="SHA-1" SIZE="6150723">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0012.jp2"
-				/>
+			<file ID="IMG00012" ADMID="techmd12" GROUPID="page12" CREATED="2015-10-09T20:22:13" MIMETYPE="image/jp2" SEQ="12" CHECKSUM="219c8ab77a00fe98c566b47419109e9909523b4d" CHECKSUMTYPE="SHA-1" SIZE="6150723">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0012.jp2"/>
 			</file>
-			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:22:45"
-				MIMETYPE="image/jp2" SEQ="13" CHECKSUM="fa7d841e33a416e4565804a3c49228732e8f4925"
-				CHECKSUMTYPE="SHA-1" SIZE="6085929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0013.jp2"
-				/>
+			<file ID="IMG00013" ADMID="techmd13" GROUPID="page13" CREATED="2015-10-09T20:22:45" MIMETYPE="image/jp2" SEQ="13" CHECKSUM="fa7d841e33a416e4565804a3c49228732e8f4925" CHECKSUMTYPE="SHA-1" SIZE="6085929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0013.jp2"/>
 			</file>
-			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:23:18"
-				MIMETYPE="image/jp2" SEQ="14" CHECKSUM="3baac5a4d39cc4cbecd4090d830b0ea4a4c92159"
-				CHECKSUMTYPE="SHA-1" SIZE="6207421">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0014.jp2"
-				/>
+			<file ID="IMG00014" ADMID="techmd14" GROUPID="page14" CREATED="2015-10-09T20:23:18" MIMETYPE="image/jp2" SEQ="14" CHECKSUM="3baac5a4d39cc4cbecd4090d830b0ea4a4c92159" CHECKSUMTYPE="SHA-1" SIZE="6207421">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0014.jp2"/>
 			</file>
-			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:23:52"
-				MIMETYPE="image/jp2" SEQ="15" CHECKSUM="2cb97c8dbaa651e756885274620a0b3153ed98d5"
-				CHECKSUMTYPE="SHA-1" SIZE="6085929">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0015.jp2"
-				/>
+			<file ID="IMG00015" ADMID="techmd15" GROUPID="page15" CREATED="2015-10-09T20:23:52" MIMETYPE="image/jp2" SEQ="15" CHECKSUM="2cb97c8dbaa651e756885274620a0b3153ed98d5" CHECKSUMTYPE="SHA-1" SIZE="6085929">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0015.jp2"/>
 			</file>
-			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:24:27"
-				MIMETYPE="image/jp2" SEQ="16" CHECKSUM="6f4a38e2f0e82aaee712976af45554968c8e88f5"
-				CHECKSUMTYPE="SHA-1" SIZE="6207426">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0016.jp2"
-				/>
+			<file ID="IMG00016" ADMID="techmd16" GROUPID="page16" CREATED="2015-10-09T20:24:27" MIMETYPE="image/jp2" SEQ="16" CHECKSUM="6f4a38e2f0e82aaee712976af45554968c8e88f5" CHECKSUMTYPE="SHA-1" SIZE="6207426">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0016.jp2"/>
 			</file>
-			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:25:03"
-				MIMETYPE="image/jp2" SEQ="17" CHECKSUM="f27c55233b68792ebb48d529c858034567f889b6"
-				CHECKSUMTYPE="SHA-1" SIZE="6058904">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0017.jp2"
-				/>
+			<file ID="IMG00017" ADMID="techmd17" GROUPID="page17" CREATED="2015-10-09T20:25:03" MIMETYPE="image/jp2" SEQ="17" CHECKSUM="f27c55233b68792ebb48d529c858034567f889b6" CHECKSUMTYPE="SHA-1" SIZE="6058904">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0017.jp2"/>
 			</file>
-			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:25:37"
-				MIMETYPE="image/jp2" SEQ="18" CHECKSUM="a1f732c58dca6e03faf990a3870732678dd3c15f"
-				CHECKSUMTYPE="SHA-1" SIZE="6207428">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0018.jp2"
-				/>
+			<file ID="IMG00018" ADMID="techmd18" GROUPID="page18" CREATED="2015-10-09T20:25:37" MIMETYPE="image/jp2" SEQ="18" CHECKSUM="a1f732c58dca6e03faf990a3870732678dd3c15f" CHECKSUMTYPE="SHA-1" SIZE="6207428">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0018.jp2"/>
 			</file>
-			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:26:12"
-				MIMETYPE="image/jp2" SEQ="19" CHECKSUM="3567f25f80015a03c1d896dbfbb585472bec50d3"
-				CHECKSUMTYPE="SHA-1" SIZE="6014826">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0019.jp2"
-				/>
+			<file ID="IMG00019" ADMID="techmd19" GROUPID="page19" CREATED="2015-10-09T20:26:12" MIMETYPE="image/jp2" SEQ="19" CHECKSUM="3567f25f80015a03c1d896dbfbb585472bec50d3" CHECKSUMTYPE="SHA-1" SIZE="6014826">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0019.jp2"/>
 			</file>
-			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:26:48"
-				MIMETYPE="image/jp2" SEQ="20" CHECKSUM="c212f8576c59794127a10c78abec76ac05a22be5"
-				CHECKSUMTYPE="SHA-1" SIZE="6176828">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0020.jp2"
-				/>
+			<file ID="IMG00020" ADMID="techmd20" GROUPID="page20" CREATED="2015-10-09T20:26:48" MIMETYPE="image/jp2" SEQ="20" CHECKSUM="c212f8576c59794127a10c78abec76ac05a22be5" CHECKSUMTYPE="SHA-1" SIZE="6176828">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0020.jp2"/>
 			</file>
-			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:27:23"
-				MIMETYPE="image/jp2" SEQ="21" CHECKSUM="44f0fe37688fb7210da20e05251ac2247d826730"
-				CHECKSUMTYPE="SHA-1" SIZE="6014829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0021.jp2"
-				/>
+			<file ID="IMG00021" ADMID="techmd21" GROUPID="page21" CREATED="2015-10-09T20:27:23" MIMETYPE="image/jp2" SEQ="21" CHECKSUM="44f0fe37688fb7210da20e05251ac2247d826730" CHECKSUMTYPE="SHA-1" SIZE="6014829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0021.jp2"/>
 			</file>
-			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:27:58"
-				MIMETYPE="image/jp2" SEQ="22" CHECKSUM="c372cc4f8e1f9d46227d350ec84a512ea512ba20"
-				CHECKSUMTYPE="SHA-1" SIZE="6176824">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0022.jp2"
-				/>
+			<file ID="IMG00022" ADMID="techmd22" GROUPID="page22" CREATED="2015-10-09T20:27:58" MIMETYPE="image/jp2" SEQ="22" CHECKSUM="c372cc4f8e1f9d46227d350ec84a512ea512ba20" CHECKSUMTYPE="SHA-1" SIZE="6176824">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0022.jp2"/>
 			</file>
-			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:28:32"
-				MIMETYPE="image/jp2" SEQ="23" CHECKSUM="30d6c54e7f362477dc2ed9db1dc5fd849dbf4ebe"
-				CHECKSUMTYPE="SHA-1" SIZE="6014814">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0023.jp2"
-				/>
+			<file ID="IMG00023" ADMID="techmd23" GROUPID="page23" CREATED="2015-10-09T20:28:32" MIMETYPE="image/jp2" SEQ="23" CHECKSUM="30d6c54e7f362477dc2ed9db1dc5fd849dbf4ebe" CHECKSUMTYPE="SHA-1" SIZE="6014814">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0023.jp2"/>
 			</file>
-			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:29:07"
-				MIMETYPE="image/jp2" SEQ="24" CHECKSUM="6a63b0f32062fb08f1bfabba0b34b9f54b8229dc"
-				CHECKSUMTYPE="SHA-1" SIZE="6176825">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0024.jp2"
-				/>
+			<file ID="IMG00024" ADMID="techmd24" GROUPID="page24" CREATED="2015-10-09T20:29:07" MIMETYPE="image/jp2" SEQ="24" CHECKSUM="6a63b0f32062fb08f1bfabba0b34b9f54b8229dc" CHECKSUMTYPE="SHA-1" SIZE="6176825">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0024.jp2"/>
 			</file>
-			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:29:45"
-				MIMETYPE="image/jp2" SEQ="25" CHECKSUM="5b851350c4461d13ef6c639cada889b23168a3fc"
-				CHECKSUMTYPE="SHA-1" SIZE="6014829">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0025.jp2"
-				/>
+			<file ID="IMG00025" ADMID="techmd25" GROUPID="page25" CREATED="2015-10-09T20:29:45" MIMETYPE="image/jp2" SEQ="25" CHECKSUM="5b851350c4461d13ef6c639cada889b23168a3fc" CHECKSUMTYPE="SHA-1" SIZE="6014829">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0025.jp2"/>
 			</file>
-			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:30:19"
-				MIMETYPE="image/jp2" SEQ="26" CHECKSUM="65025b38330ddd0e4bb56dad24d72712ccb2181e"
-				CHECKSUMTYPE="SHA-1" SIZE="6215527">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0026.jp2"
-				/>
+			<file ID="IMG00026" ADMID="techmd26" GROUPID="page26" CREATED="2015-10-09T20:30:19" MIMETYPE="image/jp2" SEQ="26" CHECKSUM="65025b38330ddd0e4bb56dad24d72712ccb2181e" CHECKSUMTYPE="SHA-1" SIZE="6215527">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0026.jp2"/>
 			</file>
-			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:30:56"
-				MIMETYPE="image/jp2" SEQ="27" CHECKSUM="6922b056736afd1c5afb4eb1d8cb56a18f863991"
-				CHECKSUMTYPE="SHA-1" SIZE="6073318">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0027.jp2"
-				/>
+			<file ID="IMG00027" ADMID="techmd27" GROUPID="page27" CREATED="2015-10-09T20:30:56" MIMETYPE="image/jp2" SEQ="27" CHECKSUM="6922b056736afd1c5afb4eb1d8cb56a18f863991" CHECKSUMTYPE="SHA-1" SIZE="6073318">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0027.jp2"/>
 			</file>
-			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:31:31"
-				MIMETYPE="image/jp2" SEQ="28" CHECKSUM="2bf92c402b1c33a349b169c6acfa62c91cefd5aa"
-				CHECKSUMTYPE="SHA-1" SIZE="6215523">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0028.jp2"
-				/>
+			<file ID="IMG00028" ADMID="techmd28" GROUPID="page28" CREATED="2015-10-09T20:31:31" MIMETYPE="image/jp2" SEQ="28" CHECKSUM="2bf92c402b1c33a349b169c6acfa62c91cefd5aa" CHECKSUMTYPE="SHA-1" SIZE="6215523">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0028.jp2"/>
 			</file>
-			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T20:32:05"
-				MIMETYPE="image/jp2" SEQ="29" CHECKSUM="82960455339da1abc996e38fb96d60529fe92ac8"
-				CHECKSUMTYPE="SHA-1" SIZE="6073327">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0029.jp2"
-				/>
+			<file ID="IMG00029" ADMID="techmd29" GROUPID="page29" CREATED="2015-10-09T20:32:05" MIMETYPE="image/jp2" SEQ="29" CHECKSUM="82960455339da1abc996e38fb96d60529fe92ac8" CHECKSUMTYPE="SHA-1" SIZE="6073327">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0029.jp2"/>
 			</file>
-			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T20:32:41"
-				MIMETYPE="image/jp2" SEQ="30" CHECKSUM="0f63116a460385c86349b831936bce2960fa2dde"
-				CHECKSUMTYPE="SHA-1" SIZE="6215518">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0030.jp2"
-				/>
+			<file ID="IMG00030" ADMID="techmd30" GROUPID="page30" CREATED="2015-10-09T20:32:41" MIMETYPE="image/jp2" SEQ="30" CHECKSUM="0f63116a460385c86349b831936bce2960fa2dde" CHECKSUMTYPE="SHA-1" SIZE="6215518">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0030.jp2"/>
 			</file>
-			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T20:33:17"
-				MIMETYPE="image/jp2" SEQ="31" CHECKSUM="f72d0300772388dbdd21c82ea57ee7c0b3fc7b71"
-				CHECKSUMTYPE="SHA-1" SIZE="6073308">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0031.jp2"
-				/>
+			<file ID="IMG00031" ADMID="techmd31" GROUPID="page31" CREATED="2015-10-09T20:33:17" MIMETYPE="image/jp2" SEQ="31" CHECKSUM="f72d0300772388dbdd21c82ea57ee7c0b3fc7b71" CHECKSUMTYPE="SHA-1" SIZE="6073308">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0031.jp2"/>
 			</file>
-			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T20:33:53"
-				MIMETYPE="image/jp2" SEQ="32" CHECKSUM="1aeacda98747c8c518a719ee72288982a2a07f04"
-				CHECKSUMTYPE="SHA-1" SIZE="6215517">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0032.jp2"
-				/>
+			<file ID="IMG00032" ADMID="techmd32" GROUPID="page32" CREATED="2015-10-09T20:33:53" MIMETYPE="image/jp2" SEQ="32" CHECKSUM="1aeacda98747c8c518a719ee72288982a2a07f04" CHECKSUMTYPE="SHA-1" SIZE="6215517">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0032.jp2"/>
 			</file>
-			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T20:34:25"
-				MIMETYPE="image/jp2" SEQ="33" CHECKSUM="d4cbb2f8dfe38a37bc0d26dbd2f4913a5d9c77fb"
-				CHECKSUMTYPE="SHA-1" SIZE="6073328">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0033.jp2"
-				/>
+			<file ID="IMG00033" ADMID="techmd33" GROUPID="page33" CREATED="2015-10-09T20:34:25" MIMETYPE="image/jp2" SEQ="33" CHECKSUM="d4cbb2f8dfe38a37bc0d26dbd2f4913a5d9c77fb" CHECKSUMTYPE="SHA-1" SIZE="6073328">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0033.jp2"/>
 			</file>
-			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T20:34:59"
-				MIMETYPE="image/jp2" SEQ="34" CHECKSUM="5bacf64609fc3a523f02b3ec237029bdeeda2f72"
-				CHECKSUMTYPE="SHA-1" SIZE="6215504">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0034.jp2"
-				/>
+			<file ID="IMG00034" ADMID="techmd34" GROUPID="page34" CREATED="2015-10-09T20:34:59" MIMETYPE="image/jp2" SEQ="34" CHECKSUM="5bacf64609fc3a523f02b3ec237029bdeeda2f72" CHECKSUMTYPE="SHA-1" SIZE="6215504">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0034.jp2"/>
 			</file>
-			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T20:35:39"
-				MIMETYPE="image/jp2" SEQ="35" CHECKSUM="d3331d37c1cf581b90d915bc3a0a0085bfa0b7bd"
-				CHECKSUMTYPE="SHA-1" SIZE="5921227">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0035.jp2"
-				/>
+			<file ID="IMG00035" ADMID="techmd35" GROUPID="page35" CREATED="2015-10-09T20:35:39" MIMETYPE="image/jp2" SEQ="35" CHECKSUM="d3331d37c1cf581b90d915bc3a0a0085bfa0b7bd" CHECKSUMTYPE="SHA-1" SIZE="5921227">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0035.jp2"/>
 			</file>
-			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T20:36:13"
-				MIMETYPE="image/jp2" SEQ="36" CHECKSUM="c044a075ddbdcd4564b6bb508454ca973625b715"
-				CHECKSUMTYPE="SHA-1" SIZE="6189404">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0036.jp2"
-				/>
+			<file ID="IMG00036" ADMID="techmd36" GROUPID="page36" CREATED="2015-10-09T20:36:13" MIMETYPE="image/jp2" SEQ="36" CHECKSUM="c044a075ddbdcd4564b6bb508454ca973625b715" CHECKSUMTYPE="SHA-1" SIZE="6189404">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/delivery/bmtnabf_1903_01_0036.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="OCR">
-			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:36:33" MIMETYPE="text/xml"
-				CHECKSUM="906babd22b18131aa8a18da5c01ff42297d3a37f" CHECKSUMTYPE="SHA-1" SIZE="5861">
+			<file ID="ALTO00001" GROUPID="page1" CREATED="2015-10-09T20:36:33" MIMETYPE="text/xml" CHECKSUM="906babd22b18131aa8a18da5c01ff42297d3a37f" CHECKSUMTYPE="SHA-1" SIZE="5861">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0001.alto.xml"/>
 			</file>
-			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:36:33" MIMETYPE="text/xml"
-				CHECKSUM="22f1138c84de01c701fa955582272765a3a54687" CHECKSUMTYPE="SHA-1" SIZE="1712">
+			<file ID="ALTO00002" GROUPID="page2" CREATED="2015-10-09T20:36:33" MIMETYPE="text/xml" CHECKSUM="22f1138c84de01c701fa955582272765a3a54687" CHECKSUMTYPE="SHA-1" SIZE="1712">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0002.alto.xml"/>
 			</file>
-			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:36:33" MIMETYPE="text/xml"
-				CHECKSUM="635416a2e8734db306001f8739a69f6baa0eabe0" CHECKSUMTYPE="SHA-1" SIZE="9020">
+			<file ID="ALTO00003" GROUPID="page3" CREATED="2015-10-09T20:36:33" MIMETYPE="text/xml" CHECKSUM="635416a2e8734db306001f8739a69f6baa0eabe0" CHECKSUMTYPE="SHA-1" SIZE="9020">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0003.alto.xml"/>
 			</file>
-			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:36:34" MIMETYPE="text/xml"
-				CHECKSUM="ddc60f0b4446c7ce89ffe552897f4f33e5118bf6" CHECKSUMTYPE="SHA-1" SIZE="1703">
+			<file ID="ALTO00004" GROUPID="page4" CREATED="2015-10-09T20:36:34" MIMETYPE="text/xml" CHECKSUM="ddc60f0b4446c7ce89ffe552897f4f33e5118bf6" CHECKSUMTYPE="SHA-1" SIZE="1703">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0004.alto.xml"/>
 			</file>
-			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:36:34" MIMETYPE="text/xml"
-				CHECKSUM="f470e8397ae51a3c6127ae126505de4981fc3256" CHECKSUMTYPE="SHA-1" SIZE="4763">
+			<file ID="ALTO00005" GROUPID="page5" CREATED="2015-10-09T20:36:34" MIMETYPE="text/xml" CHECKSUM="f470e8397ae51a3c6127ae126505de4981fc3256" CHECKSUMTYPE="SHA-1" SIZE="4763">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0005.alto.xml"/>
 			</file>
-			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:36:34" MIMETYPE="text/xml"
-				CHECKSUM="49316ca5104d82fbbc7f0e589ad7392ec6e1ef0a" CHECKSUMTYPE="SHA-1" SIZE="1710">
+			<file ID="ALTO00006" GROUPID="page6" CREATED="2015-10-09T20:36:34" MIMETYPE="text/xml" CHECKSUM="49316ca5104d82fbbc7f0e589ad7392ec6e1ef0a" CHECKSUMTYPE="SHA-1" SIZE="1710">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0006.alto.xml"/>
 			</file>
-			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:36:34" MIMETYPE="text/xml"
-				CHECKSUM="ee1b43ce136a0361546132b0401fbaef23c7cbff" CHECKSUMTYPE="SHA-1" SIZE="3788">
+			<file ID="ALTO00007" GROUPID="page7" CREATED="2015-10-09T20:36:34" MIMETYPE="text/xml" CHECKSUM="ee1b43ce136a0361546132b0401fbaef23c7cbff" CHECKSUMTYPE="SHA-1" SIZE="3788">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0007.alto.xml"/>
 			</file>
-			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:36:35" MIMETYPE="text/xml"
-				CHECKSUM="1b280c931a1c1b192f8da00b201bb75ef7d621ac" CHECKSUMTYPE="SHA-1" SIZE="2400">
+			<file ID="ALTO00008" GROUPID="page8" CREATED="2015-10-09T20:36:35" MIMETYPE="text/xml" CHECKSUM="1b280c931a1c1b192f8da00b201bb75ef7d621ac" CHECKSUMTYPE="SHA-1" SIZE="2400">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0008.alto.xml"/>
 			</file>
-			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:36:35" MIMETYPE="text/xml"
-				CHECKSUM="920e731dc9fdf36355964005ddc09c447cc06ec2" CHECKSUMTYPE="SHA-1" SIZE="2923">
+			<file ID="ALTO00009" GROUPID="page9" CREATED="2015-10-09T20:36:35" MIMETYPE="text/xml" CHECKSUM="920e731dc9fdf36355964005ddc09c447cc06ec2" CHECKSUMTYPE="SHA-1" SIZE="2923">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0009.alto.xml"/>
 			</file>
-			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:36:35" MIMETYPE="text/xml"
-				CHECKSUM="4ce6622daa57efe2c20f989e62f336bb6085e81b" CHECKSUMTYPE="SHA-1" SIZE="2411">
+			<file ID="ALTO00010" GROUPID="page10" CREATED="2015-10-09T20:36:35" MIMETYPE="text/xml" CHECKSUM="4ce6622daa57efe2c20f989e62f336bb6085e81b" CHECKSUMTYPE="SHA-1" SIZE="2411">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0010.alto.xml"/>
 			</file>
-			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:36:35" MIMETYPE="text/xml"
-				CHECKSUM="7e868900b3e74f1006e0fdf379cf3d6447c75e2a" CHECKSUMTYPE="SHA-1" SIZE="2935">
+			<file ID="ALTO00011" GROUPID="page11" CREATED="2015-10-09T20:36:35" MIMETYPE="text/xml" CHECKSUM="7e868900b3e74f1006e0fdf379cf3d6447c75e2a" CHECKSUMTYPE="SHA-1" SIZE="2935">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0011.alto.xml"/>
 			</file>
-			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:36:36" MIMETYPE="text/xml"
-				CHECKSUM="c263fd88f882d98605577e1c3ae5830909658933" CHECKSUMTYPE="SHA-1" SIZE="2409">
+			<file ID="ALTO00012" GROUPID="page12" CREATED="2015-10-09T20:36:36" MIMETYPE="text/xml" CHECKSUM="c263fd88f882d98605577e1c3ae5830909658933" CHECKSUMTYPE="SHA-1" SIZE="2409">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0012.alto.xml"/>
 			</file>
-			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:36:36" MIMETYPE="text/xml"
-				CHECKSUM="3c152eec05fc90899d551b2b565918a9c9cebc32" CHECKSUMTYPE="SHA-1" SIZE="2934">
+			<file ID="ALTO00013" GROUPID="page13" CREATED="2015-10-09T20:36:36" MIMETYPE="text/xml" CHECKSUM="3c152eec05fc90899d551b2b565918a9c9cebc32" CHECKSUMTYPE="SHA-1" SIZE="2934">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0013.alto.xml"/>
 			</file>
-			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:36:36" MIMETYPE="text/xml"
-				CHECKSUM="293f9eb766c4348c330cbd36fc9f3da153bd468b" CHECKSUMTYPE="SHA-1" SIZE="2413">
+			<file ID="ALTO00014" GROUPID="page14" CREATED="2015-10-09T20:36:36" MIMETYPE="text/xml" CHECKSUM="293f9eb766c4348c330cbd36fc9f3da153bd468b" CHECKSUMTYPE="SHA-1" SIZE="2413">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0014.alto.xml"/>
 			</file>
-			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:36:36" MIMETYPE="text/xml"
-				CHECKSUM="bc83fd211ab7b18907fa32923cf24ac9ce520a1f" CHECKSUMTYPE="SHA-1" SIZE="2922">
+			<file ID="ALTO00015" GROUPID="page15" CREATED="2015-10-09T20:36:36" MIMETYPE="text/xml" CHECKSUM="bc83fd211ab7b18907fa32923cf24ac9ce520a1f" CHECKSUMTYPE="SHA-1" SIZE="2922">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0015.alto.xml"/>
 			</file>
-			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:36:36" MIMETYPE="text/xml"
-				CHECKSUM="3decc68d0edb01ba333ebb0f8a6634ea2fb065a5" CHECKSUMTYPE="SHA-1" SIZE="2409">
+			<file ID="ALTO00016" GROUPID="page16" CREATED="2015-10-09T20:36:36" MIMETYPE="text/xml" CHECKSUM="3decc68d0edb01ba333ebb0f8a6634ea2fb065a5" CHECKSUMTYPE="SHA-1" SIZE="2409">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0016.alto.xml"/>
 			</file>
-			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:36:37" MIMETYPE="text/xml"
-				CHECKSUM="b01d6493426995b1cdf69f053d0757df90480ba4" CHECKSUMTYPE="SHA-1" SIZE="2918">
+			<file ID="ALTO00017" GROUPID="page17" CREATED="2015-10-09T20:36:37" MIMETYPE="text/xml" CHECKSUM="b01d6493426995b1cdf69f053d0757df90480ba4" CHECKSUMTYPE="SHA-1" SIZE="2918">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0017.alto.xml"/>
 			</file>
-			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:36:37" MIMETYPE="text/xml"
-				CHECKSUM="32844d61e731ef04254bc6f37210329c9200cdcb" CHECKSUMTYPE="SHA-1" SIZE="2409">
+			<file ID="ALTO00018" GROUPID="page18" CREATED="2015-10-09T20:36:37" MIMETYPE="text/xml" CHECKSUM="32844d61e731ef04254bc6f37210329c9200cdcb" CHECKSUMTYPE="SHA-1" SIZE="2409">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0018.alto.xml"/>
 			</file>
-			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:36:37" MIMETYPE="text/xml"
-				CHECKSUM="f1c87c65e3560f7626956f82a4e6c25ff9d570c9" CHECKSUMTYPE="SHA-1" SIZE="2929">
+			<file ID="ALTO00019" GROUPID="page19" CREATED="2015-10-09T20:36:37" MIMETYPE="text/xml" CHECKSUM="f1c87c65e3560f7626956f82a4e6c25ff9d570c9" CHECKSUMTYPE="SHA-1" SIZE="2929">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0019.alto.xml"/>
 			</file>
-			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:36:37" MIMETYPE="text/xml"
-				CHECKSUM="ea729f786e141bfc8ac71a07467d6e867965ab5b" CHECKSUMTYPE="SHA-1" SIZE="2409">
+			<file ID="ALTO00020" GROUPID="page20" CREATED="2015-10-09T20:36:37" MIMETYPE="text/xml" CHECKSUM="ea729f786e141bfc8ac71a07467d6e867965ab5b" CHECKSUMTYPE="SHA-1" SIZE="2409">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0020.alto.xml"/>
 			</file>
-			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:36:38" MIMETYPE="text/xml"
-				CHECKSUM="162a543a5e358ec90cfa6581777e3daaf224c30a" CHECKSUMTYPE="SHA-1" SIZE="2994">
+			<file ID="ALTO00021" GROUPID="page21" CREATED="2015-10-09T20:36:38" MIMETYPE="text/xml" CHECKSUM="162a543a5e358ec90cfa6581777e3daaf224c30a" CHECKSUMTYPE="SHA-1" SIZE="2994">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0021.alto.xml"/>
 			</file>
-			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:36:38" MIMETYPE="text/xml"
-				CHECKSUM="fe76909f5bc9eeb60a1f30a03a2bb2ad3b7ef525" CHECKSUMTYPE="SHA-1" SIZE="2409">
+			<file ID="ALTO00022" GROUPID="page22" CREATED="2015-10-09T20:36:38" MIMETYPE="text/xml" CHECKSUM="fe76909f5bc9eeb60a1f30a03a2bb2ad3b7ef525" CHECKSUMTYPE="SHA-1" SIZE="2409">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0022.alto.xml"/>
 			</file>
-			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:36:38" MIMETYPE="text/xml"
-				CHECKSUM="91b75dc7d624e6b599c720a6eb2a190f88d8802e" CHECKSUMTYPE="SHA-1" SIZE="2933">
+			<file ID="ALTO00023" GROUPID="page23" CREATED="2015-10-09T20:36:38" MIMETYPE="text/xml" CHECKSUM="91b75dc7d624e6b599c720a6eb2a190f88d8802e" CHECKSUMTYPE="SHA-1" SIZE="2933">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0023.alto.xml"/>
 			</file>
-			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:36:38" MIMETYPE="text/xml"
-				CHECKSUM="2e7d37c9de5844c8324b55ef29f4fce40396d03e" CHECKSUMTYPE="SHA-1" SIZE="2414">
+			<file ID="ALTO00024" GROUPID="page24" CREATED="2015-10-09T20:36:38" MIMETYPE="text/xml" CHECKSUM="2e7d37c9de5844c8324b55ef29f4fce40396d03e" CHECKSUMTYPE="SHA-1" SIZE="2414">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0024.alto.xml"/>
 			</file>
-			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:36:39" MIMETYPE="text/xml"
-				CHECKSUM="72c008586f1f030bfcdf4b89d182442f5ba098b7" CHECKSUMTYPE="SHA-1" SIZE="2939">
+			<file ID="ALTO00025" GROUPID="page25" CREATED="2015-10-09T20:36:39" MIMETYPE="text/xml" CHECKSUM="72c008586f1f030bfcdf4b89d182442f5ba098b7" CHECKSUMTYPE="SHA-1" SIZE="2939">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0025.alto.xml"/>
 			</file>
-			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:36:39" MIMETYPE="text/xml"
-				CHECKSUM="315728b343a22afd1bbe64f449bc0455642cc137" CHECKSUMTYPE="SHA-1" SIZE="2409">
+			<file ID="ALTO00026" GROUPID="page26" CREATED="2015-10-09T20:36:39" MIMETYPE="text/xml" CHECKSUM="315728b343a22afd1bbe64f449bc0455642cc137" CHECKSUMTYPE="SHA-1" SIZE="2409">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0026.alto.xml"/>
 			</file>
-			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:36:39" MIMETYPE="text/xml"
-				CHECKSUM="ad15c5d55f571301402b7af25b380be9e66986a5" CHECKSUMTYPE="SHA-1" SIZE="2935">
+			<file ID="ALTO00027" GROUPID="page27" CREATED="2015-10-09T20:36:39" MIMETYPE="text/xml" CHECKSUM="ad15c5d55f571301402b7af25b380be9e66986a5" CHECKSUMTYPE="SHA-1" SIZE="2935">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0027.alto.xml"/>
 			</file>
-			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:36:39" MIMETYPE="text/xml"
-				CHECKSUM="091d6f095aff82e9ccb44614ae935a9fd6b6a40f" CHECKSUMTYPE="SHA-1" SIZE="2413">
+			<file ID="ALTO00028" GROUPID="page28" CREATED="2015-10-09T20:36:39" MIMETYPE="text/xml" CHECKSUM="091d6f095aff82e9ccb44614ae935a9fd6b6a40f" CHECKSUMTYPE="SHA-1" SIZE="2413">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0028.alto.xml"/>
 			</file>
-			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T20:36:40" MIMETYPE="text/xml"
-				CHECKSUM="6ab1d9836f8b9823fd1f673bc34855842944f429" CHECKSUMTYPE="SHA-1" SIZE="2936">
+			<file ID="ALTO00029" GROUPID="page29" CREATED="2015-10-09T20:36:40" MIMETYPE="text/xml" CHECKSUM="6ab1d9836f8b9823fd1f673bc34855842944f429" CHECKSUMTYPE="SHA-1" SIZE="2936">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0029.alto.xml"/>
 			</file>
-			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T20:36:40" MIMETYPE="text/xml"
-				CHECKSUM="6f1aef1951594ac0a0de3192f507197fbf8b3943" CHECKSUMTYPE="SHA-1" SIZE="2413">
+			<file ID="ALTO00030" GROUPID="page30" CREATED="2015-10-09T20:36:40" MIMETYPE="text/xml" CHECKSUM="6f1aef1951594ac0a0de3192f507197fbf8b3943" CHECKSUMTYPE="SHA-1" SIZE="2413">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0030.alto.xml"/>
 			</file>
-			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T20:36:40" MIMETYPE="text/xml"
-				CHECKSUM="72f396bedc5d36e72045971e5697dfaed4fea49e" CHECKSUMTYPE="SHA-1" SIZE="2933">
+			<file ID="ALTO00031" GROUPID="page31" CREATED="2015-10-09T20:36:40" MIMETYPE="text/xml" CHECKSUM="72f396bedc5d36e72045971e5697dfaed4fea49e" CHECKSUMTYPE="SHA-1" SIZE="2933">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0031.alto.xml"/>
 			</file>
-			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T20:36:40" MIMETYPE="text/xml"
-				CHECKSUM="bb6fca8754b939fe62474fb85e739f8aafaa46dc" CHECKSUMTYPE="SHA-1"
-				SIZE="40190">
+			<file ID="ALTO00032" GROUPID="page32" CREATED="2015-10-09T20:36:40" MIMETYPE="text/xml" CHECKSUM="bb6fca8754b939fe62474fb85e739f8aafaa46dc" CHECKSUMTYPE="SHA-1" SIZE="40190">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0032.alto.xml"/>
 			</file>
-			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T20:36:41" MIMETYPE="text/xml"
-				CHECKSUM="133c37b86eb6797b5cfdf0d369701b7fc1c320ca" CHECKSUMTYPE="SHA-1" SIZE="2002">
+			<file ID="ALTO00033" GROUPID="page33" CREATED="2015-10-09T20:36:41" MIMETYPE="text/xml" CHECKSUM="133c37b86eb6797b5cfdf0d369701b7fc1c320ca" CHECKSUMTYPE="SHA-1" SIZE="2002">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0033.alto.xml"/>
 			</file>
-			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T20:36:41" MIMETYPE="text/xml"
-				CHECKSUM="ae6ebad75befeec9bc9d57896dda7bb9190ac4ee" CHECKSUMTYPE="SHA-1" SIZE="2002">
+			<file ID="ALTO00034" GROUPID="page34" CREATED="2015-10-09T20:36:41" MIMETYPE="text/xml" CHECKSUM="ae6ebad75befeec9bc9d57896dda7bb9190ac4ee" CHECKSUMTYPE="SHA-1" SIZE="2002">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0034.alto.xml"/>
 			</file>
-			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T20:36:41" MIMETYPE="text/xml"
-				CHECKSUM="cb4eb992b8002f46a4370956f3330cc371e4b81b" CHECKSUMTYPE="SHA-1" SIZE="2008">
+			<file ID="ALTO00035" GROUPID="page35" CREATED="2015-10-09T20:36:41" MIMETYPE="text/xml" CHECKSUM="cb4eb992b8002f46a4370956f3330cc371e4b81b" CHECKSUMTYPE="SHA-1" SIZE="2008">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0035.alto.xml"/>
 			</file>
-			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T20:36:41" MIMETYPE="text/xml"
-				CHECKSUM="ce31466d8e194ea24f5e74e57a0321c85563661d" CHECKSUMTYPE="SHA-1"
-				SIZE="36829">
+			<file ID="ALTO00036" GROUPID="page36" CREATED="2015-10-09T20:36:41" MIMETYPE="text/xml" CHECKSUM="ce31466d8e194ea24f5e74e57a0321c85563661d" CHECKSUMTYPE="SHA-1" SIZE="36829">
 				<FLocat LOCTYPE="URL" xlink:href="file://./alto/bmtnabf_1903_01_0036.alto.xml"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="PDFGRP" USE="PDF">
-			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:37:42" MIMETYPE="application/pdf"
-				CHECKSUM="4d07192f95518f1d772e7ef19cc07d3be0740128" CHECKSUMTYPE="SHA-1"
-				SIZE="31379425">
-				<FLocat LOCTYPE="URL"
-					xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/bmtnabf_1903_01.pdf"
-				/>
+			<file ID="PDF_ISSUELEVEL" CREATED="2015-10-09T20:37:42" MIMETYPE="application/pdf" CHECKSUM="4d07192f95518f1d772e7ef19cc07d3be0740128" CHECKSUMTYPE="SHA-1" SIZE="31379425">
+				<FLocat LOCTYPE="URL" xlink:href="file:///usr/share/BlueMountain/astore/periodicals/bmtnabf/issues/1903_01/bmtnabf_1903_01.pdf"/>
 			</file>
 		</fileGrp>
 	</fileSec>
@@ -4070,8 +3878,7 @@
 						</fptr>
 					</div>
 				</div>
-				<div ID="L.1.1.5" TYPE="Illustration" ORDER="5" DMDID="c004"
-					LABEL="VER SACRUM KALENDER 1903">
+				<div ID="L.1.1.5" TYPE="Illustration" ORDER="5" DMDID="c004" LABEL="VER SACRUM KALENDER 1903">
 					<div ID="L.1.1.5.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00007" BEGIN="P7_TB00001"/>
@@ -4095,8 +3902,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00009" BEGIN="P9_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="2" DMDID="c005"
-							LABEL="Zeitenfolge">
+						<div ID="L.1.1.5.3" TYPE="Illustration" ORDER="2" DMDID="c005" LABEL="Zeitenfolge">
 							<div ID="L.1.1.5.3.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00008" BEGIN="P8_CB00001"/>
@@ -4115,8 +3921,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00011" BEGIN="P11_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="4" DMDID="c007"
-							LABEL="Mummenschanz">
+						<div ID="L.1.1.5.5" TYPE="Illustration" ORDER="4" DMDID="c007" LABEL="Mummenschanz">
 							<div ID="L.1.1.5.5.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00010" BEGIN="P10_CB00001"/>
@@ -4135,8 +3940,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00013" BEGIN="P13_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="6" DMDID="c009"
-							LABEL="Strahlenküsse">
+						<div ID="L.1.1.5.7" TYPE="Illustration" ORDER="6" DMDID="c009" LABEL="Strahlenküsse">
 							<div ID="L.1.1.5.7.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00012" BEGIN="P12_CB00001"/>
@@ -4155,8 +3959,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00015" BEGIN="P15_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.9" TYPE="Illustration" ORDER="8" DMDID="c011"
-							LABEL="Wetterübermut">
+						<div ID="L.1.1.5.9" TYPE="Illustration" ORDER="8" DMDID="c011" LABEL="Wetterübermut">
 							<div ID="L.1.1.5.9.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00014" BEGIN="P14_CB00001"/>
@@ -4175,8 +3978,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00017" BEGIN="P17_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.11" TYPE="Illustration" ORDER="10" DMDID="c013"
-							LABEL="Frühlingsgeläute">
+						<div ID="L.1.1.5.11" TYPE="Illustration" ORDER="10" DMDID="c013" LABEL="Frühlingsgeläute">
 							<div ID="L.1.1.5.11.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00016" BEGIN="P16_CB00001"/>
@@ -4195,8 +3997,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00019" BEGIN="P19_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.13" TYPE="Illustration" ORDER="12" DMDID="c015"
-							LABEL="Sonnenwende">
+						<div ID="L.1.1.5.13" TYPE="Illustration" ORDER="12" DMDID="c015" LABEL="Sonnenwende">
 							<div ID="L.1.1.5.13.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00018" BEGIN="P18_CB00001"/>
@@ -4215,8 +4016,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00021" BEGIN="P21_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.15" TYPE="Illustration" ORDER="14" DMDID="c017"
-							LABEL="Die Erfüllung">
+						<div ID="L.1.1.5.15" TYPE="Illustration" ORDER="14" DMDID="c017" LABEL="Die Erfüllung">
 							<div ID="L.1.1.5.15.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00020" BEGIN="P20_CB00001"/>
@@ -4235,8 +4035,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00023" BEGIN="P23_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.17" TYPE="Illustration" ORDER="16" DMDID="c019"
-							LABEL="Die Sensen">
+						<div ID="L.1.1.5.17" TYPE="Illustration" ORDER="16" DMDID="c019" LABEL="Die Sensen">
 							<div ID="L.1.1.5.17.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00022" BEGIN="P22_CB00001"/>
@@ -4244,8 +4043,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.20" TYPE="Illustration" ORDER="19" DMDID="c022"
-						LABEL="SEPTEMBER">
+					<div ID="L.1.1.5.20" TYPE="Illustration" ORDER="19" DMDID="c022" LABEL="SEPTEMBER">
 						<div ID="L.1.1.5.20.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_CB00001"/>
@@ -4256,8 +4054,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00025" BEGIN="P25_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.19" TYPE="Illustration" ORDER="18" DMDID="c021"
-							LABEL="Heimwärts">
+						<div ID="L.1.1.5.19" TYPE="Illustration" ORDER="18" DMDID="c021" LABEL="Heimwärts">
 							<div ID="L.1.1.5.19.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00024" BEGIN="P24_CB00001"/>
@@ -4276,8 +4073,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00027" BEGIN="P27_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.21" TYPE="Illustration" ORDER="20" DMDID="c023"
-							LABEL="Die Frucht">
+						<div ID="L.1.1.5.21" TYPE="Illustration" ORDER="20" DMDID="c023" LABEL="Die Frucht">
 							<div ID="L.1.1.5.21.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00026" BEGIN="P26_CB00001"/>
@@ -4285,8 +4081,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.24" TYPE="Illustration" ORDER="23" DMDID="c026"
-						LABEL="NOVEMBER">
+					<div ID="L.1.1.5.24" TYPE="Illustration" ORDER="23" DMDID="c026" LABEL="NOVEMBER">
 						<div ID="L.1.1.5.24.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_CB00001"/>
@@ -4297,8 +4092,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00029" BEGIN="P29_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.23" TYPE="Illustration" ORDER="22" DMDID="c025"
-							LABEL="Letzte Blätter">
+						<div ID="L.1.1.5.23" TYPE="Illustration" ORDER="22" DMDID="c025" LABEL="Letzte Blätter">
 							<div ID="L.1.1.5.23.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00028" BEGIN="P28_CB00001"/>
@@ -4306,8 +4100,7 @@
 							</div>
 						</div>
 					</div>
-					<div ID="L.1.1.5.26" TYPE="Illustration" ORDER="25" DMDID="c028"
-						LABEL="DECEMBER">
+					<div ID="L.1.1.5.26" TYPE="Illustration" ORDER="25" DMDID="c028" LABEL="DECEMBER">
 						<div ID="L.1.1.5.26.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_CB00001"/>
@@ -4318,8 +4111,7 @@
 								<area BETYPE="IDREF" FILEID="ALTO00031" BEGIN="P31_TB00001"/>
 							</fptr>
 						</div>
-						<div ID="L.1.1.5.25" TYPE="Illustration" ORDER="24" DMDID="c027"
-							LABEL="Die müde Sonne">
+						<div ID="L.1.1.5.25" TYPE="Illustration" ORDER="24" DMDID="c027" LABEL="Die müde Sonne">
 							<div ID="L.1.1.5.25.1" TYPE="Image">
 								<fptr>
 									<area BETYPE="IDREF" FILEID="ALTO00030" BEGIN="P30_CB00001"/>
@@ -4328,8 +4120,7 @@
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.6" TYPE="TextContent" ORDER="6" DMDID="c029"
-					LABEL="Untitled text by Das Redaktionskomitee">
+				<div ID="L.1.1.6" TYPE="TextContent" ORDER="6" DMDID="c029" LABEL="Untitled text by Das Redaktionskomitee">
 					<div ID="L.1.1.6.1" TYPE="Illustration" ORDER="1" DMDID="c030" LABEL="[Initial]">
 						<div ID="L.1.1.6.1.1" TYPE="Image">
 							<fptr>
@@ -4342,16 +4133,14 @@
 							<div ID="L.1.1.6.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.6.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00001"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00001"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.7" TYPE="TextContent" ORDER="7" DMDID="c031"
-					LABEL="INHALT DES KALENDERHEFTES.">
+				<div ID="L.1.1.7" TYPE="TextContent" ORDER="7" DMDID="c031" LABEL="INHALT DES KALENDERHEFTES.">
 					<div ID="L.1.1.7.1" TYPE="Head">
 						<fptr>
 							<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00002"/>
@@ -4362,18 +4151,15 @@
 							<div ID="L.1.1.7.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.7.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00003"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00032" BEGIN="P32_TB00003"/>
 									</fptr>
 								</div>
 							</div>
 						</div>
 					</div>
 				</div>
-				<div ID="L.1.1.8" TYPE="TextContent" ORDER="8" DMDID="c032"
-					LABEL="Untitled text by Redaktionskomitee 1903">
-					<div ID="L.1.1.8.1" TYPE="Illustration" ORDER="1" DMDID="c033"
-						LABEL="Untitled Image">
+				<div ID="L.1.1.8" TYPE="TextContent" ORDER="8" DMDID="c032" LABEL="Untitled text by Redaktionskomitee 1903">
+					<div ID="L.1.1.8.1" TYPE="Illustration" ORDER="1" DMDID="c033" LABEL="Untitled Image">
 						<div ID="L.1.1.8.1.1" TYPE="Image">
 							<fptr>
 								<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_CB00001"/>
@@ -4385,8 +4171,7 @@
 							<div ID="L.1.1.8.2.1.1" TYPE="Paragraph" ORDER="1">
 								<div ID="L.1.1.8.2.1.1.1" TYPE="Text">
 									<fptr>
-										<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00001"
-										/>
+										<area BETYPE="IDREF" FILEID="ALTO00036" BEGIN="P36_TB00001"/>
 									</fptr>
 								</div>
 							</div>

--- a/util/xsl/metsalto2tei.xsl
+++ b/util/xsl/metsalto2tei.xsl
@@ -77,11 +77,11 @@
                 </biblScope>
               </xsl:if>
               <date>
-<!--
+
                 <xsl:attribute name="when">
                   <xsl:value-of select="$modsrec/mods:originInfo/mods:dateIssued[@encoding='w3cdtf' or @encoding='iso8601']"/>
                   </xsl:attribute>
-		  -->
+		  
                 <xsl:value-of select="$modsrec/mods:originInfo/mods:dateIssued[1]"/>
               </date>
             </imprint>

--- a/util/xsl/mods2tei.xsl
+++ b/util/xsl/mods2tei.xsl
@@ -13,11 +13,11 @@
   <xsl:template match="mods:mods">
     <biblStruct>
       <monogr>
-        <title level="j">
+
           <xsl:apply-templates select="mods:titleInfo">
 	    <xsl:with-param name="level">j</xsl:with-param>
 	  </xsl:apply-templates>
-        </title>
+        
         <imprint>
           <xsl:if test="mods:part/mods:detail[@type='volume']">
             <biblScope unit="vol">
@@ -53,11 +53,11 @@
       </xsl:if>
       <biblStruct>
         <analytic>
-          <title level="a">
+
             <xsl:apply-templates select="mods:titleInfo">
 	      <xsl:with-param name="level">a</xsl:with-param>
 	    </xsl:apply-templates>
-          </title>
+          
           <xsl:apply-templates select="mods:name"/>
           <xsl:apply-templates select="mods:language"/>
         </analytic>


### PR DESCRIPTION
The METS files received from LETA had improperly formed mods:identifiers and mods:recordIdentifiers; they were missing the issue date suffix. I wrote some throw-away xslt to repair them.